### PR TITLE
Archive timestamped params_for_id and obs_data into the param_id run dir

### DIFF
--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -54,7 +54,8 @@ try:
 except ImportError:
     corner = None
 import csv
-from datetime import date
+import shutil
+from datetime import date, datetime
 # from skopt import gp_minimize, Optimizer
 from parsers.PrimitiveParsers import CSVFileParser, ObsAndParamDataParser
 from param_id.optimisers import GeneticAlgorithmOptimiser, BayesianOptimiser, CMAESOptimiser, SciPyMinimizeOptimiser
@@ -180,6 +181,9 @@ class CVS0DParamID():
             self.plot_dir = os.path.join(self.output_dir, 'plots_param_id')
             if not os.path.exists(self.plot_dir):
                 os.mkdir(self.plot_dir)
+            # Archive the input files (timestamped) used for this run so the user can
+            # later check exactly what params_for_id / obs_data produced these outputs.
+            self._archive_input_files(params_for_id_path, param_id_obs_path)
         else:
             self.output_dir = None
         
@@ -264,6 +268,27 @@ class CVS0DParamID():
         
         self.best_output_calculated = False
         self.sensitivity_calculated = False
+
+    def _archive_input_files(self, params_for_id_path, param_id_obs_path):
+        """Copy the params_for_id and obs_data input files into the run output_dir.
+
+        A ``_<yymmdd>_<HHMMSS>`` timestamp is inserted before the extension (a single
+        timestamp shared by both files), so a user inspecting ``param_id_output/<case>/``
+        can see exactly which inputs were used for that run. Missing/None paths are
+        skipped; multiple runs into the same case dir accumulate timestamped copies.
+        """
+        if self.output_dir is None:
+            return
+        timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
+        for src in (params_for_id_path, param_id_obs_path):
+            if not src or not os.path.isfile(src):
+                continue
+            base, ext = os.path.splitext(os.path.basename(src))
+            dst = os.path.join(self.output_dir, f"{base}_{timestamp}{ext}")
+            try:
+                shutil.copy2(src, dst)
+            except OSError as e:
+                print(f"Warning: could not archive input file {src} -> {dst}: {e}")
 
     @classmethod
     def init_from_dict(cls, inp_data_dict):

--- a/tests/test_param_id.py
+++ b/tests/test_param_id.py
@@ -2578,3 +2578,47 @@ def test_parse_obs_data_json_series_std_required_for_npy_paths(tmp_path):
     with pytest.raises(ValueError, match="requires 'std'"):
         parser.parse_obs_data_json(obs_data_dict=obs_data_dict, pre_time=0.0, sim_time=1.0)
 
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_param_id_archives_input_files(resources_dir, temp_output_dir,
+                                       generated_cellml_model_factory, mpi_comm):
+    """CVS0DParamID archives the params_for_id and obs_data inputs into the run
+    output_dir with a _yymmdd_HHMMSS timestamp, so a user can see exactly which
+    inputs produced a run (issue #233)."""
+    import re
+
+    rank = mpi_comm.Get_rank()
+    model_path = generated_cellml_model_factory('3compartment', '3compartment_parameters.csv')
+    params_for_id_path = os.path.join(resources_dir, '3compartment_params_for_id.csv')
+    obs_path = os.path.join(resources_dir, '3compartment_obs_data.json')
+
+    runner = CVS0DParamID.init_from_dict({
+        'model_path': model_path,
+        'model_type': 'cellml_only',
+        'param_id_method': 'genetic_algorithm',
+        'file_name_prefix': '3compartment',
+        'params_for_id_path': params_for_id_path,
+        'param_id_obs_path': obs_path,
+        'resources_dir': resources_dir,
+        'param_id_output_dir': temp_output_dir,
+        'solver_info': {'solver': 'CVODE_myokit', 'MaximumStep': 0.001, 'MaximumNumberOfSteps': 5000},
+        'dt': 0.01, 'sim_time': 2.0, 'pre_time': 20.0, 'DEBUG': False,
+    })
+
+    if rank == 0:
+        out = runner.output_dir
+        files = os.listdir(out)
+        params_copies = [f for f in files
+                         if re.fullmatch(r'3compartment_params_for_id_\d{6}_\d{6}\.csv', f)]
+        obs_copies = [f for f in files
+                      if re.fullmatch(r'3compartment_obs_data_\d{6}_\d{6}\.json', f)]
+        assert params_copies, f"no timestamped params_for_id copy in {out}: {files}"
+        assert obs_copies, f"no timestamped obs_data copy in {out}: {files}"
+        # Archived copies must match the source inputs byte-for-byte.
+        with open(os.path.join(out, params_copies[0])) as fa, open(params_for_id_path) as fb:
+            assert fa.read() == fb.read()
+        with open(os.path.join(out, obs_copies[0])) as fa, open(obs_path) as fb:
+            assert fa.read() == fb.read()


### PR DESCRIPTION
## Summary

Closes #233.

After a parameter-identification run it was hard to know which `params_for_id` and `obs_data.json` inputs produced the outputs in `param_id_output/<case>/`, because those files live in `resources/` and can change between runs.

`CVS0DParamID` now copies each provided input into the run's `output_dir` with a `_<yymmdd>_<HHMMSS>` timestamp inserted before the extension, e.g.:

```
param_id_output/genetic_algorithm_3compartment_3compartment_obs_data/
  ├── 3compartment_params_for_id_260612_145046.csv
  └── 3compartment_obs_data_260612_145046.json
```

So a user can open a run directory and immediately see what inputs were used (and diff them against the current `resources/` versions).

## Implementation

- New `CVS0DParamID._archive_input_files(params_for_id_path, param_id_obs_path)`, called in `__init__` after the run output dir is created.
- Rank-0 only; skips `None`/missing paths; warns instead of crashing on `OSError`.
- Single timestamp shared by both files; multiple runs into the same case dir accumulate timestamped copies (an intentional history of what was used).

## Tests

- `tests/test_param_id.py::test_param_id_archives_input_files` constructs `CVS0DParamID` for the 3compartment model and asserts both timestamped copies appear (matching `_\d{6}_\d{6}`) with byte-for-byte content.
- Existing param_id tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)