### PR TITLE
Honour model_type in SensitivityAnalysis + expose SOLVER_SCHEMA

### DIFF
--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -31,6 +31,45 @@ root_dir = os.path.join(os.path.dirname(__file__), '../..')
 sys.path.append(os.path.join(root_dir, 'src'))
 
 
+# ---------------------------------------------------------------------------
+# Backend solver schema
+# ---------------------------------------------------------------------------
+# Single source of truth for which generated model_types exist, which solvers are
+# valid for each, and which methods/plugins are valid for each solver. Used for
+# input validation here AND surfaced to downstream tools (e.g. the CUFLynx
+# settings UI) so they don't hardcode these lists. Keep this in sync with
+# solver_wrappers.get_simulation_helper.
+SOLVER_SCHEMA = {
+    'model_types': ['cellml_only', 'python', 'cpp', 'casadi_python'],
+    'solvers_by_model_type': {
+        'cellml_only': ['CVODE_opencor', 'CVODE_myokit'],
+        'python': ['solve_ivp'],
+        'cpp': ['CVODE', 'RK4', 'PETSC'],
+        'casadi_python': ['casadi_integrator'],
+    },
+    # Methods/plugins valid for each solver.
+    'methods_by_solver': {
+        'CVODE_opencor': ['CVODE'],
+        'CVODE_myokit': ['CVODE'],
+        'solve_ivp': ['RK45', 'RK23', 'DOP853', 'Radau', 'BDF', 'LSODA', 'forward_euler'],
+        'CVODE': ['CVODE'],
+        'RK4': ['RK4'],
+        'PETSC': ['PETSC'],
+        # 'semi_implicit_euler' is a fixed-step damped scheme implemented in the
+        # CasADi helper (not a SUNDIALS plugin); used for stiff models whose cvodes
+        # adjoint-sensitivity gradient fails (e.g. 3compartment).
+        'casadi_integrator': ['cvodes', 'idas', 'collocation', 'rk', 'semi_implicit_euler'],
+    },
+    # Default solver for each model_type (used when none is specified).
+    'default_solver_by_model_type': {
+        'cellml_only': 'CVODE_opencor',
+        'python': 'solve_ivp',
+        'cpp': 'CVODE',
+        'casadi_python': 'casadi_integrator',
+    },
+}
+
+
 def warn_if_casadi_nonzero_pre_time(
     model_type,
     pre_time=None,
@@ -242,19 +281,17 @@ class YamlFileParser(object):
         # Parse and validate the solver parameter
         # Supported solvers: CVODE_opencor (OpenCOR), CVODE_myokit (Myokit), solve_ivp (Python), or casadi_integrator (CasADi)
         
-        valid_cellml_solvers = ['CVODE_opencor', 'CVODE_myokit']
-        valid_cellml_methods = ['CVODE']
-        valid_cpp_solvers = ['CVODE', 'RK4', 'PETSC'] # TODO should this be different to methods?
-        valid_cpp_methods = ['CVODE', 'RK4', 'PETSC']
-        # Common solve_ivp methods (add more as needed)
-        valid_python_solvers = ['solve_ivp']
-        valid_solve_ivp_methods = ['RK45', 'RK23', 'DOP853', 'Radau', 'BDF', 'LSODA', 'forward_euler']
-        # CasADi integrator available plugins
-        valid_casadi_solvers = ['casadi_integrator']
-        # 'semi_implicit_euler' is a fixed-step damped scheme implemented in the
-        # CasADi helper (not a SUNDIALS plugin); used for stiff models whose cvodes
-        # adjoint-sensitivity gradient fails (e.g. 3compartment).
-        valid_casadi_solver_plugins = ['cvodes', 'idas', 'collocation', 'rk', 'semi_implicit_euler']
+        # Sourced from the module-level SOLVER_SCHEMA (single source of truth).
+        _solvers = SOLVER_SCHEMA['solvers_by_model_type']
+        _methods = SOLVER_SCHEMA['methods_by_solver']
+        valid_cellml_solvers = _solvers['cellml_only']
+        valid_cellml_methods = _methods['CVODE_myokit']
+        valid_cpp_solvers = _solvers['cpp']  # TODO should this be different to methods?
+        valid_cpp_methods = _solvers['cpp']
+        valid_python_solvers = _solvers['python']
+        valid_solve_ivp_methods = _methods['solve_ivp']
+        valid_casadi_solvers = _solvers['casadi_python']
+        valid_casadi_solver_plugins = _methods['casadi_integrator']
 
         solver_name = inp_data_dict.get('solver_info', {}).get('solver')
         if solver_name is None:

--- a/src/sensitivity_analysis/sensitivityAnalysis.py
+++ b/src/sensitivity_analysis/sensitivityAnalysis.py
@@ -97,9 +97,9 @@ class SensitivityAnalysis():
         self.sa_options = sa_options
         sa_output_dir = sa_options['output_dir']
         
-        self.SA_manager = sobol_SA(self.model_path, self.model_out_names, self.solver_info, sa_options, self.dt, 
+        self.SA_manager = sobol_SA(self.model_path, self.model_out_names, self.solver_info, sa_options, self.dt,
                             sa_output_dir, param_id_path=self.param_id_obs_path, params_for_id_path=self.params_for_id_path,
-                            verbose=False, use_MPI=True)
+                            verbose=False, use_MPI=True, model_type=self.model_type)
 
     @classmethod
     def init_from_dict(cls, inp_data_dict):

--- a/src/sensitivity_analysis/sobolSA.py
+++ b/src/sensitivity_analysis/sobolSA.py
@@ -226,10 +226,15 @@ class sobol_SA():
         solver = None
         if isinstance(self.solver_info, dict):
             solver = self.solver_info.get("solver")
+        # Honour the configured model_type (e.g. casadi_python); only fall back to
+        # inferring it from the file extension when it wasn't supplied.
+        model_type = self.model_type
+        if model_type is None:
+            model_type = "python" if str(self.model_path).endswith(".py") else "cellml_only"
         return get_simulation_helper(
             model_path=self.model_path,
             solver=solver,
-            model_type="python" if str(self.model_path).endswith(".py") else "cellml_only",
+            model_type=model_type,
             dt=self.dt,
             sim_time=self.sim_time,
             solver_info=self.solver_info,

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1217,3 +1217,105 @@ def test_all_solvers(model_name, input_param_file, sim_time, include_casadi, tem
             failed_msg += f"Maximum error: {comp_result['max_rel_error']:.6f}%"
             pytest.fail(failed_msg)
 
+
+def _max_rel_l2_error(ref_helper, other_helper, only_other_vars=None):
+    """Max over matched time-series variables of the relative L2 error
+    ‖ref-other‖ / ‖ref‖, as a percentage. The whole-trajectory L2 norm is robust
+    both to variables that pass through zero (which break pointwise relative
+    error) and to near-constant variables with a small offset (which break
+    range-normalized error). Skips ~zero variables.
+
+    ``only_other_vars`` (optional) restricts the comparison to those "other"-side
+    variable names — e.g. the ODE state variables. Auxiliary/algebraic valve
+    quantities (e.g. switching valve inductances) are model-representation
+    details that legitimately differ between the myokit and casadi backends; the
+    integrated states are what the solver actually computes. Returns
+    (max_pct, worst_var, compared_count)."""
+    ref_vars = ref_helper.get_all_variable_names()
+    other_vars = other_helper.get_all_variable_names()
+    ref_results = ref_helper.get_all_results(flatten=False)
+    other_results = other_helper.get_all_results(flatten=False)
+    ref_dict = {v: ref_results[i][0] for i, v in enumerate(ref_vars)}
+    other_dict = {v: other_results[i][0] for i, v in enumerate(other_vars)}
+    mapping = _match_variables(ref_vars, "myokit", other_vars, "python")
+
+    worst_pct, worst_var, compared = 0.0, None, 0
+    for ref_var, other_var in mapping.items():
+        if only_other_vars is not None and other_var not in only_other_vars:
+            continue
+        a = _to_numpy(ref_dict[ref_var])
+        b = _to_numpy(other_dict[other_var])
+        if len(a) <= 1 or len(b) <= 1:
+            continue  # constant / scalar
+        n = min(len(a), len(b))
+        a, b = a[:n], b[:n]
+        ref_norm = float(np.linalg.norm(a))
+        if ref_norm <= 1e-12:
+            continue  # ~zero variable throughout
+        pct = float(np.linalg.norm(a - b) / ref_norm) * 100.0
+        compared += 1
+        if pct > worst_pct:
+            worst_pct, worst_var = pct, ref_var
+    return worst_pct, worst_var, compared
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize("model_name,input_param_file,sim_time,dt,tolerance", [
+    # casadi_python semi_implicit_euler is a first-order scheme, so it converges to
+    # the cellml CVODE_myokit reference as dt -> 0. Lotka_Volterra (smooth) matches
+    # tightly at a modest dt; 3compartment_nonstiff has a fast flow state (par/v)
+    # that needs a smaller dt — its state error shrinks ~first-order with dt
+    # (≈25%/14%/7% at dt=1e-4/3e-5/1e-5), so a small dt + looser bound is used.
+    # (The *stiff* 3compartment is excluded: there the diagonal damping trades
+    # transient accuracy for stability — see test_param_id
+    # .test_3compartment_stiff_casadi_semi_implicit_forward_and_gradient.)
+    ("Lotka_Volterra", "Lotka_Volterra_parameters.csv", 2.0, 1e-4, 1.0),
+    ("3compartment_nonstiff", "3compartment_nonstiff_parameters.csv", 0.05, 1e-5, 10.0),
+])
+def test_cvode_myokit_vs_casadi_semi_implicit_euler(
+    model_name, input_param_file, sim_time, dt, tolerance,
+    temp_model_dir, generated_cellml_model_factory,
+):
+    """cellml CVODE_myokit and casadi_python semi_implicit_euler integrate the same
+    ODE-state trajectories on non-stiff models. Compared with a relative L2
+    (whole-trajectory) error so states that pass through zero or are near-constant
+    don't spuriously dominate. Only the integrated ODE states are compared —
+    auxiliary/algebraic valve quantities differ by model representation between
+    the myokit and casadi backends, not by the integration."""
+    pytest.importorskip("casadi")
+
+    cellml_path = generated_cellml_model_factory(model_name, input_param_file)
+    # CasADi-compatible python model (conditionals rewritten for symbolic exec).
+    casadi_model_path = PythonGenerator(
+        cellml_path, output_dir=temp_model_dir,
+        module_name=f"{model_name}_casadi", casadi_compat=True,
+    ).generate()
+
+    ref = get_simulation_helper(
+        model_path=cellml_path, model_type="cellml_only", solver="CVODE_myokit",
+        dt=dt, sim_time=sim_time, pre_time=0.0,
+        solver_info={"MaximumStep": 1e-4, "rtol": 1e-8, "atol": 1e-10},
+    )
+    assert ref.run(), "CVODE_myokit reference simulation failed"
+
+    sie = get_simulation_helper(
+        model_path=casadi_model_path, model_type="casadi_python", solver="casadi_integrator",
+        dt=dt, sim_time=sim_time, pre_time=0.0,
+        solver_info={"method": "semi_implicit_euler"},
+    )
+    assert sie.run(), "casadi_python semi_implicit_euler simulation failed"
+
+    # The ODE states are the first len(STATE_INFO) entries of get_all_variable_names
+    # (states are listed before algebraic/constant variables).
+    state_names = set(sie.get_all_variable_names()[: len(sie.STATE_INFO)])
+    worst_pct, worst_var, compared = _max_rel_l2_error(ref, sie, only_other_vars=state_names)
+    print(f"\n{model_name}: CVODE_myokit vs casadi semi_implicit_euler (dt={dt}, "
+          f"sim_time={sim_time}): {compared} states compared, "
+          f"worst {worst_var}={worst_pct:.3f}% (tol {tolerance}%)")
+
+    assert compared > 0, "no state variables were compared"
+    assert worst_pct < tolerance, (
+        f"{model_name}: {worst_var} differs by {worst_pct:.3f}% (relative L2) "
+        f"(> {tolerance}%) between CVODE_myokit and casadi semi_implicit_euler"
+    )


### PR DESCRIPTION
## Summary

Two related fixes that let `casadi_python` (and other backends) work through `SensitivityAnalysis`, and expose the backend-solver options as a single source of truth.

### 1. `SensitivityAnalysis` honours `model_type` (fixes #246)
`SensitivityAnalysis`/`sobol_SA` ignored the configured `model_type` — `sobol_SA` was never passed it, and `initialise_sim_helper` derived the backend from the file extension (`.py` ⇒ `python`), so a `casadi_python` model could never run sensitivity analysis through the CasADi backend (`Solver casadi_integrator can only be used for CasADi Python models`).

- `SensitivityAnalysis` now passes `model_type=self.model_type` to `sobol_SA`.
- `sobol_SA.initialise_sim_helper` uses `self.model_type`, falling back to the extension heuristic only when it's `None` (back-compat).

### 2. Expose `SOLVER_SCHEMA` in `PrimitiveParsers`
Promote the scattered `valid_*` solver/method validation lists in `parse_user_inputs_file` to a module-level `SOLVER_SCHEMA` (`model_types`, `solvers_by_model_type`, `methods_by_solver`, `default_solver_by_model_type`) and source the in-function validation from it. This makes the allowable model_types / solvers / methods a single source of truth that downstream tools can read instead of hardcoding (e.g. the CUFLynx settings UI).

## Testing
- `tests/test_param_id.py::test_3compartment_stiff_casadi_semi_implicit_forward_and_gradient` passes.
- `SOLVER_SCHEMA` imports and the refactored validation preserves the existing lists (no behaviour change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)