### PR TITLE
Stream sp_minimize cost/param history per iteration (live progress plots)

### DIFF
--- a/src/param_id/optimisers.py
+++ b/src/param_id/optimisers.py
@@ -830,15 +830,36 @@ class SciPyMinimizeOptimiser(Optimiser):
                 else:
                     gradient_func = lambda q: approx_fprime(q, cost_fun, epsilon=1e-4)
 
+                cost_history_path = os.path.join(self.output_dir, 'best_cost_history.csv')
+                param_history_path = os.path.join(self.output_dir, 'best_param_vals_history.csv')
+
+                def _append_history(cost_val, x_norm):
+                    # Append one row per L-BFGS-B iteration so the cost / parameter
+                    # progress plots update live during the run (same CSV format the
+                    # population-based optimisers use). x_norm is already in
+                    # normalised parameter space, matching best_param_vals_history.
+                    with open(cost_history_path, 'a') as file:
+                        np.savetxt(file, np.array([[float(cost_val)]]), fmt='%1.9f', delimiter=', ')
+                    with open(param_history_path, 'a') as file:
+                        np.savetxt(file, np.asarray(x_norm, dtype=float).reshape(1, -1),
+                                   fmt='%.5e', delimiter=', ')
+
+                # Record the starting point so the progress curve begins at the
+                # pre-optimisation cost.
+                _append_history(init_cost, self.param_norm_obj.normalise(init_param_vals))
+
                 step_counter = [0]
                 last_iterate = {"x_norm": None, "cost": None}
 
                 def lbfgsb_callback(x_norm):
                     step_counter[0] += 1
-                    last_iterate["x_norm"] = np.asarray(x_norm, dtype=float).copy()
+                    x_norm = np.asarray(x_norm, dtype=float).copy()
+                    last_iterate["x_norm"] = x_norm
                     param_vals = self.param_norm_obj.unnormalise(x_norm)
                     cost_val = float(self.param_id_obj.get_cost_ca(param_vals))
                     last_iterate["cost"] = cost_val
+                    # Live progress: one history row per accepted iteration.
+                    _append_history(cost_val, x_norm)
                     if self.DEBUG:
                         print(f'[sp_minimize] step {step_counter[0]}: cost = {cost_val:.6e}')
                         for i, names in enumerate(self.param_id_info["param_names"]):
@@ -906,12 +927,16 @@ class SciPyMinimizeOptimiser(Optimiser):
         self.best_gradient = best_gradient_vals
 
         if rank == 0:
-            costs = np.array([float(init_cost), float(best_cost_array[0])])
-            with open(os.path.join(self.output_dir, 'best_cost_history.csv'), 'a') as file:
-                np.savetxt(file, costs.reshape(-1, 1), fmt='%1.9f', delimiter=',')
+            # The per-iteration callback already streamed the cost / parameter
+            # history during the run. Record the final best as the last point, but
+            # only when L-BFGS-B refined past the last callback iterate (otherwise
+            # it would duplicate the last streamed row).
+            if last_iterate["cost"] is None or float(best_cost_array[0]) < float(last_iterate["cost"]):
+                with open(os.path.join(self.output_dir, 'best_cost_history.csv'), 'a') as file:
+                    np.savetxt(file, np.array([[float(best_cost_array[0])]]), fmt='%1.9f', delimiter=', ')
+                with open(os.path.join(self.output_dir, 'best_param_vals_history.csv'), 'a') as file:
+                    param_vals_norm = self.param_norm_obj.normalise(self.best_param_vals)
+                    np.savetxt(file, np.asarray(param_vals_norm, dtype=float).reshape(1, -1),
+                               fmt='%.5e', delimiter=', ')
 
-            with open(os.path.join(self.output_dir, 'best_param_vals_history.csv'), 'a') as file:
-                param_vals_norm = self.param_norm_obj.normalise(self.best_param_vals.reshape(-1, 1))
-                np.savetxt(file, param_vals_norm.reshape(1,-1), fmt='%.5e', delimiter=', ')
-            
             self._save_best_params()

--- a/tests/test_param_id.py
+++ b/tests/test_param_id.py
@@ -2793,3 +2793,62 @@ def test_param_id_archives_input_files(resources_dir, temp_output_dir,
             assert fa.read() == fb.read()
         with open(os.path.join(out, obs_copies[0])) as fa, open(obs_path) as fb:
             assert fa.read() == fb.read()
+
+
+def test_sp_minimize_streams_cost_history_per_iteration(temp_output_dir):
+    """SciPyMinimizeOptimiser appends a cost / parameter history row per L-BFGS-B
+    iteration (not just a start + end pair), so the live progress plots update
+    during a gradient-based calibration. Uses a Rosenbrock cost so L-BFGS-B takes
+    several iterations; no model/casadi needed."""
+    from param_id.optimisers import SciPyMinimizeOptimiser
+
+    mins = np.array([-10.0, -10.0])
+    maxs = np.array([10.0, 10.0])
+
+    class _Norm:
+        def normalise(self, p):
+            return (np.asarray(p, dtype=float) - mins) / (maxs - mins)
+
+        def unnormalise(self, q):
+            return mins + np.asarray(q, dtype=float) * (maxs - mins)
+
+    class _ParamId:
+        param_init = np.array([-1.2, 1.0])  # classic Rosenbrock start
+
+        def __init__(self):
+            self.best = None
+
+        def get_cost_ca(self, p):
+            p = np.asarray(p, dtype=float)
+            return 100.0 * (p[1] - p[0] ** 2) ** 2 + (1.0 - p[0]) ** 2
+
+        def get_jac_cost_ca(self, p):
+            p = np.asarray(p, dtype=float)
+            return np.array([
+                -400.0 * p[0] * (p[1] - p[0] ** 2) - 2.0 * (1.0 - p[0]),
+                200.0 * (p[1] - p[0] ** 2),
+            ])
+
+        def set_best_param_vals(self, p):
+            self.best = np.asarray(p, dtype=float)
+
+    param_id_info = {"param_names": [["a"], ["b"]], "param_mins": mins, "param_maxs": maxs}
+    opt = SciPyMinimizeOptimiser(
+        param_id_obj=_ParamId(), param_id_info=param_id_info, param_norm_obj=_Norm(),
+        num_params=2, output_dir=temp_output_dir,
+        optimiser_options={"cost_convergence": 1e-15}, do_ad=True, DEBUG=False,
+    )
+    opt.run()
+
+    cost_path = os.path.join(temp_output_dir, "best_cost_history.csv")
+    param_path = os.path.join(temp_output_dir, "best_param_vals_history.csv")
+    assert os.path.exists(cost_path)
+    cost_rows = [ln for ln in open(cost_path).read().splitlines() if ln.strip()]
+    costs = [float(ln.split(",")[0]) for ln in cost_rows]
+    # init row + one per L-BFGS-B iteration => clearly more than the old start+end pair.
+    assert len(costs) > 2, f"expected per-iteration history, got {len(costs)} rows"
+    # Progress was made: the final recorded cost is well below the starting cost.
+    assert costs[-1] < costs[0]
+    # Parameter history is written in lockstep with the cost history.
+    param_rows = [ln for ln in open(param_path).read().splitlines() if ln.strip()]
+    assert len(param_rows) == len(costs)


### PR DESCRIPTION
## Summary

`SciPyMinimizeOptimiser` (the gradient-based `sp_minimize` method) only wrote a **start + end** pair to `best_cost_history.csv` / `best_param_vals_history.csv`, so a downstream live progress plot (e.g. CUFLynx's calibration progress panel, which polls these CSVs) couldn't track a gradient-based run — unlike the population-based optimisers, which append a row per generation.

The L-BFGS-B callback already computes the cost and parameters at each accepted iteration (for the convergence check / DEBUG print). This change **appends a history row there** (plus an initial-point row), in the same CSV format the GA/CMA-ES paths use, so the cost/parameter progress streams live during the run.

## Changes
- Write the initial cost/params as the first history row (curve starts at the pre-optimisation point).
- Append one cost row + one normalised-parameter row per L-BFGS-B iteration in `lbfgsb_callback`.
- Replace the redundant end-of-run two-row write with a single final-best row, written only when L-BFGS-B refined past the last callback iterate (avoids a duplicate point).
- No extra computation — the cost is already evaluated in the callback. History files are still cleared at the start of `run_param_id`.

## Test
`test_sp_minimize_streams_cost_history_per_iteration` — runs the optimiser on a Rosenbrock cost (no model/CasADi needed, ~0.5s) and asserts the cost history has more than the old 2 rows, that the cost decreases, and that the cost/param histories are written in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)