### PR TITLE
Archive a dated user_inputs_YYMMDD.yaml of each resolved run config

### DIFF
--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -18,6 +18,7 @@ try:
 except Exception:
     ScalarFloat = None
 import re
+from datetime import date
 
 try:
     from mpi4py import MPI
@@ -68,6 +69,34 @@ SOLVER_SCHEMA = {
         'casadi_python': 'casadi_integrator',
     },
 }
+
+
+def save_dated_user_inputs(inp_data_dict):
+    """Best-effort: archive the resolved run config as ``user_inputs_<yymmdd>.yaml``
+    in ``resources_dir``, so every run keeps a dated, reproducible record of what
+    was run (mirrors the params_for_id / obs_data archival). Never raises — a
+    failure here must not abort a run. Only rank 0 writes (avoids MPI clobber)."""
+    if rank != 0:
+        return
+    try:
+        resources_dir = inp_data_dict.get('resources_dir')
+        if not resources_dir or not os.path.isdir(resources_dir):
+            return
+        # Keep only yaml-serialisable entries so a stray object never breaks a run.
+        safe = {}
+        for key, value in inp_data_dict.items():
+            try:
+                yaml.safe_dump({key: value})
+            except Exception:
+                continue
+            safe[key] = value
+        out_path = os.path.join(
+            resources_dir, f"user_inputs_{date.today().strftime('%y%m%d')}.yaml"
+        )
+        with open(out_path, 'w') as f:
+            yaml.safe_dump(safe, f, default_flow_style=False, sort_keys=False)
+    except Exception:
+        pass
 
 
 def warn_if_casadi_nonzero_pre_time(
@@ -609,6 +638,9 @@ class YamlFileParser(object):
             inp_data_dict['file_prefix_1d'] = file_prefix_1d
             inp_data_dict['vessels_0d_csv_abs_path'] = vessel_filename_0d
             inp_data_dict['vessels_1d_csv_abs_path'] = vessel_filename_1d
+
+        # Archive a dated copy of the resolved config for reproducibility.
+        save_dated_user_inputs(inp_data_dict)
 
         return inp_data_dict
 

--- a/tests/test_user_inputs_archive.py
+++ b/tests/test_user_inputs_archive.py
@@ -1,0 +1,51 @@
+"""Tests for the dated user_inputs.yaml archival (reproducibility snapshot)."""
+
+import os
+from datetime import date
+
+import yaml
+
+from parsers.PrimitiveParsers import save_dated_user_inputs
+
+
+def _dated_name():
+    return f"user_inputs_{date.today().strftime('%y%m%d')}.yaml"
+
+
+def test_save_dated_user_inputs_writes_resolved_config(tmp_path):
+    cfg = {
+        "resources_dir": str(tmp_path),
+        "file_prefix": "3compartment",
+        "model_type": "casadi_python",
+        "dt": 0.01,
+        "do_sensitivity": True,
+        "optimiser_options": {"num_calls_to_function": 100, "cost_convergence": 1e-4},
+    }
+    save_dated_user_inputs(cfg)
+
+    out = tmp_path / _dated_name()
+    assert out.is_file()
+    loaded = yaml.safe_load(out.read_text())
+    assert loaded["file_prefix"] == "3compartment"
+    assert loaded["model_type"] == "casadi_python"
+    assert loaded["do_sensitivity"] is True
+    assert loaded["optimiser_options"]["num_calls_to_function"] == 100
+
+
+def test_save_dated_user_inputs_skips_unserialisable_values(tmp_path):
+    class _Obj:
+        pass
+
+    cfg = {"resources_dir": str(tmp_path), "file_prefix": "m", "_handle": _Obj()}
+    save_dated_user_inputs(cfg)  # must not raise
+
+    loaded = yaml.safe_load((tmp_path / _dated_name()).read_text())
+    assert "_handle" not in loaded  # non-serialisable entry dropped
+    assert loaded["file_prefix"] == "m"
+
+
+def test_save_dated_user_inputs_no_resources_dir_is_noop(tmp_path):
+    # Missing/invalid resources_dir: best-effort, writes nothing, never raises.
+    save_dated_user_inputs({"file_prefix": "m"})
+    save_dated_user_inputs({"resources_dir": str(tmp_path / "does_not_exist")})
+    assert not (tmp_path / _dated_name()).exists()


### PR DESCRIPTION
## Summary

`parse_user_inputs_file` now best-effort writes a dated copy `user_inputs_<yymmdd>.yaml` of the fully-resolved run config into `resources_dir`, so **every run keeps a dated, reproducible record of what was run** — mirroring the existing `params_for_id` / `obs_data` archival convention.

- Rank-0 only (avoids MPI clobber).
- Never raises — a failure here must not abort a run.
- Skips non-serialisable entries so a stray object can't break the dump.

This pairs with the CUFLynx pipeline-export feature: the exported `run_pipeline.py` is yaml-driven, so each export run leaves a `user_inputs_YYMMDD.yaml` snapshot.

## Tests
`tests/test_user_inputs_archive.py` — writes the resolved config, drops non-serialisable values, and is a no-op when `resources_dir` is missing/invalid. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)