### PR TITLE
Add model_type python_user_defined to wrap arbitrary Python ODE models for SA / calibration / UQ

### DIFF
--- a/funcs_user/example_model/README.md
+++ b/funcs_user/example_model/README.md
@@ -1,0 +1,65 @@
+# Example `python_user_defined` model — damped oscillator
+
+A minimal, self-contained example of plugging an arbitrary Python ODE model into
+circulatory_autogen via `model_type: python_user_defined`. The model is a damped
+linear oscillator `x'' + c·x' + k·x = 0`, and the parameters `c` (damping) and
+`k` (stiffness) are calibrated / analysed by the standard pipelines.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `oscillator_wrapper.py` | The model wrapper (`PARAMETERS`, `STATES`, `OUTPUT_NAMES`, `rhs`). |
+| `oscillator_params_for_id.csv` | Parameters to calibrate / sweep (`c`, `k`) with bounds. |
+| `oscillator_parameters.csv` | Default parameter values (the calibration start point). |
+| `oscillator_obs_data.json` | Target observables (`mean(x)`, `min(x)`, `range(v)`) — computed from the "true" `c=0.7, k=5.0`. |
+
+The wrapper template to copy for your own model is
+`funcs_user/model_wrapper_funcs_user.py`.
+
+## How it works
+
+There is **no code generation**. The framework imports `oscillator_wrapper.py`,
+builds a model from `rhs` + `STATES` + `PARAMETERS`, and integrates it with the
+same scipy `solve_ivp` machinery used by the generated-python backend
+(`src/solver_wrappers/python_solver_helper.py`). Calibration, sensitivity
+analysis and identifiability analysis then run unchanged.
+
+Only `PARAMETERS` are swept; initial conditions in `STATES` are fixed.
+Parameter / output names use the canonical `component/variable` form so they match
+the `params_for_id` CSV (`vessel_name`/`param_name`) and the obs_data `operands`.
+
+## `user_inputs.yaml` settings
+
+```yaml
+file_prefix: oscillator
+input_param_file: oscillator_parameters.csv
+model_type: python_user_defined
+solver: user_defined
+# Default wrapper location is funcs_user/{file_prefix}_wrapper.py. This example
+# lives in a subdirectory, so point at it explicitly:
+model_wrapper_path: <repo>/funcs_user/example_model/oscillator_wrapper.py
+# Point resources_dir at this directory so the CSV/JSON above are found:
+resources_dir: <repo>/funcs_user/example_model
+pre_time: 0.0
+sim_time: 10.0
+dt: 0.05
+param_id_method: genetic_algorithm
+```
+
+## Running
+
+```bash
+# Calibration (2 MPI ranks)
+./run_param_id.sh 2
+# Sensitivity analysis
+./run_sensitivity_analysis.sh 2
+# Identifiability analysis
+./run_identifiability_analysis.sh
+```
+
+Calibration should recover `c ≈ 0.7`, `k ≈ 5.0` (the values used to generate
+`oscillator_obs_data.json`), starting from the `c=0.5, k=4.0` defaults.
+
+See `tests/test_python_user_defined.py` for an automated end-to-end check of all
+three workflows against this example.

--- a/funcs_user/example_model/oscillator_obs_data.json
+++ b/funcs_user/example_model/oscillator_obs_data.json
@@ -1,0 +1,38 @@
+[
+  { "variable": "displacement mean",
+    "name_for_plotting": "mean(x)",
+    "data_type": "constant",
+    "operation": "mean",
+    "operands": ["oscillator/x"],
+    "unit": "dimensionless",
+    "weight": 1.0,
+    "value": 0.01663962,
+    "std": 0.002,
+    "cost_type": "gaussian_MLE",
+    "plot_type": "horizontal"
+  },
+  { "variable": "displacement min",
+    "name_for_plotting": "min(x)",
+    "data_type": "constant",
+    "operation": "min",
+    "operands": ["oscillator/x"],
+    "unit": "dimensionless",
+    "weight": 1.0,
+    "value": -0.60704870,
+    "std": 0.03,
+    "cost_type": "gaussian_MLE",
+    "plot_type": "horizontal"
+  },
+  { "variable": "velocity range",
+    "name_for_plotting": "range(v)",
+    "data_type": "constant",
+    "operation": "max_minus_min",
+    "operands": ["oscillator/v"],
+    "unit": "dimensionless",
+    "weight": 1.0,
+    "value": 2.87274456,
+    "std": 0.1,
+    "cost_type": "gaussian_MLE",
+    "plot_type": "horizontal_from_min"
+  }
+]

--- a/funcs_user/example_model/oscillator_parameters.csv
+++ b/funcs_user/example_model/oscillator_parameters.csv
@@ -1,0 +1,3 @@
+variable_name,units,value,data_reference
+c,dimensionless,0.5,user_defined
+k,dimensionless,4.0,user_defined

--- a/funcs_user/example_model/oscillator_params_for_id.csv
+++ b/funcs_user/example_model/oscillator_params_for_id.csv
@@ -1,0 +1,3 @@
+vessel_name,  param_name,  param_type,  min,   max,   name_for_plotting
+oscillator,   c,           const,       0.05,  2.0,   c
+oscillator,   k,           const,       1.0,   10.0,  k

--- a/funcs_user/example_model/oscillator_wrapper.py
+++ b/funcs_user/example_model/oscillator_wrapper.py
@@ -1,0 +1,46 @@
+"""
+Example user-defined model wrapper: a damped linear oscillator.
+
+    x'' + c*x' + k*x = 0
+
+state vector y = [x, v] with v = x'. Parameters are the damping ``c`` and the
+stiffness ``k``; the framework integrates ``rhs`` with scipy solve_ivp.
+
+This demonstrates ``model_type: python_user_defined``. See README.md in this
+directory for the user_inputs.yaml settings and how SA / calibration /
+identifiability are run against it. Names use the canonical ``component/variable``
+form ("oscillator/c" etc.) so they line up with oscillator_params_for_id.csv and
+oscillator_obs_data.json.
+"""
+
+# Calibratable constants (overridden by oscillator_params_for_id.csv during a run).
+PARAMETERS = {
+    "oscillator/c": 0.5,   # damping
+    "oscillator/k": 4.0,   # stiffness
+}
+
+# Initial conditions for [x, v].
+STATES = {
+    "oscillator/x": 1.0,   # initial displacement
+    "oscillator/v": 0.0,   # initial velocity
+}
+
+# Observables referenced by the obs_data operands. Both are states here, so no
+# compute_outputs() is needed (an algebraic example is shown commented out below).
+OUTPUT_NAMES = ["oscillator/x", "oscillator/v"]
+
+
+def rhs(t, y, params):
+    x, v = y
+    c = params["oscillator/c"]
+    k = params["oscillator/k"]
+    return [v, -c * v - k * x]
+
+
+# Example of an algebraic output (total mechanical energy). Uncomment this and add
+# "oscillator/energy" to OUTPUT_NAMES to expose it as an observable:
+#
+# def compute_outputs(t, y, params):
+#     x, v = y
+#     k = params["oscillator/k"]
+#     return {"oscillator/energy": 0.5 * (v ** 2 + k * x ** 2)}

--- a/funcs_user/model_wrapper_funcs_user.py
+++ b/funcs_user/model_wrapper_funcs_user.py
@@ -1,0 +1,91 @@
+"""
+Template wrapper for ``model_type: python_user_defined``.
+
+Use this when you already have your own Python ODE model and want to run it
+through circulatory_autogen's calibration / sensitivity / identifiability
+pipelines without expressing it as a CVS0D vessel-array CSV.
+
+HOW TO USE
+----------
+1. Copy this file to ``funcs_user/{file_prefix}_wrapper.py`` where ``file_prefix``
+   matches the one in your ``user_inputs.yaml`` (e.g. ``oscillator`` ->
+   ``funcs_user/oscillator_wrapper.py``). Alternatively keep it anywhere and set
+   ``model_wrapper_path: /abs/path/to/your_wrapper.py`` in ``user_inputs.yaml``.
+2. In ``user_inputs.yaml`` set::
+
+       model_type: python_user_defined
+       solver: user_defined
+
+3. Fill in the three required pieces below (``PARAMETERS``, ``STATES``,
+   ``OUTPUT_NAMES``) and the ``rhs`` function. Optionally add ``compute_outputs``
+   for observables that are algebraic functions of the states/parameters rather
+   than states themselves.
+
+NAMING
+------
+Parameter / state / output names use the canonical ``component/variable`` form.
+They MUST match:
+  * ``PARAMETERS`` keys  <->  ``{vessel_name}/{param_name}`` in
+                              ``resources/{file_prefix}_params_for_id.csv``
+                              (vessel_name -> component, param_name -> variable),
+  * ``OUTPUT_NAMES``     <->  the ``operands`` entries in
+                              ``resources/{file_prefix}_obs_data.json``.
+
+WHAT THE FRAMEWORK DOES
+-----------------------
+The framework integrates ``rhs`` with scipy ``solve_ivp`` (the same machinery the
+generated-python backend uses) and handles parameter sweeping, pre_time spin-up,
+per-experiment resets and result extraction. You only describe the model.
+
+Only ``PARAMETERS`` values are swept during calibration / SA (they are the
+constants referenced in ``rhs``). Initial conditions in ``STATES`` are fixed.
+"""
+
+# 1. Parameter defaults. The optimiser overrides those listed in
+#    {file_prefix}_params_for_id.csv; the rest stay at these defaults.
+PARAMETERS = {
+    "model/k": 1.0,
+}
+
+# 2. Initial state values (the ODE state vector, in this order).
+STATES = {
+    "model/x": 1.0,
+}
+
+# 3. Observable outputs referenced by the obs_data operands. These may be state
+#    names (read directly) and/or algebraic names produced by compute_outputs().
+OUTPUT_NAMES = ["model/x"]
+
+
+def rhs(t, y, params):
+    """Right-hand side of the ODE system: dy/dt = rhs(t, y, params).
+
+    Args:
+        t: current time (float).
+        y: list of state values, in the order of STATES.
+        params: dict of all parameter values (PARAMETERS overlaid with the
+            current calibration/SA values), keyed by the PARAMETERS names.
+
+    Returns:
+        list of derivatives, one per state, in the order of STATES.
+    """
+    x = y[0]
+    k = params["model/k"]
+    dx_dt = -k * x
+    return [dx_dt]
+
+
+# OPTIONAL. Delete if every OUTPUT_NAMES entry is a state name.
+def compute_outputs(t, y, params):
+    """Compute algebraic outputs that are NOT themselves states.
+
+    Args:
+        t: current time (float).
+        y: list of state values, in the order of STATES.
+        params: dict of all parameter values.
+
+    Returns:
+        dict mapping output names (a subset of OUTPUT_NAMES that are not states)
+        to their scalar value at time t.
+    """
+    return {}

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -315,7 +315,7 @@ class CVS0DParamID():
                                            DEBUG=self.DEBUG, model_type=self.model_type)
             self.n_steps = mcmc_object.n_steps
         else:
-            if model_type in ['cellml_only', 'python', 'casadi_python', 'aadc_python']:
+            if model_type in ['cellml_only', 'python', 'casadi_python', 'aadc_python', 'python_user_defined']:
                 self.param_id = OpencorParamID(self.model_path, self.param_id_method,
                                                self.obs_info, self.param_id_info, self.protocol_info,
                                                self.prediction_info, self.solver_info, dt=self.dt,

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -41,13 +41,16 @@ sys.path.append(os.path.join(root_dir, 'src'))
 # settings UI) so they don't hardcode these lists. Keep this in sync with
 # solver_wrappers.get_simulation_helper.
 SOLVER_SCHEMA = {
-    'model_types': ['cellml_only', 'python', 'cpp', 'casadi_python', 'aadc_python'],
+    'model_types': ['cellml_only', 'python', 'cpp', 'casadi_python', 'aadc_python', 'python_user_defined'],
     'solvers_by_model_type': {
         'cellml_only': ['CVODE_opencor', 'CVODE_myokit'],
         'python': ['solve_ivp'],
         'cpp': ['CVODE', 'RK4', 'PETSC'],
         'casadi_python': ['casadi_integrator'],
         'aadc_python': ['aadc_semi_implicit'],
+        # The user supplies their own ODE wrapper in funcs_user/; it is integrated
+        # by the shared SciPy PythonSimulationHelper (see solver_wrappers).
+        'python_user_defined': ['user_defined'],
     },
     # Methods/plugins valid for each solver.
     'methods_by_solver': {
@@ -73,6 +76,9 @@ SOLVER_SCHEMA = {
         # rk4 instead -- cost and gradient were different functions. Use 'semi_implicit' for
         # stiff models, or model_type 'casadi_python' for a differentiable symbolic BDF.
         'aadc_semi_implicit': ['adaptive_rk45', 'semi_implicit', 'implicit_euler_ift', 'rk4'],
+        # The user wrapper supplies the rhs; the framework integrates it with the
+        # same scipy solve_ivp methods as model_type 'python'.
+        'user_defined': ['RK45', 'RK23', 'DOP853', 'Radau', 'BDF', 'LSODA', 'forward_euler'],
     },
     # Default solver for each model_type (used when none is specified).
     'default_solver_by_model_type': {
@@ -81,6 +87,7 @@ SOLVER_SCHEMA = {
         'cpp': 'CVODE',
         'casadi_python': 'casadi_integrator',
         'aadc_python': 'aadc_semi_implicit',
+        'python_user_defined': 'user_defined',
     },
 }
 
@@ -106,23 +113,29 @@ _CVODE_FAMILY_SOLVER_INFO = [
     _SI_RTOL, _SI_ATOL,
 ]
 
+# Shared by 'solve_ivp' and 'user_defined': the user wrapper supplies only the RHS and is
+# integrated by the same scipy solve_ivp helper, so the two accept an identical settings set.
+# Shared rather than duplicated so they cannot drift apart.
+_SOLVE_IVP_SOLVER_INFO = [
+    _SI_RTOL, _SI_ATOL,
+    {'name': 'max_step', 'type': 'float', 'default': 0.001, 'required': False,
+     'description': 'Maximum step size passed to scipy.integrate.solve_ivp.'},
+    {'name': 'vectorized', 'type': 'bool', 'default': False, 'required': False,
+     'description': 'Whether the RHS accepts vectorised input (scipy solve_ivp option).'},
+    {'name': 'dense_output', 'type': 'bool', 'default': False, 'required': False,
+     'description': 'Whether to compute a continuous (dense) solution.'},
+    {'name': 'jac', 'type': 'str', 'default': None, 'required': False,
+     'description': 'Optional Jacobian specification for implicit methods.'},
+]
+
 SOLVER_INFO_FIELDS = {
     'CVODE_opencor': _CVODE_FAMILY_SOLVER_INFO,
     'CVODE_myokit': _CVODE_FAMILY_SOLVER_INFO,
     'CVODE': _CVODE_FAMILY_SOLVER_INFO,
     'RK4': _CVODE_FAMILY_SOLVER_INFO,
     'PETSC': _CVODE_FAMILY_SOLVER_INFO,
-    'solve_ivp': [
-        _SI_RTOL, _SI_ATOL,
-        {'name': 'max_step', 'type': 'float', 'default': 0.001, 'required': False,
-         'description': 'Maximum step size passed to scipy.integrate.solve_ivp.'},
-        {'name': 'vectorized', 'type': 'bool', 'default': False, 'required': False,
-         'description': 'Whether the RHS accepts vectorised input (scipy solve_ivp option).'},
-        {'name': 'dense_output', 'type': 'bool', 'default': False, 'required': False,
-         'description': 'Whether to compute a continuous (dense) solution.'},
-        {'name': 'jac', 'type': 'str', 'default': None, 'required': False,
-         'description': 'Optional Jacobian specification for implicit methods.'},
-    ],
+    'solve_ivp': _SOLVE_IVP_SOLVER_INFO,
+    'user_defined': _SOLVE_IVP_SOLVER_INFO,
     'casadi_integrator': [
         {'name': 'max_step_size', 'type': 'float', 'default': 0.001, 'required': False,
          'description': 'Maximum step size for the adaptive CasADi integrators (cvodes/idas/etc).'},
@@ -568,7 +581,17 @@ class YamlFileParser(object):
         if 'model_type' not in inp_data_dict.keys():
             inp_data_dict['model_type'] = 'cellml_only'
             
-        if inp_data_dict.get('model_type') in ['python', 'casadi_python']:
+        if inp_data_dict.get('model_type') == 'python_user_defined':
+            model_ext = None
+            # The "model" is the user's hand-written ODE wrapper in funcs_user/,
+            # not a generated file. Default to funcs_user/{file_prefix}_wrapper.py,
+            # but allow an explicit override via 'model_wrapper_path'.
+            wrapper_path = inp_data_dict.get('model_wrapper_path')
+            if not wrapper_path:
+                wrapper_path = os.path.join(base_dir, 'funcs_user', f'{file_prefix}_wrapper.py')
+            inp_data_dict['model_path'] = wrapper_path
+            inp_data_dict['uncalibrated_model_path'] = wrapper_path
+        elif inp_data_dict.get('model_type') in ['python', 'casadi_python']:
             model_ext = '.py'
         elif inp_data_dict.get('model_type') == 'cellml_only':
             model_ext = '.cellml'
@@ -580,13 +603,14 @@ class YamlFileParser(object):
             print(f'Invalid model type: {inp_data_dict.get("model_type")}')
             exit()
 
-        inp_data_dict['model_path'] = os.path.join(inp_data_dict['generated_models_subdir'], f'{file_prefix}{model_ext}')
+        if model_ext is not None:
+            inp_data_dict['model_path'] = os.path.join(inp_data_dict['generated_models_subdir'], f'{file_prefix}{model_ext}')
 
-        if do_generation_with_fit_parameters:
-            inp_data_dict['uncalibrated_model_path'] = os.path.join(inp_data_dict["generated_models_dir"], file_prefix,
-                                               file_prefix + model_ext)
-        else:
-            inp_data_dict['uncalibrated_model_path'] = inp_data_dict['model_path']
+            if do_generation_with_fit_parameters:
+                inp_data_dict['uncalibrated_model_path'] = os.path.join(inp_data_dict["generated_models_dir"], file_prefix,
+                                                   file_prefix + model_ext)
+            else:
+                inp_data_dict['uncalibrated_model_path'] = inp_data_dict['model_path']
 
 
         if 'dt' not in inp_data_dict.keys():
@@ -624,6 +648,7 @@ class YamlFileParser(object):
         valid_casadi_solvers = _solvers['casadi_python']
         valid_casadi_solver_plugins = _methods['casadi_integrator']
         valid_aadc_solvers = _solvers.get('aadc_python', [])
+        valid_user_defined_solvers = _solvers.get('python_user_defined', [])
 
         solver_name = inp_data_dict.get('solver_info', {}).get('solver')
         if solver_name is None:
@@ -644,6 +669,8 @@ class YamlFileParser(object):
                 solver_name = 'cvodes'
             elif inp_data_dict.get('model_type') == 'aadc_python':
                 solver_name = 'aadc_semi_implicit'
+            elif inp_data_dict.get('model_type') == 'python_user_defined':
+                solver_name = 'user_defined'
             else:
                 print(f'Invalid model type: {inp_data_dict.get("model_type")}')
                 exit()
@@ -653,7 +680,8 @@ class YamlFileParser(object):
                 solver_name not in valid_cpp_solvers and
                 solver_name not in valid_python_solvers and
                 solver_name not in valid_casadi_solvers and
-                solver_name not in valid_aadc_solvers):
+                solver_name not in valid_aadc_solvers and
+                solver_name not in valid_user_defined_solvers):
                 print(f'Invalid solver: {solver_name}')
                 exit()
         
@@ -675,6 +703,8 @@ class YamlFileParser(object):
                     inp_data_dict['solver_info']['max_step'] = defaults.get('max_step', 0.001)
             elif inp_data_dict.get('model_type') == 'aadc_python':
                 pass  # AADC solver handles its own defaults
+            elif inp_data_dict.get('model_type') == 'python_user_defined':
+                pass  # user wrapper handles its own integration
             elif 'MaximumNumberOfSteps' not in inp_data_dict['solver_info']:
                 inp_data_dict['solver_info']['MaximumNumberOfSteps'] = defaults['MaximumNumberOfSteps']
         if 'solver' not in inp_data_dict['solver_info'].keys():
@@ -726,6 +756,10 @@ class YamlFileParser(object):
                     inp_data_dict['solver_info']['method'] = solver_method # TODO Bea: add specific solver to be used within PETSC (CN / BDF1 / BDF2 / ...)
                 else:
                     print(f'solver set {solver_name} not compatible with model_type cpp : change this in the user_inputs.yaml file')
+            elif solver_name in valid_user_defined_solvers:
+                # The user wrapper is integrated by solve_ivp; default to RK45.
+                solver_method = 'RK45'
+                inp_data_dict['solver_info']['method'] = solver_method
             else:
                 if solver_name.startswith('CVODE'):
                     solver_method = 'CVODE'
@@ -745,13 +779,15 @@ class YamlFileParser(object):
             and solver_name not in valid_python_solvers
             and solver_name not in valid_cpp_solvers
             and solver_name not in valid_casadi_solvers
-            and solver_name not in valid_aadc_solvers):
+            and solver_name not in valid_aadc_solvers
+            and solver_name not in valid_user_defined_solvers):
             print(f'Invalid solver: {solver_name}')
             print(f'Valid CellML solvers: {valid_cellml_solvers}')
             print(f'Valid Python solvers: {valid_python_solvers}')
             print(f'Valid Cpp solvers: {valid_cpp_solvers}')
             print(f'Valid CasADi solvers: {valid_casadi_solvers}')
             print(f'Valid AADC solvers: {valid_aadc_solvers}')
+            print(f'Valid user-defined solvers: {valid_user_defined_solvers}')
             exit()
         
         
@@ -762,9 +798,9 @@ class YamlFileParser(object):
                 print(f'Use {valid_python_solvers} for Python models')
                 exit()
 
-        # solve_ivp methods can only be used with Python models
+        # solve_ivp methods can only be used with Python models (generated or user-defined)
         if solver_method in valid_solve_ivp_methods:
-            if inp_data_dict.get('model_type') not in ['python', None]:
+            if inp_data_dict.get('model_type') not in ['python', 'python_user_defined', None]:
                 print(f'solve_ivp method {solver_method} requires model_type to be "python"')
                 print('Use CVODE_opencor (or legacy CVODE) or CVODE_myokit for CellML models')
                 print('Use CVODE or RK4 or PETSC for Cpp models')
@@ -1098,6 +1134,14 @@ def get_solver_info_default(model_type):
             'method': 'adaptive_rk45',
             'tol': 1e-8,
             'threads': 4,
+        }
+    if model_type == 'python_user_defined':
+        return {
+            'solver': 'user_defined',
+            'method': 'RK45',
+            'max_step': 0.001,
+            'rtol': 1e-8,
+            'atol': 1e-8,
         }
     raise ValueError(f'Invalid model type: {model_type}')
 

--- a/src/scripts/script_generate_with_new_architecture.py
+++ b/src/scripts/script_generate_with_new_architecture.py
@@ -68,8 +68,20 @@ def generate_with_new_architecture(do_generation_with_fit_parameters=False,
         bool: True if generation succeeded, False otherwise.
     """
     yaml_parser = YamlFileParser()
-    inp_data_dict = yaml_parser.parse_user_inputs_file(inp_data_dict, obs_path_needed=False, 
+    inp_data_dict = yaml_parser.parse_user_inputs_file(inp_data_dict, obs_path_needed=False,
                                                        do_generation_with_fit_parameters=do_generation_with_fit_parameters)
+
+    if inp_data_dict['model_type'] == 'python_user_defined':
+        # No code generation: the "model" is the user's hand-written ODE wrapper
+        # in funcs_user/ (see solver_wrappers.python_solver_helper). Just verify it
+        # exists so misconfiguration fails early with a clear message.
+        wrapper_path = inp_data_dict['model_path']
+        if not os.path.exists(wrapper_path):
+            print(f'python_user_defined wrapper not found: {wrapper_path}')
+            print('Create it (copy funcs_user/model_wrapper_funcs_user.py) or set '
+                  'model_wrapper_path in user_inputs.yaml.')
+            return False
+        return True
 
     DEBUG = inp_data_dict['DEBUG']
     file_prefix = inp_data_dict['file_prefix']

--- a/src/solver_wrappers/__init__.py
+++ b/src/solver_wrappers/__init__.py
@@ -71,11 +71,13 @@ def get_simulation_helper(model_path: str = None, solver: str = None,
     solve_ivp_methods = ['RK45', 'RK23', 'DOP853', 'Radau', 'BDF', 'LSODA', 'RK4', 'forward_euler']
     casadi_solvers = ['casadi_integrator']
     aadc_solvers = ['aadc_semi_implicit']
+    user_defined_solvers = ['user_defined']
 
     # Determine if this is a Python model
     is_python_model = (model_type == 'python')
     is_casadi_python_model = (model_type == 'casadi_python')
     is_aadc_python_model = (model_type == 'aadc_python')
+    is_user_defined_model = (model_type == 'python_user_defined')
 
     # Check for explicit solver specification with validation
     if solver == 'CVODE_opencor':
@@ -112,9 +114,16 @@ def get_simulation_helper(model_path: str = None, solver: str = None,
             return AadcPythonSimulationHelper(model_path, dt, sim_time, solver_info, pre_time=pre_time)
         else:
             raise RuntimeError("AADC solver requested but aadc package is not installed. pip install aadc")
+    elif solver in user_defined_solvers:
+        if not is_user_defined_model:
+            raise ValueError(f"Solver {solver} can only be used for user-defined Python models (model_type='python_user_defined').")
+        if not model_path.endswith('.py'):
+            raise ValueError(f"model_path {model_path} does not end with .py, which is required for python_user_defined models (the wrapper module)")
+        # The user wrapper is integrated by the shared SciPy PythonSimulationHelper.
+        return PythonSimulationHelper(model_path, dt, sim_time, solver_info, pre_time=pre_time)
     elif solver is not None:
         # Unknown solver type
-        raise ValueError(f"Unknown solver {solver}. Valid options are: {cellml_solvers} for CellML models, {python_solvers} for Python models, and {casadi_solvers} for CasADi Python models.")
+        raise ValueError(f"Unknown solver {solver}. Valid options are: {cellml_solvers} for CellML models, {python_solvers} for Python models, {casadi_solvers} for CasADi Python models, and {user_defined_solvers} for user-defined Python models.")
 
     # Backward compatibility logic
     if is_python_model:

--- a/src/solver_wrappers/python_solver_helper.py
+++ b/src/solver_wrappers/python_solver_helper.py
@@ -3,6 +3,7 @@ import numpy as np
 from scipy.integrate import solve_ivp
 import copy
 import sys
+from enum import Enum
 from .name_resolver import VariableNameResolver
 DEBUG = False
 
@@ -69,11 +70,26 @@ class SimulationHelper:
         self.solve_ivp_method = method 
         
     # ---- setup helpers ----
+    @staticmethod
+    def _is_user_defined_wrapper(module):
+        """A user wrapper exposes rhs/PARAMETERS/STATES instead of the
+        libCellML-generated STATE_COUNT/compute_rates surface."""
+        return (callable(getattr(module, "rhs", None))
+                and hasattr(module, "PARAMETERS")
+                and hasattr(module, "STATES"))
+
     def _load_model(self):
         spec = importlib.util.spec_from_file_location("generated_model", self.model_path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         self.model = module
+
+        if self._is_user_defined_wrapper(module):
+            # model_type == 'python_user_defined': build a synthetic model from
+            # the user's wrapper so the rest of this class works unchanged.
+            self._load_user_defined_model(module)
+            self._finalise_name_maps()
+            return
 
         if not hasattr(module, 'STATE_COUNT') and not hasattr(module, 'VARIABLE_INFO'):
             raise ValueError(f"Module {self.model_path} Does have any states or variables. Model invalid")
@@ -82,6 +98,11 @@ class SimulationHelper:
         self.VARIABLE_INFO = module.VARIABLE_INFO
         self.STATE_INFO = module.STATE_INFO
 
+        self._finalise_name_maps()
+
+    def _finalise_name_maps(self):
+        """Build the resolver + convenience index maps from STATE_INFO/VARIABLE_INFO.
+        Shared by the libCellML and user-defined load paths."""
         self._resolver = VariableNameResolver(self.STATE_INFO, self.VARIABLE_INFO)
 
         # Convenience maps (derived from resolver, kept for compatibility)
@@ -93,6 +114,120 @@ class SimulationHelper:
         # identify constants and algebraics
         self.constant_indices = [i for i, info in enumerate(self.VARIABLE_INFO) if info["type"].name in ["CONSTANT", "COMPUTED_CONSTANT"]]
         self.algebraic_indices = [i for i, info in enumerate(self.VARIABLE_INFO) if info["type"].name == "ALGEBRAIC"]
+
+    def _load_user_defined_model(self, module):
+        """Adapt a user wrapper (rhs/STATES/PARAMETERS/OUTPUT_NAMES) into the
+        libCellML-style model surface (STATE_COUNT, STATE_INFO, VARIABLE_INFO,
+        create_*_array, initialise_variables, compute_*) that the rest of this
+        class relies on. Integration is still done by this class's run() via
+        scipy solve_ivp on self.model.compute_rates."""
+        parameters = dict(getattr(module, "PARAMETERS"))
+        states = dict(getattr(module, "STATES"))
+        output_names = list(getattr(module, "OUTPUT_NAMES", list(states.keys())))
+        user_rhs = getattr(module, "rhs")
+        user_compute_outputs = getattr(module, "compute_outputs", None)
+
+        if not isinstance(parameters, dict):
+            raise ValueError(f"{self.model_path}: PARAMETERS must be a dict of name->float")
+        if not isinstance(states, dict):
+            raise ValueError(f"{self.model_path}: STATES must be a dict of name->float")
+        if not isinstance(output_names, (list, tuple)):
+            raise ValueError(f"{self.model_path}: OUTPUT_NAMES must be a list of names")
+        if user_compute_outputs is not None and not callable(user_compute_outputs):
+            raise ValueError(f"{self.model_path}: compute_outputs must be callable if defined")
+
+        class VariableType(Enum):
+            STATE = 0
+            CONSTANT = 1
+            COMPUTED_CONSTANT = 2
+            ALGEBRAIC = 3
+
+        def _split(name):
+            comp, _, var = name.rpartition("/")
+            return comp, (var or name)
+
+        state_names = list(states.keys())
+        param_names = list(parameters.keys())
+        # Outputs that are themselves states resolve as states; only the rest
+        # need an algebraic variable slot.
+        state_name_set = set(state_names)
+        algebraic_names = [n for n in output_names if n not in state_name_set]
+
+        self.STATE_COUNT = len(state_names)
+        self.STATE_INFO = []
+        for n in state_names:
+            comp, var = _split(n)
+            self.STATE_INFO.append({"name": var, "units": "dimensionless",
+                                    "component": comp, "type": VariableType.STATE})
+
+        # VARIABLE_INFO: parameters (constants) first, then algebraic outputs.
+        self.VARIABLE_INFO = []
+        for n in param_names:
+            comp, var = _split(n)
+            self.VARIABLE_INFO.append({"name": var, "units": "dimensionless",
+                                       "component": comp, "type": VariableType.CONSTANT})
+        for n in algebraic_names:
+            comp, var = _split(n)
+            self.VARIABLE_INFO.append({"name": var, "units": "dimensionless",
+                                       "component": comp, "type": VariableType.ALGEBRAIC})
+
+        state_idx = {n: i for i, n in enumerate(state_names)}
+        param_var_idx = {n: i for i, n in enumerate(param_names)}
+        algebraic_var_idx = {n: len(param_names) + i for i, n in enumerate(algebraic_names)}
+        variable_count = len(param_names) + len(algebraic_names)
+
+        state_init_vals = [float(states[n]) for n in state_names]
+        param_default_vals = [float(parameters[n]) for n in param_names]
+
+        def _params_from_variables(variables):
+            return {n: variables[param_var_idx[n]] for n in param_names}
+
+        class _UserModelAdapter:
+            STATE_COUNT = self.STATE_COUNT
+            VARIABLE_COUNT = variable_count
+
+            @staticmethod
+            def create_states_array():
+                return np.zeros(len(state_names))
+
+            @staticmethod
+            def create_variables_array():
+                return np.zeros(variable_count)
+
+            @staticmethod
+            def initialise_variables(states_arr, rates_arr, variables_arr):
+                for i, v in enumerate(state_init_vals):
+                    states_arr[i] = v
+                for i, v in enumerate(param_default_vals):
+                    variables_arr[i] = v
+
+            @staticmethod
+            def compute_computed_constants(variables_arr):
+                pass
+
+            @staticmethod
+            def compute_rates(voi, states_arr, rates_arr, variables_arr):
+                params = _params_from_variables(variables_arr)
+                drvs = user_rhs(voi, list(states_arr), params)
+                for i, d in enumerate(drvs):
+                    rates_arr[i] = d
+
+            @staticmethod
+            def compute_variables(voi, states_arr, rates_arr, variables_arr):
+                if user_compute_outputs is None:
+                    return
+                params = _params_from_variables(variables_arr)
+                outs = user_compute_outputs(voi, list(states_arr), params) or {}
+                for name, idx in algebraic_var_idx.items():
+                    if name in outs:
+                        variables_arr[idx] = outs[name]
+
+        self.model = _UserModelAdapter()
+
+        # The wrapper is integrated with solve_ivp; ensure a real method is set
+        # even if the config left it unset or at the 'user_defined' placeholder.
+        if self.solve_ivp_method in (None, 'user_defined'):
+            self.solve_ivp_method = 'RK45'
 
     def _init_state(self):
         self.states = self.model.create_states_array()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,7 @@ _TEST_OUTPUT_ROOT = os.path.join(os.path.dirname(__file__), "test_outputs")
 #     {"file_prefix": "test_fft", "input_param_file": "test_fft_parameters.csv", "model_type": "cellml_only", "solver": "CVODE"},
 # ]
 _LOCK_FILE = os.path.realpath(os.path.join(_TEST_ROOT, ".pytest_param_id_lock"))
-_PARAM_ID_TRIGGERS = ("test_param_id", "compare_optimisers", "test_sensitivity_analysis")
+_PARAM_ID_TRIGGERS = ("test_param_id", "compare_optimisers", "test_sensitivity_analysis", "test_python_user_defined")
 
 
 def _is_autogen_like_nodeid(nodeid: str) -> bool:

--- a/tests/test_python_user_defined.py
+++ b/tests/test_python_user_defined.py
@@ -1,0 +1,187 @@
+"""
+Tests for the ``model_type: python_user_defined`` backend.
+
+These verify that an arbitrary user-supplied Python ODE model (wrapped in
+funcs_user/) can be driven through the calibration, sensitivity-analysis and
+identifiability pipelines, using the shipped damped-oscillator example in
+funcs_user/example_model/.
+"""
+import os
+import shutil
+
+import numpy as np
+import pytest
+from mpi4py import MPI
+
+from parsers.PrimitiveParsers import YamlFileParser
+from solver_wrappers import get_simulation_helper_from_inp_data_dict
+from scripts.script_generate_with_new_architecture import generate_with_new_architecture
+from scripts.sensitivity_analysis_run_script import run_SA
+from scripts.param_id_run_script import run_param_id
+
+
+_EXAMPLE_DIR = os.path.realpath(
+    os.path.join(os.path.dirname(__file__), '..', 'funcs_user', 'example_model')
+)
+_WRAPPER_PATH = os.path.join(_EXAMPLE_DIR, 'oscillator_wrapper.py')
+# Ground truth used to build oscillator_obs_data.json.
+_TRUE_C, _TRUE_K = 0.7, 5.0
+
+
+def _make_resources(temp_output_dir):
+    """Copy the example resource files into an isolated per-test resources dir
+    (so the run never writes dated configs back into the repo example dir)."""
+    comm = MPI.COMM_WORLD
+    resources_dir = os.path.join(temp_output_dir, 'resources')
+    if comm.Get_rank() == 0:
+        os.makedirs(resources_dir, exist_ok=True)
+        for name in ('oscillator_params_for_id.csv', 'oscillator_parameters.csv',
+                     'oscillator_obs_data.json'):
+            shutil.copy(os.path.join(_EXAMPLE_DIR, name),
+                        os.path.join(resources_dir, name))
+    if comm.Get_size() > 1:
+        comm.Barrier()
+    return resources_dir
+
+
+def _oscillator_config(base_user_inputs, temp_output_dir, temp_generated_models_dir):
+    resources_dir = _make_resources(temp_output_dir)
+    config = base_user_inputs.copy()
+    config.update({
+        'file_prefix': 'oscillator',
+        'input_param_file': 'oscillator_parameters.csv',
+        'model_type': 'python_user_defined',
+        'solver': 'user_defined',
+        # The wrapper is integrated by solve_ivp; override the base solver_info
+        # (which carries CVODE-only keys) and let the method default to RK45.
+        'solver_info': {'solver': 'user_defined'},
+        'model_wrapper_path': _WRAPPER_PATH,
+        'resources_dir': resources_dir,
+        'param_id_method': 'genetic_algorithm',
+        'pre_time': 0.0,
+        'sim_time': 10.0,
+        'dt': 0.05,
+        'DEBUG': True,
+        'do_mcmc': False,
+        'do_ad': False,
+        'plot_predictions': False,
+        'model_out_names': ['oscillator/x'],
+        'param_id_obs_path': os.path.join(resources_dir, 'oscillator_obs_data.json'),
+        'param_id_output_dir': temp_output_dir,
+        'generated_models_dir': temp_generated_models_dir,
+        'debug_optimiser_options': {'num_calls_to_function': 150, 'cost_type': 'gaussian_MLE'},
+    })
+    return config
+
+
+@pytest.mark.unit
+def test_python_user_defined_generation_is_noop(base_user_inputs, temp_output_dir, temp_generated_models_dir):
+    """Generation is a no-op success when the wrapper exists, and fails clearly when it doesn't."""
+    config = _oscillator_config(base_user_inputs, temp_output_dir, temp_generated_models_dir)
+    assert generate_with_new_architecture(False, config) is True
+
+    missing = _oscillator_config(base_user_inputs, temp_output_dir, temp_generated_models_dir)
+    missing['model_wrapper_path'] = os.path.join(_EXAMPLE_DIR, 'does_not_exist_wrapper.py')
+    assert generate_with_new_architecture(False, missing) is False
+
+
+@pytest.mark.unit
+@pytest.mark.solver
+def test_python_user_defined_backend_roundtrip(base_user_inputs, temp_output_dir, temp_generated_models_dir):
+    """The factory routes python_user_defined to a working SimulationHelper that
+    integrates the user's rhs and returns named results."""
+    config = _oscillator_config(base_user_inputs, temp_output_dir, temp_generated_models_dir)
+    parsed = YamlFileParser().parse_user_inputs_file(config, obs_path_needed=False)
+
+    assert parsed['model_path'] == _WRAPPER_PATH
+    assert parsed['solver_info']['solver'] == 'user_defined'
+
+    sim = get_simulation_helper_from_inp_data_dict(parsed)
+    assert 'oscillator/x' in sim.get_all_variable_names()
+
+    # Defaults come from the wrapper PARAMETERS.
+    assert sim.get_init_param_vals(['oscillator/c', 'oscillator/k']) == [0.5, 4.0]
+
+    sim.set_param_vals(['oscillator/c', 'oscillator/k'], [_TRUE_C, _TRUE_K])
+    assert sim.run() is True
+
+    t = sim.get_time()
+    x = sim.get_results(['oscillator/x'], flatten=True)[0]
+    assert len(t) == len(x)
+    assert abs(t[0]) < 1e-9
+    # Targets baked into oscillator_obs_data.json (computed at the true params).
+    assert np.mean(x) == pytest.approx(0.01663962, abs=2e-3)
+    assert np.min(x) == pytest.approx(-0.60704870, abs=3e-2)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_sensitivity_analysis_python_user_defined_succeeds(base_user_inputs, temp_output_dir, temp_generated_models_dir):
+    """Sobol sensitivity analysis runs end-to-end on a python_user_defined model."""
+    rank = MPI.COMM_WORLD.Get_rank()
+    config = _oscillator_config(base_user_inputs, temp_output_dir, temp_generated_models_dir)
+    config['sa_options'] = {
+        'method': 'sobol',
+        'num_samples': 16,
+        'sample_type': 'saltelli',
+        'output_dir': os.path.join(temp_output_dir, 'oscillator_SA_results'),
+    }
+
+    run_SA(config)
+
+    if rank == 0:
+        assert os.path.exists(config['sa_options']['output_dir'])
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_param_id_python_user_defined_recovers_params(base_user_inputs, temp_output_dir, temp_generated_models_dir):
+    """Calibration runs end-to-end and recovers the oscillator parameters used to
+    build the observed data (starting from the c=0.5, k=4.0 defaults)."""
+    rank = MPI.COMM_WORLD.Get_rank()
+    config = _oscillator_config(base_user_inputs, temp_output_dir, temp_generated_models_dir)
+
+    run_param_id(config)
+
+    if rank == 0:
+        output_dir = os.path.join(temp_output_dir, 'genetic_algorithm_oscillator_oscillator_obs_data')
+        best_path = os.path.join(output_dir, 'best_param_vals.npy')
+        assert os.path.exists(best_path), f"expected calibration output at {best_path}"
+
+        best = np.load(best_path)
+        names = np.loadtxt(os.path.join(output_dir, 'param_names.csv'), dtype=str, delimiter=',')
+        vals = {str(n): float(v) for n, v in zip(np.atleast_1d(names), np.atleast_1d(best))}
+
+        # Within bounds and in the right ballpark of the ground truth (genetic
+        # algorithm with a small budget, so tolerances are generous).
+        c = vals.get('oscillator/c')
+        k = vals.get('oscillator/k')
+        assert c is not None and k is not None, f"unexpected param names: {vals}"
+        assert 0.05 <= c <= 2.0 and 1.0 <= k <= 10.0
+        assert c == pytest.approx(_TRUE_C, abs=0.4)
+        assert k == pytest.approx(_TRUE_K, abs=2.0)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_identifiability_python_user_defined_succeeds(base_user_inputs, temp_output_dir, temp_generated_models_dir):
+    """Laplace identifiability/UQ analysis runs end-to-end after calibration."""
+    rank = MPI.COMM_WORLD.Get_rank()
+    config = _oscillator_config(base_user_inputs, temp_output_dir, temp_generated_models_dir)
+    config['do_ia'] = True
+    config['ia_options'] = {'method': 'Laplace'}
+
+    run_param_id(config)
+
+    if rank == 0:
+        # Laplace writes {prefix}_laplace_{mean,covariance}.npy to the parent of
+        # param_id_output_dir.
+        parent_dir = os.path.dirname(temp_output_dir)
+        cov_path = os.path.join(parent_dir, 'oscillator_laplace_covariance.npy')
+        assert os.path.exists(cov_path), f"expected Laplace covariance at {cov_path}"
+        cov = np.load(cov_path)
+        assert cov.shape == (2, 2)
+        assert np.all(np.isfinite(cov))


### PR DESCRIPTION
## Summary

Adds a new `model_type: python_user_defined` so a user with an **arbitrary Python ODE model** (one not expressible as a CVS0D vessel-array CSV) can plug it straight into the **sensitivity-analysis, calibration (param_id), and identifiability/UQ** pipelines.

The user writes a small wrapper (`rhs` + `STATES` + `PARAMETERS` + optional algebraic `compute_outputs`); the framework integrates it with the existing `solve_ivp` machinery in `python_solver_helper` and drives it through the same `ProtocolExecutor` every other backend uses — so no pipeline code changes.

Closes #253.

## Wrapper contract

Copy `funcs_user/model_wrapper_funcs_user.py` to `funcs_user/{file_prefix}_wrapper.py` (or point `model_wrapper_path` at it) and fill in:

```python
PARAMETERS   = {"comp/k": 1.0, ...}    # calibratable constants used in rhs
STATES       = {"comp/x": 0.0, ...}    # initial state values
OUTPUT_NAMES = ["comp/x", ...]         # observables referenced by obs_data operands

def rhs(t, y, params):                 # framework integrates this with solve_ivp
    return [dx_dt, ...]

def compute_outputs(t, y, params):     # OPTIONAL — algebraic outputs that aren't states
    return {}
```

Names use the canonical `component/variable` form so they line up with `{prefix}_params_for_id.csv` and the obs_data `operands`.

## Implementation

- **`solver_wrappers/python_solver_helper.py`** — consolidated (no new backend file). `_load_model` detects a user wrapper (by its `rhs`/`PARAMETERS`/`STATES` attributes) and builds a synthetic in-memory model + `STATE_INFO`/`VARIABLE_INFO`. `run()` (solve_ivp), `set_param_vals`, `get_results` and resets are reused unchanged for both generated and user-defined Python models.
- **`solver_wrappers/__init__.py`** — new `solver: user_defined` routed to the same helper.
- **`parsers/PrimitiveParsers.py`** — `python_user_defined` model_type (model_path → the wrapper), `SOLVER_SCHEMA`/validation wiring; `user_defined` mirrors `solve_ivp`'s method/key contract (default `RK45`, accepts `rtol`/`atol`/`max_step`).
- **`scripts/script_generate_with_new_architecture.py`** — no-op-success generation for this model_type (the "model" is the user's wrapper).
- **`param_id/paramID.py`** — allow `python_user_defined` when constructing the optimiser.
- **`funcs_user/model_wrapper_funcs_user.py`** — copy-me template.
- **`funcs_user/example_model/`** — self-contained damped-oscillator example (wrapper + resources + README).

## Tests

`tests/test_python_user_defined.py`:
- generation is a no-op success (and fails clearly when the wrapper is missing);
- backend roundtrip via the factory;
- **SA**, **calibration**, and **Laplace identifiability** end-to-end on the oscillator example.

Verified passing under 2 MPI ranks (`3 passed in 12.6s`); calibration recovers `c≈0.74, k≈5.18` vs the ground truth `0.7, 5.0` used to build the obs data. Unrelated pre-existing failures in `test_solvers.py` (`test_aadc_vs_cvode_3compartment`, `test_python_BDF_solver[SN_simple]`) were confirmed to fail identically without these changes.

## Out of scope (v1)

- Calibrating initial conditions (only `PARAMETERS` constants are calibratable for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)