### PR TITLE
fix(run): prefer MPICH launcher for OpenCOR's MPICH mpi4py in run_param_id.sh

### DIFF
--- a/user_run_files/run_param_id.sh
+++ b/user_run_files/run_param_id.sh
@@ -9,7 +9,26 @@ source python_path.sh
 if [ $? -eq 0 ]; then
   echo "Autogeneration completed successfully."
 
-  mpiexec -n $1 ${python_path} ../src/scripts/param_id_run_script.py
+  # Pick an MPI launcher that matches the mpi4py runtime. OpenCOR bundles an
+  # MPICH-based mpi4py, but the system default `mpiexec` is often Open MPI, whose
+  # PMIx launcher aborts MPICH ranks at MPI_Init with
+  # "unsupported PMI version PMIx". When mpi4py is MPICH, prefer an MPICH/Hydra
+  # launcher so the launcher's PMI matches the runtime.
+  MPIEXEC=mpiexec
+  mpi_vendor=$(${python_path} -c "from mpi4py import MPI; print(MPI.get_vendor()[0])" 2>/dev/null)
+  if [ "${mpi_vendor}" = "MPICH" ]; then
+    if command -v mpiexec.mpich >/dev/null 2>&1; then
+      MPIEXEC=mpiexec.mpich
+    elif command -v mpiexec.hydra >/dev/null 2>&1; then
+      MPIEXEC=mpiexec.hydra
+    elif mpiexec --version 2>&1 | grep -qiE 'open.?mpi|openrte'; then
+      echo "WARNING: mpi4py is MPICH but the default 'mpiexec' is Open MPI; MPI ranks may" >&2
+      echo "         abort with 'unsupported PMI version PMIx'. Install MPICH (e.g." >&2
+      echo "         'sudo apt-get install mpich') to get a matching mpiexec.hydra." >&2
+    fi
+  fi
+
+  ${MPIEXEC} -n $1 ${python_path} ../src/scripts/param_id_run_script.py
 
 else
   echo "Error: Autogeneration failed. Aborting."


### PR DESCRIPTION
## Problem

Launching a multi-processor `param_id` run via `run_param_id.sh` aborts on every rank at `MPI_Init`:

```
check_MPIR_CVAR_PMI_VERSION(167):  Runtime environment uses unsupported PMI version PMIx. Aborting.
```

OpenCOR bundles an **MPICH**-based `mpi4py`, but the system default `mpiexec` is often **Open MPI** (`OpenRTE`), whose **PMIx** launcher the MPICH runtime can't parse — so it aborts. The launcher and the MPI runtime linked into `mpi4py` are mismatched.

## Fix

In `run_param_id.sh`, detect the `mpi4py` vendor via the OpenCOR python. When it's `MPICH`, prefer an MPICH/Hydra launcher (`mpiexec.mpich`, then `mpiexec.hydra`) so the launcher's PMI matches the runtime. Otherwise keep the default `mpiexec`, and print a hint to install MPICH when only Open MPI's `mpiexec` is present.

- No behaviour change on systems whose default launcher already matches `mpi4py` (the vendor guard + `command -v` checks only diverge when `mpi4py` is MPICH *and* an MPICH launcher exists).
- Only `run_param_id.sh` is patched here; the other `mpiexec`-based scripts (`run_sensitivity_analysis.sh`, `run_sequential_param_id.sh`, `run_multiple_param_id.sh`) share the same pattern and can get the same treatment if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)