### PR TITLE
docs: mark OpenCOR pythonshell deprecated, to be replaced by pip install libopencor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,8 @@ This file documents the conventions, gotchas, and entry points an agent needs th
 ## Build / run / test
 
 - **Tests MUST run under the OpenCOR Python shell** — not the system Python. Always use `./run_pytest.sh`, which sources `user_run_files/python_path.sh` and runs pytest under `mpiexec`. The path to the OpenCOR python is in `user_run_files/opencor_pythonshell_path.sh` (sourced by `python_path.sh`).
+  - **DEPRECATED — do not build on it.** OpenCOR's `pythonshell` is on its way out: it will be replaced by a plain `pip install libopencor` into a normal Python env once libOpenCOR reaches PyPI, and `python_path.sh` / `opencor_pythonshell_path.sh` will be removed. Don't add new code paths that assume the bundled interpreter; prefer a standard venv + `pip install -e ".[dev]"`.
+  - Gotcha it causes today: OpenCOR bundles a **dual-ABI `mpi4py`** (`MPI.mpich.*.so` **and** `MPI.openmpi.*.so`, dispatched by `mpi4py._mpiabi`). If the variant picked at import doesn't match the MPI owning the system `mpiexec`, every rank aborts at `MPI_Init` with `unsupported PMI version PMIx`. Fix by pinning the ABI to the installed launcher — `export MPI4PY_MPIABI=openmpi` (or `mpich`) — **not** by installing a second MPI.
   - `./run_pytest.sh` — full suite, 1 MPI rank.
   - `./run_pytest.sh -n 4 -v -s` — `-n N` sets **MPI rank count** (it is *not* pytest-xdist; xdist is force-disabled with `-p no:xdist` because ranks and xdist workers conflict).
   - `./run_pytest.sh -m "not slow"` / `-m "not compare_optimisers"` — deselect expensive tests.

--- a/tutorial/docs/getting-started.md
+++ b/tutorial/docs/getting-started.md
@@ -235,6 +235,22 @@ You should now have:
 
 This section documents the **older workflow** that used **OpenCOR’s bundled Python** and `python_path.sh`. It is **not required** for the default Myokit-based path described above. Keep it only if you maintain legacy scripts or environments that still call OpenCOR’s interpreter.
 
+!!! warning "OpenCOR’s `pythonshell` is deprecated — it will be replaced by `pip install libopencor`"
+    Do not build new workflows on OpenCOR’s bundled interpreter. Once
+    [libOpenCOR](https://opencor.ws/libopencor/) is available on PyPI, the OpenCOR
+    functionality will be obtained with a plain `pip install libopencor` into a
+    normal Python environment, and `pythonshell` / `python_path.sh` /
+    `opencor_pythonshell_path.sh` will be removed.
+
+    Prefer the standard `pip install -e .` setup above. Relying on the bundled
+    interpreter pins you to whatever OpenCOR ships, which causes real problems —
+    e.g. OpenCOR bundles a **dual-ABI `mpi4py`** (both an `MPI.mpich.*.so` and an
+    `MPI.openmpi.*.so`), and the variant chosen at import time may not match the
+    system `mpiexec`, aborting MPI runs with
+    `unsupported PMI version PMIx`. Pin it with `MPI4PY_MPIABI=openmpi` (or
+    `mpich`) to match your installed launcher. A pip-installed `mpi4py` builds
+    against the one system MPI and has no such ambiguity.
+
 ### Install OpenCOR (legacy)
 
 Download OpenCOR (e.g. version 0.8.1) from the [OpenCOR downloads page](https://opencor.ws/downloads/index.html). A zip/tarball install in a directory you control (e.g. `~/Desktop`) is typical.

--- a/user_run_files/opencor_pythonshell_path.sh
+++ b/user_run_files/opencor_pythonshell_path.sh
@@ -1,5 +1,11 @@
 #_______python paths _________
 # Users should modify opencor_pythonshell_path to the path of their own opencor pythonshell
+#
+# DEPRECATED: this file exists only to locate OpenCOR's bundled `pythonshell`.
+# OpenCOR's pythonshell is deprecated and will be replaced by a plain
+# `pip install libopencor` into a normal Python environment once libOpenCOR is
+# published to PyPI; this file will then be removed. Do not add new dependencies
+# on it -- see user_run_files/python_path.sh and tutorial/docs/getting-started.md.
 
 # the below for my hpc
 # opencor_pythonshell_path=/hpc/farg967/OpenCOR-0-8-1-Linux/pythonshell

--- a/user_run_files/python_path.sh
+++ b/user_run_files/python_path.sh
@@ -1,5 +1,18 @@
 #_______python paths _________
 # Users should modify python_path to the path of their own python
+#
+# DEPRECATED: pointing python_path at OpenCOR's bundled `pythonshell` is deprecated.
+# It will be replaced by a plain `pip install libopencor` into a normal Python
+# environment once libOpenCOR is published to PyPI, after which this file (and
+# opencor_pythonshell_path.sh) will be removed. Prefer a standard venv +
+# `pip install -e .` and point python_path at that interpreter.
+#
+# Why it matters: OpenCOR ships a dual-ABI mpi4py (both MPI.mpich.*.so and
+# MPI.openmpi.*.so). The variant selected at import time can differ from the MPI
+# that the system `mpiexec` belongs to, which aborts MPI runs with
+# "unsupported PMI version PMIx". Pin it to match your launcher, e.g.
+#   export MPI4PY_MPIABI=openmpi   # or: mpich
+# A pip-installed mpi4py links the single system MPI and avoids the ambiguity.
 
 # the below for my hpc
 # python_path=/hpc/farg967/OpenCOR-0-8-1-Linux/pythonshell


### PR DESCRIPTION
Records that OpenCOR's bundled `pythonshell` is **deprecated** and will be replaced by a plain **`pip install libopencor`** into a normal Python environment once libOpenCOR is on PyPI — at which point `python_path.sh` and `opencor_pythonshell_path.sh` go away.

Noted in the places people actually look:

- `tutorial/docs/getting-started.md` — a warning admonition in the existing "Deprecated: OpenCOR-based setup" section.
- `user_run_files/python_path.sh` and `user_run_files/opencor_pythonshell_path.sh` — inline comments.
- `CLAUDE.md` — which previously stated the OpenCOR shell as an unqualified requirement.

Docs/comments only; no behaviour change (both scripts still parse and set their variables).

## Why this matters concretely

The bundled interpreter pins you to whatever OpenCOR ships. A live example: OpenCOR bundles a **dual-ABI `mpi4py`** — both `MPI.mpich.*.so` and `MPI.openmpi.*.so`, dispatched at import by `mpi4py._mpiabi`. If the selected variant doesn't match the MPI that owns the system `mpiexec`, every rank aborts at `MPI_Init`:

```
check_MPIR_CVAR_PMI_VERSION(167):  Runtime environment uses unsupported PMI version PMIx. Aborting.
```

Verified on a machine with only Open MPI 4.1.2 installed:

- `MPI4PY_MPIABI=openmpi` → binds Open MPI 4.1.2; a 2-rank `mpiexec` run initializes cleanly.
- `MPI4PY_MPIABI=mpich` → fails, since no MPICH is installed.

So the correct fix is to **pin the ABI to the launcher you already have**, not to install a second MPI implementation. A pip-installed `mpi4py` links the single system MPI and has no such ambiguity — one more reason to move off the bundled shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)