### PR TITLE
fix(deps): unblock CI from libcellml 0.7.0 (pin <0.7.0 + renamed-API shims)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,14 @@ dependencies = [
     "SALib==1.5.1",
     "seaborn>=0.11.0",
     "rdflib>=5.0.0",
-    "libcellml>=0.6.3",
+    # libCellML 0.7.0 (released 2026-07-09) is a breaking change: it renames
+    # Analyser.model() -> Analyser.analyserModel(), drops Generator.setModel()/setProfile() in
+    # favour of arguments, changes the generated Python code (no VARIABLE_COUNT), and resolves
+    # units differently when flattening (SN_simple then fails to connect a_2 across components).
+    # The first two are handled by the shims in utilities/libcellml_helper_funcs.py; the last
+    # two are a real migration. Pin below 0.7 until that is done -- without an upper bound CI
+    # silently picks up 0.7.0 and every model-generating test fails.
+    "libcellml>=0.6.3,<0.7.0",
     "ruamel.yaml>=0.17.0",
     "sympy>=1.8.0",
     "tqdm>=4.62.0",

--- a/src/generators/CVSCellMLGenerator.py
+++ b/src/generators/CVSCellMLGenerator.py
@@ -118,7 +118,7 @@ class CVS0DCellMLGenerator(object):
             a = Analyser()
 
             a.analyseModel(flat_model)
-            analysed_model = a.model()
+            analysed_model = cellml.get_analysed_model(a)
 
             libcellml_utils.print_issues(a)
 

--- a/src/generators/CVSCppGenerator.py
+++ b/src/generators/CVSCppGenerator.py
@@ -1250,8 +1250,6 @@ class CVS0DCppGenerator(object):
         # TODO I should create my own profile with most of the below code so I don't have to change it when changes are made to libcellml
         profile = GeneratorProfile(GeneratorProfile.Profile.C)
         profile.setInterfaceFileNameString(f'{self.output_cpp_file_name}.h')
-        gen.setProfile(profile)
-        gen.setModel(analysed_model)
 
 
         #XXX HEADER FILE
@@ -1292,7 +1290,7 @@ class CVS0DCppGenerator(object):
         interFaceCodePreClass = ''
         interFaceCodeInClass = ''
         pre_class = True
-        for line in gen.interfaceCode().split('\n'):
+        for line in cellml.generate_interface_code(gen, analysed_model, profile).split('\n'):
             # print(line)
             if 'extern ' in line:
                 if 'VERSION' in line:
@@ -1732,7 +1730,7 @@ Model0d::Model0d() :
         in_class_init = False
 
         # TODO The below is all really susceptible to changes in libcellml, I should create my own profile
-        lines = gen.implementationCode().split('\n')
+        lines = cellml.generate_implementation_code(gen, analysed_model, profile).split('\n')
         max_func_found = any(l.startswith('double max') for l in lines)
         
         lines_to_pass = []

--- a/src/generators/CVSCppGenerator.py
+++ b/src/generators/CVSCppGenerator.py
@@ -1116,7 +1116,7 @@ class CVS0DCppGenerator(object):
 
         
         a.analyseModel(flat_model)
-        analysed_model = a.model()
+        analysed_model = cellml.get_analysed_model(a)
 
         if self.DEBUG:
             # parse_model seems to print most of the necessary issues, so we don't need to print them here

--- a/src/generators/PythonGenerator.py
+++ b/src/generators/PythonGenerator.py
@@ -534,7 +534,7 @@ class PythonGenerator:
         analyser = lc.Analyser()
         analyser.analyseModel(flat_model)
         libcellml_utils.print_issues(analyser)
-        analysed_model = analyser.model()
+        analysed_model = cellml_utils.get_analysed_model(analyser)
         if analysed_model.type() != lc.AnalyserModel.Type.ODE:
             raise ValueError(
                 'Generated model is not a valid ODE model according to'

--- a/src/generators/PythonGenerator.py
+++ b/src/generators/PythonGenerator.py
@@ -552,10 +552,8 @@ class PythonGenerator:
 
         profile = lc.GeneratorProfile(lc.GeneratorProfile.Profile.PYTHON)
         generator = lc.Generator()
-        generator.setProfile(profile)
-        generator.setModel(analysed_model)
 
-        code = generator.implementationCode()
+        code = cellml_utils.generate_implementation_code(generator, analysed_model, profile)
         utilities_filename = None
         utilities_code = None
         if self.human_readable and code:

--- a/src/scripts/generate_modules_files.py
+++ b/src/scripts/generate_modules_files.py
@@ -366,7 +366,7 @@ def main():
 
     flat_model = cellml.flatten_model(model, importer)
     analyser.analyseModel(flat_model)
-    analysed_model = analyser.model()
+    analysed_model = cellml.get_analysed_model(analyser)
 
     # TODO this commented out temporarily
     # libcellml_utils.print_issues(analyser)

--- a/src/utilities/libcellml_helper_funcs.py
+++ b/src/utilities/libcellml_helper_funcs.py
@@ -57,6 +57,17 @@ def flatten_model(model, importer):
     flat_model = importer.flattenModel(model)
     return flat_model
 
+def get_analysed_model(analyser):
+    """The AnalyserModel produced by analyser.analyseModel(...).
+
+    libCellML renamed this accessor from Analyser.model() to Analyser.analyserModel() in
+    0.7.0, so support both rather than pinning users to one side of that release.
+    """
+    if hasattr(analyser, 'analyserModel'):
+        return analyser.analyserModel()
+    return analyser.model()
+
+
 def analyse_model(model):
     analyser = Analyser()
     a = analyser.analyseModel(model)

--- a/src/utilities/libcellml_helper_funcs.py
+++ b/src/utilities/libcellml_helper_funcs.py
@@ -68,6 +68,29 @@ def get_analysed_model(analyser):
     return analyser.model()
 
 
+def _generator_is_pre_0_7(generator):
+    """libCellML 0.6.x configured the Generator with setModel()/setProfile() and then called
+    implementationCode() with no arguments. 0.7.0 dropped those setters and takes the analysed
+    model and profile as arguments instead."""
+    return hasattr(generator, 'setProfile')
+
+
+def generate_implementation_code(generator, analysed_model, profile):
+    if _generator_is_pre_0_7(generator):
+        generator.setProfile(profile)
+        generator.setModel(analysed_model)
+        return generator.implementationCode()
+    return generator.implementationCode(analysed_model, profile)
+
+
+def generate_interface_code(generator, analysed_model, profile):
+    if _generator_is_pre_0_7(generator):
+        generator.setProfile(profile)
+        generator.setModel(analysed_model)
+        return generator.interfaceCode()
+    return generator.interfaceCode(analysed_model, profile)
+
+
 def analyse_model(model):
     analyser = Analyser()
     a = analyser.analyseModel(model)


### PR DESCRIPTION
CI has been red on `master` since 2026-07-09 for reasons unrelated to any code change.

libCellML 0.7.0 was released that day. `pyproject.toml` asked for `libcellml>=0.6.3` with no upper bound, so every fresh CI run started resolving 0.7.0, and every test that generates a model began failing with:

```
AttributeError: 'Analyser' object has no attribute 'model'
```

This is dependency drift, not a regression: the last green run on master (2026-06-18) resolved libcellml 0.6.3; runs from 2026-07 resolve 0.7.0 and die. It affects every open PR branched off master (#254, #255, #260, #261, #263) — the failure reproduces on `master` itself.

## How 0.7.0 breaks us

1. `Analyser.model()` renamed to `Analyser.analyserModel()`
   → `AttributeError: 'Analyser' object has no attribute 'model'`
2. `Generator.setModel()` / `setProfile()` dropped; the analysed model and profile are now passed as arguments to `interfaceCode()` / `implementationCode()`
   → `AttributeError: 'Generator' object has no attribute 'setProfile'`
3. The generated Python code no longer defines `VARIABLE_COUNT`, which `PythonGenerator` reads out of the generated namespace
   → `KeyError: 'VARIABLE_COUNT'`
4. Units are resolved differently when flattening: SN_simple then fails to connect `a_2` between `soma_SN_module` and `soma_SN` (`Found Units mol_per_m3 and per_millimolar`)

## What this PR does

(1) and (2) are mechanical, and are handled here by `get_analysed_model()`, `generate_interface_code()` and `generate_implementation_code()` in `utilities/libcellml_helper_funcs.py`. They pick the API by feature detection, so they work on both 0.6.x and 0.7.x. The four `analyser.model()` call sites — `CVSCellMLGenerator`, `CVSCppGenerator`, `PythonGenerator`, `generate_modules_files` — are routed through the accessor.

(3) and (4) are a real migration and are **not** attempted here.

So the dependency is pinned to `<0.7.0`, which is what actually restores a green CI, and the shims stay so the eventual 0.7 migration only has to deal with (3) and (4).

## Verification

Verified in a clean CI-like venv (python 3.10, the exact CI pytest command): libcellml resolves to 0.6.3 and `tests/test_param_id.py` + `tests/test_sensitivity_analysis.py` give **45 passed, 0 failed**.

Also re-ran the specific test that surfaced this, under the OpenCOR shell:
`tests/test_param_id.py::test_3compartment_nonstiff_casadi_forward_and_gradient` — **PASSED**.

Note that the local OpenCOR environment already carries libcellml 0.6.3, so that run confirms the shims do not regress 0.6.x rather than exercising 0.7.0; the pin is what protects CI.

**Pre-existing, unrelated:** the `test (3.9/3.10/3.11)` matrix job is a separate failure — it was already red on master on 2026-06-18 under libcellml 0.6.3, so it is not caused by this PR or by the libcellml release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
