### PR TITLE
fix(parsers): declare sample_type and sub_method as enums with choices

### DIFF
--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -293,8 +293,12 @@ ANALYSIS_OPTIONS = {
             {'name': 'method', 'type': 'enum', 'default': 'sobol', 'required': False,
              'choices': ['sobol', 'naive'],
              'description': 'Sensitivity method: Sobol indices or a naive one-at-a-time sweep.'},
-            {'name': 'sample_type', 'type': 'str', 'default': 'saltelli', 'required': False,
-             'description': 'SALib sampling scheme (e.g. saltelli for Sobol).'},
+            # enum, not str: sobol_SA.generate_samples dispatches on exactly these two
+            # and raises ValueError on anything else, so a free string only lets a
+            # typo through to run time.
+            {'name': 'sample_type', 'type': 'enum', 'default': 'saltelli', 'required': False,
+             'choices': ['saltelli', 'sobol'],
+             'description': 'SALib sampling scheme: saltelli or sobol.'},
             {'name': 'num_samples', 'type': 'int', 'default': None, 'required': True,
              'description': ('Base sample count; the actual number of runs is num_samples*(2M+2) '
                              'for Sobol, where M is the number of parameters.')},
@@ -319,8 +323,13 @@ ANALYSIS_OPTIONS = {
             {'name': 'method', 'type': 'enum', 'default': 'Laplace', 'required': True,
              'choices': ['Laplace', 'profile_likelihood'],
              'description': 'Identifiability method: Laplace approximation or profile likelihood.'},
-            {'name': 'sub_method', 'type': 'str', 'default': 'parabola_fit', 'required': False,
-             'description': "Hessian method for the Laplace approximation (e.g. 'parabola_fit')."},
+            # enum, not str: utility_funcs.calculate_hessian dispatches on these.
+            # 'AD' is a fourth branch there but raises NotImplementedError, so it is
+            # deliberately not offered; any other value falls back to plain finite
+            # differences with only a printed warning, which a free string invites.
+            {'name': 'sub_method', 'type': 'enum', 'default': 'parabola_fit', 'required': False,
+             'choices': ['parabola_fit', 'numdifftools_finite_diff'],
+             'description': 'Hessian method for the Laplace approximation.'},
         ],
     },
 }

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -180,6 +180,61 @@ def test_analysis_options_schema_well_formed():
         'do_sensitivity', 'do_mcmc', 'do_ia'}
 
 
+def _option(mode, name):
+    return next(o for o in analysis_options(mode) if o['name'] == name)
+
+
+def test_closed_set_analysis_options_are_enums_with_choices():
+    """Every option whose consumer dispatches on a fixed set of values must be declared
+    'enum' with those values in 'choices' -- not a free 'str'.
+
+    The schema is what front-ends build their settings forms from, so a free string
+    becomes a text box for what is really a menu: the user can type something that
+    only fails once the run is under way, and a GUI cannot offer a dropdown without
+    hardcoding the list (which then drifts from CA).
+
+    Choices are pinned to the dispatch sites, so adding a branch there without
+    updating the schema fails here:
+      * sample_type -> sobolSA._generate_samples (raises ValueError otherwise)
+      * sub_method  -> utility_funcs.calculate_hessian
+      * method      -> sensitivityAnalysis / identifiabilityAnalysis
+    """
+    expected = {
+        ('sensitivity_analysis', 'method'): ['sobol', 'naive'],
+        ('sensitivity_analysis', 'sample_type'): ['saltelli', 'sobol'],
+        ('identifiability_analysis', 'method'): ['Laplace', 'profile_likelihood'],
+        # 'AD' is a branch in calculate_hessian but raises NotImplementedError, so it
+        # is deliberately absent -- offering it would let a user pick a guaranteed crash.
+        ('identifiability_analysis', 'sub_method'): ['parabola_fit', 'numdifftools_finite_diff'],
+    }
+    for (mode, name), choices in expected.items():
+        opt = _option(mode, name)
+        assert opt['type'] == 'enum', f'{mode}.{name} should be enum, got {opt["type"]!r}'
+        assert opt['choices'] == choices, f'{mode}.{name} choices drifted from the dispatch'
+        assert opt['default'] in opt['choices'], f'{mode}.{name} default not selectable'
+
+
+def test_sample_type_choices_match_sobolsa_dispatch():
+    """Guards the pairing directly: each declared sample_type must be a branch in
+    sobol_SA.generate_samples, and an unknown one must still raise.
+
+    Reads the source rather than importing sobolSA, which pulls in SALib/mpi4py and
+    would make a pure schema test depend on the analysis stack being installed.
+    """
+    import re
+    from pathlib import Path
+
+    src_file = Path(__file__).resolve().parents[1] / 'src' / 'sensitivity_analysis' / 'sobolSA.py'
+    src = src_file.read_text()
+    body = src[src.index('def generate_samples'):]
+    body = body[:body.index('\n    def ', 1)]  # just this method
+
+    for choice in _option('sensitivity_analysis', 'sample_type')['choices']:
+        assert re.search(rf'sample_type"?\'?\]?\s*==\s*[\'"]{choice}[\'"]', body), \
+            f'sample_type {choice!r} is offered but generate_samples does not dispatch on it'
+    assert 'raise ValueError' in body, 'generate_samples should still reject an unknown sample_type'
+
+
 def test_cost_func_metadata_discovers_builtins():
     """The obs-data editor discovers valid cost_type values + flags at runtime (costs are a
     user-extensible registry, not a static schema)."""


### PR DESCRIPTION
Fixes #275. Stacked on **#274** (`drop-aadc-bdf`) — see "Base" below.

## The change

Two options in `ANALYSIS_OPTIONS` are declared `'type': 'str'` while their consumers dispatch on a **closed set**:

| option | consumer | accepted |
|---|---|---|
| `sample_type` | `sobol_SA.generate_samples` | `saltelli`, `sobol` — `raise ValueError` otherwise |
| `sub_method` | `utility_funcs.calculate_hessian` | `parabola_fit`, `numdifftools_finite_diff` |

`ANALYSIS_OPTIONS` is the discoverable schema front-ends build their settings forms from, so `'str'` means "free text": a user gets a text box for what is really a two-item menu and can type a value that only fails once the run is under way. A downstream GUI can't offer a dropdown without hardcoding the list — which defeats a discoverable schema and silently drifts.

The sibling options already model this correctly, so this is an inconsistency rather than a new convention:

| option | type | choices |
|---|---|---|
| `method` (sensitivity) | `enum` | `['sobol', 'naive']` |
| `method` (identifiability) | `enum` | `['Laplace', 'profile_likelihood']` |
| `start_sampling` (multistart) | `enum` | `['sobol', 'latin_hypercube', 'random']` |
| **`sample_type`** → | **`enum`** | `['saltelli', 'sobol']` |
| **`sub_method`** → | **`enum`** | `['parabola_fit', 'numdifftools_finite_diff']` |

I checked all three existing enums against their dispatch — their choices match.

**No behaviour change.** The defaults and accepted values are exactly what the code already does; the schema now states what the dispatch already enforces.

### `AD` deliberately omitted

`calculate_hessian` has a fourth branch, `'AD'`, which `raise NotImplementedError`. Listing it would let a user select a guaranteed crash. Its `else` branch also falls back to finite differences with only a printed warning — the silent-fallback behaviour a free string invites. Left as-is; out of scope.

## Base

`ANALYSIS_OPTIONS` is not on `master` — it was introduced by `65d759f` and is still unmerged. This is based on `drop-aadc-bdf` (#274), the furthest-along branch carrying it, so the diff here is just the two files.

`drop-aadc-bdf` has been pushed to this repo to serve as the base; it is identical to `FinbarArgus:drop-aadc-bdf` (`256fa56`), which #274 still runs from. **Merge #274 first**, then this retargets to `master` cleanly.

## Tests

Two additions to `tests/test_solver_info_validation.py`:

- `test_closed_set_analysis_options_are_enums_with_choices` — pins all four closed-set options to their expected choices, so schema and dispatch can't drift apart.
- `test_sample_type_choices_match_sobolsa_dispatch` — reads `generate_samples`' source and asserts every offered choice is a real branch and that an unknown one still raises. Reads the file rather than importing `sobolSA`, so a pure schema test doesn't start depending on SALib/mpi4py being installed.

Verified by mutation, not just by passing:

| mutation | result |
|---|---|
| revert `sample_type` to `'str'` | 2 failed |
| add an undispatched choice (`'latin'`) | 2 failed |

`tests/test_solver_info_validation.py`: **21 passed** on this base.

## Not changed

`jac` (`solve_ivp` solver_info) is also `'str'` and should stay so — it's forwarded to `scipy.integrate.solve_ivp`, which expects an array or callable, not a name from a fixed list.

## Downstream

CUFLynx physiomelinks/CUFLynx#61 fixes the complementary rendering bug (a `'str'` descriptor was falling through to a numeric input and showing `NaN`). That is independent and needed regardless: `'str'` stays a legitimate type, and an older CA will keep sending it. Once this lands, those two options become dropdowns in CUFLynx with no further change there.