### PR TITLE
fix(param-id): FSA chain rule for init-value params, removing the FD fallback (#270)

### DIFF
--- a/src/param_id/fsa_backend.py
+++ b/src/param_id/fsa_backend.py
@@ -39,9 +39,11 @@ def ensure_setup(pid):
     """Enable CVODES forward sensitivities on the Myokit sim helper (once).
 
     Dependents are the unique observable-operand variables; independents are the AD
-    parameters. Parameters that appear in a state's initial-value expression are
-    FSA-ineligible (Myokit cannot make them sensitivity independents) and fall back to
-    finite differences; a single warning reports how many and which.
+    parameters. A parameter that feeds a state's initial-value expression (and only that) is
+    handled analytically by the chain rule through an ``init(state)`` sensitivity -- see
+    ``myokit_helper.enable_fsa`` / ``_init_chain_rule_targets``. Only a parameter that also
+    enters the dynamics (so the chain rule would be incomplete) stays FSA-ineligible and falls
+    back to finite differences; a single warning reports how many and which.
     """
     if getattr(pid, '_fsa_setup_done', False):
         return
@@ -68,9 +70,10 @@ def ensure_setup(pid):
         n_total = len(pid._fsa_param_names_flat)
         warnings.warn(
             f"FSA: {len(pid._fsa_ineligible_names)} of {n_total} parameters are "
-            f"unsuitable for CVODES forward sensitivity (they appear in a state's "
-            f"initial-value expression): {pid._fsa_ineligible_names}; these will use "
-            f"finite-difference gradients (2 extra simulations each per gradient).")
+            f"unsuitable for CVODES forward sensitivity (they enter the dynamics *and* a "
+            f"state's initial-value expression, so the initial-value chain rule is "
+            f"incomplete): {pid._fsa_ineligible_names}; these will use finite-difference "
+            f"gradients (2 extra simulations each per gradient).")
     pid._fsa_setup_done = True
 
 
@@ -105,6 +108,12 @@ def get_jac_cost(pid, param_vals, return_cost=False):
     num_sub_per_exp = pid.protocol_info["num_sub_per_exp"]
 
     eligible_names = set(pid.sim_helper._fsa_eligible_param_names or [])
+    # Params handled by the chain rule d(obs)/d(param) = sum_s d(obs)/d(init s)*d(init_s)/d(param):
+    # they carry no column of their own, so their operand sensitivity is synthesised below from
+    # the init(state) columns and then treated exactly like an eligible param (issue #270).
+    chain_rule_map = getattr(pid.sim_helper, '_fsa_chain_rule_map', None) or {}
+    chain_state_qnames = sorted({sq for tgts in chain_rule_map.values() for sq, _ in tgts})
+    has_sensitivity = eligible_names | set(chain_rule_map)
     # Map each flattened param name to its column index in param_vals.
     flat_names = pid._fsa_param_names_flat
     grad = np.zeros(n_params)
@@ -141,9 +150,28 @@ def get_jac_cost(pid, param_vals, return_cost=False):
             sens = pid.sim_helper.get_sensitivities(
                 pid._fsa_dependent_names, flat_names, sensitivities=sens_arr)
 
+            # Synthesise the operand sensitivity of each chain-rule param and inject it into
+            # `sens` under the param's own name, so the directional-difference loop below treats
+            # it identically to a param that had its own FSA column. For dependent var d:
+            #   d(d)/d(param) = sum_s [ d(d)/d(init s) ] * [ d(init_s)/d(param) ]
+            if chain_rule_map:
+                init_sens = pid.sim_helper.get_init_state_sensitivities(
+                    pid._fsa_dependent_names, chain_state_qnames, sensitivities=sens_arr)
+                for pname, targets in chain_rule_map.items():
+                    for dep_name in pid._fsa_dependent_names:
+                        acc = None
+                        for state_qname, dinit in targets:
+                            s_trace = init_sens.get(dep_name, {}).get(state_qname)
+                            if s_trace is None:
+                                continue
+                            term = np.asarray(s_trace, dtype=float) * dinit
+                            acc = term if acc is None else acc + term
+                        if acc is not None:
+                            sens.setdefault(dep_name, {})[pname] = acc
+
             for j in range(n_params):
                 pname = flat_names[j]
-                if pname not in eligible_names:
+                if pname not in has_sensitivity:
                     continue
                 pj = float(param_vals[j])
                 # Central directional difference along the exact sensitivity S. The step acts
@@ -161,7 +189,7 @@ def get_jac_cost(pid, param_vals, return_cost=False):
     grad /= denom
 
     # ---- Ineligible params: central finite difference over the full mean cost ----
-    ineligible_idx = [j for j in range(n_params) if flat_names[j] not in eligible_names]
+    ineligible_idx = [j for j in range(n_params) if flat_names[j] not in has_sensitivity]
     if ineligible_idx:
         base_cost = float(pid.get_cost_from_params(param_vals))
         if not np.isfinite(base_cost):

--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -39,9 +39,11 @@ class SimulationHelper:
         self._fsa_enabled = False
         self._fsa_dependent_qnames = None       # ordered myokit qnames of dependents
         self._fsa_dependent_specs = None        # myokit dependent spec strings
-        self._fsa_independent_specs = None       # myokit independent spec strings (eligible only)
-        self._fsa_eligible_param_names = None    # framework param names, order matches independents
+        self._fsa_independent_specs = None       # myokit independent spec strings (eligible + chain init(state))
+        self._fsa_independent_keys = None        # retrieval key per independent: param name or ('init_state', qname)
+        self._fsa_eligible_param_names = None    # framework param names whose own column is the sensitivity
         self._fsa_ineligible_param_names = None  # framework param names needing FD fallback
+        self._fsa_chain_rule_map = {}            # param name -> [(state_qname, d(init_state)/d(param)), ...]
         self._fsa_independent_state_qnames = None  # state qnames that ARE FSA independents (init params)
         self._last_sensitivities = None
         # Per-sub-experiment sensitivities within one experiment: run() appends, reset_states()
@@ -978,10 +980,15 @@ class SimulationHelper:
                                 w.r.t. parameters we need.
         independent_param_names : framework names of the parameters to differentiate.
 
-        A parameter that appears inside a state's initial-value expression cannot be a
-        CVODES independent (Myokit raises NotImplementedError); such parameters are
-        classified as FSA-ineligible and returned so the caller can fall back to finite
-        differences. Returns the list of ineligible parameter names.
+        A parameter that appears inside a state's initial-value expression cannot be a CVODES
+        independent directly (Myokit raises NotImplementedError). When such a parameter feeds
+        *only* initial values (not the dynamics) it is handled analytically by the chain rule
+        d(obs)/d(param) = sum_s d(obs)/d(init s) * d(init_s)/d(param) -- the first factor from an
+        ``init(state)`` sensitivity independent, the second from the initial-value expression --
+        and is not ineligible. Only parameters that also enter the dynamics, or whose derivative
+        cannot be reduced to a fixed factor, remain FSA-ineligible and fall back to finite
+        differences. Returns the list of ineligible parameter names (empty when the chain rule
+        covers them all).
         """
         dep_specs = []
         dep_qnames = []
@@ -990,18 +997,41 @@ class SimulationHelper:
             dep_specs.append(qname)
             dep_qnames.append(qname)
 
+        # A constant that appears in a state's initial-value expression cannot be a CVODES
+        # independent directly -- Myokit raises "Sensitivities with respect to parameters used
+        # in initial conditions is not implemented". But the information is still analytic: by
+        # the chain rule d(obs)/d(param) = sum_s d(obs)/d(init s) * d(init_s)/d(param), where the
+        # first factor is an ordinary FSA independent `init(state)` (which Myokit *does* support,
+        # even when the initial value is an expression) and the second is the derivative of the
+        # initial-value expression w.r.t. the constant. `_init_chain_rule_targets` finds those
+        # states and derivatives; such params are then handled by that product instead of falling
+        # back to two extra full simulations per gradient evaluation (issue #270).
+        calib_qnames = {self._resolve_name(n)[1] for n in independent_param_names}
+
         cand_specs = []
         cand_names = []
         indep_state_qnames = set()
+        chain_rule_map = {}          # param name -> [(state_qname, d(init_state)/d(param)), ...]
+        chain_state_qnames = []      # extra init(state) independents needed by the chain rule
         for name in independent_param_names:
             kind, qname = self._resolve_name(name)
-            # A directly-overridden state uses its initial value as the independent;
-            # a constant uses the constant itself.
-            spec = f'init({qname})' if kind == 'state' else qname
             if kind == 'state':
+                # A directly-overridden state uses its own initial value as the independent.
+                cand_specs.append(f'init({qname})')
+                cand_names.append(name)
                 indep_state_qnames.add(qname)
-            cand_specs.append(spec)
-            cand_names.append(name)
+                continue
+            # A constant: use it directly unless it feeds a state initial value, in which case
+            # route it through the chain rule.
+            targets = self._init_chain_rule_targets(qname, calib_qnames)
+            if targets is None:
+                cand_specs.append(qname)
+                cand_names.append(name)
+            else:
+                chain_rule_map[name] = targets
+                for state_qname, _ in targets:
+                    if state_qname not in chain_state_qnames:
+                        chain_state_qnames.append(state_qname)
         # States that are calibration (FSA-independent) params: Myokit seeds their sensitivity
         # (identity at t=0), so a set_param_vals state override of these must NOT be treated as a
         # protocol re-seed (see set_param_vals). params_to_change state overrides are everything
@@ -1011,11 +1041,26 @@ class SimulationHelper:
         eligible_specs, eligible_names, ineligible_names = self._classify_fsa_independents(
             dep_specs, cand_specs, cand_names)
 
+        # The init(state) columns the chain rule needs, deduplicated against any state that is
+        # already a direct independent (a directly-calibrated state reuses its own column).
+        eligible_state_qnames = {
+            s[len('init('):-1] for s in eligible_specs if s.startswith('init(')}
+        indep_specs = list(eligible_specs)
+        indep_keys = list(eligible_names)  # retrieval key parallel to indep_specs
+        for state_qname in chain_state_qnames:
+            if state_qname in eligible_state_qnames:
+                continue
+            indep_specs.append(f'init({state_qname})')
+            indep_keys.append(('init_state', state_qname))
+            eligible_state_qnames.add(state_qname)
+
         self._fsa_dependent_specs = dep_specs
         self._fsa_dependent_qnames = dep_qnames
-        self._fsa_independent_specs = eligible_specs
+        self._fsa_independent_specs = indep_specs
+        self._fsa_independent_keys = indep_keys
         self._fsa_eligible_param_names = eligible_names
         self._fsa_ineligible_param_names = ineligible_names
+        self._fsa_chain_rule_map = chain_rule_map
         self._fsa_enabled = True
 
         # Rebuild the simulation with sensitivities and refresh derived maps/defaults.
@@ -1067,6 +1112,50 @@ class SimulationHelper:
                 ineligible_names.append(name)
         return eligible_specs, eligible_names, ineligible_names
 
+    def _init_chain_rule_targets(self, const_qname, calib_qnames):
+        """Chain-rule targets for a constant that feeds state initial-value expressions.
+
+        Returns ``[(state_qname, d(init_state)/d(const)), ...]`` if the constant ``const_qname``
+        can be differentiated through state initial values instead of being a direct CVODES
+        independent, or ``None`` if it should be handled the usual way (direct independent, or
+        FD fallback if Myokit then refuses it).
+
+        Chain-rule handling is used only when it is *exact*:
+          * the constant appears in at least one state's initial-value expression, and
+          * it does not appear in any dynamic equation (``refs_by()`` is empty) -- otherwise the
+            gradient has a component through the dynamics that ``init(state)`` sensitivities do
+            not capture, so we must keep the full-cost FD, and
+          * every ``d(init_state)/d(const)`` is a compile-time constant, i.e. its expression does
+            not reference another calibration parameter (if it did, the factor would vary with
+            those params and a value captured now would go stale between gradient evaluations).
+        Any expression Myokit cannot differentiate/evaluate here drops the constant back to the
+        normal path rather than risk a wrong number.
+        """
+        try:
+            const_var = self.model.get(const_qname)
+        except Exception:
+            return None
+        # Used in the dynamics as well as an initial value -> chain rule would be incomplete.
+        if list(const_var.refs_by()):
+            return None
+        const_name = myokit.Name(const_var)
+        targets = []
+        for state in self.model.states():
+            init_expr = state.initial_value()
+            if init_expr is None:
+                continue
+            if not any(ref.var().qname() == const_qname for ref in init_expr.references()):
+                continue
+            try:
+                deriv = init_expr.diff(const_name)
+                # A derivative that depends on another calibration param is not a fixed factor.
+                if any(ref.var().qname() in calib_qnames for ref in deriv.references()):
+                    return None
+                targets.append((state.qname(), float(deriv.eval())))
+            except Exception:
+                return None
+        return targets or None
+
     def get_fsa_ineligible_params(self):
         """Framework names of AD params that fall back to finite differences (or None)."""
         return self._fsa_ineligible_param_names
@@ -1098,5 +1187,37 @@ class SimulationHelper:
             for pname in param_names:
                 if pname in indep_index:
                     out[dname][pname] = sens[:, di, indep_index[pname]].copy()
+        return out
+
+    def get_init_state_sensitivities(self, dependent_names, state_qnames, sensitivities=None):
+        """d(dependent_trace)/d(init state) from a FSA run, for the chain-rule fallback.
+
+        Returns ``{dependent_name: {state_qname: np.ndarray}}`` for each requested state whose
+        ``init(state_qname)`` was set up as a sensitivity independent (either a directly
+        calibrated state or one added because a constant feeds its initial value -- see
+        ``enable_fsa`` / ``_init_chain_rule_targets``). Column positions are read from
+        ``_fsa_independent_specs`` so both key forms (param name and ``('init_state', qname)``)
+        resolve identically. States without an ``init(...)`` column are omitted.
+        """
+        if sensitivities is None:
+            sensitivities = self._last_sensitivities
+        if sensitivities is None:
+            raise RuntimeError(
+                "No sensitivities available: FSA is not enabled or run() has not been called.")
+        sens = np.asarray(sensitivities, dtype=float)  # [n_time, n_dep, n_indep]
+        dep_index = {q: i for i, q in enumerate(self._fsa_dependent_qnames)}
+        # Map each state qname to its column via the init(<qname>) independent specs.
+        state_col = {}
+        for i, spec in enumerate(self._fsa_independent_specs):
+            if spec.startswith('init(') and spec.endswith(')'):
+                state_col[spec[len('init('):-1]] = i
+        out = {}
+        for dname in dependent_names:
+            _, dqname = self._resolve_name(dname)
+            di = dep_index[dqname]
+            out[dname] = {}
+            for sq in state_qnames:
+                if sq in state_col:
+                    out[dname][sq] = sens[:, di, state_col[sq]].copy()
         return out
 

--- a/tests/test_param_id.py
+++ b/tests/test_param_id.py
@@ -1917,6 +1917,7 @@ def test_3compartment_casadi_bdf_longrun_gradient_and_cache(
 def _build_3compartment_fsa_runner(
     base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir,
     pre_time=20.0, sim_time=2.0, obs_file='3compartment_obs_data.json',
+    params_for_id=None,
 ):
     """Generate the (stiff) 3compartment cellml_only model, run through Myokit, and build a
     CVS0DParamID configured for the CVODES forward-sensitivity (FSA) gradient path.
@@ -1963,16 +1964,17 @@ def _build_3compartment_fsa_runner(
         obs_data = json.load(f)
     runner.set_ground_truth_data(obs_data)
 
-    params_for_id = [
-        {'vessel_name': 'global',      'param_name': 'q_lv_init', 'param_type': 'const', 'min': 200e-6, 'max': 1500e-6},
-        {'vessel_name': 'aortic_root', 'param_name': 'C',         'param_type': 'const', 'min': 1e-9,   'max': 5e-8},
-        {'vessel_name': 'global',      'param_name': 'E_lv_A',    'param_type': 'const', 'min': 1e8,    'max': 5e8},
-        {'vessel_name': 'global',      'param_name': 'E_lv_B',    'param_type': 'const', 'min': 1e6,    'max': 5e7},
-    ]
+    if params_for_id is None:
+        params_for_id = [
+            {'vessel_name': 'global',      'param_name': 'q_lv_init', 'param_type': 'const', 'min': 200e-6, 'max': 1500e-6},
+            {'vessel_name': 'aortic_root', 'param_name': 'C',         'param_type': 'const', 'min': 1e-9,   'max': 5e-8},
+            {'vessel_name': 'global',      'param_name': 'E_lv_A',    'param_type': 'const', 'min': 1e8,    'max': 5e8},
+            {'vessel_name': 'global',      'param_name': 'E_lv_B',    'param_type': 'const', 'min': 1e6,    'max': 5e7},
+        ]
     runner.set_params_for_id(params_for_id)
     baseline_vals = runner.param_id.sim_helper.get_init_param_vals(
         runner.param_id.param_id_info['param_names'])
-    assert baseline_vals is not None and len(baseline_vals) == 4
+    assert baseline_vals is not None and len(baseline_vals) == len(params_for_id)
     return runner, baseline_vals
 
 
@@ -1985,11 +1987,13 @@ def test_3compartment_fsa_longrun_gradient(
     (nonzero pre_time) run matches central finite differences of the same cost.
 
     This is the gradient path for cellml_only / CVODE_myokit models. FSA gives d(operand)/dp
-    for constant parameters; q_lv_init sets a state initial value so it is FSA-ineligible and
-    falls back to finite differences (verified below). The gradient is checked at an arbitrary
-    interior point (not the optimum, so cost != 0), which is all a correct descent direction
-    needs. The reference FD uses a rel~1e-3 step: a convergence study showed rel 1e-4 sits in
-    the integrator noise floor for this stiff oscillatory model.
+    for constant parameters; q_lv_init sets a state initial value, so Myokit cannot make it a
+    CVODES independent directly. It is handled analytically by the initial-value chain rule
+    (issue #270) -- d(obs)/d(q_lv_init) = d(obs)/d(init q_lv) * d(init q_lv)/d(q_lv_init) -- not
+    the finite-difference fallback, so it must be FSA-eligible (verified below). The gradient is
+    checked at an arbitrary interior point (not the optimum, so cost != 0), which is all a
+    correct descent direction needs. The reference FD uses a rel~1e-3 step: a convergence study
+    showed rel 1e-4 sits in the integrator noise floor for this stiff oscillatory model.
     """
     runner, _ = _build_3compartment_fsa_runner(
         base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir,
@@ -2006,9 +2010,15 @@ def test_3compartment_fsa_longrun_gradient(
     assert np.all(np.isfinite(gradient))
     assert not np.all(gradient == 0)
 
-    # q_lv_init feeds a state initial-value expression -> FSA-ineligible -> FD fallback.
-    assert inner._fsa_ineligible_names == ['global/q_lv_init'], inner._fsa_ineligible_names
-    # its gradient column is still populated (via the finite-difference fallback).
+    # q_lv_init feeds a state initial-value expression and nothing else, so it is handled by
+    # the chain rule (issue #270), not the FD fallback: no parameter is FSA-ineligible.
+    assert inner._fsa_ineligible_names == [], inner._fsa_ineligible_names
+    # It is routed through init(heart_module.q_lv) with an analytic d(init q_lv)/d(q_lv_init).
+    assert 'global/q_lv_init' in inner.sim_helper._fsa_chain_rule_map
+    targets = inner.sim_helper._fsa_chain_rule_map['global/q_lv_init']
+    assert [sq for sq, _ in targets] == ['heart_module.q_lv'], targets
+    assert targets[0][1] == pytest.approx(1.0)  # init q_lv = q_lv_init, so the factor is 1
+    # its gradient column is populated (via the chain rule, not FD).
     assert abs(gradient[0]) > 1e-6
 
     fd = np.zeros(4)
@@ -2020,6 +2030,59 @@ def test_3compartment_fsa_longrun_gradient(
         fd[i] = (float(inner.get_cost(p_plus)) - float(inner.get_cost(p_minus))) / (2 * dp)
 
     for i, label in enumerate(["q_lv_init", "C_aortic", "E_lv_A", "E_lv_B"]):
+        if abs(fd[i]) > 1e-6:
+            assert gradient[i] == pytest.approx(fd[i], rel=0.10), (
+                f"FSA gradient[{i}] ({label}) = {gradient[i]:.6e} != FD {fd[i]:.6e} "
+                f"(AD/FD={gradient[i]/fd[i]:.4f})")
+
+    runner.close_simulation()
+
+
+@pytest.mark.slow
+@pytest.mark.need_opencor
+def test_3compartment_fsa_multiple_init_params_chain_rule(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir):
+    """Two parameters feeding *different* state initial values are both handled by the chain
+    rule (issue #270) in the same run, and the gradient still matches finite differences.
+
+    q_lv_init -> init(heart_module.q_lv) and q_rv_init -> init(heart_module.q_rv) each add their
+    own init(state) sensitivity independent; neither is FSA-ineligible. This exercises the
+    multi-chain-param path (two distinct init(state) columns) that the single-param longrun test
+    does not, alongside one ordinary FSA-eligible constant.
+    """
+    params_for_id = [
+        {'vessel_name': 'global',      'param_name': 'q_lv_init', 'param_type': 'const', 'min': 200e-6, 'max': 1500e-6},
+        {'vessel_name': 'global',      'param_name': 'q_rv_init', 'param_type': 'const', 'min': 200e-6, 'max': 1500e-6},
+        {'vessel_name': 'aortic_root', 'param_name': 'C',         'param_type': 'const', 'min': 1e-9,   'max': 5e-8},
+    ]
+    runner, _ = _build_3compartment_fsa_runner(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir,
+        pre_time=20.0, sim_time=2.0, params_for_id=params_for_id)
+    inner = runner.param_id
+
+    mins = np.asarray(inner.param_id_info['param_mins'], dtype=float)
+    maxs = np.asarray(inner.param_id_info['param_maxs'], dtype=float)
+    p = mins + 0.4 * (maxs - mins)
+
+    gradient = np.asarray(inner.get_gradient(p), dtype=float).ravel()
+    assert gradient.shape == (3,)
+    assert np.all(np.isfinite(gradient))
+
+    # Both init params are chain-ruled (nothing falls back to FD); each maps to its own state.
+    assert inner._fsa_ineligible_names == [], inner._fsa_ineligible_names
+    chain = inner.sim_helper._fsa_chain_rule_map
+    assert [sq for sq, _ in chain['global/q_lv_init']] == ['heart_module.q_lv']
+    assert [sq for sq, _ in chain['global/q_rv_init']] == ['heart_module.q_rv']
+
+    fd = np.zeros(3)
+    for i in range(3):
+        dp = max(abs(p[i]) * 1e-3, 1e-14)
+        p_plus, p_minus = p.copy(), p.copy()
+        p_plus[i] += dp
+        p_minus[i] -= dp
+        fd[i] = (float(inner.get_cost(p_plus)) - float(inner.get_cost(p_minus))) / (2 * dp)
+
+    for i, label in enumerate(["q_lv_init", "q_rv_init", "C_aortic"]):
         if abs(fd[i]) > 1e-6:
             assert gradient[i] == pytest.approx(fd[i], rel=0.10), (
                 f"FSA gradient[{i}] ({label}) = {gradient[i]:.6e} != FD {fd[i]:.6e} "


### PR DESCRIPTION
Closes #270 — replaces the finite-difference fallback for parameters that feed a state's initial value with an analytic chain rule.

## The problem

Myokit accepts a *directly-calibrated state* as a CVODES sensitivity independent (`init(qname)`), but refuses a **constant that merely appears inside a state's initial-value expression** — it raises `NotImplementedError: Sensitivities with respect to parameters used in initial conditions is not implemented`. So `_classify_fsa_independents` marked those params FSA-ineligible, and each one cost **two extra full simulations per gradient evaluation** (a central FD over the whole cost). `3compartment`'s `global/q_lv_init` is exactly this case — pure overhead, since the information is analytic.

## The fix

Close it with the chain rule:

```
d(obs)/d(param) = Σ_s  d(obs)/d(init s) · d(init_s)/d(param)
```

- **First factor** `d(obs)/d(init s)` — an ordinary FSA `init(state)` independent. I verified Myokit accepts this *even when the initial value is an expression* referencing the constant (it returns real sensitivities; the bare constant is what it refuses).
- **Second factor** `d(init_s)/d(param)` — taken analytically from the Myokit model via `Expression.diff(...).eval()`. For the `*_init` constants it is simply `1`.

Each chain-rule param's operand sensitivity is synthesised as `Σ_s (init-state sensitivity) · d(init_s)/d(param)` and fed into the **existing** directional-difference machinery, so it is handled identically to a param with its own FSA column. The FD block now runs only for genuinely-ineligible params — which for the target models is none.

## Correctness guard — chain rule only when it is *exact*

`_init_chain_rule_targets` returns targets (and the param leaves the FD path) only when:

1. the constant appears in at least one state's initial-value expression, **and**
2. it does **not** appear in any dynamic equation (`refs_by()` is empty) — otherwise there is a gradient component through the RHS that `init(state)` sensitivities don't capture, so it stays on FD; **and**
3. every `d(init)/d(const)` is a compile-time constant (its expression doesn't reference another calibration param, which would make the factor go stale between evaluations).

Anything Myokit can't differentiate/evaluate drops back to the normal path. So the change is strictly "same answer, less work" for the covered cases and "unchanged behaviour" otherwise — it never trades correctness for speed.

## Verification

- `test_3compartment_fsa_longrun_gradient` — updated: `q_lv_init` is now FSA-eligible via the chain rule (ineligible list empty; chain map → `heart_module.q_lv`, factor `1.0`), and the gradient is still checked against central FD (rel 0.10) at an interior point.
- `test_3compartment_fsa_multiple_init_params_chain_rule` — **new**: `q_lv_init` and `q_rv_init` in one run, each routed to its own `init(state)` column (exercising the multi-chain / dedup path), gradient vs FD.
- **Full suite: 178 passed, 5 failed, 3 skipped.** The 5 are the known baseline — 3 deliberate AADC stiff-accuracy failures (#274) and 2 pre-existing `SN_simple`/`PythonGenerator` failures — unchanged from master. **No new failures.** All FSA tests pass, including the multi-sub-experiment sensitivity carry (the extra `init(state)` columns flow through `_s_state` transparently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
