### PR TITLE
feat(sensitivity): expose Myokit CVODES sensitivities as a local SA method (#283)

### DIFF
--- a/src/param_id/casadi_backend.py
+++ b/src/param_id/casadi_backend.py
@@ -189,6 +189,46 @@ def get_cost(pid, param_vals):
     return cost
 
 
+def get_observable_sensitivities(pid, param_vals):
+    """d(observable feature)/d(param) for the scalar (const) observables, via the exact CasADi
+    jacobian of the symbolic observable vector w.r.t. the parameters.
+
+    Returns ``{observable_label: {param_name: d(feature)/d(param)}}`` (see
+    ``OpencorParamID._observable_label``). This is the CasADi arm of
+    ``OpencorParamID.get_observable_sensitivities`` -- the backend-agnostic local-sensitivity
+    accessor -- and mirrors how get_jac_cost differentiates the cost, but for each observable
+    output instead of the aggregated cost.
+    """
+    import casadi as ca
+    param_names = pid.param_id_info["param_names"]
+    flat_names = [n[0] if isinstance(n, list) else n for n in param_names]
+    build_functions(pid, param_names, param_vals)
+
+    # jacobian of the flattened observable vector w.r.t. the differentiated parameter subset.
+    jac_symb = ca.jacobian(pid.obs_vec, pid.sim_helper.variables_symb_subset)
+    jac_func = ca.Function(
+        'obs_jac_func',
+        [pid.sim_helper.states_symb, pid.sim_helper.variables_symb],
+        [jac_symb])
+    jac = np.array(jac_func(pid.sim_helper.states, pid.sim_helper.variables))  # [n_rows x n_params]
+
+    # obs_meta slices obs_vec by (field, observable-item, size); the single 'const' entry holds
+    # all scalar-feature rows in const-index order, so row idx+k is const observable k, whose
+    # observable index is const_idx_to_obs_idx[k] (identical mapping to the Myokit arm). See
+    # casadi_backend.get_obs, which slices obs_vec the same way.
+    const_to_obs = pid.obs_info["const_idx_to_obs_idx"]
+    out = {}
+    idx = 0
+    for key, _item, size in pid.obs_meta:
+        n_rows = sum(size) if isinstance(size, list) else size
+        if key == 'const':
+            for k in range(n_rows):
+                label = pid._observable_label(const_to_obs[k])
+                out[label] = {flat_names[j]: float(jac[idx + k, j]) for j in range(len(flat_names))}
+        idx += n_rows
+    return out
+
+
 def get_obs(pid, param_vals, get_all_series=False):
     param_names = pid.param_id_info["param_names"]
     build_functions(pid, param_names, param_vals, get_all_series)

--- a/src/param_id/fsa_backend.py
+++ b/src/param_id/fsa_backend.py
@@ -23,6 +23,92 @@ import warnings
 import numpy as np
 
 
+def operand_sensitivities(sim_helper, dependent_names, param_names, sensitivities=None):
+    """d(operand_trace)/d(param) for every param that carries a sensitivity.
+
+    Returns ``{dependent_name: {param_name: np.ndarray}}``. Wraps the Myokit helper's
+    ``get_sensitivities`` (FSA-eligible params, whose own CVODES column *is* the sensitivity)
+    and folds in the initial-value **chain-rule** params (issue #270): a constant that feeds a
+    state's initial value has no column of its own, so its operand sensitivity is synthesised as
+    ``sum_s d(operand)/d(init s) * d(init_s)/d(param)`` from the ``init(state)`` columns and the
+    per-state factors in ``sim_helper._fsa_chain_rule_map``. Params that are neither eligible nor
+    chain-ruled (true FD-fallback params) are simply absent from the inner dicts.
+
+    Shared by the FSA gradient (``get_jac_cost``) and the local sensitivity analysis
+    (``sobolSA.run_local_sensitivity``) so both see exactly the same d(operand)/d(param).
+    """
+    sens = sim_helper.get_sensitivities(dependent_names, param_names, sensitivities=sensitivities)
+    chain_rule_map = getattr(sim_helper, '_fsa_chain_rule_map', None) or {}
+    if chain_rule_map:
+        chain_state_qnames = sorted({sq for tgts in chain_rule_map.values() for sq, _ in tgts})
+        init_sens = sim_helper.get_init_state_sensitivities(
+            dependent_names, chain_state_qnames, sensitivities=sensitivities)
+        for pname, targets in chain_rule_map.items():
+            for dep_name in dependent_names:
+                acc = None
+                for state_qname, dinit in targets:
+                    s_trace = init_sens.get(dep_name, {}).get(state_qname)
+                    if s_trace is None:
+                        continue
+                    term = np.asarray(s_trace, dtype=float) * dinit
+                    acc = term if acc is None else acc + term
+                if acc is not None:
+                    sens.setdefault(dep_name, {})[pname] = acc
+    return sens
+
+
+def observable_feature_sensitivities(pid, param_vals):
+    """d(observable feature)/d(param) for the scalar (const) observables, via the Myokit CVODES
+    sensitivities and a directional derivative.
+
+    Returns ``{observable_label: {param_name: d(feature)/d(param)}}`` -- the same shape as the
+    CasADi arm -- so the two backends report the identical quantity. FSA gives the exact operand
+    sensitivity S = d(operand)/d(param); the feature (max/min/mean/...) is re-evaluated on
+    ``operands +/- h*S`` and central-differenced, so d(feature)/d(param) reuses the existing
+    operation/observable code with no re-simulation, exactly as get_jac_cost does for the cost.
+    Single sub-experiment only (the SA local path); the multi-sub carry stays in get_jac_cost.
+
+    This is the Myokit arm of ``OpencorParamID.get_observable_sensitivities``. Only parameters
+    that carry a CVODES sensitivity (FSA-eligible plus initial-value chain-rule, #270) are
+    included; there is no finite-difference fallback here.
+    """
+    ensure_setup(pid)
+    param_vals = np.asarray(param_vals, dtype=float)
+    flat_names = pid._fsa_param_names_flat
+
+    num_sub_total = sum(len(st) for st in pid.protocol_info["sim_times"])
+    if num_sub_total != 1:
+        raise NotImplementedError(
+            "Local (CVODES) observable sensitivities currently support a single sub-experiment; "
+            f"this protocol has {num_sub_total} sub-experiments.")
+
+    _, operands_list, _ = pid.get_cost_obs_and_pred_from_params(
+        param_vals, reset=True, only_one_exp=0)
+    if not operands_list or operands_list[0] is None:
+        raise RuntimeError("Local sensitivity nominal simulation failed to converge.")
+    operands = operands_list[0]
+
+    sens = operand_sensitivities(pid.sim_helper, pid._fsa_dependent_names, flat_names)
+    has_sensitivity = (set(pid.sim_helper._fsa_eligible_param_names or [])
+                       | set(getattr(pid.sim_helper, '_fsa_chain_rule_map', None) or {}))
+
+    const_to_obs = pid.obs_info["const_idx_to_obs_idx"]
+    out = {pid._observable_label(obs_idx): {} for obs_idx in const_to_obs}
+    for j, pname in enumerate(flat_names):
+        if pname not in has_sensitivity:
+            continue
+        pj = float(param_vals[j])
+        h = 1e-3 * abs(pj) if pj != 0.0 else 1e-4
+        pert_p = perturb_operands_along_sensitivity(pid, operands, sens, pname, h)
+        pert_m = perturb_operands_along_sensitivity(pid, operands, sens, pname, -h)
+        const_p = np.asarray(pid.get_obs_output_dict(pert_p)['const'], dtype=float)
+        const_m = np.asarray(pid.get_obs_output_dict(pert_m)['const'], dtype=float)
+        d_feature = (const_p - const_m) / (2.0 * h)
+        for k, obs_idx in enumerate(const_to_obs):
+            out[pid._observable_label(obs_idx)][pname] = float(d_feature[k])
+    return out
+
+
 def gradient_available(pid):
     """True when this run can produce an analytic gradient via Myokit CVODES FSA.
 
@@ -109,10 +195,9 @@ def get_jac_cost(pid, param_vals, return_cost=False):
 
     eligible_names = set(pid.sim_helper._fsa_eligible_param_names or [])
     # Params handled by the chain rule d(obs)/d(param) = sum_s d(obs)/d(init s)*d(init_s)/d(param):
-    # they carry no column of their own, so their operand sensitivity is synthesised below from
-    # the init(state) columns and then treated exactly like an eligible param (issue #270).
+    # they carry no FSA column of their own (issue #270). operand_sensitivities() covers both
+    # these and the eligible params, so both are "has_sensitivity" here.
     chain_rule_map = getattr(pid.sim_helper, '_fsa_chain_rule_map', None) or {}
-    chain_state_qnames = sorted({sq for tgts in chain_rule_map.values() for sq, _ in tgts})
     has_sensitivity = eligible_names | set(chain_rule_map)
     # Map each flattened param name to its column index in param_vals.
     flat_names = pid._fsa_param_names_flat
@@ -147,27 +232,10 @@ def get_jac_cost(pid, param_vals, return_cost=False):
             raw_cost += float(pid.get_cost_from_operands(
                 operands, exp_idx=exp_idx, sub_idx=sub_idx))
             sens_arr = sens_history[sub_idx] if sub_idx < len(sens_history) else None
-            sens = pid.sim_helper.get_sensitivities(
-                pid._fsa_dependent_names, flat_names, sensitivities=sens_arr)
-
-            # Synthesise the operand sensitivity of each chain-rule param and inject it into
-            # `sens` under the param's own name, so the directional-difference loop below treats
-            # it identically to a param that had its own FSA column. For dependent var d:
-            #   d(d)/d(param) = sum_s [ d(d)/d(init s) ] * [ d(init_s)/d(param) ]
-            if chain_rule_map:
-                init_sens = pid.sim_helper.get_init_state_sensitivities(
-                    pid._fsa_dependent_names, chain_state_qnames, sensitivities=sens_arr)
-                for pname, targets in chain_rule_map.items():
-                    for dep_name in pid._fsa_dependent_names:
-                        acc = None
-                        for state_qname, dinit in targets:
-                            s_trace = init_sens.get(dep_name, {}).get(state_qname)
-                            if s_trace is None:
-                                continue
-                            term = np.asarray(s_trace, dtype=float) * dinit
-                            acc = term if acc is None else acc + term
-                        if acc is not None:
-                            sens.setdefault(dep_name, {})[pname] = acc
+            # d(operand)/d(param) for every param that has a sensitivity -- FSA-eligible plus
+            # init-value chain-rule params, synthesised identically (see operand_sensitivities).
+            sens = operand_sensitivities(
+                pid.sim_helper, pid._fsa_dependent_names, flat_names, sensitivities=sens_arr)
 
             for j in range(n_params):
                 pname = flat_names[j]

--- a/src/param_id/fsa_backend.py
+++ b/src/param_id/fsa_backend.py
@@ -35,7 +35,7 @@ def operand_sensitivities(sim_helper, dependent_names, param_names, sensitivitie
     chain-ruled (true FD-fallback params) are simply absent from the inner dicts.
 
     Shared by the FSA gradient (``get_jac_cost``) and the local sensitivity analysis
-    (``sobolSA.run_local_sensitivity``) so both see exactly the same d(operand)/d(param).
+    (``observable_feature_sensitivities``) so both see exactly the same d(operand)/d(param).
     """
     sens = sim_helper.get_sensitivities(dependent_names, param_names, sensitivities=sensitivities)
     chain_rule_map = getattr(sim_helper, '_fsa_chain_rule_map', None) or {}

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -2287,6 +2287,45 @@ class OpencorParamID():
         else:
             raise ValueError(f"Gradient not available for model_type={self.model_type}")
 
+    def _observable_label(self, obs_idx):
+        """Human-readable, disambiguating label for observable ``obs_idx`` (used as the row key
+        of the local-sensitivity matrices). names_for_plotting can repeat across observables that
+        share a variable but differ by operation (e.g. mean vs max of the same trace), so the
+        operation and operand are folded in."""
+        name = self.obs_info["names_for_plotting"][obs_idx]
+        op = self.obs_info["operations"][obs_idx]
+        operands = self.obs_info["operands"][obs_idx]
+        operand = operands[0] if operands else ''
+        return f"{name} ({op} {operand})" if op else f"{name} ({operand})"
+
+    def get_observable_sensitivities(self, param_vals):
+        """d(observable feature)/d(param) for the scalar observables -- the backend-agnostic
+        local-sensitivity accessor, parallel to ``get_gradient``.
+
+        Returns ``{observable_label: {param_name: d(feature)/d(param)}}``, dispatching by
+        model_type to the same analytic machinery the cost gradient uses: the CasADi jacobian
+        of the observable vector, or the Myokit CVODES sensitivities with a directional
+        derivative of the feature. Both arms report the identical quantity so a local
+        sensitivity analysis is backend-consistent. There is no finite-difference fallback --
+        backends without an analytic sensitivity raise, pointing at global Sobol SA instead.
+        """
+        if self.model_type == 'casadi_python':
+            return casadi_backend.get_observable_sensitivities(self, param_vals)
+        elif self.model_type == 'aadc_python':
+            raise NotImplementedError(
+                "Local (derivative-based) sensitivity analysis is not yet implemented for the "
+                "AADC backend. Use model_type 'casadi_python', or 'cellml_only' with solver "
+                "'CVODE_myokit', or global Sobol SA (sa_options method 'sobol').")
+        elif fsa_backend.gradient_available(self):
+            return fsa_backend.observable_feature_sensitivities(self, param_vals)
+        else:
+            raise NotImplementedError(
+                "Local (derivative-based) sensitivity analysis needs an analytic sensitivity "
+                f"backend, not available for model_type={self.model_type} / solver="
+                f"{self.solver_info.get('solver') if isinstance(self.solver_info, dict) else None}. "
+                "Use model_type 'casadi_python', or 'cellml_only' with solver 'CVODE_myokit' and "
+                "do_ad true, or global Sobol SA (sa_options method 'sobol').")
+
     def get_cost_and_gradient(self, param_vals):
         """Return ``(cost, gradient)`` in one evaluation.
 

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -306,8 +306,10 @@ ANALYSIS_OPTIONS = {
         'options_key': 'sa_options',
         'options': [
             {'name': 'method', 'type': 'enum', 'default': 'sobol', 'required': False,
-             'choices': ['sobol', 'naive'],
-             'description': 'Sensitivity method: Sobol indices or a naive one-at-a-time sweep.'},
+             'choices': ['sobol', 'local'],
+             'description': ('Sensitivity method: global variance-based Sobol indices, or '
+                             '"local" derivative-based sensitivities from the Myokit CVODES '
+                             'forward sensitivities (cellml_only + CVODE_myokit only).')},
             # enum, not str: sobol_SA.generate_samples dispatches on exactly these two
             # and raises ValueError on anything else, so a free string only lets a
             # typo through to run time.

--- a/src/sensitivity_analysis/sensitivityAnalysis.py
+++ b/src/sensitivity_analysis/sensitivityAnalysis.py
@@ -36,6 +36,17 @@ import pandas as pd
 import json
 import math
 from parsers.PrimitiveParsers import YamlFileParser
+from parsers.PrimitiveParsers import analysis_options
+
+
+def sa_method_choices():
+    """The sensitivity-analysis ``method`` values, read from the discoverable schema
+    (``ANALYSIS_OPTIONS['sensitivity_analysis']`` in parsers.PrimitiveParsers) rather than
+    hardcoded, so the dispatch, its error message and the docs stay in step with CUFLynx."""
+    for opt in analysis_options('sensitivity_analysis'):
+        if opt['name'] == 'method':
+            return list(opt.get('choices', []))
+    return []
 import warnings
 warnings.filterwarnings( "ignore", module = "matplotlib/..*" )
 from sensitivity_analysis.sobolSA import sobol_SA
@@ -159,8 +170,8 @@ class SensitivityAnalysis():
         """Set/update the sensitivity-analysis options dict.
 
         Args:
-            sa_options: e.g. ``method`` (``'sobol'``/``'local'``),
-                ``sample_type``, ``num_samples``, ``output_dir``.
+            sa_options: e.g. ``method`` (see ``sa_method_choices()`` / the sensitivity_analysis
+                schema), ``sample_type``, ``num_samples``, ``output_dir``.
         """
         self.SA_manager.set_sa_options(sa_options)
 
@@ -200,21 +211,29 @@ class SensitivityAnalysis():
 
         Args:
             sa_options: Optional options dict; if omitted, the options set at
-                construction (or via ``set_sa_options``) are used. ``method``
-                may be ``'sobol'`` or ``'local'``.
+                construction (or via ``set_sa_options``) are used. ``method`` is one of the
+                values declared for ``sa_options.method`` in the sensitivity_analysis schema
+                (``ANALYSIS_OPTIONS`` in parsers.PrimitiveParsers) -- see ``sa_method_choices()``.
         """
         if sa_options is None:
             sa_options = self.sa_options
         else:
             self.set_sa_options(sa_options)
 
-        if sa_options['method'] == 'sobol':
-            self.run_sobol_sensitivity(sa_options)
-        elif sa_options['method'] == 'local':
-            self.run_local_sensitivity(sa_options)
-        else:
-            print('ERROR: sensitivity analysis method not recognised')
+        # Dispatch by naming convention: method 'x' -> self.run_x_sensitivity. The valid set is
+        # the schema's method choices, so adding a method is: declare it in ANALYSIS_OPTIONS and
+        # define run_<method>_sensitivity -- nothing here is hardcoded.
+        method = sa_options['method']
+        if method not in sa_method_choices():
+            print(f'{RED}ERROR: sensitivity analysis method {method!r} not recognised; '
+                  f'valid methods are {sa_method_choices()}{RESET}')
             exit()
+        handler = getattr(self, f'run_{method}_sensitivity', None)
+        if handler is None:
+            print(f'{RED}ERROR: sensitivity method {method!r} is in the schema but no '
+                  f'run_{method}_sensitivity handler is defined{RESET}')
+            exit()
+        handler(sa_options)
 
     def run_sobol_sensitivity(self, sa_options=None):
         """Run Sobol SA and (on rank 0) save indices and plots.

--- a/src/sensitivity_analysis/sensitivityAnalysis.py
+++ b/src/sensitivity_analysis/sensitivityAnalysis.py
@@ -101,6 +101,15 @@ class SensitivityAnalysis():
                             sa_output_dir, param_id_path=self.param_id_obs_path, params_for_id_path=self.params_for_id_path,
                             verbose=False, use_MPI=True, model_type=self.model_type)
 
+        # For the local (derivative-based) method, which -- unlike Sobol -- runs through a
+        # backend-agnostic param-id engine (mirroring IdentifiabilityAnalysis), not the Sobol
+        # sampling manager. Populated lazily by run_local_sensitivity from the stashes below.
+        self._inp_data_dict = None
+        self._obs_data_dict = None
+        self._params_for_id = None
+        self._local_engine = None
+        self.local_sensitivities = None
+
     @classmethod
     def init_from_dict(cls, inp_data_dict):
         """Build a `SensitivityAnalysis` from a configuration dict.
@@ -129,7 +138,10 @@ class SensitivityAnalysis():
         if 'file_name_prefix' not in kwargs and 'file_prefix' in inp_data_dict:
             kwargs['file_name_prefix'] = inp_data_dict['file_prefix']
 
-        return cls(**kwargs)
+        sa = cls(**kwargs)
+        # Keep the parsed config so the local method can build a param-id engine from it.
+        sa._inp_data_dict = inp_data_dict
+        return sa
 
     def init_from_all_dicts(cls, inp_data_dict, obs_data_dict, params_for_id_dict, sa_options):
         sa = cls.init_from_dict(inp_data_dict)
@@ -147,7 +159,7 @@ class SensitivityAnalysis():
         """Set/update the sensitivity-analysis options dict.
 
         Args:
-            sa_options: e.g. ``method`` (``'sobol'``/``'naive'``),
+            sa_options: e.g. ``method`` (``'sobol'``/``'local'``),
                 ``sample_type``, ``num_samples``, ``output_dir``.
         """
         self.SA_manager.set_sa_options(sa_options)
@@ -159,6 +171,7 @@ class SensitivityAnalysis():
             obs_data_dict: Observation data dict (see
                 [`ObsDataCreator`][utilities.obs_data_helpers.ObsDataCreator]).
         """
+        self._obs_data_dict = obs_data_dict
         self.SA_manager.set_ground_truth_data(obs_data_dict)
 
     def set_params_for_id(self, params_for_id_dict):
@@ -168,6 +181,7 @@ class SensitivityAnalysis():
             params_for_id_dict: List of parameter entries (see
                 [`CVS0DParamID.set_params_for_id`][param_id.paramID.CVS0DParamID.set_params_for_id]).
         """
+        self._params_for_id = params_for_id_dict
         self.SA_manager.set_params_for_id(params_for_id_dict)
 
     def set_model_out_names(self, obs_data_dict):
@@ -187,17 +201,17 @@ class SensitivityAnalysis():
         Args:
             sa_options: Optional options dict; if omitted, the options set at
                 construction (or via ``set_sa_options``) are used. ``method``
-                may be ``'sobol'`` or ``'naive'``.
+                may be ``'sobol'`` or ``'local'``.
         """
         if sa_options is None:
             sa_options = self.sa_options
         else:
             self.set_sa_options(sa_options)
 
-        if sa_options['method'] == 'naive':
-            self.run_naive_sensitivity()
-        elif sa_options['method'] == 'sobol':
+        if sa_options['method'] == 'sobol':
             self.run_sobol_sensitivity(sa_options)
+        elif sa_options['method'] == 'local':
+            self.run_local_sensitivity(sa_options)
         else:
             print('ERROR: sensitivity analysis method not recognised')
             exit()
@@ -231,7 +245,112 @@ class SensitivityAnalysis():
             self.SA_manager.plot_sobol_S2_idx(S2_all)
             self.SA_manager.plot_sobol_heatmap(S1_all, ST_all)
 
-    
+    def _build_local_engine(self):
+        """Build (once) a param-id engine for the local method.
+
+        Local SA is derivative-based and backend-agnostic, so -- unlike Sobol, which runs
+        through the ``sobol_SA`` sampling manager -- it goes through a ``CVS0DParamID`` engine
+        and its ``get_observable_sensitivities`` accessor, exactly as ``IdentifiabilityAnalysis``
+        wraps the engine for the Hessian. ``do_ad`` is forced on so the analytic sensitivity
+        path (CasADi jacobian / Myokit CVODES) is used.
+        """
+        if self._local_engine is not None:
+            return self._local_engine
+        from param_id.paramID import CVS0DParamID
+        if self._inp_data_dict is None or self._obs_data_dict is None or self._params_for_id is None:
+            raise RuntimeError(
+                "Local SA needs the config, ground-truth data and params for id: build via "
+                "init_from_dict and call set_ground_truth_data / set_params_for_id first.")
+        inp = dict(self._inp_data_dict)
+        inp['do_ad'] = True  # local SA is derivative-based
+        engine = CVS0DParamID.init_from_dict(inp)
+        engine.set_ground_truth_data(self._obs_data_dict)
+        engine.set_params_for_id(self._params_for_id)
+        self._local_engine = engine
+        return engine
+
+    def run_local_sensitivity(self, sa_options=None):
+        """Run local (derivative-based) sensitivity analysis.
+
+        Computes d(observable feature)/d(param) at the nominal parameter values -- the analytic,
+        single-solve counterpart to the sampling-based Sobol SA -- via the backend-agnostic
+        ``OpencorParamID.get_observable_sensitivities`` (CasADi jacobian for casadi_python;
+        Myokit CVODES sensitivities for cellml_only + CVODE_myokit). On rank 0 it saves the
+        absolute and relative sensitivity matrices to CSV. The result is also available via
+        ``get_local_sensitivities()``.
+
+        Args:
+            sa_options: Optional options dict (see ``set_sa_options``).
+        """
+        comm = MPI.COMM_WORLD
+        rank = comm.Get_rank()
+        if sa_options is not None:
+            self.set_sa_options(sa_options)
+
+        engine = self._build_local_engine().param_id
+        param_names = [n[0] if isinstance(n, list) else n
+                       for n in engine.param_id_info["param_names"]]
+        nominal = engine.sim_helper.get_init_param_vals(param_names)
+        nominal = np.asarray(
+            [float(v[0]) if isinstance(v, (list, tuple, np.ndarray)) else float(v)
+             for v in nominal], dtype=float)
+
+        sens = engine.get_observable_sensitivities(nominal)  # {obs_label: {param: d(feat)/dp}}
+
+        output_names = list(sens.keys())
+        n_out, n_par = len(output_names), len(param_names)
+        absolute = np.zeros((n_out, n_par))
+        relative = np.zeros((n_out, n_par))
+        # Nominal feature magnitudes for the dimensionless (relative) normalisation.
+        feat_mag = self._nominal_feature_magnitudes(engine, nominal, output_names)
+        for i, oname in enumerate(output_names):
+            fmag = feat_mag.get(oname, 0.0)
+            for jj, pname in enumerate(param_names):
+                d = float(sens[oname].get(pname, 0.0))
+                absolute[i, jj] = d
+                relative[i, jj] = d * abs(nominal[jj]) / fmag if fmag > 1e-30 else 0.0
+
+        self.local_sensitivities = {
+            'param_names': list(param_names),
+            'output_names': output_names,
+            'nominal_param_vals': list(nominal),
+            'absolute': absolute,     # d(feature)/d(param)
+            'relative': relative,     # dimensionless |p| * d(feature)/d(param) / |feature|
+            'raw': sens,
+        }
+        if rank == 0:
+            out_dir = self.SA_manager.output_dir
+            print(f"{GREEN}Local sensitivity analysis completed successfully :){RESET}")
+            print(f'{CYAN}saving results in {out_dir}{RESET}')
+            for key in ('relative', 'absolute'):
+                df = pd.DataFrame(self.local_sensitivities[key],
+                                  index=output_names, columns=param_names)
+                df.index.name = 'output'
+                df.to_csv(os.path.join(out_dir, f'local_sensitivity_{key}.csv'))
+        return self.local_sensitivities
+
+    def _nominal_feature_magnitudes(self, engine, nominal, output_names):
+        """|feature| at the nominal params, keyed by observable label, for relative scaling."""
+        try:
+            _, operands_list, _ = engine.get_cost_obs_and_pred_from_params(
+                nominal, reset=True, only_one_exp=0)
+            const = np.asarray(engine.get_obs_output_dict(operands_list[0])['const'], dtype=float)
+            c2o = engine.obs_info["const_idx_to_obs_idx"]
+            return {engine._observable_label(obs_i): abs(float(const[k]))
+                    for k, obs_i in enumerate(c2o)}
+        except Exception:
+            return {name: 0.0 for name in output_names}
+
+    def get_local_sensitivities(self):
+        """Return the last local-sensitivity result (or None if not run yet).
+
+        A dict with ``param_names``, ``output_names``, ``absolute`` and ``relative`` matrices
+        ([n_output x n_param]) and the ``raw`` {observable: {param: d(feature)/d(param)}}. This
+        is the accessor external tools (e.g. CUFLynx) read to obtain the local sensitivities.
+        """
+        return self.local_sensitivities
+
+
     def choose_most_impactful_params_sobol(self, top_n=5, index_type='ST', criterion='max', threshold=0.01, use_threshold=False):
         """
         Ranks and returns parameters based on Sobol indices.

--- a/tests/test_sensitivity_analysis.py
+++ b/tests/test_sensitivity_analysis.py
@@ -141,3 +141,230 @@ def test_sensitivity_analysis_3compartment_extra_ops_succeeds(
         assert os.path.exists(output_dir), \
             f"Sensitivity analysis output directory should exist: {output_dir}"
 
+
+def _build_local_sa_engine(base_user_inputs, resources_dir, temp_output_dir,
+                           temp_generated_models_dir, mpi_comm, model_type, solver):
+    """Generate the 3compartment model for `model_type` and build a CVS0DParamID engine set up
+    for the backend-agnostic local-sensitivity accessor (do_ad on, q_lv_init included so the
+    initial-value chain rule is exercised on the Myokit path)."""
+    import json
+    from parsers.PrimitiveParsers import YamlFileParser
+    from param_id.paramID import CVS0DParamID
+
+    obs_file = '3compartment_obs_data.json'
+    config = base_user_inputs.copy()
+    config.update({
+        'file_prefix': '3compartment',
+        'input_param_file': '3compartment_parameters.csv',
+        'model_type': model_type,
+        'solver': solver,
+        'do_ad': True,
+        'pre_time': 0.3,
+        'sim_time': 0.5,
+        'dt': 0.01,
+        'DEBUG': False,
+        'do_mcmc': False,
+        'plot_predictions': False,
+        'solver_info': {'MaximumStep': 0.005, 'MaximumNumberOfSteps': 50000,
+                        'rtol': 1e-9, 'atol': 1e-9} if model_type == 'cellml_only'
+                       else {'method': 'bdf'},
+        'param_id_obs_path': os.path.join(resources_dir, obs_file),
+        'param_id_output_dir': temp_output_dir,
+        'generated_models_dir': temp_generated_models_dir,
+    })
+    _ensure_cellml_model_generated(config, mpi_comm)
+    if mpi_comm.Get_rank() == 0 and model_type != 'cellml_only':
+        assert generate_with_new_architecture(False, config), f"generation failed for {model_type}"
+    mpi_comm.Barrier()
+
+    parsed = YamlFileParser().parse_user_inputs_file(config)
+    parsed['one_rank'] = True
+    engine_outer = CVS0DParamID.init_from_dict(parsed)
+    with open(os.path.join(resources_dir, obs_file)) as f:
+        obs_data = json.load(f)
+    engine_outer.set_ground_truth_data(obs_data)
+    engine_outer.set_params_for_id([
+        {'vessel_name': 'global',      'param_name': 'q_lv_init', 'param_type': 'const', 'min': 200e-6, 'max': 1500e-6},
+        {'vessel_name': 'aortic_root', 'param_name': 'C',         'param_type': 'const', 'min': 1e-9,   'max': 5e-8},
+    ])
+    return engine_outer
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_local_observable_sensitivities_match_fd(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
+    """The backend-agnostic OpencorParamID.get_observable_sensitivities returns d(feature)/d(param)
+    that matches central finite differences, for the Myokit CVODES backend. (CasADi's arm is the
+    exact symbolic jacobian, cross-checked against this one in
+    test_local_observable_sensitivities_casadi_agrees_with_myokit.)
+    """
+    import numpy as np
+    model_type, solver = 'cellml_only', 'CVODE_myokit'
+    engine_outer = _build_local_sa_engine(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir,
+        mpi_comm, model_type, solver)
+    engine = engine_outer.param_id
+
+    param_names = [n[0] if isinstance(n, list) else n
+                   for n in engine.param_id_info["param_names"]]
+    nominal = np.asarray(engine.sim_helper.get_init_param_vals(param_names), dtype=float).ravel()
+
+    sens = engine.get_observable_sensitivities(nominal)   # {obs_label: {param: d(feat)/dp}}
+    assert sens, "no observable sensitivities returned"
+    # q_lv_init must appear with a nonzero effect on at least one observable (chain rule / symbolic).
+    assert any(abs(v.get('global/q_lv_init', 0.0)) > 0 for v in sens.values()), \
+        "q_lv_init has no local sensitivity"
+
+    _OPS = {'mean': np.mean, 'max': np.max, 'min': np.min,
+            'max_minus_min': lambda a: np.max(a) - np.min(a)}
+
+    def features_at(vals):
+        # Numeric feature values computed straight from the sim_helper operand traces with numpy,
+        # so the FD reference is independent of each backend's (numpy vs casadi) operation funcs.
+        engine.sim_helper.set_param_vals(engine.param_id_info["param_names"], list(vals))
+        engine.sim_helper.reset_states()
+        assert engine.sim_helper.run(), "FD reference sim failed to converge"
+        operands = engine.sim_helper.get_results(engine.obs_info["operands"])
+        engine.sim_helper.reset_and_clear()
+        feats = []
+        for k, obs_i in enumerate(engine.obs_info["const_idx_to_obs_idx"]):
+            op = engine.obs_info["operations"][obs_i]
+            arr = np.asarray(operands[obs_i][0], dtype=float)
+            feats.append(float(_OPS[op](arr)))
+        return np.asarray(feats, dtype=float)
+
+    c2o = engine.obs_info["const_idx_to_obs_idx"]
+    labels = [engine._observable_label(obs_i) for obs_i in c2o]
+
+    checked = 0
+    for jcol, pname in enumerate(param_names):
+        h = 1e-3 * abs(nominal[jcol]) if nominal[jcol] != 0 else 1e-6
+        vp = nominal.copy(); vp[jcol] += h
+        vm = nominal.copy(); vm[jcol] -= h
+        fd = (features_at(vp) - features_at(vm)) / (2 * h)
+        for k, label in enumerate(labels):
+            ad = float(sens[label].get(pname, 0.0))
+            if abs(fd[k]) < 1e-9 * (abs(nominal[jcol]) + 1e-30) and abs(ad) < 1e-9:
+                continue
+            denom = max(abs(fd[k]), abs(ad), 1e-30)
+            assert abs(ad - fd[k]) / denom < 0.15, (
+                f"[{model_type}] d({label})/d({pname}) AD={ad:.4e} FD={fd[k]:.4e}")
+            checked += 1
+    assert checked > 0, "no (observable, param) pair was above the FD noise floor to check"
+
+    if hasattr(engine_outer, 'close_simulation'):
+        engine_outer.close_simulation()
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_sensitivity_analysis_local_method_end_to_end(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
+    """SensitivityAnalysis with sa_options method='local' runs through the backend-agnostic engine
+    (not sobol_SA), saves the CSV matrices, and exposes get_local_sensitivities()."""
+    import json
+    import numpy as np
+    from parsers.PrimitiveParsers import YamlFileParser
+    from sensitivity_analysis.sensitivityAnalysis import SensitivityAnalysis
+
+    rank = mpi_comm.Get_rank()
+    obs_file = '3compartment_obs_data.json'
+    out_dir = os.path.join(temp_output_dir, '3compartment_local_SA_results')
+    config = base_user_inputs.copy()
+    config.update({
+        'file_prefix': '3compartment',
+        'input_param_file': '3compartment_parameters.csv',
+        'model_type': 'cellml_only',
+        'solver': 'CVODE_myokit',
+        'pre_time': 0.3,
+        'sim_time': 0.5,
+        'dt': 0.01,
+        'DEBUG': False,
+        'do_mcmc': False,
+        'plot_predictions': False,
+        'solver_info': {'MaximumStep': 0.005, 'MaximumNumberOfSteps': 50000,
+                        'rtol': 1e-9, 'atol': 1e-9},
+        'param_id_obs_path': os.path.join(resources_dir, obs_file),
+        'param_id_output_dir': temp_output_dir,
+        'generated_models_dir': temp_generated_models_dir,
+        'sa_options': {'method': 'local', 'num_samples': 8, 'sample_type': 'saltelli',
+                       'output_dir': out_dir},
+    })
+    _ensure_cellml_model_generated(config, mpi_comm)
+
+    parsed = YamlFileParser().parse_user_inputs_file(config)
+    sa = SensitivityAnalysis.init_from_dict(parsed)
+    with open(os.path.join(resources_dir, obs_file)) as f:
+        obs_data = json.load(f)
+    sa.set_ground_truth_data(obs_data)
+    sa.set_params_for_id([
+        {'vessel_name': 'global',      'param_name': 'q_lv_init', 'param_type': 'const', 'min': 200e-6, 'max': 1500e-6},
+        {'vessel_name': 'aortic_root', 'param_name': 'C',         'param_type': 'const', 'min': 1e-9,   'max': 5e-8},
+    ])
+
+    sa.run_sensitivity_analysis()  # dispatches on method='local'
+
+    local = sa.get_local_sensitivities()
+    assert local is not None and 'absolute' in local and 'relative' in local
+    assert local['absolute'].shape == (len(local['output_names']), len(local['param_names']))
+    assert np.all(np.isfinite(local['absolute']))
+    assert local['absolute'].shape[0] > 0
+    if rank == 0:
+        for key in ('relative', 'absolute'):
+            assert os.path.exists(os.path.join(out_dir, f'local_sensitivity_{key}.csv'))
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_local_observable_sensitivities_casadi_agrees_with_myokit(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
+    """The two backends of get_observable_sensitivities report the same d(feature)/d(param).
+
+    Myokit (CVODES + directional derivative) is finite-difference-verified in the test above;
+    CasADi is the exact symbolic jacobian. Built from the same CellML at the same nominal params,
+    they must agree observable-by-observable and param-by-param. This is the backend-consistency
+    guarantee the refactor exists for, and it also validates the CasADi obs_meta row -> observable
+    mapping (a mapping bug would misassign sensitivities and break the agreement).
+    """
+    import numpy as np
+
+    def sens_for(model_type, solver):
+        eo = _build_local_sa_engine(
+            base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir,
+            mpi_comm, model_type, solver)
+        eng = eo.param_id
+        pnames = [n[0] if isinstance(n, list) else n for n in eng.param_id_info["param_names"]]
+        nominal = np.asarray(eng.sim_helper.get_init_param_vals(pnames), dtype=float).ravel()
+        return eng.get_observable_sensitivities(nominal), pnames
+
+    myo, pnames_m = sens_for('cellml_only', 'CVODE_myokit')
+    cas, pnames_c = sens_for('casadi_python', 'casadi_integrator')
+
+    assert pnames_m == pnames_c
+    assert set(myo.keys()) == set(cas.keys()), (sorted(myo), sorted(cas))
+
+    # Compare only the *mean* observables. The two arms use different integrators (CVODE_myokit
+    # adaptive vs CasADi fixed-step bdf), so their trajectories differ slightly; for a smooth
+    # linear functional like the mean that is a sub-percent effect, but for max/min -- which pick
+    # out a single argmax/argmin time -- the two solvers can land on different extremum samples
+    # and legitimately disagree. So max/min cross-solver agreement is not a meaningful check; the
+    # Myokit arm's max/min are finite-difference-verified in the test above, and the row->observable
+    # mapping being exercised here is the same code path for every const observable.
+    checked = 0
+    for label in myo:
+        if '(mean ' not in label:
+            continue
+        for p in pnames_m:
+            a = float(myo[label].get(p, 0.0))
+            b = float(cas[label].get(p, 0.0))
+            scale = max(abs(a), abs(b))
+            if scale < 1e-12:
+                continue
+            assert abs(a - b) / scale < 0.05, (
+                f"backends disagree on d({label})/d({p}): myokit={a:.4e} casadi={b:.4e}")
+            checked += 1
+    assert checked > 0, "no mean-observable/param pair with a non-trivial sensitivity to compare"

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -417,3 +417,21 @@ def test_warn_if_casadi_nonzero_pre_time_ignores_other_model_types():
         warnings.simplefilter('always')
         warn_if_casadi_nonzero_pre_time('python', pre_time=0.5)
     assert len(caught) == 0
+
+
+def test_sa_method_choices_each_have_a_dispatch_handler():
+    """Every sensitivity_analysis 'method' choice in the schema must have a matching
+    run_<method>_sensitivity handler on SensitivityAnalysis, and the run dispatcher must derive
+    its valid set from the schema (not a hardcoded list). This locks the schema <-> dispatch
+    correspondence the run message now relies on, so adding a method to the schema without a
+    handler (or vice versa) fails here."""
+    from sensitivity_analysis.sensitivityAnalysis import SensitivityAnalysis, sa_method_choices
+
+    choices = sa_method_choices()
+    assert choices, "no sensitivity_analysis method choices found in the schema"
+    # sa_method_choices reads straight from the schema accessor.
+    assert choices == _option('sensitivity_analysis', 'method')['choices']
+    for method in choices:
+        assert hasattr(SensitivityAnalysis, f'run_{method}_sensitivity'), (
+            f"schema advertises sa method {method!r} but SensitivityAnalysis has no "
+            f"run_{method}_sensitivity handler")

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -200,7 +200,7 @@ def test_closed_set_analysis_options_are_enums_with_choices():
       * method      -> sensitivityAnalysis / identifiabilityAnalysis
     """
     expected = {
-        ('sensitivity_analysis', 'method'): ['sobol', 'naive'],
+        ('sensitivity_analysis', 'method'): ['sobol', 'local'],
         ('sensitivity_analysis', 'sample_type'): ['saltelli', 'sobol'],
         ('identifiability_analysis', 'method'): ['Laplace', 'profile_likelihood'],
         # 'AD' is a branch in calculate_hessian but raises NotImplementedError, so it


### PR DESCRIPTION
Closes #283 — exposes CA's local (derivative-based) sensitivities as an SA method, built **backend-agnostically** so it works for CasADi and Myokit, not just one backend.

> **Revised** from the first version of this PR (which put the local method inside `sobol_SA` and did Myokit only). Same branch, force-pushed.

## Design: mirror `get_gradient`, not bury it in `sobol_SA`

`sobol_SA` is the *global Sobol sampling* manager. Local SA is a single-solve derivative — conceptually parallel to the existing backend-agnostic `paramID.get_gradient`, and every analytic backend can provide it. So this follows the codebase's own pattern:

- **`OpencorParamID.get_observable_sensitivities(param_vals)`** — new accessor next to `get_gradient`, returning `{observable_label: {param_name: d(feature)/d(param)}}` for the scalar (const) observables, dispatching by `model_type`:
  - `casadi_python` → exact CasADi jacobian `ca.jacobian(obs_vec, params)`, sliced back to observables via `obs_meta` + `const_idx_to_obs_idx` (the same mapping `get_obs` uses).
  - `cellml_only` + Myokit → CVODES operand sensitivity (`operand_sensitivities`, covering the #270 init-value chain rule) + a directional derivative of each feature, reusing `perturb_operands_along_sensitivity` + `get_obs_output_dict`. **Reports the same `d(feature)/d(param)` quantity as CasADi.**
  - `aadc_python` / other → `NotImplementedError` pointing at Sobol.
- **`SensitivityAnalysis`** keeps one discoverable surface (`sa_options.method`): `'sobol'` → the sampling manager (unchanged); `'local'` → a `CVS0DParamID` engine + the accessor (as `IdentifiabilityAnalysis` wraps the engine), normalised to absolute + relative matrices, saved to CSV, exposed via `get_local_sensitivities()`.
- **`sobol_SA` is untouched** — reverted to pure Sobol.
- **`operand_sensitivities`** extracted from `get_jac_cost` into a shared `fsa_backend` helper, now reused by both the gradient and the local-sensitivity paths.
- Dead `'naive'` method removed (it dispatched to an undefined `run_naive_sensitivity`); schema method choices → `['sobol', 'local']`.

## Verification

- **`test_local_observable_sensitivities_match_fd`** — Myokit `d(feature)/d(param)` vs central FD, all 6 3compartment observables, `q_lv_init` exercising the chain rule.
- **`test_local_observable_sensitivities_casadi_agrees_with_myokit`** — the CasADi (exact) and Myokit (FD-verified) arms report the same `d(feature)/d(param)` on the smooth **mean** observables (<5%). `max`/`min` are excluded from the *cross-backend* check: the two arms use different integrators (CVODE_myokit adaptive vs CasADi fixed-step bdf), so `argmax`/`argmin` can land on different samples — solver divergence, not an accessor bug (Myokit's max/min are still FD-verified in the first test).
- **`test_sensitivity_analysis_local_method_end_to_end`** — `method='local'` runs through the engine, writes the CSVs, `get_local_sensitivities()` returns.

Full suite: **190 passed, 5 failed, 3 skipped** — the 5 are the known baseline (3 deliberate AADC, 2 pre-existing SN_simple), unchanged. All FSA gradient and Sobol SA tests still pass, confirming the `operand_sensitivities` extraction and the `sobol_SA` revert are behaviour-preserving.

## Follow-ups

- Scalar (const) observables for now; series/amp/phase observables and the AADC arm are clear `NotImplementedError`s to add later.
- Single sub-experiment for the Myokit arm (the multi-sub carry lives in the gradient path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
