### PR TITLE
WIP (do not merge): calisim as an optional calibration backend (#288)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,13 @@ dev = [
     "flake8>=4.0.0",
     "mypy>=0.950",
 ]
+# The calisim calibration backends (param_id/calisim_wrapper.py, param_id_method: calisim_*).
+# Optional: CA imports and runs without it, and only a calisim_* method needs it.
+# NOTE calisim 1.0.0 pins numpy<2 and scipy<1.12 and requires python >=3.10,<3.13, so it cannot
+# currently be installed alongside a numpy 2.x environment. See issue #288.
+calisim = [
+    "calisim>=1.0.0",
+]
 docs = [
     "mkdocs-material>=9.0",
     "mkdocstrings[python]>=0.24",

--- a/src/param_id/calisim_methods.py
+++ b/src/param_id/calisim_methods.py
@@ -1,0 +1,196 @@
+"""Discoverable schema for the calisim calibration backends.
+
+calisim (https://github.com/Plant-Food-Research-Open/calisim) is a unified interface over many
+optimisation libraries. Rather than hand-writing one `Optimiser` subclass per library, CA wraps
+calisim once (see `param_id/calisim_wrapper.py`) and exposes every calisim optimisation
+engine/method pair as a `param_id_method` named ``calisim_<engine>[_<method>]``.
+
+This module is the *schema* half of that: it builds the PARAM_ID_METHODS entries for those
+methods so downstream tools (CUFLynx) pick them up automatically, without hardcoding a list on
+the GUI side. It deliberately imports nothing from CA (PrimitiveParsers imports it, so any CA
+import here would be circular) and nothing from calisim at module scope -- calisim is an
+*optional* dependency and CA must import and run exactly as before without it.
+
+Discovery is static-table-first, then extended from the installed calisim:
+
+* the static table below is always exposed, so the CUFLynx menu is the same on a machine that has
+  not installed calisim yet as on one that has;
+* if calisim *is* installed, any extra optimisation engine registered with it (including
+  third-party ones registered through the ``calisim.external.optimisation`` entry-point group) is
+  added, and OpenTURNS' Pagmo algorithm list -- which is only knowable at run time -- is queried
+  and added.
+
+Keep the option descriptors in sync with what `CalisimOptimiser` actually reads from
+`optimiser_options`; `tests/test_solver_info_validation.py` fails the build if they drift.
+"""
+
+import re
+
+# calisim's optimisation module. `method` selects the sampler/algorithm within an engine; for
+# emukit and botorch the wrapper ignores `method` entirely (control is via acquisition_func /
+# Ax's own generation strategy), so those engines get a single, method-less CA entry.
+CALISIM_TASK = 'optimisation'
+
+_CALISIM_ENGINE_METHODS = {
+    # engine: (methods, needs_acquisition_func, description)
+    'optuna': (
+        # The samplers calisim's optuna wrapper accepts (its `supported_samplers` dict).
+        ['tpes', 'cmaes', 'nsga', 'qmc', 'gp'],
+        False,
+        'Optuna sampler',
+    ),
+    'openturns': (
+        # 'kriging' is OpenTURNS' EGO; the rest are Pagmo algorithms. The authoritative list comes
+        # from ot.Pagmo.GetAlgorithmNames() at run time (see _discover_openturns_methods); these
+        # are the ones present in every OpenTURNS we know of, listed so the menu is populated even
+        # without calisim/openturns installed.
+        ['kriging', 'de', 'sade', 'de1220', 'pso', 'sga', 'cmaes', 'xnes'],
+        False,
+        'OpenTURNS EGO / Pagmo algorithm',
+    ),
+    'emukit': (
+        [],
+        True,
+        'Emukit Bayesian optimisation (the method is selected by acquisition_func)',
+    ),
+    'botorch': (
+        [],
+        True,
+        'BoTorch/Ax Bayesian optimisation (requires the calisim [torch] extra)',
+    ),
+}
+
+
+# ---------------------------------------------------------------------------------------------
+# optimiser_options descriptors. Every name here MUST be read by CalisimOptimiser.
+# ---------------------------------------------------------------------------------------------
+_CALISIM_COMMON_OPTIONS = [
+    {'name': 'num_calls_to_function', 'type': 'int', 'default': 100, 'required': False,
+     'description': 'Evaluation budget: number of calisim iterations (cost-function calls).'},
+    {'name': 'cost_convergence', 'type': 'float', 'default': 1e-4, 'required': False,
+     'description': 'Stop once the cost drops below this value.'},
+    {'name': 'n_init', 'type': 'int', 'default': 10, 'required': False,
+     'description': ('Number of initial (design-of-experiment) evaluations before the algorithm '
+                     'proper takes over. Used by the surrogate-based engines (emukit, botorch, '
+                     'openturns); optuna samplers take their start-up count through '
+                     'method_kwargs instead. For the openturns/Pagmo algorithms this is the '
+                     'population size, and they impose algorithm-specific minima (differential '
+                     'evolution needs at least 5).')},
+    {'name': 'random_seed', 'type': 'int', 'default': 0, 'required': False,
+     'description': 'Seed for reproducible runs (passed to the sampler for the optuna engine).'},
+    {'name': 'n_jobs', 'type': 'int', 'default': 1, 'required': False,
+     'description': 'Number of parallel workers calisim itself may use within one MPI rank.'},
+    {'name': 'method_kwargs', 'type': 'dict', 'default': None, 'required': False,
+     'description': ('Extra keyword arguments passed straight through to the calisim '
+                     'sampler/algorithm constructor, e.g. {"n_startup_trials": 20}.')},
+]
+
+_CALISIM_ACQUISITION_OPTION = {
+    'name': 'acquisition_func', 'type': 'enum', 'default': 'ei', 'required': False,
+    'choices': ['ei', 'poi', 'lp', 'nlcb'],
+    'description': ('Acquisition function for the surrogate-based engines (expected improvement, '
+                    'probability of improvement, local penalisation, negative lower confidence '
+                    'bound).'),
+}
+
+
+def calisim_method_name(engine, method=None):
+    """The `param_id_method` string for a calisim engine/method pair."""
+    if method:
+        return f'calisim_{engine}_{method}'
+    return f'calisim_{engine}'
+
+
+def split_calisim_method_name(param_id_method):
+    """Inverse of `calisim_method_name`: ``calisim_optuna_tpes`` -> ``('optuna', 'tpes')``.
+
+    Returns ``(engine, method)`` with ``method == ''`` for the method-less engines. Raises
+    ValueError if the string is not a calisim method name.
+    """
+    if not is_calisim_method(param_id_method):
+        raise ValueError(f"'{param_id_method}' is not a calisim param_id_method")
+    remainder = param_id_method[len('calisim_'):]
+    if not remainder:
+        raise ValueError("calisim param_id_method must name an engine, e.g. 'calisim_optuna_tpes'")
+    engine, _, method = remainder.partition('_')
+    return engine, method
+
+
+def is_calisim_method(param_id_method):
+    """True if `param_id_method` selects a calisim backend."""
+    return isinstance(param_id_method, str) and param_id_method.startswith('calisim_')
+
+
+def _discover_openturns_methods():
+    """Pagmo algorithm names, which only the installed OpenTURNS knows. Empty if unavailable."""
+    try:
+        import openturns as ot
+        return [str(name) for name in ot.Pagmo.GetAlgorithmNames()]
+    except Exception:
+        return []
+
+
+def _discover_calisim_engines():
+    """Optimisation engines registered with the *installed* calisim, if any.
+
+    Covers engines added since this file was written and third-party ones registered through the
+    ``calisim.external.optimisation`` entry-point group. Returns an empty list when calisim is not
+    installed or its registry cannot be read -- discovery must never break CA's import.
+    """
+    try:
+        # Module-level helper in calisim: BASE_IMPLEMENTATIONS merged with whatever is registered
+        # under the `calisim.external.optimisation` entry-point group. Keyed by engine name.
+        from calisim.optimisation.implementation import get_implementations
+        return [str(engine) for engine in get_implementations()]
+    except Exception:
+        return []
+
+
+def _method_entry(engine, method, needs_acquisition_func, engine_description):
+    label_method = method.replace('_', ' ') if method else 'default'
+    options = list(_CALISIM_COMMON_OPTIONS)
+    if needs_acquisition_func:
+        options = options + [_CALISIM_ACQUISITION_OPTION]
+    return {
+        'label': f'calisim: {engine} / {label_method}',
+        'gradient_based': False,
+        'description': (f'Gradient-free calibration through calisim using the {engine} engine '
+                        f'({engine_description}'
+                        + (f", method '{method}'" if method else '') + '). '
+                        'Requires the optional `calisim` package.'),
+        'options': options,
+        'calisim': {'engine': engine, 'method': method},
+    }
+
+
+def calisim_param_id_methods():
+    """The PARAM_ID_METHODS entries for every available calisim optimisation engine/method.
+
+    Merged into PARAM_ID_METHODS by `parsers.PrimitiveParsers` so CUFLynx auto-populates its
+    calibration-method menu and the per-method settings form with no hardcoding.
+    """
+    engine_methods = {engine: (list(methods), acq, desc)
+                      for engine, (methods, acq, desc) in _CALISIM_ENGINE_METHODS.items()}
+
+    # Extend the static table with whatever the installed calisim/openturns actually offer.
+    for name in _discover_openturns_methods():
+        methods, acq, desc = engine_methods['openturns']
+        if name not in methods:
+            methods.append(name)
+    for engine in _discover_calisim_engines():
+        engine_methods.setdefault(engine, ([], False, 'engine discovered from installed calisim'))
+
+    methods_schema = {}
+    for engine, (methods, acq, desc) in engine_methods.items():
+        if not methods:
+            methods_schema[calisim_method_name(engine)] = _method_entry(engine, '', acq, desc)
+            continue
+        for method in methods:
+            if not re.fullmatch(r'[A-Za-z0-9_]+', str(method)):
+                # `calisim_<engine>_<method>` is split back apart on the first underscore, so an
+                # underscore inside the method name is fine (engine names have none) but anything
+                # else would not round-trip. Skip rather than register an unparseable name.
+                continue
+            methods_schema[calisim_method_name(engine, method)] = _method_entry(
+                engine, method, acq, desc)
+    return methods_schema

--- a/src/param_id/calisim_wrapper.py
+++ b/src/param_id/calisim_wrapper.py
@@ -1,0 +1,270 @@
+"""calisim as a calibration backend for circulatory_autogen.
+
+calisim (https://github.com/Plant-Food-Research-Open/calisim) wraps many optimisation libraries
+(optuna, emukit, openturns, botorch, ...) behind one `specify() / execute() / analyze()`
+interface. `CalisimOptimiser` plugs that interface into CA's existing `Optimiser` contract, so
+every calisim optimisation engine becomes usable as a `param_id_method` without writing a new
+optimiser loop per library. The available engine/method pairs are surfaced to CUFLynx by
+`param_id/calisim_methods.py`.
+
+How CA's inputs become calisim inputs (deliberately thin -- no new user input files):
+
+* `{prefix}_params_for_id.csv` is already parsed into `param_id_info` (`param_names`,
+  `param_mins`, `param_maxs`). Each calibrated parameter becomes one calisim `DistributionModel`
+  with a uniform distribution over ``[min, max]``, i.e. calisim samples in *real* (un-normalised)
+  parameter space, in the same order as `param_id_info['param_names']`.
+* `{prefix}_obs_data.json` is *not* re-parsed here. calisim's `calibration_func` is a thin adapter
+  over `OpencorParamID.get_cost_from_params()`, so the observation weights, protocols,
+  multi-experiment setup, cost type and any user-defined operations all keep working exactly as
+  they do for the built-in optimisers.
+
+How calisim's outputs become CA's outputs: the best (cost, params) pair is tracked inside the
+objective rather than read back from the engine, which is both engine-independent and immune to
+calisim's `analyze()` step being optional/absent. The usual CA artefacts are written --
+`best_cost.npy`, `best_param_vals.npy`, and the `best_cost_history.csv` /
+`best_param_vals_history.csv` progress files in the same format as the other optimisers -- so
+plotting, `simulate_with_best_param_vals()` and everything downstream is unchanged. Whatever
+calisim itself emits (trial CSVs, plots) lands in a `calisim/` subdirectory of the output dir.
+
+MPI: calisim owns its optimisation loop and evaluates one parameter set at a time, so this first
+implementation runs the loop on rank 0 and leaves the other ranks idle, exactly like
+`sp_minimize`. Rank-0 failures are broadcast so no rank is left waiting.
+"""
+
+import os
+import re
+import traceback
+
+import numpy as np
+
+from param_id.calisim_methods import split_calisim_method_name
+from param_id.optimisers import Optimiser
+
+try:
+    import calisim  # noqa: F401
+    CALISIM_AVAILABLE = True
+except ImportError:
+    CALISIM_AVAILABLE = False
+
+# Cost returned to calisim when a simulation fails. The built-in optimisers hand np.inf straight
+# to their samplers, but optuna/botorch surrogates fit a model through the returned values and a
+# non-finite one poisons that fit, so failures are reported as a large finite penalty instead.
+FAILED_SIMULATION_COST = 1e10
+
+
+class CalisimOptimiser(Optimiser):
+    """Run any calisim optimisation engine against CA's cost function."""
+
+    def __init__(self, param_id_obj, param_id_info, param_norm_obj, num_params, output_dir,
+                 optimiser_options=None, param_id_method=None, DEBUG=False):
+        super().__init__(param_id_obj, param_id_info, param_norm_obj, num_params, output_dir,
+                         optimiser_options=optimiser_options, DEBUG=DEBUG)
+
+        self.engine, self.method = split_calisim_method_name(param_id_method)
+
+        self.param_mins = np.asarray(param_id_info['param_mins'], dtype=float)
+        self.param_maxs = np.asarray(param_id_info['param_maxs'], dtype=float)
+
+        opts = self.optimiser_options
+        self.num_calls_to_function = int(opts.get('num_calls_to_function', 100))
+        if self.DEBUG:
+            # Keep a debug run short even if the user left a production budget in place.
+            self.num_calls_to_function = min(self.num_calls_to_function, 20)
+        self.n_init = int(opts.get('n_init', 10))
+        self.random_seed = opts.get('random_seed', 0)
+        self.n_jobs = int(opts.get('n_jobs', 1))
+        self.method_kwargs = opts.get('method_kwargs', None) or {}
+        self.acquisition_func = opts.get('acquisition_func', 'ei')
+        self.cost_convergence = opts.get('cost_convergence', 1e-4)
+
+        # An initial design bigger than the whole budget makes the engines either error or spend
+        # the entire run sampling at random, so clamp it.
+        self.n_init = max(1, min(self.n_init, max(1, self.num_calls_to_function // 2)))
+
+        self.calisim_param_names = self._make_calisim_param_names()
+        self.num_evaluations = 0
+        self._stopped_early = False
+
+    # -------------------------------------------------------------------------------------
+    # CA <-> calisim translation
+    # -------------------------------------------------------------------------------------
+    def _make_calisim_param_names(self):
+        """One calisim-safe, unique name per calibrated parameter, in param_id_info order.
+
+        CA parameter names are ``component/variable`` (and one calibrated parameter may be shared
+        by several components), which is not usable as a calisim/optuna parameter key, so they are
+        sanitised and index-prefixed to guarantee uniqueness while staying readable in calisim's
+        own trial output.
+        """
+        names = []
+        for idx, name_or_list in enumerate(self.param_id_info['param_names']):
+            name = name_or_list[0] if isinstance(name_or_list, (list, tuple)) else name_or_list
+            safe = re.sub(r'[^0-9a-zA-Z_]', '_', str(name))[:60]
+            names.append(f'p{idx}_{safe}')
+        return names
+
+    def _parameter_spec(self):
+        """`param_id_info` bounds -> a calisim ParameterSpecification (uniform over [min, max])."""
+        from calisim.data_model import (DistributionModel, ParameterDataType,
+                                        ParameterSpecification)
+
+        parameters = []
+        for idx, name in enumerate(self.calisim_param_names):
+            lower = float(self.param_mins[idx])
+            upper = float(self.param_maxs[idx])
+            parameters.append(DistributionModel(
+                name=name,
+                distribution_name='uniform',
+                distribution_args=[lower, upper],
+                data_type=ParameterDataType.CONTINUOUS,
+            ))
+        return ParameterSpecification(parameters=parameters)
+
+    def _params_dict_to_array(self, parameters):
+        """calisim's ``{name: value}`` -> CA's ordered parameter vector (real space)."""
+        return np.array([float(parameters[name]) for name in self.calisim_param_names])
+
+    def _evaluate(self, parameters):
+        """Evaluate one calisim parameter dict with CA's cost function."""
+        if self._stopped_early or self.num_evaluations >= self.num_calls_to_function:
+            # calisim owns the loop and some engines overshoot n_iterations (initial designs,
+            # batched asks). Once the budget is spent, or the cost has converged, stop simulating
+            # and hand back the incumbent so the remaining asks cost nothing.
+            self._stopped_early = True
+            return float(min(self.best_cost, FAILED_SIMULATION_COST))
+
+        param_vals = self._params_dict_to_array(parameters)
+        cost = self.param_id_obj.get_cost_from_params(param_vals)
+        self.num_evaluations += 1
+
+        if cost is None or not np.isfinite(cost):
+            return FAILED_SIMULATION_COST
+
+        cost = float(cost)
+        if cost < self.best_cost:
+            self.best_cost = cost
+            self.best_param_vals = param_vals
+            self._save_best_params()
+        self._write_history()
+
+        if self.best_cost < self.cost_convergence:
+            print(f'[calisim] cost {self.best_cost:.6e} is below cost_convergence='
+                  f'{self.cost_convergence}; stopping early.')
+            self._stopped_early = True
+        return cost
+
+    def _calibration_func(self, parameters, simulation_id, observed_data, **kwargs):
+        """The function calisim calls. Returns the CA cost (a scalar loss to minimise).
+
+        calisim passes a list of parameter dicts instead of one when a vectorised engine runs with
+        `batched=True`; that is handled so a future switch to batched engines does not silently
+        break.
+        """
+        if isinstance(parameters, (list, tuple)):
+            return [self._evaluate(one) for one in parameters]
+        return self._evaluate(parameters)
+
+    def _write_history(self):
+        """Append to the same progress files the other optimisers write, so the existing plotting
+        (plot_param_id) works unchanged: one best-cost per row, and the best params normalised."""
+        if self.output_dir is None or self.best_param_vals is None:
+            return
+        with open(os.path.join(self.output_dir, 'best_cost_history.csv'), 'a') as file:
+            np.savetxt(file, np.array([[self.best_cost]]), fmt='%1.9f', delimiter=', ')
+        best_norm = self.param_norm_obj.normalise(np.asarray(self.best_param_vals).reshape(-1, 1))
+        with open(os.path.join(self.output_dir, 'best_param_vals_history.csv'), 'a') as file:
+            np.savetxt(file, np.asarray(best_norm).reshape(1, -1), fmt='%.5e', delimiter=', ')
+
+    # -------------------------------------------------------------------------------------
+    # run
+    # -------------------------------------------------------------------------------------
+    def _build_calibrator(self):
+        from calisim.optimisation import OptimisationMethod, OptimisationMethodModel
+
+        calisim_outdir = os.path.join(self.output_dir, 'calisim')
+        os.makedirs(calisim_outdir, exist_ok=True)
+
+        method_kwargs = dict(self.method_kwargs)
+        if self.engine == 'optuna' and self.random_seed is not None:
+            # calisim's optuna wrapper passes method_kwargs to the sampler constructor and never
+            # looks at specification.random_seed, so seed the sampler here to make the run
+            # reproducible. An explicit user seed in method_kwargs still wins.
+            method_kwargs.setdefault('seed', int(self.random_seed))
+
+        specification = OptimisationMethodModel(
+            experiment_name=f'CA_{self.engine}_{self.method or "default"}',
+            parameter_spec=self._parameter_spec(),
+            observed_data=None,
+            outdir=calisim_outdir,
+            method=self.method,
+            directions=['minimize'],
+            output_labels=['cost'],
+            n_iterations=self.num_calls_to_function,
+            n_init=self.n_init,
+            n_jobs=self.n_jobs,
+            random_seed=self.random_seed,
+            acquisition_func=self.acquisition_func,
+            method_kwargs=method_kwargs,
+        )
+        return OptimisationMethod(calibration_func=self._calibration_func,
+                                  specification=specification, engine=self.engine)
+
+    def _run_on_rank_0(self):
+        print(f'Running calisim optimisation: engine={self.engine!r}, '
+              f'method={self.method or "<engine default>"!r}')
+        print(f'  Budget: {self.num_calls_to_function} cost-function calls, '
+              f'n_init={self.n_init}, seed={self.random_seed}')
+
+        calibrator = self._build_calibrator()
+        calibrator.specify().execute()
+
+        # analyze() is what writes calisim's own plots/CSV artefacts. It is decorative for CA (the
+        # best point is tracked in the objective), and it pulls in plotting backends, so a failure
+        # here must not lose a completed calibration.
+        try:
+            calibrator.analyze()
+            artifacts = calibrator.get_artifacts()
+            if artifacts:
+                print('[calisim] artifacts:\n  ' + '\n  '.join(str(a) for a in artifacts))
+        except Exception as analyze_error:
+            print(f'[calisim] WARNING: analyze() failed ({analyze_error}); the calibration result '
+                  'is unaffected, only calisim\'s own plots/tables were not written.')
+
+        if self.best_param_vals is None:
+            raise RuntimeError(
+                f'calisim engine {self.engine!r} finished without a successful simulation; every '
+                'cost evaluation failed. Check the parameter bounds and the model setup.')
+
+    def run(self):
+        if not CALISIM_AVAILABLE:
+            raise ImportError(
+                'The calisim package is required for the calisim_* param_id_methods but is not '
+                'installed. Install it with `pip install calisim` (the botorch engine also needs '
+                'the `calisim[torch]` extra). Note calisim requires python >=3.10,<3.13.')
+
+        comm = self.comm
+        if self.rank == 0 and self.num_procs > 1:
+            print(f'WARNING calisim drives its own optimisation loop, so it runs on rank 0 only; '
+                  f'the other {self.num_procs - 1} rank(s) will be idle.')
+
+        error = None
+        if self.rank == 0:
+            try:
+                self._run_on_rank_0()
+            except Exception:
+                error = traceback.format_exc()
+
+        error = comm.bcast(error, root=0)
+        if error is not None:
+            raise RuntimeError(f'calisim optimisation failed on rank 0:\n{error}')
+
+        self.best_param_vals, self.best_cost = comm.bcast(
+            (self.best_param_vals, self.best_cost), root=0)
+        self._save_best_params()
+
+        if hasattr(self.param_id_obj, 'set_best_param_vals'):
+            self.param_id_obj.set_best_param_vals(self.best_param_vals)
+
+        if self.rank == 0:
+            print(f'calisim optimisation finished after {self.num_evaluations} cost evaluations; '
+                  f'best cost {self.best_cost}')

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -66,6 +66,7 @@ from param_id.differentiable import (
     is_circulatory_differentiable,
 )
 from param_id.operation_funcs import resolve_operation_kwargs, validate_operation_kwargs
+from param_id.calisim_methods import is_calisim_method
 from param_id.plot_outputs import ParamIDPlotOutputs
 from param_id import casadi_backend
 from param_id import fsa_backend
@@ -1531,6 +1532,20 @@ class OpencorParamID():
             self.best_cost = optimiser.best_cost
             self.init_gradient = optimiser.init_gradient
             self.best_gradient = optimiser.best_gradient
+
+        elif is_calisim_method(self.param_id_method):
+            # Any calisim optimisation engine, named calisim_<engine>[_<method>]. Imported lazily
+            # so CA still runs when the optional calisim package is not installed.
+            from param_id.calisim_wrapper import CalisimOptimiser
+            optimiser = CalisimOptimiser(
+                self, self.param_id_info, self.param_norm_obj,
+                self.num_params, self.output_dir,
+                optimiser_options=self.optimiser_options,
+                param_id_method=self.param_id_method, DEBUG=self.DEBUG
+            )
+            optimiser.run()
+            self.best_param_vals = optimiser.best_param_vals
+            self.best_cost = optimiser.best_cost
 
         else:
             print(f"param_id_method '{self.param_id_method}' is not implemented. Valid options: "

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -337,6 +337,20 @@ PARAM_ID_METHODS = {
 }
 
 
+
+# The calisim backends (param_id/calisim_wrapper.py) expose one calibration method per calisim
+# optimisation engine/method pair. There are many, and which ones exist depends on the installed
+# calisim/openturns, so they are generated rather than written out here -- CUFLynx then picks them
+# up automatically. calisim is an optional dependency: if anything about the discovery fails, CA
+# must still import, so the merge is best-effort and the built-in methods above are unaffected.
+try:
+    from param_id.calisim_methods import calisim_param_id_methods as _calisim_param_id_methods
+    PARAM_ID_METHODS.update(_calisim_param_id_methods())
+except Exception as _calisim_schema_error:  # pragma: no cover - defensive
+    print('WARNING could not add the calisim calibration methods to the schema: '
+          f'{_calisim_schema_error}')
+
+
 def valid_param_id_methods():
     """All accepted `param_id_method` strings: canonical names plus their aliases."""
     names = []

--- a/tests/test_calisim_wrapper.py
+++ b/tests/test_calisim_wrapper.py
@@ -1,0 +1,214 @@
+"""Unit tests for the calisim calibration backend (param_id/calisim_wrapper.py).
+
+These exercise the CA <-> calisim translation with a stub cost function, so they run without a
+model and (except where marked) without calisim installed. The end-to-end runs against a real
+generated model live in tests/test_param_id.py.
+"""
+import os
+
+import numpy as np
+import pytest
+
+from param_id.calisim_methods import (
+    calisim_method_name,
+    calisim_param_id_methods,
+    is_calisim_method,
+    split_calisim_method_name,
+)
+from param_id.calisim_wrapper import FAILED_SIMULATION_COST, CalisimOptimiser
+from parsers.PrimitiveParsers import PARAM_ID_METHODS, param_id_method_options
+from utility_funcs import Normalise_class
+
+pytestmark = pytest.mark.unit
+
+# The three engine/method pairs the integration tests use: the two most common optuna samplers
+# plus differential evolution through OpenTURNS/Pagmo.
+COMMON_METHODS = ['calisim_optuna_tpes', 'calisim_optuna_cmaes', 'calisim_openturns_de']
+
+
+class _StubParamID:
+    """Stands in for OpencorParamID: a quadratic cost with a known minimum."""
+
+    def __init__(self, optimum=(1.5, 3.0), fail_every=0):
+        self.optimum = np.asarray(optimum, dtype=float)
+        self.fail_every = fail_every
+        self.num_calls = 0
+        self.best_param_vals_set = None
+
+    def get_cost_from_params(self, param_vals, reset=True):
+        self.num_calls += 1
+        if self.fail_every and self.num_calls % self.fail_every == 0:
+            return np.inf
+        return float(np.sum((np.asarray(param_vals) - self.optimum) ** 2))
+
+    def set_best_param_vals(self, param_vals):
+        self.best_param_vals_set = param_vals
+
+
+def _make_optimiser(tmp_path, param_id_method='calisim_optuna_tpes', stub=None, **options):
+    param_id_info = {
+        'param_names': [['heart/R_a', 'aorta/R_a'], ['venous/C']],
+        'param_mins': np.array([0.0, 0.0]),
+        'param_maxs': np.array([5.0, 5.0]),
+    }
+    norm_obj = Normalise_class(param_id_info['param_mins'], param_id_info['param_maxs'])
+    # OpencorParamID.run() writes the param-name header before the optimiser starts.
+    with open(os.path.join(tmp_path, 'best_param_vals_history.csv'), 'w') as f:
+        f.write('heart R_a, venous C\n')
+    opts = {'num_calls_to_function': 20, 'n_init': 4, 'cost_convergence': 1e-6}
+    opts.update(options)
+    optimiser = CalisimOptimiser(
+        stub if stub is not None else _StubParamID(), param_id_info, norm_obj, 2, str(tmp_path),
+        optimiser_options=opts, param_id_method=param_id_method)
+    return optimiser
+
+
+# -------------------------------------------------------------------------------------------
+# schema / method names
+# -------------------------------------------------------------------------------------------
+def test_calisim_methods_are_registered_in_the_param_id_schema():
+    """CUFLynx builds its calibration menu from PARAM_ID_METHODS, so the calisim engines must be
+    merged in automatically -- without that, none of them are selectable in the GUI."""
+    for method in COMMON_METHODS:
+        assert method in PARAM_ID_METHODS, f'{method} missing from PARAM_ID_METHODS'
+        meta = PARAM_ID_METHODS[method]
+        assert meta['label'] and meta['description']
+        assert meta['gradient_based'] is False
+        assert meta['calisim']['engine'] and 'method' in meta['calisim']
+        # the per-method settings form is populated from here
+        assert {opt['name'] for opt in param_id_method_options(method)} >= {
+            'num_calls_to_function', 'cost_convergence', 'method_kwargs'}
+
+
+def test_calisim_method_names_round_trip():
+    for engine, method in [('optuna', 'tpes'), ('openturns', 'simulated_annealing'),
+                           ('emukit', '')]:
+        name = calisim_method_name(engine, method)
+        assert is_calisim_method(name)
+        assert split_calisim_method_name(name) == (engine, method)
+
+    assert not is_calisim_method('genetic_algorithm')
+    with pytest.raises(ValueError):
+        split_calisim_method_name('genetic_algorithm')
+
+
+def test_calisim_schema_covers_every_engine_and_is_well_formed():
+    schema = calisim_param_id_methods()
+    engines = {meta['calisim']['engine'] for meta in schema.values()}
+    assert {'optuna', 'openturns', 'emukit', 'botorch'} <= engines
+    # surrogate-based engines expose the acquisition function; samplers do not
+    assert 'acquisition_func' in {o['name'] for o in schema['calisim_emukit']['options']}
+    assert 'acquisition_func' not in {
+        o['name'] for o in schema['calisim_optuna_tpes']['options']}
+
+
+# -------------------------------------------------------------------------------------------
+# params_for_id / obs_data -> calisim inputs
+# -------------------------------------------------------------------------------------------
+def test_param_names_are_calisim_safe_and_ordered(tmp_path):
+    """CA parameter names are `component/variable` and may be shared across components, which is
+    not a usable calisim/optuna key, so they are sanitised while keeping param_id_info order."""
+    optimiser = _make_optimiser(tmp_path)
+    assert optimiser.calisim_param_names == ['p0_heart_R_a', 'p1_venous_C']
+    # and the mapping back to CA's ordered vector is the exact inverse
+    values = {'p0_heart_R_a': 1.25, 'p1_venous_C': 4.0}
+    assert np.array_equal(optimiser._params_dict_to_array(values), np.array([1.25, 4.0]))
+
+
+def test_bounds_from_params_for_id_become_uniform_distributions(tmp_path):
+    """The min/max columns of {prefix}_params_for_id.csv are the calisim search box, in real
+    (un-normalised) parameter space."""
+    pytest.importorskip('calisim')
+    optimiser = _make_optimiser(tmp_path)
+    spec = optimiser._parameter_spec()
+    assert [p.name for p in spec.parameters] == optimiser.calisim_param_names
+    for parameter, lower, upper in zip(spec.parameters, [0.0, 0.0], [5.0, 5.0]):
+        assert parameter.distribution_name == 'uniform'
+        assert parameter.distribution_args == [lower, upper]
+
+
+# -------------------------------------------------------------------------------------------
+# calisim outputs -> CA outputs
+# -------------------------------------------------------------------------------------------
+def test_evaluate_tracks_best_and_writes_ca_artifacts(tmp_path):
+    optimiser = _make_optimiser(tmp_path)
+    # deliberately never hits the optimum exactly, so cost_convergence does not cut the run short
+    optimiser._evaluate({'p0_heart_R_a': 0.0, 'p1_venous_C': 0.0})
+    optimiser._evaluate({'p0_heart_R_a': 1.4, 'p1_venous_C': 3.1})  # best of the three
+    optimiser._evaluate({'p0_heart_R_a': 5.0, 'p1_venous_C': 5.0})
+
+    assert optimiser.best_cost == pytest.approx(0.02)
+    assert np.allclose(optimiser.best_param_vals, [1.4, 3.1])
+    # CA's usual artefacts, so plotting/simulate_with_best_param_vals need no special-casing
+    assert np.load(os.path.join(tmp_path, 'best_cost.npy')) == pytest.approx(0.02)
+    assert np.allclose(np.load(os.path.join(tmp_path, 'best_param_vals.npy')), [1.4, 3.1])
+
+    costs = np.atleast_1d(np.loadtxt(os.path.join(tmp_path, 'best_cost_history.csv'),
+                                     delimiter=','))
+    assert len(costs) == 3 and np.all(np.diff(costs) <= 0), 'best-cost history must be monotone'
+    params = np.loadtxt(os.path.join(tmp_path, 'best_param_vals_history.csv'), delimiter=',',
+                        skiprows=1)
+    # history is in normalised space, like every other optimiser writes it
+    assert params.shape == (3, 2)
+    assert np.allclose(params[-1], [1.4 / 5.0, 3.1 / 5.0])
+
+
+def test_failed_simulation_becomes_a_finite_penalty(tmp_path):
+    """np.inf poisons the surrogate fits the calisim engines build, so failures are reported as a
+    large finite cost and never become the incumbent."""
+    stub = _StubParamID(fail_every=1)
+    optimiser = _make_optimiser(tmp_path, stub=stub)
+    assert optimiser._evaluate({'p0_heart_R_a': 1.0, 'p1_venous_C': 1.0}) == FAILED_SIMULATION_COST
+    assert optimiser.best_param_vals is None
+    assert optimiser.best_cost == np.inf
+
+
+def test_budget_is_enforced_even_if_the_engine_overshoots(tmp_path):
+    """calisim owns the loop and some engines ask for more points than n_iterations, so the
+    wrapper stops simulating once num_calls_to_function is spent."""
+    stub = _StubParamID()
+    optimiser = _make_optimiser(tmp_path, stub=stub, num_calls_to_function=5)
+    for i in range(20):
+        optimiser._evaluate({'p0_heart_R_a': 0.1 * i, 'p1_venous_C': 0.1 * i})
+    assert stub.num_calls == 5
+
+
+def test_cost_convergence_stops_the_run_early(tmp_path):
+    stub = _StubParamID()
+    optimiser = _make_optimiser(tmp_path, stub=stub, cost_convergence=1e3)
+    optimiser._evaluate({'p0_heart_R_a': 1.5, 'p1_venous_C': 3.0})
+    assert optimiser._stopped_early
+    optimiser._evaluate({'p0_heart_R_a': 0.0, 'p1_venous_C': 0.0})
+    assert stub.num_calls == 1, 'no further simulations after convergence'
+
+
+def test_missing_calisim_raises_a_helpful_import_error(tmp_path, monkeypatch):
+    """calisim is an optional dependency: CA must import fine without it and only complain when a
+    calisim_* method is actually selected."""
+    import param_id.calisim_wrapper as wrapper
+    monkeypatch.setattr(wrapper, 'CALISIM_AVAILABLE', False)
+    optimiser = _make_optimiser(tmp_path)
+    with pytest.raises(ImportError, match='pip install calisim'):
+        optimiser.run()
+
+
+# -------------------------------------------------------------------------------------------
+# end to end through calisim itself (still no model: the stub is the "simulator")
+# -------------------------------------------------------------------------------------------
+@pytest.mark.parametrize('param_id_method', COMMON_METHODS)
+def test_calisim_engines_optimise_the_stub_cost(tmp_path, param_id_method):
+    """The three most common methods really drive CA's cost function through calisim and come
+    back with a better-than-random optimum, in CA's format."""
+    pytest.importorskip('calisim')
+    stub = _StubParamID()
+    optimiser = _make_optimiser(tmp_path, param_id_method=param_id_method, stub=stub,
+                                num_calls_to_function=30, n_init=5, random_seed=7)
+    optimiser.run()
+
+    assert stub.num_calls <= 30
+    assert np.isfinite(optimiser.best_cost)
+    # a uniform draw over the 5x5 box averages a cost of ~8; anything sensible beats 2
+    assert optimiser.best_cost < 2.0, f'{param_id_method} did not optimise: {optimiser.best_cost}'
+    assert optimiser.best_param_vals.shape == (2,)
+    assert stub.best_param_vals_set is not None, 'the best params must be pushed back to param_id'
+    assert np.load(os.path.join(tmp_path, 'best_cost.npy')) == pytest.approx(optimiser.best_cost)

--- a/tests/test_param_id.py
+++ b/tests/test_param_id.py
@@ -702,6 +702,73 @@ def test_param_id_3compartment_python_succeeds(base_user_inputs, resources_dir, 
 
 
 @pytest.mark.integration
+@pytest.mark.mpi
+@pytest.mark.parametrize('param_id_method', ['calisim_optuna_tpes',
+                                             'calisim_optuna_cmaes',
+                                             'calisim_openturns_de'])
+def test_param_id_3compartment_calisim_python_model(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm,
+        param_id_method):
+    """The three most common calisim optimisation methods calibrate a *generated python* model.
+
+    python + solve_ivp is the CUFLynx target for these backends, and it exercises the whole
+    translation: {prefix}_params_for_id.csv bounds -> calisim ParameterSpecification,
+    {prefix}_obs_data.json -> CA's cost function behind calisim's calibration_func, and calisim's
+    result -> CA's usual best_cost.npy / best_param_vals.npy / history files.
+
+    Skipped when the optional calisim package is absent (see param_id/calisim_wrapper.py).
+    """
+    pytest.importorskip('calisim',
+                        reason='calisim is an optional dependency (pip install calisim)')
+    rank = mpi_comm.Get_rank()
+
+    config = base_user_inputs.copy()
+    config.update({
+        'file_prefix': '3compartment',
+        'input_param_file': '3compartment_parameters.csv',
+        'model_type': 'python',
+        'solver': 'solve_ivp',
+        'param_id_method': param_id_method,
+        'pre_time': 0.5,
+        'sim_time': 0.3,
+        'dt': 0.01,
+        'DEBUG': True,
+        'do_mcmc': False,
+        'plot_predictions': False,
+        'do_ia': False,
+        'solver_info': {'method': 'BDF', 'rtol': 1e-6, 'atol': 1e-8},
+        'param_id_obs_path': os.path.join(resources_dir, '3compartment_obs_data.json'),
+        'param_id_output_dir': temp_output_dir,
+        'generated_models_dir': temp_generated_models_dir,
+        # Small budget: this is a smoke test that the backend runs and produces CA outputs, not
+        # an accuracy test. DEBUG clamps it to 20 in any case. n_init is the population size for
+        # the openturns/Pagmo algorithms, which have algorithm-specific minima (DE needs >= 5),
+        # so it cannot be made arbitrarily small.
+        'debug_optimiser_options': {'num_calls_to_function': 20, 'n_init': 8,
+                                    'cost_convergence': 1e-8, 'random_seed': 1},
+    })
+
+    if rank == 0:
+        assert generate_with_new_architecture(False, config), 'python model generation failed'
+    mpi_comm.Barrier()
+
+    run_param_id(config)
+
+    if rank == 0:
+        out_dir = os.path.join(temp_output_dir,
+                               f'{param_id_method}_3compartment_3compartment_obs_data')
+        best_cost = float(np.load(os.path.join(out_dir, 'best_cost.npy')))
+        best_params = np.load(os.path.join(out_dir, 'best_param_vals.npy'))
+        assert np.isfinite(best_cost) and best_cost >= 0, f'bad best cost {best_cost}'
+        assert best_params.shape[0] > 0
+        # the progress files the plotting reads must be written in the usual format
+        costs = np.atleast_1d(np.loadtxt(os.path.join(out_dir, 'best_cost_history.csv'),
+                                         delimiter=','))
+        assert len(costs) > 0 and np.all(np.diff(costs) <= 0)
+    mpi_comm.Barrier()
+
+
+@pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.mpi
 def test_param_id_test_fft_cost_is_zero(base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -47,9 +47,18 @@ def test_param_id_methods_schema_matches_dispatch():
     """PARAM_ID_METHODS is the discoverable list of calibration methods surfaced to downstream
     tools (e.g. the CUFLynx settings UI), so it must stay in sync with the param_id_method
     dispatch in OpencorParamID.run(). If a method is added/removed there, update this set."""
-    assert set(PARAM_ID_METHODS.keys()) == {
+    builtin_methods = {name for name in PARAM_ID_METHODS if not name.startswith('calisim_')}
+    assert builtin_methods == {
         'genetic_algorithm', 'CMA-ES', 'bayesian', 'sp_minimize', 'multi_start_sp_minimize'
     }
+    # The calisim_* methods are generated (one per calisim optimisation engine/method pair, see
+    # param_id/calisim_methods.py) rather than listed here: which ones exist depends on the
+    # installed calisim/openturns, so pin the shape, not the full set. They all dispatch through
+    # the same is_calisim_method() branch of OpencorParamID.run().
+    from param_id.calisim_methods import is_calisim_method
+    calisim_methods = {name for name in PARAM_ID_METHODS if name.startswith('calisim_')}
+    assert 'calisim_optuna_tpes' in calisim_methods
+    assert all(is_calisim_method(name) for name in calisim_methods)
     for name, meta in PARAM_ID_METHODS.items():
         assert meta.get('label') and meta.get('description')
         assert isinstance(meta.get('gradient_based'), bool)
@@ -87,6 +96,12 @@ def test_param_id_method_options_match_optimiser_reads():
         'no_new_starts_on_convergence', 'convergence_cluster_tol_frac', 'cost_convergence'}
     # multi-start is a superset of sp_minimize's gradient-descent settings
     assert names('sp_minimize') <= names('multi_start_sp_minimize')
+    # the calisim backends (param_id/calisim_wrapper.py) all read the same block, plus
+    # acquisition_func on the surrogate-based engines
+    calisim_common = {'num_calls_to_function', 'cost_convergence', 'n_init', 'random_seed',
+                      'n_jobs', 'method_kwargs'}
+    assert names('calisim_optuna_tpes') == calisim_common
+    assert names('calisim_emukit') == calisim_common | {'acquisition_func'}
 
 
 def test_solver_info_fields_schema_well_formed():

--- a/tutorial/docs/parameter-identification.md
+++ b/tutorial/docs/parameter-identification.md
@@ -398,6 +398,7 @@ To run the parameter identification we need to set a few entries in the `[CA_dir
     - **bayesian**: Bayesian optimization using scikit-optimize (deprecated, untested)
     - **sp_minimize**: Gradient-based optimizer (L-BFGS-B, local only)
     - **multi_start_sp_minimize**: Multi-start L-BFGS-B — a gradient-based descent from many scattered starting points, so it exploits the gradient but still escapes local minima
+    - **calisim_&lt;engine&gt;[_&lt;method&gt;]**: any optimisation method provided by [calisim](https://github.com/Plant-Food-Research-Open/calisim), e.g. `calisim_optuna_tpes`, `calisim_optuna_cmaes`, `calisim_openturns_de`, `calisim_emukit` (experimental, see below)
 - **pre_time**: this is the amount of time the simulation is run to get to steady state before comparing to the observables from `obs_data.json`. IMPORTANT: THis is overwritten by the pre_times within the obs_data.json file, see the next section.
 - **sim_time**: The amount of time used to compare simulation output and observable data. This should be equal to the length of a series observable entry divided by the "sample_rate". If not, only up to the minimum length of observable data and modelled data will be compared. 
 - **dt**: The output (sample) time step for model outputs
@@ -478,6 +479,43 @@ optimiser_options:
   cost_convergence: 0.001         # shared option
   sigma0: 0.1                      # CMA-ES specific (optional, initial standard deviation)
   # Note: Initial parameter values are automatically loaded from {file_prefix}_parameters.csv
+```
+
+### calisim backends (calisim_&lt;engine&gt;[_&lt;method&gt;]) — experimental
+
+[calisim](https://github.com/Plant-Food-Research-Open/calisim) wraps many optimisation libraries
+(optuna, OpenTURNS/Pagmo, emukit, BoTorch) behind one interface. CA wraps calisim once, so every
+calisim optimisation engine/method pair is usable as a `param_id_method` named
+`calisim_<engine>_<method>` — no new input files, and no new optimiser code per library.
+
+- **Pros**: a large family of global optimisers (TPE, CMA-ES, differential evolution, particle
+  swarm, simulated annealing, Bayesian optimisation, ...) with no further CA changes; the full
+  list is discovered automatically and shown in CUFLynx.
+- **Cons**: optional heavy dependency; calisim drives its own loop, so the run currently occupies
+  **rank 0 only** (the other MPI ranks idle); experimental.
+- **Best for**: trying an optimiser CA does not implement natively, before committing to it.
+
+Install with `pip install calisim` (the `botorch` engine additionally needs `pip install
+"calisim[torch]"`). calisim requires python `>=3.10,<3.13` and currently pins `numpy<2` and
+`scipy<1.12`.
+
+Everything else is unchanged: the bounds in `{file_prefix}_params_for_id.csv` become the calisim
+search box, `obs_data.json` is still evaluated by CA's own cost function (so all cost types,
+protocols, multi-experiment setups and user operations work), and the results are written as the
+usual `best_cost.npy`, `best_param_vals.npy` and history files, so plotting works as normal.
+calisim's own trial tables and plots land in a `calisim/` subdirectory of the output directory.
+
+```yaml
+param_id_method: calisim_optuna_tpes   # or calisim_optuna_cmaes, calisim_openturns_de, ...
+model_type: python
+solver: solve_ivp
+optimiser_options:
+  num_calls_to_function: 500   # calisim iterations (cost-function calls)
+  cost_convergence: 0.0001
+  n_init: 10                   # initial design size; the population size for openturns/Pagmo
+  random_seed: 0
+  method_kwargs:               # passed straight to the calisim sampler/algorithm
+    n_startup_trials: 50
 ```
 
 ### Gradient-based Optimizer (sp_minimize)


### PR DESCRIPTION
Closes #288 (feasibility spike).

## :warning: NOT READY TO MERGE

The blocker is a **dependency conflict that needs to be sorted out first**:

| package | this repo's working env | calisim 1.0.0 requires |
|---|---|---|
| numpy | 2.2.6 | `<2.0.0` |
| scipy | 1.14.1 | `<1.12.0` |
| python | 3.10 / 3.12 | `>=3.10,<3.13` |

So calisim **cannot currently be installed into an environment that has numpy 2.x**. Nothing was
installed into the project `venv/` for this work, precisely to avoid downgrading numpy/scipy under
other branches and agents.

Good news: CA's own pins are compatible with calisim's. A clean venv resolves
`calisim` + the full CA dependency list with no conflict, landing on numpy 1.26.4 / scipy 1.11.4 /
libcellml 0.6.3 / myokit 1.39.2, and everything below was verified there. The open question is
whether CA wants to (a) hold an env at numpy<2 for calisim, (b) wait for calisim to relax its
pins, or (c) keep calisim as a strictly separate optional environment.

## What this adds

Wraps [calisim](https://github.com/Plant-Food-Research-Open/calisim) once, so **every optimisation
engine/method it offers becomes a CA `param_id_method`** called `calisim_<engine>[_<method>]` —
instead of hand-writing an `Optimiser` subclass per library. 27 methods are exposed on a machine
with calisim + OpenTURNS installed (optuna tpes/cmaes/nsga/qmc/gp, 19 OpenTURNS/Pagmo algorithms
plus kriging, emukit, botorch).

* **`src/param_id/calisim_wrapper.py`** — `CalisimOptimiser(Optimiser)`, plugged into the existing
  `OpencorParamID.run()` dispatch.
* **`src/param_id/calisim_methods.py`** — generates the `PARAM_ID_METHODS` entries; merged in by
  `PrimitiveParsers`.
* `pyproject.toml` — new optional extra `calisim`.
* Tutorial section under Parameter Identification Settings.

### Inputs → calisim (deliberately thin; no new user input files)

* `{prefix}_params_for_id.csv` → the already-parsed `param_id_info` bounds become one calisim
  `DistributionModel` per parameter, uniform over `[min, max]`, in *real* (un-normalised) space and
  in `param_id_info` order. CA names (`component/variable`, possibly shared across components) are
  sanitised to unique calisim keys.
* `{prefix}_obs_data.json` is **not** re-parsed. calisim's `calibration_func` is a thin adapter over
  `OpencorParamID.get_cost_from_params()`, so every cost type, protocol, multi-experiment setup and
  user-defined operation keeps working untouched.

### calisim → CA outputs

The best `(cost, params)` pair is tracked inside the objective — engine-independent, and it sidesteps
calisim's `analyze()`-only parameter estimates and its ascending-sort "best trial" selection. CA then
writes its usual `best_cost.npy`, `best_param_vals.npy`, `best_cost_history.csv` and
`best_param_vals_history.csv` (normalised, same format as the other optimisers), so `plot_param_id`,
`simulate_with_best_param_vals()` and everything downstream need no special-casing. calisim's own
trial tables/plots go to `<output_dir>/calisim/`.

Other details: failed simulations are reported as a large **finite** penalty instead of `inf`, which
would poison the surrogate fits the engines build; the evaluation budget is enforced in the wrapper
because some engines overshoot `n_iterations`; `analyze()` failures cannot lose a completed
calibration.

## CUFLynx / schema

The methods are **generated**, not hardcoded, so CUFLynx picks them up with no GUI-side change:
static table first (identical menu on a machine without calisim), then extended from the installed
calisim's engine registry — including third-party engines registered through the
`calisim.external.optimisation` entry-point group — and from OpenTURNS' run-time
`ot.Pagmo.GetAlgorithmNames()`. Each method advertises the `optimiser_options` the wrapper actually
reads (`num_calls_to_function`, `cost_convergence`, `n_init`, `random_seed`, `n_jobs`,
`method_kwargs`, plus `acquisition_func` on the surrogate engines); the existing schema tests that
check "advertised == actually read" cover them.

## Optional dependency

CA imports and runs exactly as before without calisim — only selecting a `calisim_*` method raises,
with install instructions. Verified by running the suite in an env without calisim.

## Testing

* `tests/test_calisim_wrapper.py` — the translation both ways against a stub cost function (bounds →
  spec, names round-trip, best-tracking, CA artefact formats, budget/convergence stopping, the
  helpful ImportError), plus a real run through calisim for the three methods.
* `tests/test_param_id.py::test_param_id_3compartment_calisim_python_model` — calibrates a
  **generated `model_type: python` model** (the CUFLynx target) with the three most common methods:
  `calisim_optuna_tpes`, `calisim_optuna_cmaes`, `calisim_openturns_de`. All calisim tests
  `importorskip` cleanly.

Results:

* clean venv **with** calisim: **40 passed** (unit + schema + the three end-to-end python-model
  calibrations).
* project `venv/` **without** calisim (numpy 2.2.6): **53 passed, 7 skipped**, no regressions.

## Known limitations / follow-ups

1. **The numpy/scipy conflict above — the merge blocker.**
2. calisim owns its optimisation loop, so the run occupies **rank 0 only**; the other MPI ranks idle
   (same as `sp_minimize`). Parallel evaluation across ranks would need calisim's batched path.
3. `calisim_optuna_gp` needs the `calisim[torch]` extra; `calisim_openturns_kriging` fails on current
   OpenTURNS (`ot.EfficientGlobalOptimization` was removed) — a calisim-side issue. Both are exposed
   in the menu because whether they work depends on the install; failures surface as a clear error.
4. `n_init` is the population size for openturns/Pagmo, which impose algorithm-specific minima (DE
   needs ≥ 5) — documented in the schema description.
5. Only calisim's optimisation module is wrapped; sensitivity / UQ / ABC could follow the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
