### PR TITLE
fix(sensitivity): sample_type 'sobol' called the analyzer, not the sampler

### DIFF
--- a/src/sensitivity_analysis/sobolSA.py
+++ b/src/sensitivity_analysis/sobolSA.py
@@ -30,6 +30,11 @@ except:
 from solver_wrappers import get_simulation_helper
 from protocol_runners.protocol_executor import ProtocolExecutor
 from SALib.sample import saltelli
+# The Sobol *sampler* and the Sobol *analyzer* are different SALib modules that share the name
+# `sobol`. Import the sampler under a distinct name so it does not shadow (or get shadowed by)
+# the analyzer below -- `sample_type: sobol` previously called SALib.analyze.sobol.sample(),
+# which does not exist, so it raised AttributeError.
+from SALib.sample import sobol as sobol_sampler
 import pandas as pd
 from SALib.analyze import sobol
 import numpy as np
@@ -272,7 +277,7 @@ class sobol_SA():
         if self.SA_info["sample_type"] == "saltelli":
             samples = saltelli.sample(problem, self.num_samples, calc_second_order=True)  # Enable second-order interactions
         elif self.SA_info["sample_type"] == "sobol":
-            samples = sobol.sample(problem, self.num_samples, calc_second_order=True)  # Enable second-order interactions
+            samples = sobol_sampler.sample(problem, self.num_samples, calc_second_order=True)  # Enable second-order interactions
         else:
             raise ValueError(f"Unsupported sample type: {self.SA_info['sample_type']}")
         

--- a/tests/test_sensitivity_analysis.py
+++ b/tests/test_sensitivity_analysis.py
@@ -368,3 +368,34 @@ def test_local_observable_sensitivities_casadi_agrees_with_myokit(
                 f"backends disagree on d({label})/d({p}): myokit={a:.4e} casadi={b:.4e}")
             checked += 1
     assert checked > 0, "no mean-observable/param pair with a non-trivial sensitivity to compare"
+
+
+@pytest.mark.unit
+def test_sobolSA_generate_samples_supports_both_sample_types():
+    """Both advertised sample_type choices must actually produce samples.
+
+    `sample_type: sobol` used to raise `AttributeError: module 'SALib.analyze.sobol' has no
+    attribute 'sample'` because the name `sobol` in sobolSA.py was the SALib *analyzer* import,
+    not the *sampler* -- so only `saltelli` worked, even though the schema advertises both. This
+    exercises generate_samples directly (no model needed) for both types.
+    """
+    import numpy as np
+    from sensitivity_analysis.sobolSA import sobol_SA
+
+    # generate_samples only reads num_params + SA_info, so build a bare instance to avoid the
+    # heavy __init__ (which loads a model). This keeps the check a fast unit test of the dispatch.
+    mgr = object.__new__(sobol_SA)
+    mgr.num_params = 2
+    for sample_type in ('saltelli', 'sobol'):
+        mgr.SA_info = {
+            'param_names': ['a', 'b'],
+            'param_mins': [0.0, 0.0],
+            'param_maxs': [1.0, 1.0],
+            'num_samples': 8,
+            'sample_type': sample_type,
+        }
+        samples = mgr.generate_samples()
+        samples = np.asarray(samples)
+        assert samples.ndim == 2 and samples.shape[1] == 2, (sample_type, samples.shape)
+        assert samples.shape[0] > 0, sample_type
+        assert np.all(np.isfinite(samples)), sample_type


### PR DESCRIPTION
`sample_type: sobol` threw an error — `saltelli` was the only working sample type — even though the schema advertises both. It's a plain import-shadowing bug, not a missing feature.

## What happened

```
AttributeError: module 'SALib.analyze.sobol' has no attribute 'sample'
```

In `src/sensitivity_analysis/sobolSA.py`, the name `sobol` was bound to the SALib **analyzer** (`from SALib.analyze import sobol`, used correctly for `sobol.analyze(...)`). `generate_samples` then called `sobol.sample(...)` for `sample_type == "sobol"` — but the analyzer has no `.sample()`. The Sobol **sampler** (`SALib.sample.sobol`, which *does* have `.sample`) was never imported. `saltelli` worked because its sampler is imported correctly.

## The fix

Import the Sobol sampler under a distinct name so it neither shadows nor is shadowed by the analyzer:

```python
from SALib.sample import sobol as sobol_sampler
...
samples = sobol_sampler.sample(problem, self.num_samples, calc_second_order=True)
```

Verified against the installed SALib: `SALib.analyze.sobol` has `.analyze` and no `.sample`; `SALib.sample.sobol` has `.sample` and now produces samples (e.g. `(48, 2)` for 8 base samples over 2 params with second order).

## Test

`test_sobolSA_generate_samples_supports_both_sample_types` drives `generate_samples` for **both** `saltelli` and `sobol` and asserts each returns finite samples. It raised `AttributeError` for `sobol` before the fix; passes now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
