### PR TITLE
feat(param-id): stream per-start parameter-value history for multi_start_sp_minimize

### DIFF
--- a/src/param_id/optimisers.py
+++ b/src/param_id/optimisers.py
@@ -1203,6 +1203,36 @@ class MultiStartSciPyMinimizeOptimiser(Optimiser):
         except OSError:
             pass
 
+    def _param_labels(self):
+        """Column labels for the parameters (a param shared across vessels uses its first name),
+        with '/' replaced by ' ' -- matching multi_start_summary.csv so both files line up."""
+        return [(names[0] if isinstance(names, (list, tuple)) else str(names)).replace('/', ' ')
+                for names in self.param_id_info["param_names"]]
+
+    def _append_start_params(self, start_idx, iteration, x_norm):
+        """Append one ``start_idx, iteration, <param values>`` row to the live per-start parameter
+        stream, so a GUI can plot each parameter's per-start trajectory during the run alongside
+        the cost (issue #286 follow-up). The values are the *actual* (unnormalised) parameters,
+        matching multi_start_summary.csv; the header column order is ``_param_labels()``.
+
+        Sibling of ``_append_start_cost`` -- same global ``start_idx`` keying, same unconditional
+        (not DEBUG-gated) best-effort write via ``self._stream_output_dir``. Each row is one line
+        under O_APPEND (atomic on POSIX for the typical short rows), keyed by start_idx+iteration,
+        so concurrent multi-rank appends demux cleanly. Skips silently when no output dir is set.
+        """
+        if self._stream_output_dir is None:
+            return
+        try:
+            vals = np.asarray(self.param_norm_obj.unnormalise(np.asarray(x_norm, dtype=float)),
+                              dtype=float).flatten()
+            row = (f'{int(start_idx)}, {int(iteration)}, '
+                   + ', '.join(f'{v:.9e}' for v in vals) + '\n')
+            path = os.path.join(self._stream_output_dir, 'multi_start_param_vals_history.csv')
+            with open(path, 'a') as file:
+                file.write(row)
+        except OSError:
+            pass
+
     def _run_one_start(self, start_idx, x0_norm, cost_fun, gradient_func, bounds_norm):
         """Run a single bounded L-BFGS-B descent. Returns a result dict (never raises for a
         cost-converged early stop)."""
@@ -1211,8 +1241,9 @@ class MultiStartSciPyMinimizeOptimiser(Optimiser):
         start_wall = time.perf_counter()
         init_cost = cost_fun(x0_norm)
         iterates.append((init_cost, np.asarray(x0_norm, dtype=float).copy()))
-        # iteration 0 = the start point, so the live curve begins at the pre-descent cost.
+        # iteration 0 = the start point, so the live curves begin at the pre-descent state.
         self._append_start_cost(start_idx, 0, init_cost)
+        self._append_start_params(start_idx, 0, x0_norm)
 
         last_iterate = {"x_norm": None, "cost": None}
 
@@ -1224,6 +1255,7 @@ class MultiStartSciPyMinimizeOptimiser(Optimiser):
             iterates.append((cost_val, x_norm))
             # len(iterates)-1 is this iteration's number (0 was the start point above).
             self._append_start_cost(start_idx, len(iterates) - 1, cost_val)
+            self._append_start_params(start_idx, len(iterates) - 1, x_norm)
             if self.DEBUG:
                 print(f'[multi_start_sp_minimize] rank {self.rank} start {start_idx}: '
                       f'cost = {cost_val:.6e}')
@@ -1265,25 +1297,32 @@ class MultiStartSciPyMinimizeOptimiser(Optimiser):
         rank = self.rank
         num_procs = self.num_procs
 
-        # Live per-start cost stream. output_dir is set on rank 0 only (set_output_dir is
-        # rank-0-guarded, so it is None on every other rank), but every rank streams the starts
-        # it runs, so broadcast the path first. Directory creation stays on rank 0. If no output
-        # dir is configured at all (rank 0 also None) the whole stream is skipped.
+        # Live per-start streams: cost (multi_start_cost_history.csv) and parameter values
+        # (multi_start_param_vals_history.csv), one row per L-BFGS-B iteration so a GUI can plot a
+        # cost-vs-iteration and parameter-vs-iteration line per start *during* the run. output_dir
+        # is set on rank 0 only (set_output_dir is rank-0-guarded, so it is None on every other
+        # rank), but every rank streams the starts it runs, so broadcast the path first. Directory
+        # creation stays on rank 0. If no output dir is configured at all (rank 0 also None) the
+        # streams are skipped.
         self._stream_output_dir = comm.bcast(self.output_dir, root=0)
-        # Start the stream fresh (header + empty). Rank 0 truncates before any rank writes a row;
+        # Start the streams fresh (header + empty). Rank 0 truncates before any rank writes a row;
         # the barrier makes that ordering safe. This is done here, at the very top before any
         # per-rank divergence, so every rank reaches the barrier together (a blocking collective
         # inside the start loop could hang with uneven start counts, hence the point-to-point
-        # machinery there -- but this prelude is identical on every rank). Failing to prepare the
-        # stream must not abort the run: the end-of-run csvs are the record of truth, this file is
-        # only the live feed. See _append_start_cost / issue #286.
+        # machinery there -- but this prelude is identical on every rank). Failing to prepare a
+        # stream must not abort the run: the end-of-run csvs are the record of truth, these files
+        # are only the live feed. See _append_start_cost / _append_start_params / issue #286.
         if rank == 0 and self._stream_output_dir is not None:
             try:
-                stream_path = os.path.join(self._stream_output_dir, 'multi_start_cost_history.csv')
-                with open(stream_path, 'w') as f:
+                cost_path = os.path.join(self._stream_output_dir, 'multi_start_cost_history.csv')
+                with open(cost_path, 'w') as f:
                     f.write('start_idx, iteration, cost\n')
+                param_path = os.path.join(self._stream_output_dir,
+                                          'multi_start_param_vals_history.csv')
+                with open(param_path, 'w') as f:
+                    f.write('start_idx, iteration, ' + ', '.join(self._param_labels()) + '\n')
             except OSError as exc:
-                print(f'warning: could not initialise multi_start_cost_history.csv: {exc}')
+                print(f'warning: could not initialise the multi_start live-history csvs: {exc}')
         comm.Barrier()
 
         cost_fun = self._make_cost_func()

--- a/tests/test_param_id.py
+++ b/tests/test_param_id.py
@@ -3792,6 +3792,69 @@ def test_multi_start_streams_per_start_cost_history_live(temp_output_dir):
     MPI.COMM_WORLD.Barrier()
 
 
+def test_multi_start_streams_per_start_param_vals_history_live(temp_output_dir):
+    """multi_start_param_vals_history.csv streams the actual parameter values per L-BFGS-B
+    iteration per start (iteration 0 = the start point), live and independent of DEBUG, so a GUI
+    can plot each parameter's per-start trajectory during the run alongside the cost.
+
+    Checks: the header names the parameters; a named value column per parameter; a row for every
+    global start 0..N-1 with iterations 0,1,2,...; the (start, iteration) keys match the cost
+    history exactly; and each start's last streamed params equal its multi_start_summary.csv
+    final parameter values.
+    """
+    import csv as _csv
+    import numpy as np
+    out_dir = os.path.join(temp_output_dir, 'multi_start_param_stream')
+    os.makedirs(out_dir, exist_ok=True)
+
+    num_starts = 5
+    opt = _make_multi_start_optimiser(
+        out_dir, _TwoWellParamId(param_init=(1.2, 1.2)),
+        {'num_starts': num_starts, 'start_sampling': 'latin_hypercube', 'seed': 1,
+         'cost_convergence': 1e-12})
+    assert opt.DEBUG is False
+    opt.run()
+
+    if MPI.COMM_WORLD.Get_rank() == 0:
+        rows = list(_csv.reader(open(os.path.join(out_dir, 'multi_start_param_vals_history.csv'))))
+        header = [c.strip() for c in rows[0]]
+        # header: start_idx, iteration, <one column per parameter> (the two-well params).
+        assert header[:2] == ['start_idx', 'iteration']
+        assert header[2:] == ['well x', 'well y'], header
+
+        per_start = {}
+        for r in rows[1:]:
+            if not r:
+                continue
+            s_idx, it = int(r[0]), int(r[1])
+            vals = [float(v) for v in r[2:]]
+            assert len(vals) == 2, r
+            per_start.setdefault(s_idx, []).append((it, vals))
+
+        assert sorted(per_start) == list(range(num_starts)), sorted(per_start)
+
+        # The param and cost streams are written together, so they must share the same
+        # (start_idx, iteration) keys.
+        cost_lines = [ln for ln in
+                      open(os.path.join(out_dir, 'multi_start_cost_history.csv')).read().splitlines()
+                      if ln.strip()][1:]
+        cost_keys = {(int(ln.split(',')[0]), int(ln.split(',')[1])) for ln in cost_lines}
+        param_keys = {(s, it) for s, rws in per_start.items() for it, _ in rws}
+        assert param_keys == cost_keys
+
+        summary = {int(row['start_idx']): row for row in
+                   _csv.DictReader(open(os.path.join(out_dir, 'multi_start_summary.csv')))}
+        for s_idx, rws in per_start.items():
+            iters = [it for it, _ in rws]
+            assert iters == list(range(len(iters))), (s_idx, iters)
+            # last streamed params == the start's recorded final (unnormalised) params.
+            last_vals = rws[-1][1]
+            final = [float(summary[s_idx][lbl]) for lbl in ('well x', 'well y')]
+            assert np.allclose(last_vals, final, rtol=1e-6, atol=1e-9), (s_idx, last_vals, final)
+
+    MPI.COMM_WORLD.Barrier()
+
+
 # The FitzHugh-Nagumo excitable-cell model is a standard multi-modal parameter-estimation
 # benchmark: its least-squares surface has many local minima, because a wrong recovery rate
 # c puts the simulated spike train out of phase with the data (Ramsay et al. 2007, JRSS-B,

--- a/tutorial/docs/parameter-identification.md
+++ b/tutorial/docs/parameter-identification.md
@@ -446,7 +446,7 @@ optimiser_options:
 
 Alongside the usual `best_cost_history.csv` / `best_param_vals_history.csv` (written as a running-best curve over the concatenated starts), this optimiser writes a **`multi_start_summary.csv`** with one row per start — its initial cost, final cost, iteration count and final parameter values. That tells you how many distinct basins your starts fell into, which is the quickest way to see whether `num_starts` is high enough.
 
-It also streams **`multi_start_cost_history.csv`** live *during* the run — one `start_idx, iteration, cost` row per L-BFGS-B iteration (iteration `0` is the start point), appended as it happens and independent of `DEBUG`. Group by `start_idx` and order by `iteration` to plot a cost-vs-iteration line per start while the run is still going (`start_idx` is a stable global index, so rows from starts running concurrently on different MPI ranks demux cleanly regardless of interleaving).
+It also streams two live per-start histories *during* the run, appended one row per L-BFGS-B iteration (iteration `0` is the start point), independent of `DEBUG`: **`multi_start_cost_history.csv`** (`start_idx, iteration, cost`) and **`multi_start_param_vals_history.csv`** (`start_idx, iteration,` then one named column per parameter, holding the *actual* parameter values — same columns as `multi_start_summary.csv`). Group by `start_idx` and order by `iteration` to plot a cost-vs-iteration and a parameter-vs-iteration line per start while the run is still going. The two files share the same `(start_idx, iteration)` keys, and `start_idx` is a stable global index, so rows from starts running concurrently on different MPI ranks demux cleanly regardless of interleaving.
 
 #### Benchmark: FitzHugh-Nagumo
 


### PR DESCRIPTION
Follow-up to the live cost stream (#286/#287): multi-start L-BFGS-B now also streams **`multi_start_param_vals_history.csv`**, so a GUI (CUFLynx) can plot each parameter's per-start trajectory *during* the run — alongside the cost — not just the final values in `multi_start_summary.csv`.

## What it writes

Mirrors `multi_start_cost_history.csv` exactly:

- One row per L-BFGS-B iteration (iteration `0` = the start point).
- Header: `start_idx, iteration,` then **one named column per parameter**, holding the **actual (unnormalised)** parameter values — the same columns `multi_start_summary.csv` uses (`/` → space).
- Written **unconditionally** (not gated on `DEBUG`), keyed by the **global** `start_idx`.
- Best-effort append via the broadcast `_stream_output_dir`, so every rank streams its own starts and non-rank-0's `None` `output_dir` is handled; atomic short-line `O_APPEND` for concurrent multi-rank safety.
- The two live files share the same `(start_idx, iteration)` keys, so a consumer can join them.

## Verification

- **`test_multi_start_streams_per_start_param_vals_history_live`** (new): header names the params; one value column per param; a row for every start `0..N-1` with iterations `0,1,2,…`; the `(start, iteration)` keys **match the cost history**; each start's last streamed params equal its summary final params.
- **End-to-end at 2 ranks** (output_dir on rank 0 only, the real MPI condition): all 8 starts stream, 86 rows (matching the cost stream), no torn lines.
- **All 16 `multi_start` tests pass.**

Docs (`parameter-identification.md`) updated to describe both live files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
