### PR TITLE
feat(parsers): discoverable gradient_sources accessor for the calibration UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,10 +74,11 @@ The GUI front-end **CUFLynx** auto-populates its menus and settings forms by rea
 
 - `SOLVER_SCHEMA` — model types, solvers per model type, integrator `method`s per solver, and `solver_info_fields_by_solver` (`SOLVER_INFO_FIELDS`: the `solver_info` settings per solver). `_SOLVER_INTEGRATOR_KEYS` (validation) is **derived** from `SOLVER_INFO_FIELDS`, so add a solver_info field there.
 - `PARAM_ID_METHODS` — calibration methods, each with an `options` list = the `optimiser_options` it reads. Add a new optimiser knob here.
+- `gradient_sources(model_type, solver)` — the gradient sources (FD / AD / FSA) the gradient-based methods (`sp_minimize`, `multi_start_sp_minimize`) can use for a given model, each with the `do_ad` flag it implies. There is **no** per-method "gradient" option: AD vs FD is the top-level `do_ad` flag, and which analytic backend runs follows from `model_type`/`solver` (mirrors `OpencorParamID.get_gradient`). Keep it in step with that dispatch.
 - `ANALYSIS_OPTIONS` — the `sa_options` / `mcmc_options` / `ia_options` settings for the sensitivity / MCMC / identifiability modes.
 - Cost functions are a runtime registry (user-extensible), so they're discovered via `funcs_user.cost_funcs_user.cost_func_metadata()` (names + `is_MLE`/`is_combiner`/`differentiable` flags), not a static schema.
 
-Each setting is a descriptor `{name, type, default, required, description, choices?}`. Accessors: `solver_info_fields(solver)`, `param_id_method_options(method)`, `analysis_options(mode)`. Tests in `tests/test_solver_info_validation.py` lock every schema's shape **and** its correspondence to what the code actually reads (e.g. an option the optimiser doesn't read, or a read the schema omits, fails the suite) — extend those when you add settings.
+Each setting is a descriptor `{name, type, default, required, description, choices?}`. Accessors: `solver_info_fields(solver)`, `param_id_method_options(method)`, `analysis_options(mode)`, `gradient_sources(model_type, solver)`. Tests in `tests/test_solver_info_validation.py` lock every schema's shape **and** its correspondence to what the code actually reads (e.g. an option the optimiser doesn't read, or a read the schema omits, fails the suite) — extend those when you add settings.
 
 ## Source layout (`src/`)
 

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -235,7 +235,8 @@ PARAM_ID_METHODS = {
         'description': ('Local bounded L-BFGS-B. Uses an automatic-differentiation gradient for '
                         'casadi_python, aadc_python, or cellml_only + CVODE_myokit + do_ad; '
                         'finite differences otherwise.'),
-        # The gradient source is the top-level `do_ad` user input, not an optimiser_option.
+        # The gradient source is the top-level `do_ad` user input, not an optimiser_option; the
+        # sources available for a given model_type/solver are exposed by gradient_sources().
         'options': [_OPT_COST_CONVERGENCE],
     },
     'multi_start_sp_minimize': {
@@ -292,6 +293,64 @@ def solver_info_fields(solver):
     """The `solver_info` settings a given solver accepts (see SOLVER_INFO_FIELDS), for tools that
     auto-populate the solver settings form. Empty list for an unknown solver."""
     return SOLVER_INFO_FIELDS.get(solver, [])
+
+
+def gradient_sources(model_type, solver=None):
+    """The gradient sources available for the gradient-based param-id methods (`sp_minimize`,
+    `multi_start_sp_minimize`) with this `model_type` + `solver`, for a front-end that offers a
+    "Gradient" menu without hardcoding CA's rules.
+
+    Each descriptor:
+      * ``value``  -- 'FD' | 'AD' | 'FSA' (the UI selector value)
+      * ``label``  -- human-readable name
+      * ``do_ad``  -- the top-level ``do_ad`` user-input flag CA needs for this source. There is
+                      no per-method "gradient" option in CA: AD vs finite differences is chosen by
+                      ``do_ad``, and which analytic backend runs follows from model_type/solver.
+                      Finite differences is ``do_ad`` False; every analytic source is ``do_ad`` True.
+      * ``requires_all_differentiable`` -- True only for CasADi AD, which needs every operation in
+                      the specific model to be differentiable. That is a per-model runtime property
+                      (not knowable from model_type/solver alone), so a caller that has loaded the
+                      model should gate the source on it -- e.g. via ``is_circulatory_differentiable``
+                      over the cost/operation funcs. All other sources are False.
+      * ``description``
+
+    The analytic source, if any, follows exactly ``OpencorParamID.get_gradient`` dispatch (and
+    ``AD_GRADIENT_MODEL_TYPES`` / ``fsa_gradient_available`` in the optimisers):
+      * ``casadi_python``               -> symbolic CasADi AD
+      * ``aadc_python``                 -> AADC tape AD (needs a Matlogica licence at runtime)
+      * ``cellml_only`` + ``CVODE_myokit`` -> Myokit CVODES forward sensitivity (FSA)
+      * otherwise                       -> finite differences only
+    Finite differences is always available. This is the single source of truth these rules were
+    previously duplicated from in downstream tools (e.g. CUFLynx); keep it in step with
+    get_gradient.
+    """
+    sources = [{
+        'value': 'FD', 'label': 'Finite difference', 'do_ad': False,
+        'requires_all_differentiable': False,
+        'description': ('Central finite differences of the cost; works for any model_type, at '
+                        'the cost of extra simulations per gradient.'),
+    }]
+    if model_type == 'casadi_python':
+        sources.append({
+            'value': 'AD', 'label': 'Automatic differentiation (CasADi)', 'do_ad': True,
+            'requires_all_differentiable': True,
+            'description': ('Exact symbolic CasADi gradient. Requires every operation in the '
+                            'model to be differentiable.'),
+        })
+    elif model_type == 'aadc_python':
+        sources.append({
+            'value': 'AD', 'label': 'Automatic differentiation (AADC)', 'do_ad': True,
+            'requires_all_differentiable': False,
+            'description': 'Exact AADC tape gradient (requires a Matlogica AADC licence at runtime).',
+        })
+    elif model_type == 'cellml_only' and solver == 'CVODE_myokit':
+        sources.append({
+            'value': 'FSA', 'label': 'Forward sensitivity (Myokit CVODES)', 'do_ad': True,
+            'requires_all_differentiable': False,
+            'description': ('Myokit CVODES forward-sensitivity gradient; the analytic gradient path '
+                            'for stiff cellml_only models.'),
+        })
+    return sources
 
 
 # Settings blocks for the non-calibration analysis modes (sensitivity, MCMC, identifiability), in

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -14,6 +14,7 @@ from parsers.PrimitiveParsers import (
     SOLVER_SCHEMA,
     SOLVER_INFO_FIELDS,
     solver_info_fields,
+    gradient_sources,
     ANALYSIS_OPTIONS,
     analysis_options,
     _SOLVER_INTEGRATOR_KEYS,
@@ -435,3 +436,49 @@ def test_sa_method_choices_each_have_a_dispatch_handler():
         assert hasattr(SensitivityAnalysis, f'run_{method}_sensitivity'), (
             f"schema advertises sa method {method!r} but SensitivityAnalysis has no "
             f"run_{method}_sensitivity handler")
+
+
+def test_gradient_sources_well_formed_and_match_get_gradient_dispatch():
+    """gradient_sources(model_type, solver) must advertise exactly the sources CA can actually
+    produce, keyed to the top-level do_ad flag, so a front-end can build a gradient menu without
+    hand-mirroring CA's rules. Pinned to OpencorParamID.get_gradient's dispatch: the AD-capable
+    model types are AD_GRADIENT_MODEL_TYPES, and cellml_only+CVODE_myokit gets FSA.
+    """
+    from param_id.optimisers import AD_GRADIENT_MODEL_TYPES
+
+    _REQUIRED_KEYS = {'value', 'label', 'do_ad', 'requires_all_differentiable', 'description'}
+
+    def _check_shape(srcs):
+        assert srcs, 'at least finite differences must always be offered'
+        for s in srcs:
+            assert set(s) == _REQUIRED_KEYS, s
+            assert s['value'] in {'FD', 'AD', 'FSA'}
+            assert isinstance(s['do_ad'], bool)
+            assert isinstance(s['requires_all_differentiable'], bool)
+        # Finite differences is always present, and is the only do_ad=False source.
+        fd = [s for s in srcs if s['value'] == 'FD']
+        assert len(fd) == 1 and fd[0]['do_ad'] is False
+        assert [s for s in srcs if not s['do_ad']] == fd
+        # Only CasADi AD needs all-differentiable.
+        for s in srcs:
+            assert s['requires_all_differentiable'] == (
+                s['value'] == 'AD' and 'CasADi' in s['label'])
+
+    # Every AD-capable model type offers an AD source with do_ad=True (matching get_gradient).
+    for mt in AD_GRADIENT_MODEL_TYPES:
+        srcs = gradient_sources(mt)
+        _check_shape(srcs)
+        ad = [s for s in srcs if s['value'] == 'AD']
+        assert len(ad) == 1 and ad[0]['do_ad'] is True, mt
+
+    # cellml_only gets the Myokit CVODES FSA source only with the Myokit solver.
+    myokit = gradient_sources('cellml_only', 'CVODE_myokit')
+    _check_shape(myokit)
+    fsa = [s for s in myokit if s['value'] == 'FSA']
+    assert len(fsa) == 1 and fsa[0]['do_ad'] is True
+
+    # No analytic source for cellml_only under a non-FSA solver, or for non-AD model types.
+    for mt, sv in [('cellml_only', 'CVODE_opencor'), ('python', 'solve_ivp'), ('cpp', 'RK4')]:
+        srcs = gradient_sources(mt, sv)
+        _check_shape(srcs)
+        assert [s['value'] for s in srcs] == ['FD'], (mt, sv)


### PR DESCRIPTION
Makes the gradient source (AD / FSA / FD) for the gradient-based calibration methods **discoverable**, so a front-end (CUFLynx) can offer an "AD" gradient option without hand-mirroring CA's rules.

## Why

Whether `sp_minimize` / `multi_start_sp_minimize` uses AD, Myokit CVODES FSA, or finite differences is controlled by the top-level `do_ad` flag plus `model_type`/`solver` — and **none of it was machine-readable**: `do_ad` is in no schema, and the one option that was (`gradient_method`) was removed because nothing read it. So CUFLynx had to hand-mirror CA's rules in its own `gradient_sources()`, and that mirror is incomplete (no `aadc_python`), which is why AD didn't appear for some models.

## What

`parsers.PrimitiveParsers.gradient_sources(model_type, solver=None)` → the sources available for that model, each:

```python
{"value": "FD"|"AD"|"FSA", "label": str,
 "do_ad": bool,                        # the top-level flag CA needs (FD->False, analytic->True)
 "requires_all_differentiable": bool,  # True only for CasADi AD
 "description": str}
```

The analytic source follows `OpencorParamID.get_gradient` exactly:

| model_type / solver | analytic source |
|---|---|
| `casadi_python` | CasADi AD (`requires_all_differentiable`) |
| `aadc_python` | AADC AD |
| `cellml_only` + `CVODE_myokit` | Myokit CVODES FSA |
| otherwise | finite differences only |

`requires_all_differentiable` is a per-model runtime gate CA can't know statically, so a caller that has loaded the model applies it (CUFLynx already computes it via `is_circulatory_differentiable`); the flag just names the rule.

Sits alongside `solver_info_fields` / `param_id_method_options` / `analysis_options` as the single source of truth these rules were previously duplicated from.

## Test

`test_gradient_sources_well_formed_and_match_get_gradient_dispatch`: descriptor shape; FD always present as the only `do_ad=False` source; the AD-capable model types **match `AD_GRADIENT_MODEL_TYPES`**; `cellml_only` gets FSA only with `CVODE_myokit`; non-AD model types get FD only. All 25 schema tests pass. Docs/CLAUDE.md schema list updated.

## Downstream (CUFLynx, separate PR)

CUFLynx introspects this accessor in place of its hand-coded `apps/api/solver_options.py::gradient_sources`, keeping the current logic only as the CA-unavailable fallback, and applies the `requires_all_differentiable` gate on its side. Net: AD becomes selectable for `casadi_python` (when differentiable) and `aadc_python`, FSA for `cellml_only + CVODE_myokit`, without hardcoding CA's rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
