### PR TITLE
fix(identifiability): temporarily disable the Laplace approximation (issue #293)

### DIFF
--- a/src/identifiabilty_analysis/identifiabilityAnalysis.py
+++ b/src/identifiabilty_analysis/identifiabilityAnalysis.py
@@ -131,9 +131,21 @@ class IdentifiabilityAnalysis():
         if ia_options['method'] == 'profile_likelihood':
             self.run_profile_likelihood(ia_options)
         elif ia_options['method'] == 'Laplace':
-            if self.rank == 0:
-                # currently Laplace is not parallelised, so only run on rank 0
-                self.run_laplace_approximation(ia_options)
+            # TEMPORARILY DISABLED (issue #293). The Laplace covariance is computed by inverting a
+            # Hessian fitted in raw, un-normalised parameter space; for models whose parameters
+            # span a wide magnitude range (e.g. 3compartment, ~1e-9 to ~1e8) that fit is
+            # astronomically ill-conditioned, so the uncertainties come out massively inflated and
+            # numerically meaningless. Raise instead of emitting a wrong covariance. Raised on
+            # every rank so an MPI run fails together, not just rank 0. When #293 is fixed, restore
+            # the original dispatch below (which the raise replaced):
+            #     if self.rank == 0:  # Laplace is not parallelised
+            #         self.run_laplace_approximation(ia_options)
+            raise NotImplementedError(
+                "The Laplace approximation is temporarily disabled: it produces massively "
+                "inflated, numerically meaningless parameter uncertainties for models whose "
+                "parameters span a wide magnitude range (an ill-conditioned Hessian fitted in "
+                "raw parameter space). Tracked in issue #293. Use 'profile_likelihood', or wait "
+                "for the fix.")
         return
 
     def run_profile_likelihood(self, ia_options):

--- a/src/scripts/generate_omex_analysis_script.py
+++ b/src/scripts/generate_omex_analysis_script.py
@@ -243,7 +243,16 @@ def run_pipeline():
     best_param_vals = param_id.get_best_param_vals()
     id_analysis = IdentifiabilityAnalysis.init_from_dict(inp_data_dict, param_id.param_id)
     id_analysis.set_best_param_vals(best_param_vals)
-    id_analysis.run(inp_data_dict["ia_options"])
+    # The Laplace approximation is temporarily disabled (raises NotImplementedError; CA issue
+    # #293). Skip identifiability rather than fail the whole pipeline -- SA and calibration have
+    # already succeeded; the summary just records that no Laplace output was produced.
+    identifiability_ran = True
+    try:
+        id_analysis.run(inp_data_dict["ia_options"])
+    except NotImplementedError as exc:
+        identifiability_ran = False
+        if MPI.COMM_WORLD.Get_rank() == 0:
+            print(f"Skipping identifiability analysis: {{exc}}")
 
     if MPI.COMM_WORLD.Get_rank() == 0:
         summary = {{
@@ -255,8 +264,10 @@ def run_pipeline():
             "selected_param_names": selected_param_names,
             "best_cost": float(np.load(os.path.join(param_id.output_dir, "best_cost.npy"))),
             "best_param_vals_path": os.path.join(param_id.output_dir, "best_param_vals.npy"),
-            "laplace_mean_path": os.path.join(OUTPUT_ROOT, f"{{FILE_PREFIX}}_laplace_mean.npy"),
-            "laplace_covariance_path": os.path.join(OUTPUT_ROOT, f"{{FILE_PREFIX}}_laplace_covariance.npy"),
+            "laplace_mean_path": (os.path.join(OUTPUT_ROOT, f"{{FILE_PREFIX}}_laplace_mean.npy")
+                                  if identifiability_ran else None),
+            "laplace_covariance_path": (os.path.join(OUTPUT_ROOT, f"{{FILE_PREFIX}}_laplace_covariance.npy")
+                                        if identifiability_ran else None),
         }}
         with open(SUMMARY_PATH, "w", encoding="utf-8") as wf:
             json.dump(summary, wf, indent=2)

--- a/tests/test_omex_analysis_pipeline.py
+++ b/tests/test_omex_analysis_pipeline.py
@@ -164,12 +164,9 @@ def test_generate_omex_analysis_pipeline_runs_successfully(temp_output_dir):
     assert best_cost >= 0.0, f"Calibration cost should be non-negative, got {best_cost}"
     assert best_cost < 150.0, f"Calibration cost should remain below threshold, got {best_cost}"
 
-    assert os.path.exists(laplace_mean_path), f"Laplace mean file missing: {laplace_mean_path}"
-    assert os.path.exists(laplace_covariance_path), (
-        f"Laplace covariance file missing: {laplace_covariance_path}"
-    )
-
-    covariance = np.load(laplace_covariance_path)
-    assert covariance.shape[0] == covariance.shape[1], "Covariance matrix should be square"
-    assert not np.isnan(covariance).any(), "Covariance matrix should not contain NaN values"
-    assert not np.isinf(covariance).any(), "Covariance matrix should not contain Inf values"
+    # Laplace is temporarily disabled (issue #293): the pipeline skips identifiability rather than
+    # emit a numerically meaningless covariance, and records no Laplace output in the summary. The
+    # rest of the pipeline (SA, calibration) still succeeds -- which is the point of skipping
+    # instead of hard-failing. When #293 is fixed, restore the file/covariance assertions here.
+    assert laplace_mean_path is None, laplace_mean_path
+    assert laplace_covariance_path is None, laplace_covariance_path

--- a/tests/test_python_user_defined.py
+++ b/tests/test_python_user_defined.py
@@ -167,21 +167,22 @@ def test_param_id_python_user_defined_recovers_params(base_user_inputs, temp_out
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.mpi
-def test_identifiability_python_user_defined_succeeds(base_user_inputs, temp_output_dir, temp_generated_models_dir):
-    """Laplace identifiability/UQ analysis runs end-to-end after calibration."""
-    rank = MPI.COMM_WORLD.Get_rank()
+def test_identifiability_python_user_defined_laplace_disabled(base_user_inputs, temp_output_dir, temp_generated_models_dir):
+    """Laplace identifiability/UQ is temporarily disabled (issue #293): the run reaches the
+    identifiability step after calibration and raises NotImplementedError rather than emitting a
+    numerically meaningless covariance.
+
+    When #293 is fixed and Laplace is re-enabled, restore this to assert the covariance is written
+    (and validate its values, per #293's acceptance criteria).
+    """
     config = _oscillator_config(base_user_inputs, temp_output_dir, temp_generated_models_dir)
     config['do_ia'] = True
     config['ia_options'] = {'method': 'Laplace'}
 
-    run_param_id(config)
+    with pytest.raises(NotImplementedError, match="#293"):
+        run_param_id(config)
 
-    if rank == 0:
-        # Laplace writes {prefix}_laplace_{mean,covariance}.npy to the parent of
-        # param_id_output_dir.
-        parent_dir = os.path.dirname(temp_output_dir)
-        cov_path = os.path.join(parent_dir, 'oscillator_laplace_covariance.npy')
-        assert os.path.exists(cov_path), f"expected Laplace covariance at {cov_path}"
-        cov = np.load(cov_path)
-        assert cov.shape == (2, 2)
-        assert np.all(np.isfinite(cov))
+    # No covariance should have been written.
+    parent_dir = os.path.dirname(temp_output_dir)
+    cov_path = os.path.join(parent_dir, 'oscillator_laplace_covariance.npy')
+    assert not os.path.exists(cov_path)


### PR DESCRIPTION
Temporarily disables the Laplace approximation so it can't silently emit wrong uncertainties. **Interim mitigation for #293** (not the fix).

## Why

Laplace returns **massively inflated, numerically meaningless** parameter uncertainties for models whose parameters span a wide magnitude range (3compartment, ~`1e-9` to ~`1e8`): the covariance is `inv(-Hessian)` of a Hessian fitted (`parabola_fit`) in **raw, un-normalised parameter space**, which is astronomically ill-conditioned. The code already carries `# TODO ... not correct yet. Finbar to fix.`. Full diagnosis and the real fix (normalise the Hessian, Jacobian-transform the covariance back, add value-level tests) are in **#293**.

The existing tests are smoke-only (covariance file exists / square / finite), so a covariance full of astronomically large numbers passed — the bug was uncaught.

## What

- `IdentifiabilityAnalysis.run` raises `NotImplementedError` (pointing at #293) for `method: Laplace`, on **every rank** so an MPI run fails together. The original rank-0 dispatch is preserved in a comment to restore when #293 lands. `profile_likelihood` is unaffected; Laplace stays a valid (if disabled) `ia_options` choice.
- The **OMEX pipeline** auto-includes identifiability, and a hard failure there would take down the whole pipeline (SA + calibration already succeeded). So the generated pipeline now **catches** the `NotImplementedError`, skips identifiability, and records `laplace_*_path = null` in `pipeline_summary.json` instead of crashing.

## Tests

- `test_identifiability_python_user_defined_laplace_disabled` (renamed from `..._succeeds`): the run reaches identifiability after calibration and raises `NotImplementedError` with `#293`; no covariance is written. **Passes.**
- `test_omex_analysis_pipeline`: asserts the pipeline still succeeds and records `laplace_*_path = None`. Both tests carry a note on how to restore them when #293 is fixed.
- `test_mcmc_and_laplace_require_is_mle_cost` and the `ia_options` schema test still pass.

## Verification note

The identifiability disablement test passes here. The full OMEX pipeline test is **skipped in my environment** (its venv Python has no CellML backend — a pre-existing skip), so it'll first exercise in CI. I verified the generated pipeline script **compiles** and the skip logic is correct statically, and confirmed the dispatch raises on all ranks — but the end-to-end OMEX subprocess run is unverified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
