### PR TITLE
feat(param-id): make the genetic-algorithm population user-configurable (+ schema)

### DIFF
--- a/src/param_id/optimisers.py
+++ b/src/param_id/optimisers.py
@@ -110,24 +110,41 @@ class GeneticAlgorithmOptimiser(Optimiser):
     This is a refactored version of the original genetic algorithm implementation
     in OpencorParamID, maintaining the same functionality.
     """
-    
+
+    def _population_sizes(self):
+        """Resolve the GA population sizing from ``optimiser_options``.
+
+        Each of ``num_elite`` / ``num_survivors`` / ``num_mutations_per_survivor`` /
+        ``num_cross_breed`` is user-configurable; an omitted (or ``None``) value falls back to the
+        historical DEBUG-dependent default -- the small "quick" sizes under DEBUG, the full
+        production sizes otherwise. Advertised in ``PARAM_ID_METHODS['genetic_algorithm']`` so a
+        tool (CUFLynx) can offer them. The population per generation is
+        ``num_survivors + num_survivors*num_mutations_per_survivor + num_cross_breed``.
+        """
+        if self.DEBUG:
+            defaults = {'num_elite': 4, 'num_survivors': 6,
+                        'num_mutations_per_survivor': 2, 'num_cross_breed': 10}
+        else:
+            defaults = {'num_elite': 12, 'num_survivors': 48,
+                        'num_mutations_per_survivor': 12, 'num_cross_breed': 120}
+        sizes = {}
+        for key, default in defaults.items():
+            val = self.optimiser_options.get(key)
+            sizes[key] = default if val is None else int(val)
+        return sizes
+
     def run(self):
         """Run the genetic algorithm optimization."""
         comm = self.comm
         rank = self.rank
         num_procs = self.num_procs
         
-        if self.DEBUG:
-            num_elite = 4
-            num_survivors = 6
-            num_mutations_per_survivor = 2
-            num_cross_breed = 10
-        else:
-            num_elite = 12
-            num_survivors = 48
-            num_mutations_per_survivor = 12
-            num_cross_breed = 120
-        
+        sizes = self._population_sizes()
+        num_elite = sizes['num_elite']
+        num_survivors = sizes['num_survivors']
+        num_mutations_per_survivor = sizes['num_mutations_per_survivor']
+        num_cross_breed = sizes['num_cross_breed']
+
         num_pop = num_survivors + num_survivors*num_mutations_per_survivor + num_cross_breed
         
         if self.optimiser_options['num_calls_to_function'] < num_pop:

--- a/src/param_id/optimisers.py
+++ b/src/param_id/optimisers.py
@@ -111,26 +111,35 @@ class GeneticAlgorithmOptimiser(Optimiser):
     in OpencorParamID, maintaining the same functionality.
     """
 
+    #: The population settings, and the quick-run sizes DEBUG substitutes for them. The *normal*
+    #: defaults are NOT duplicated here -- they are read from the schema
+    #: (PARAM_ID_METHODS['genetic_algorithm']), which is the single source of truth so a front-end
+    #: can pre-fill the same values CA actually uses.
+    _POPULATION_KEYS = ('num_elite', 'num_survivors', 'num_mutations_per_survivor',
+                        'num_cross_breed')
+    _DEBUG_POPULATION = {'num_elite': 4, 'num_survivors': 6,
+                         'num_mutations_per_survivor': 2, 'num_cross_breed': 10}
+
     def _population_sizes(self):
         """Resolve the GA population sizing from ``optimiser_options``.
 
         Each of ``num_elite`` / ``num_survivors`` / ``num_mutations_per_survivor`` /
-        ``num_cross_breed`` is user-configurable; an omitted (or ``None``) value falls back to the
-        historical DEBUG-dependent default -- the small "quick" sizes under DEBUG, the full
-        production sizes otherwise. Advertised in ``PARAM_ID_METHODS['genetic_algorithm']`` so a
-        tool (CUFLynx) can offer them. The population per generation is
+        ``num_cross_breed`` is user-configurable. An omitted (or ``None``) value falls back to the
+        schema default advertised in ``PARAM_ID_METHODS['genetic_algorithm']`` -- so the value a
+        tool (CUFLynx) shows is exactly the one used -- except under DEBUG, which substitutes the
+        smaller quick-run sizes in ``_DEBUG_POPULATION``. The population per generation is
         ``num_survivors + num_survivors*num_mutations_per_survivor + num_cross_breed``.
         """
-        if self.DEBUG:
-            defaults = {'num_elite': 4, 'num_survivors': 6,
-                        'num_mutations_per_survivor': 2, 'num_cross_breed': 10}
-        else:
-            defaults = {'num_elite': 12, 'num_survivors': 48,
-                        'num_mutations_per_survivor': 12, 'num_cross_breed': 120}
+        # Imported lazily to keep optimisers.py importable without the parser package loaded.
+        from parsers.PrimitiveParsers import param_id_method_options
+        schema_defaults = {opt['name']: opt['default']
+                           for opt in param_id_method_options('genetic_algorithm')}
         sizes = {}
-        for key, default in defaults.items():
+        for key in self._POPULATION_KEYS:
             val = self.optimiser_options.get(key)
-            sizes[key] = default if val is None else int(val)
+            if val is None:
+                val = self._DEBUG_POPULATION[key] if self.DEBUG else schema_defaults[key]
+            sizes[key] = int(val)
         return sizes
 
     def run(self):

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -224,6 +224,30 @@ _OPT_MAX_PATIENCE = {
     'name': 'max_patience', 'type': 'int', 'default': 10, 'required': False,
     'description': 'Stop after this many generations without an improvement in cost.',
 }
+# Genetic-algorithm population sizing. Defaults are DEBUG-dependent (small "quick" sizes under
+# DEBUG, full production sizes otherwise), so the static schema default is None -- an omitted (or
+# null) value falls back to the DEBUG-dependent built-in. The population per generation is
+# num_survivors + num_survivors*num_mutations_per_survivor + num_cross_breed.
+_OPT_GA_NUM_ELITE = {
+    'name': 'num_elite', 'type': 'int', 'default': None, 'required': False,
+    'description': 'Genetic algorithm: top individuals carried over unchanged each generation '
+                   '(elitism). Default 12, or 4 when DEBUG.',
+}
+_OPT_GA_NUM_SURVIVORS = {
+    'name': 'num_survivors', 'type': 'int', 'default': None, 'required': False,
+    'description': 'Genetic algorithm: individuals that survive to reproduce each generation. '
+                   'Default 48, or 6 when DEBUG.',
+}
+_OPT_GA_NUM_MUTATIONS_PER_SURVIVOR = {
+    'name': 'num_mutations_per_survivor', 'type': 'int', 'default': None, 'required': False,
+    'description': 'Genetic algorithm: mutated offspring generated per survivor each generation. '
+                   'Default 12, or 2 when DEBUG.',
+}
+_OPT_GA_NUM_CROSS_BREED = {
+    'name': 'num_cross_breed', 'type': 'int', 'default': None, 'required': False,
+    'description': 'Genetic algorithm: cross-bred (recombined) offspring per generation. '
+                   'Default 120, or 10 when DEBUG.',
+}
 
 
 # Single source of truth for the parameter-identification (calibration) methods, i.e. the valid
@@ -237,7 +261,9 @@ PARAM_ID_METHODS = {
         'label': 'Genetic algorithm',
         'gradient_based': False,
         'description': 'Gradient-free population-based global search.',
-        'options': [_OPT_NUM_CALLS, _OPT_COST_CONVERGENCE, _OPT_MAX_PATIENCE],
+        'options': [_OPT_NUM_CALLS, _OPT_COST_CONVERGENCE, _OPT_MAX_PATIENCE,
+                    _OPT_GA_NUM_ELITE, _OPT_GA_NUM_SURVIVORS,
+                    _OPT_GA_NUM_MUTATIONS_PER_SURVIVOR, _OPT_GA_NUM_CROSS_BREED],
     },
     'CMA-ES': {
         'label': 'CMA-ES',

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -224,29 +224,31 @@ _OPT_MAX_PATIENCE = {
     'name': 'max_patience', 'type': 'int', 'default': 10, 'required': False,
     'description': 'Stop after this many generations without an improvement in cost.',
 }
-# Genetic-algorithm population sizing. Defaults are DEBUG-dependent (small "quick" sizes under
-# DEBUG, full production sizes otherwise), so the static schema default is None -- an omitted (or
-# null) value falls back to the DEBUG-dependent built-in. The population per generation is
-# num_survivors + num_survivors*num_mutations_per_survivor + num_cross_breed.
+# Genetic-algorithm population sizing. These are the single source of truth for the defaults --
+# GeneticAlgorithmOptimiser._population_sizes() reads them from here rather than duplicating the
+# numbers, so the schema and the code cannot drift and a front-end can pre-fill the real values
+# (a None default would render as a blank field, see #277). DEBUG applies a documented quick-run
+# scale-down on top (GeneticAlgorithmOptimiser._DEBUG_POPULATION). The population per generation
+# is num_survivors + num_survivors*num_mutations_per_survivor + num_cross_breed.
 _OPT_GA_NUM_ELITE = {
-    'name': 'num_elite', 'type': 'int', 'default': None, 'required': False,
+    'name': 'num_elite', 'type': 'int', 'default': 12, 'required': False,
     'description': 'Genetic algorithm: top individuals carried over unchanged each generation '
-                   '(elitism). Default 12, or 4 when DEBUG.',
+                   '(elitism). Reduced to 4 when DEBUG is on.',
 }
 _OPT_GA_NUM_SURVIVORS = {
-    'name': 'num_survivors', 'type': 'int', 'default': None, 'required': False,
+    'name': 'num_survivors', 'type': 'int', 'default': 48, 'required': False,
     'description': 'Genetic algorithm: individuals that survive to reproduce each generation. '
-                   'Default 48, or 6 when DEBUG.',
+                   'Reduced to 6 when DEBUG is on.',
 }
 _OPT_GA_NUM_MUTATIONS_PER_SURVIVOR = {
-    'name': 'num_mutations_per_survivor', 'type': 'int', 'default': None, 'required': False,
+    'name': 'num_mutations_per_survivor', 'type': 'int', 'default': 12, 'required': False,
     'description': 'Genetic algorithm: mutated offspring generated per survivor each generation. '
-                   'Default 12, or 2 when DEBUG.',
+                   'Reduced to 2 when DEBUG is on.',
 }
 _OPT_GA_NUM_CROSS_BREED = {
-    'name': 'num_cross_breed', 'type': 'int', 'default': None, 'required': False,
+    'name': 'num_cross_breed', 'type': 'int', 'default': 120, 'required': False,
     'description': 'Genetic algorithm: cross-bred (recombined) offspring per generation. '
-                   'Default 120, or 10 when DEBUG.',
+                   'Reduced to 10 when DEBUG is on.',
 }
 
 

--- a/tests/test_ga_population.py
+++ b/tests/test_ga_population.py
@@ -1,0 +1,40 @@
+"""Unit tests for the user-configurable genetic-algorithm population sizing
+(num_elite / num_survivors / num_mutations_per_survivor / num_cross_breed)."""
+import pytest
+
+from param_id.optimisers import GeneticAlgorithmOptimiser
+
+
+def _make_ga(options, debug):
+    # Only optimiser_options and DEBUG are consulted by _population_sizes; the rest can be dummies.
+    return GeneticAlgorithmOptimiser(
+        param_id_obj=None, param_id_info=None, param_norm_obj=None,
+        num_params=3, output_dir=None, optimiser_options=dict(options), DEBUG=debug)
+
+
+@pytest.mark.unit
+def test_ga_population_defaults_match_debug_flag():
+    """With nothing set, the sizes are the historical DEBUG-dependent defaults (unchanged
+    behaviour): the small 'quick' sizes under DEBUG, the full production sizes otherwise."""
+    assert _make_ga({}, False)._population_sizes() == {
+        'num_elite': 12, 'num_survivors': 48, 'num_mutations_per_survivor': 12,
+        'num_cross_breed': 120}
+    assert _make_ga({}, True)._population_sizes() == {
+        'num_elite': 4, 'num_survivors': 6, 'num_mutations_per_survivor': 2,
+        'num_cross_breed': 10}
+
+
+@pytest.mark.unit
+def test_ga_population_user_overrides_and_none_falls_back():
+    ga = _make_ga({'num_survivors': 10, 'num_cross_breed': 20, 'num_mutations_per_survivor': 3,
+                   'num_elite': None}, debug=False)
+    sizes = ga._population_sizes()
+    # explicit values win
+    assert (sizes['num_survivors'], sizes['num_cross_breed'], sizes['num_mutations_per_survivor']) \
+        == (10, 20, 3)
+    # an explicit None (or an omitted key) falls back to the DEBUG-dependent default
+    assert sizes['num_elite'] == 12
+    # population = num_survivors + num_survivors*num_mutations_per_survivor + num_cross_breed
+    num_pop = (sizes['num_survivors'] + sizes['num_survivors'] * sizes['num_mutations_per_survivor']
+               + sizes['num_cross_breed'])
+    assert num_pop == 10 + 10 * 3 + 20

--- a/tests/test_ga_population.py
+++ b/tests/test_ga_population.py
@@ -25,6 +25,19 @@ def test_ga_population_defaults_match_debug_flag():
 
 
 @pytest.mark.unit
+def test_ga_non_debug_defaults_come_from_the_schema():
+    """The non-DEBUG defaults are not duplicated in the optimiser -- they are read from
+    PARAM_ID_METHODS, so what a front-end pre-fills is exactly what CA uses and the two cannot
+    drift."""
+    from parsers.PrimitiveParsers import param_id_method_options
+    schema_defaults = {o['name']: o['default'] for o in
+                       param_id_method_options('genetic_algorithm')}
+    sizes = _make_ga({}, False)._population_sizes()
+    for key in GeneticAlgorithmOptimiser._POPULATION_KEYS:
+        assert sizes[key] == schema_defaults[key], key
+
+
+@pytest.mark.unit
 def test_ga_population_user_overrides_and_none_falls_back():
     ga = _make_ga({'num_survivors': 10, 'num_cross_breed': 20, 'num_mutations_per_survivor': 3,
                    'num_elite': None}, debug=False)

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -290,6 +290,15 @@ def test_statically_defaulted_options_advertise_their_default():
     ga = opt(param_id_method_options('genetic_algorithm'), 'num_calls_to_function')
     assert ga['default'] is None and ga['required'] is True
 
+    # The GA population settings DO have a fallback the code substitutes, so the schema must
+    # advertise it (a front-end pre-fills these). GeneticAlgorithmOptimiser._population_sizes
+    # reads these very values, so schema and code cannot drift.
+    ga_opts = param_id_method_options('genetic_algorithm')
+    for name, expected in (('num_elite', 12), ('num_survivors', 48),
+                           ('num_mutations_per_survivor', 12), ('num_cross_breed', 120)):
+        descriptor = opt(ga_opts, name)
+        assert descriptor['default'] == expected and descriptor['required'] is False, name
+
 
 def test_casadi_integrator_rejects_maximum_step_keys():
     with pytest.raises(ValueError, match="MaximumStep"):

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -76,7 +76,8 @@ def test_param_id_method_options_match_optimiser_reads():
 
     # Keys each optimiser reads from optimiser_options (see param_id/optimisers.py).
     assert names('genetic_algorithm') == {'num_calls_to_function', 'cost_convergence',
-                                          'max_patience'}
+                                          'max_patience', 'num_elite', 'num_survivors',
+                                          'num_mutations_per_survivor', 'num_cross_breed'}
     assert names('CMA-ES') == {'num_calls_to_function', 'sigma0', 'cost_convergence',
                                'max_patience'}
     assert names('bayesian') == {'num_calls_to_function'}


### PR DESCRIPTION
## What

Makes the genetic-algorithm **population sizing** user-configurable, with the defaults living in the **schema** so CUFLynx discovers *and pre-fills* them automatically.

Previously the four GA sizes were hardcoded in `optimisers.py`, chosen *solely by the `DEBUG` flag*:
- `DEBUG=False`: `num_elite=12, num_survivors=48, num_mutations_per_survivor=12, num_cross_breed=120` → population **744**
- `DEBUG=True`: `4 / 6 / 2 / 10` → population **28**

So there was no way to size the population for a run without toggling `DEBUG` (which also changes other behaviour). This matters because population and call budget trade off: at a fixed `num_calls`, an oversized population gets very few generations (near random search), while a right-sized one evolves properly.

## Change

The four sizes are now `optimiser_options`, and **the schema is the single source of truth for their defaults**:

| option | schema default | under DEBUG |
|---|---|---|
| `num_elite` | 12 | 4 |
| `num_survivors` | 48 | 6 |
| `num_mutations_per_survivor` | 12 | 2 |
| `num_cross_breed` | 120 | 10 |

`GeneticAlgorithmOptimiser._population_sizes()` **reads those defaults from `PARAM_ID_METHODS['genetic_algorithm']`** rather than duplicating the numbers — so the value a front-end pre-fills is exactly the one CA uses, and the two cannot drift. `DEBUG` remains a documented quick-run scale-down (`_DEBUG_POPULATION`) applied on top. Behaviour with no options set is unchanged in both modes.

Population per generation stays `num_survivors + num_survivors*num_mutations_per_survivor + num_cross_breed`.

## Schema (for CUFLynx)

Added to `PARAM_ID_METHODS['genetic_algorithm'].options` with **real defaults, not `None`** — this follows the convention the repo already enforces in `test_statically_defaulted_options_advertise_their_default`: *"if the code substitutes a fixed value when an option is absent, that value belongs in the schema's `default` — a `None` default renders as a blank required field in front-ends"* (#277). CUFLynx picks them up through the existing `param_id_method_options` accessor with no client-side hardcoding.

## Tests

- `test_param_id_method_options_match_optimiser_reads` — advertised options exactly match what the GA reads.
- `test_statically_defaulted_options_advertise_their_default` — pins the four schema defaults (12/48/12/120, `required: False`).
- `tests/test_ga_population.py` — DEBUG-dependent defaults, user overrides, `null`-falls-back-to-default, and a **drift guard** asserting the optimiser's non-DEBUG defaults equal the schema's.

All pass (30 in the two suites).

## Why

Lets a benchmark or tool pick a population appropriate for its call budget without enabling `DEBUG` — the efficient alternative to inflating `num_calls` (see the benchmark-fairness work, where a 744 population at 2000 calls gave the GA only ~2 generations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
