### PR TITLE
Fix: Algebraic variables in Myokit solver

### DIFF
--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -956,8 +956,15 @@ class SimulationHelper:
         if kind == "state":
             return np.asarray([self.simulation.state()[self.state_index[qname]]])
         if kind == "var":
-            if qname in self.default_values:
-                return np.asarray([self.default_values[qname]])
+            # if qname in self.default_values:
+            #     return np.asarray([self.default_values[qname]])
+            # Evaluate algebraic variable from current model state  
+            if qname in self.qname_to_var:  
+                try:  
+                    current_value = self.qname_to_var[qname].eval()  
+                    return np.asarray([current_value])  
+                except Exception:  
+                    pass  
         raise ValueError(f"variable {name} not found")
 
     def _resolve_name(self, name):


### PR DESCRIPTION
Returning the current value instead of initial (default) value for algebraic variables in Myokit solver. Closes physiomelinks/circulatory_autogen#309