### PR TITLE
feat(schema): advertise the DEBUG genetic-algorithm population as debug_default (#313)

### DIFF
--- a/src/param_id/optimisers.py
+++ b/src/param_id/optimisers.py
@@ -111,14 +111,23 @@ class GeneticAlgorithmOptimiser(Optimiser):
     in OpencorParamID, maintaining the same functionality.
     """
 
-    #: The population settings, and the quick-run sizes DEBUG substitutes for them. The *normal*
-    #: defaults are NOT duplicated here -- they are read from the schema
-    #: (PARAM_ID_METHODS['genetic_algorithm']), which is the single source of truth so a front-end
-    #: can pre-fill the same values CA actually uses.
+    #: The population settings. Neither the *normal* defaults nor the DEBUG quick-run sizes are
+    #: duplicated here -- both are read from the schema (PARAM_ID_METHODS['genetic_algorithm']),
+    #: which is the single source of truth so a front-end can pre-fill the same values CA actually
+    #: uses. The normal value is each option's ``default``; the DEBUG value is its ``debug_default``
+    #: (see ``_debug_population()``).
     _POPULATION_KEYS = ('num_elite', 'num_survivors', 'num_mutations_per_survivor',
                         'num_cross_breed')
-    _DEBUG_POPULATION = {'num_elite': 4, 'num_survivors': 6,
-                         'num_mutations_per_survivor': 2, 'num_cross_breed': 10}
+
+    @classmethod
+    def _debug_population(cls):
+        """The quick-run population DEBUG substitutes, read from each option's ``debug_default``
+        in the schema (``PARAM_ID_METHODS['genetic_algorithm']``) rather than duplicated here, so
+        the schema and the code cannot drift (#313)."""
+        # Imported lazily to keep optimisers.py importable without the parser package loaded.
+        from parsers.PrimitiveParsers import param_id_method_options
+        by_name = {opt['name']: opt for opt in param_id_method_options('genetic_algorithm')}
+        return {key: by_name[key]['debug_default'] for key in cls._POPULATION_KEYS}
 
     def _population_sizes(self):
         """Resolve the GA population sizing from ``optimiser_options``.
@@ -127,18 +136,19 @@ class GeneticAlgorithmOptimiser(Optimiser):
         ``num_cross_breed`` is user-configurable. An omitted (or ``None``) value falls back to the
         schema default advertised in ``PARAM_ID_METHODS['genetic_algorithm']`` -- so the value a
         tool (CUFLynx) shows is exactly the one used -- except under DEBUG, which substitutes the
-        smaller quick-run sizes in ``_DEBUG_POPULATION``. The population per generation is
-        ``num_survivors + num_survivors*num_mutations_per_survivor + num_cross_breed``.
+        smaller quick-run sizes advertised there as ``debug_default``. The population per generation
+        is ``num_survivors + num_survivors*num_mutations_per_survivor + num_cross_breed``.
         """
         # Imported lazily to keep optimisers.py importable without the parser package loaded.
         from parsers.PrimitiveParsers import param_id_method_options
         schema_defaults = {opt['name']: opt['default']
                            for opt in param_id_method_options('genetic_algorithm')}
+        debug_population = self._debug_population() if self.DEBUG else None
         sizes = {}
         for key in self._POPULATION_KEYS:
             val = self.optimiser_options.get(key)
             if val is None:
-                val = self._DEBUG_POPULATION[key] if self.DEBUG else schema_defaults[key]
+                val = debug_population[key] if self.DEBUG else schema_defaults[key]
             sizes[key] = int(val)
         return sizes
 

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -227,26 +227,31 @@ _OPT_MAX_PATIENCE = {
 # Genetic-algorithm population sizing. These are the single source of truth for the defaults --
 # GeneticAlgorithmOptimiser._population_sizes() reads them from here rather than duplicating the
 # numbers, so the schema and the code cannot drift and a front-end can pre-fill the real values
-# (a None default would render as a blank field, see #277). DEBUG applies a documented quick-run
-# scale-down on top (GeneticAlgorithmOptimiser._DEBUG_POPULATION). The population per generation
-# is num_survivors + num_survivors*num_mutations_per_survivor + num_cross_breed.
+# (a None default would render as a blank field, see #277). DEBUG substitutes a documented
+# quick-run scale-down, and that too is advertised here via `debug_default` -- the single source
+# of truth GeneticAlgorithmOptimiser._debug_population() derives from, so a front-end can show/pass
+# the exact values CA runs under DEBUG without hardcoding them (#313). An option with no DEBUG
+# variant simply omits `debug_default`. The population per generation is
+# num_survivors + num_survivors*num_mutations_per_survivor + num_cross_breed.
 _OPT_GA_NUM_ELITE = {
-    'name': 'num_elite', 'type': 'int', 'default': 12, 'required': False,
+    'name': 'num_elite', 'type': 'int', 'default': 12, 'debug_default': 4, 'required': False,
     'description': 'Genetic algorithm: top individuals carried over unchanged each generation '
                    '(elitism). Reduced to 4 when DEBUG is on.',
 }
 _OPT_GA_NUM_SURVIVORS = {
-    'name': 'num_survivors', 'type': 'int', 'default': 48, 'required': False,
+    'name': 'num_survivors', 'type': 'int', 'default': 48, 'debug_default': 6, 'required': False,
     'description': 'Genetic algorithm: individuals that survive to reproduce each generation. '
                    'Reduced to 6 when DEBUG is on.',
 }
 _OPT_GA_NUM_MUTATIONS_PER_SURVIVOR = {
-    'name': 'num_mutations_per_survivor', 'type': 'int', 'default': 12, 'required': False,
+    'name': 'num_mutations_per_survivor', 'type': 'int', 'default': 12, 'debug_default': 2,
+    'required': False,
     'description': 'Genetic algorithm: mutated offspring generated per survivor each generation. '
                    'Reduced to 2 when DEBUG is on.',
 }
 _OPT_GA_NUM_CROSS_BREED = {
-    'name': 'num_cross_breed', 'type': 'int', 'default': 120, 'required': False,
+    'name': 'num_cross_breed', 'type': 'int', 'default': 120, 'debug_default': 10,
+    'required': False,
     'description': 'Genetic algorithm: cross-bred (recombined) offspring per generation. '
                    'Reduced to 10 when DEBUG is on.',
 }

--- a/tests/test_ga_population.py
+++ b/tests/test_ga_population.py
@@ -38,6 +38,21 @@ def test_ga_non_debug_defaults_come_from_the_schema():
 
 
 @pytest.mark.unit
+def test_ga_debug_population_comes_from_the_schema():
+    """The DEBUG quick-run sizes are not duplicated in the optimiser either -- they are read from
+    each option's `debug_default` in PARAM_ID_METHODS (#313), so a front-end can show/pass the
+    exact values DEBUG runs and the schema and code cannot drift."""
+    from parsers.PrimitiveParsers import param_id_method_options
+    schema_debug_defaults = {o['name']: o.get('debug_default') for o in
+                             param_id_method_options('genetic_algorithm')}
+    debug_sizes = _make_ga({}, True)._population_sizes()
+    derived = GeneticAlgorithmOptimiser._debug_population()
+    for key in GeneticAlgorithmOptimiser._POPULATION_KEYS:
+        assert debug_sizes[key] == schema_debug_defaults[key], key
+        assert derived[key] == schema_debug_defaults[key], key
+
+
+@pytest.mark.unit
 def test_ga_population_user_overrides_and_none_falls_back():
     ga = _make_ga({'num_survivors': 10, 'num_cross_breed': 20, 'num_mutations_per_survivor': 3,
                    'num_elite': None}, debug=False)

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -302,6 +302,34 @@ def test_statically_defaulted_options_advertise_their_default():
         assert descriptor['default'] == expected and descriptor['required'] is False, name
 
 
+def test_ga_population_debug_defaults_advertised_and_match_the_optimiser():
+    """DEBUG substitutes a quick-run population, so each GA population option advertises it as
+    `debug_default` (#313) -- otherwise a tool can't show/pass the DEBUG values without hardcoding
+    them. The advertised values must equal what GeneticAlgorithmOptimiser derives (and runs) under
+    DEBUG, so schema and code cannot drift."""
+    from param_id.optimisers import GeneticAlgorithmOptimiser
+
+    def opt(options, name):
+        return next(o for o in options if o['name'] == name)
+
+    ga_opts = param_id_method_options('genetic_algorithm')
+    for name, expected in (('num_elite', 4), ('num_survivors', 6),
+                           ('num_mutations_per_survivor', 2), ('num_cross_breed', 10)):
+        assert opt(ga_opts, name)['debug_default'] == expected, name
+
+    # the optimiser derives its DEBUG population from these very descriptors
+    derived = GeneticAlgorithmOptimiser._debug_population()
+    for name in GeneticAlgorithmOptimiser._POPULATION_KEYS:
+        assert derived[name] == opt(ga_opts, name)['debug_default'], name
+
+    # debug_default is confined to the GA population knobs; no other advertised option carries one
+    for method, meta in PARAM_ID_METHODS.items():
+        for o in meta['options']:
+            if 'debug_default' in o:
+                assert method == 'genetic_algorithm' and o['name'] in \
+                    GeneticAlgorithmOptimiser._POPULATION_KEYS, (method, o['name'])
+
+
 def test_casadi_integrator_rejects_maximum_step_keys():
     with pytest.raises(ValueError, match="MaximumStep"):
         validate_solver_info('casadi_integrator', {


### PR DESCRIPTION
Closes #313.

## What

Advertise the DEBUG genetic-algorithm population in the discoverable schema so downstream tools (CUFLynx) can show/pass it without hardcoding CA's numbers.

- Add a **`debug_default`** field to each of the four GA population options in `PARAM_ID_METHODS['genetic_algorithm']` — `num_elite: 4`, `num_survivors: 6`, `num_mutations_per_survivor: 2`, `num_cross_breed: 10` (exactly what CA runs under DEBUG).
- Make `GeneticAlgorithmOptimiser` **derive** its DEBUG population from the schema: the hardcoded `_DEBUG_POPULATION` dict is replaced by `_debug_population()`, which reads each option's `debug_default` — mirroring how `_population_sizes()` already reads `default`. One source of truth; schema and code cannot drift.

## Why

Tools build the calibration settings form from `PARAM_ID_METHODS[...]['options']`, pre-filling each field from `default`. The DEBUG population was hardcoded in `optimisers.py` and undiscoverable, so:
1. a tool couldn't reflect the DEBUG population without hardcoding 4/6/2/10 (which would drift), and
2. if a tool pre-filled the normal defaults and passed them in `optimiser_options`, `_population_sizes()` used them (non-`None`) and DEBUG became a no-op.

Now a tool can swap in the `debug_default` values on its DEBUG toggle and DEBUG works end-to-end.

## Backward compatibility

Additive: a new optional key on existing option dicts. Tools that don't read it are unaffected (`dict(o)` passthrough already forwards it). Options with no DEBUG variant simply omit `debug_default`.

## Tests

- `tests/test_ga_population.py::test_ga_debug_population_comes_from_the_schema` — the DEBUG sizes `_population_sizes()` resolves, and `_debug_population()`, both equal the schema's `debug_default`.
- `tests/test_solver_info_validation.py::test_ga_population_debug_defaults_advertised_and_match_the_optimiser` — pins the advertised values, their equality with what the optimiser derives, and that `debug_default` is confined to the GA population knobs.

`./run_pytest.sh tests/test_ga_population.py tests/test_solver_info_validation.py` → 32 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
