### PR TITLE
fix(param-id): use numpy-mode funcs for the numeric cost path on casadi_python (#315)

### DIFF
--- a/funcs_user/cost_funcs_user.py
+++ b/funcs_user/cost_funcs_user.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from param_id.differentiable import differentiable
-from param_id.math_backend import make_math_backend
+from param_id.math_backend import make_math_backend, bind_backend
 
 """
 These functions can be used as cost functions. Specify a name of one of these functions as the "cost_type" in obs_data.json to
@@ -127,7 +127,8 @@ def norm_additive(costs):
 ##
 
 def register_cost_funcs(registry, backend):
-    """Bind ``mb`` to ``backend`` and register all cost callables defined in this module."""
+    """Register all cost callables defined in this module, each bound to ``backend`` (so
+    registries for different backends stay independent -- see math_backend.bind_backend, #315)."""
     global mb
     mb = backend
     g = globals()
@@ -149,7 +150,7 @@ def register_cost_funcs(registry, backend):
             continue
         if getattr(obj, "__module__", None) != mod:
             continue
-        registry[name] = obj
+        registry[name] = bind_backend(obj, backend)
 
 
 # Decorator/hook helper names an external cost-funcs file might define locally; excluded so they

--- a/funcs_user/operation_funcs_user.py
+++ b/funcs_user/operation_funcs_user.py
@@ -9,7 +9,7 @@ except ImportError:  # optional dependency
 from scipy.signal import find_peaks
 
 from param_id.differentiable import differentiable
-from param_id.math_backend import make_math_backend
+from param_id.math_backend import make_math_backend, bind_backend
 
 mb = make_math_backend("numpy")
 """
@@ -693,8 +693,8 @@ def register_user_operations(registry, backend):
             continue
         if getattr(obj, "__module__", None) != mod:
             continue
-        registry[name] = obj
-        
+        registry[name] = bind_backend(obj, backend)
+
 
 
 

--- a/src/param_id/external_funcs.py
+++ b/src/param_id/external_funcs.py
@@ -12,6 +12,8 @@ import hashlib
 import importlib.util
 import os
 
+from param_id.math_backend import bind_backend
+
 
 def _load_module_from_path(path):
     """Import an arbitrary ``.py`` file as a module (module name derived from the absolute path,
@@ -53,5 +55,7 @@ def register_funcs_from_file(path, registry, backend, exclude=frozenset()):
             continue
         if getattr(obj, "__module__", None) != modname:
             continue
-        registry[name] = obj
+        # Bind each func to this backend so registries for different backends stay independent
+        # even though the funcs read the file's module-level ``mb`` (see bind_backend, #315).
+        registry[name] = bind_backend(obj, backend)
     return registry

--- a/src/param_id/math_backend.py
+++ b/src/param_id/math_backend.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import functools
+import sys
+
 import numpy as np
 
 try:
@@ -14,6 +17,38 @@ try:
     import aadc as _aadc
 except ImportError:
     _aadc = None
+
+
+def bind_backend(func, backend):
+    """Wrap ``func`` so it runs with its module's ``mb`` global temporarily set to ``backend``.
+
+    The built-in / user / external operation and cost funcs dispatch through a *module-level*
+    ``mb`` math backend, and each ``register_*`` hook rebinds that global. When two registries for
+    different backends must coexist -- e.g. a ``casadi_python`` model needs casadi-mode funcs for
+    the AD path AND numpy-mode funcs for the numeric (gradient-free) cost path -- building the
+    second registry would otherwise silently change the backend of the first, so numpy operands
+    reach the casadi backend (``ca.sum(x)/x.numel()`` -> ``'numpy.ndarray' has no attribute
+    'numel'``, issue #315). Binding each registered func to its backend keeps the registries
+    independent regardless of build order. Funcs that don't use a module-level ``mb`` are returned
+    unchanged.
+
+    The save/restore is safe because observable/cost evaluation is sequential within a process;
+    nested calls (an op func calling another) restore correctly via the try/finally stack.
+    """
+    module = sys.modules.get(getattr(func, "__module__", None))
+    if module is None or not hasattr(module, "mb"):
+        return func
+
+    @functools.wraps(func)  # preserves __dict__ markers (@differentiable, series_to_constant, is_MLE)
+    def bound(*args, **kwargs):
+        saved = module.mb
+        module.mb = backend
+        try:
+            return func(*args, **kwargs)
+        finally:
+            module.mb = saved
+
+    return bound
 
 
 def make_math_backend(mode: str):

--- a/src/param_id/operation_funcs.py
+++ b/src/param_id/operation_funcs.py
@@ -8,7 +8,7 @@ if _opp_dir not in sys.path:
     sys.path.insert(0, _opp_dir)
 
 from differentiable import differentiable
-from math_backend import make_math_backend
+from math_backend import make_math_backend, bind_backend
 
 
 def series_to_constant(func):
@@ -78,7 +78,8 @@ def division(x1, x2):
 
 def register_core_operations(registry, backend):
     """
-    Bind ``mb`` to ``backend`` and register every operation callable defined in this module.
+    Register every operation callable defined in this module, each bound to ``backend`` (so
+    registries for different backends stay independent -- see math_backend.bind_backend, #315).
 
     Skips private names (``_`` prefix), ``series_to_constant``, and the dict builders.
     Imported callables are skipped via ``__module__`` checks.
@@ -102,7 +103,7 @@ def register_core_operations(registry, backend):
             continue
         if getattr(obj, "__module__", None) != mod:
             continue
-        registry[name] = obj
+        registry[name] = bind_backend(obj, backend)
 
 
 # Decorator/hook helper names an external operation-funcs file might define locally (mirroring

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -1146,14 +1146,27 @@ class OpencorParamID():
             operation_funcs_external_path=operation_funcs_external_path,
             cost_funcs_external_path=cost_funcs_external_path)
 
+        # The operation/cost funcs are backend-dispatched (#199): the casadi-mode funcs build a
+        # symbolic graph (e.g. mean is ``ca.sum(x)/x.numel()``) while the numpy-mode funcs operate
+        # on arrays. A casadi_python model needs BOTH -- the casadi funcs for the AD-gradient
+        # (do_ad) path, whose operands are casadi symbols, and the numpy funcs for the numeric
+        # (gradient-free) cost path, whose operands are numpy arrays. Feeding numpy operands to a
+        # casadi func raises ``'numpy.ndarray' has no attribute 'numel'`` (#315), so keep one dict
+        # of each and select by ``is_symbolic`` at evaluation time (see get_obs_output_dict /
+        # cost_calc). For non-casadi models the two are the same numpy dict.
+        self.operation_funcs_dict = self.sfp.get_operation_funcs_dict("numpy")
+        self.cost_funcs_dict = self.sfp.get_cost_funcs_dict("numpy")
         if self.model_type == "casadi_python":
             mode = "casadi"
-        elif self.model_type == "aadc_python":
-            mode = "numpy"  # AADC uses numpy for passive (non-tape) cost evaluation
+            self.operation_funcs_dict_symbolic = self.sfp.get_operation_funcs_dict("casadi")
+            self.cost_funcs_dict_symbolic = self.sfp.get_cost_funcs_dict("casadi")
         else:
+            # aadc_python uses numpy for passive (non-tape) cost evaluation; all other model types
+            # are numeric only. Alias the symbolic dicts to the numpy ones so the selection below
+            # is uniform.
             mode = "numpy"
-        self.operation_funcs_dict = self.sfp.get_operation_funcs_dict(mode)
-        self.cost_funcs_dict = self.sfp.get_cost_funcs_dict(mode)
+            self.operation_funcs_dict_symbolic = self.operation_funcs_dict
+            self.cost_funcs_dict_symbolic = self.cost_funcs_dict
 
         # set up opencor simulation
         self.dt = dt
@@ -1253,7 +1266,8 @@ class OpencorParamID():
             self.cost_type = None
         if mode == "casadi":
             assert_casadi_differentiable(
-                self.obs_info, self.cost_type, self.operation_funcs_dict, self.cost_funcs_dict
+                self.obs_info, self.cost_type,
+                self.operation_funcs_dict_symbolic, self.cost_funcs_dict_symbolic
             )
         self.DEBUG = DEBUG
 
@@ -1311,14 +1325,20 @@ class OpencorParamID():
             raise ValueError(
                 f"User operation {func.__name__!r} must be decorated with @differentiable for casadi_python mode."
             )
+        # Register into both the numeric and symbolic dicts so the func is available on whichever
+        # path evaluates it (a @differentiable func dispatches through the backend in either mode).
         self.operation_funcs_dict = self.sfp.add_user_operation_func(self.operation_funcs_dict, func)
-    
+        if self.operation_funcs_dict_symbolic is not self.operation_funcs_dict:
+            self.sfp.add_user_operation_func(self.operation_funcs_dict_symbolic, func)
+
     def add_user_cost_func(self, func):
         if self.model_type == "casadi_python" and not is_circulatory_differentiable(func):
             raise ValueError(
                 f"User cost function {func.__name__!r} must be decorated with @differentiable for casadi_python mode."
             )
         self.cost_funcs_dict = self.sfp.add_user_cost_func(self.cost_funcs_dict, func)
+        if self.cost_funcs_dict_symbolic is not self.cost_funcs_dict:
+            self.sfp.add_user_cost_func(self.cost_funcs_dict_symbolic, func)
     
     def set_best_param_vals(self, best_param_vals):
         self.best_param_vals = best_param_vals
@@ -1595,7 +1615,7 @@ class OpencorParamID():
 
                 sub_cost = self.get_cost_from_operands(
                     operands_outputs_list[subexp_count],
-                    exp_idx=exp_idx, sub_idx=this_sub_idx,
+                    exp_idx=exp_idx, sub_idx=this_sub_idx, do_ad=do_ad,
                 )
                 cost += sub_cost
                 if self._num_weighted_obs_by_exp_sub is not None:
@@ -1709,12 +1729,13 @@ class OpencorParamID():
         pred_outputs = np.concatenate(pred_output_list, axis=1)
         return pred_outputs
 
-    def get_cost_from_operands(self, operands_outputs, exp_idx = 0, sub_idx = 0):
+    def get_cost_from_operands(self, operands_outputs, exp_idx = 0, sub_idx = 0, do_ad=False):
 
-        if self.model_type == 'casadi_python':
-            is_symbolic = True
-        else:
-            is_symbolic = False
+        # The operands are symbolic (casadi SX) only on the AD path of a casadi_python model; every
+        # other evaluation -- including gradient-free calibration on casadi_python -- produces numpy
+        # operands, which must go through the numpy-mode funcs (#315). model_type alone does NOT
+        # imply symbolic: casadi_python evaluated numerically is not.
+        is_symbolic = do_ad and self.model_type == 'casadi_python'
 
         obs_dict = self.get_obs_output_dict(operands_outputs, is_symbolic=is_symbolic)
         # calculate error between the observables of this set of parameters
@@ -1793,6 +1814,10 @@ class OpencorParamID():
 
     def cost_calc(self, obs_dict, exp_idx=0, sub_idx=0, is_symbolic=False):
 
+        # Symbolic cost terms use the casadi-mode cost funcs; numeric ones the numpy-mode funcs
+        # (#315). For non-casadi models both are the same numpy dict.
+        cost_funcs_dict = (self.cost_funcs_dict_symbolic if is_symbolic
+                           else self.cost_funcs_dict)
 
         const = obs_dict['const']
         series = obs_dict['series']
@@ -1836,7 +1861,7 @@ class OpencorParamID():
                 for const_idx in range(const.size1()):
                     obs_idx = self.obs_info['const_idx_to_obs_idx'][const_idx]
                     if updated_weight_const_vec[const_idx] != 0:
-                        cost += self.cost_funcs_dict[self.cost_type[obs_idx]](const[const_idx], self.obs_info["ground_truth_const"][const_idx],
+                        cost += cost_funcs_dict[self.cost_type[obs_idx]](const[const_idx], self.obs_info["ground_truth_const"][const_idx],
                                                         self.obs_info["std_const_vec"][const_idx], updated_weight_const_vec[const_idx])
 
             if series is not None:
@@ -1859,7 +1884,7 @@ class OpencorParamID():
                     obs_entry = ca.DM(obs_np.reshape(-1, 1))
                     std_entry = ca.DM(std_np.reshape(-1, 1))
 
-                    cost += self.cost_funcs_dict[self.cost_type[obs_idx]](
+                    cost += cost_funcs_dict[self.cost_type[obs_idx]](
                         series_entry, obs_entry, std_entry, weight_entry)
 
             # Silently returning a zero cost for observables we can't differentiate would look
@@ -1887,7 +1912,7 @@ class OpencorParamID():
             for const_idx in range(len(const)):
                 obs_idx = self.obs_info['const_idx_to_obs_idx'][const_idx]
                 if updated_weight_const_vec[const_idx] != 0:
-                    cost += self.cost_funcs_dict[self.cost_type[obs_idx]](const[const_idx], self.obs_info["ground_truth_const"][const_idx],
+                    cost += cost_funcs_dict[self.cost_type[obs_idx]](const[const_idx], self.obs_info["ground_truth_const"][const_idx],
                                                     self.obs_info["std_const_vec"][const_idx], updated_weight_const_vec[const_idx])
         
         # TODO debugging a strange error that occurs occasionally in GA
@@ -1922,7 +1947,7 @@ class OpencorParamID():
 
                 obs_idx = self.obs_info['series_idx_to_obs_idx'][series_idx]
                 if weight_entry != 0:
-                    series_cost += self.cost_funcs_dict[self.cost_type[obs_idx]](series_entry, obs_entry, std_entry, weight_entry)
+                    series_cost += cost_funcs_dict[self.cost_type[obs_idx]](series_entry, obs_entry, std_entry, weight_entry)
 
 
         amp_cost = 0
@@ -1945,10 +1970,10 @@ class OpencorParamID():
                 std_entry = self.obs_info["std_amp_vec"][amp_idx]
                 if hasattr(weight_entry, '__len__'):
                     if not all(val==0 for val in weight_entry):
-                        amp_cost += self.cost_funcs_dict[self.cost_type[obs_idx]](amp_entry, obs_entry, std_entry, weight_entry)
+                        amp_cost += cost_funcs_dict[self.cost_type[obs_idx]](amp_entry, obs_entry, std_entry, weight_entry)
                 else:
                     if weight_entry != 0:
-                        amp_cost += self.cost_funcs_dict[self.cost_type[obs_idx]](amp_entry, obs_entry, std_entry, weight_entry)
+                        amp_cost += cost_funcs_dict[self.cost_type[obs_idx]](amp_entry, obs_entry, std_entry, weight_entry)
 
         phase_cost = 0
         if phase is not None:
@@ -1972,17 +1997,17 @@ class OpencorParamID():
                 weight_entry = updated_weight_phase_vec[phase_idx]
                 if hasattr(weight_entry, '__len__'):
                     if not all(val==0 for val in weight_entry):
-                        phase_cost += self.cost_funcs_dict[self.cost_type[obs_idx]](phase_entry, obs_entry, std_entry, weight_entry)
+                        phase_cost += cost_funcs_dict[self.cost_type[obs_idx]](phase_entry, obs_entry, std_entry, weight_entry)
                 else:
                     if weight_entry != 0:
-                        phase_cost += self.cost_funcs_dict[self.cost_type[obs_idx]](phase_entry, obs_entry, std_entry, weight_entry)
+                        phase_cost += cost_funcs_dict[self.cost_type[obs_idx]](phase_entry, obs_entry, std_entry, weight_entry)
 
         prob_dist_cost = 0
         if val_for_prob_dist is not None:
             for prob_dist_idx in range(len(val_for_prob_dist)):
                 obs_idx = self.obs_info['prob_dist_idx_to_obs_idx'][prob_dist_idx]
                 if updated_weight_prob_dist_vec[prob_dist_idx] != 0:
-                    prob_dist_cost += self.cost_funcs_dict[self.cost_type[obs_idx]](val_for_prob_dist[prob_dist_idx], 
+                    prob_dist_cost += cost_funcs_dict[self.cost_type[obs_idx]](val_for_prob_dist[prob_dist_idx], 
                                                                     self.obs_info["ground_truth_prob_dist_params"][prob_dist_idx],
                                                                     updated_weight_prob_dist_vec[prob_dist_idx])
             
@@ -1992,7 +2017,12 @@ class OpencorParamID():
     def get_obs_output_dict(self, operands_outputs, get_all_series=False, is_symbolic=False):
         #need to added an array to save tmp data, each calibration need to updated/re-initial
         self.temp_results = {}
-        
+
+        # Symbolic (SX) operands go through the casadi-mode operation funcs; numeric operands go
+        # through the numpy-mode ones (#315). For non-casadi models both are the same numpy dict.
+        operation_funcs_dict = (self.operation_funcs_dict_symbolic if is_symbolic
+                                else self.operation_funcs_dict)
+
         if operands_outputs == None:
             if get_all_series:
                 return None, None
@@ -2028,7 +2058,7 @@ class OpencorParamID():
             elif get_all_series:
                 if self.obs_info["operations"][JJ] is None:
                     obs_series_array_all[JJ] = operands_outputs[JJ][0]
-                elif hasattr(self.operation_funcs_dict[self.obs_info["operations"][JJ]], 'series_to_constant'):
+                elif hasattr(operation_funcs_dict[self.obs_info["operations"][JJ]], 'series_to_constant'):
                     raw_kwargs = self.obs_info["operation_kwargs"][JJ]
                     kwargs = raw_kwargs.copy() if isinstance(raw_kwargs, dict) else {}
 
@@ -2039,9 +2069,9 @@ class OpencorParamID():
                                 kwargs[k] = self.temp_results[v]
                             else:
                                 raise KeyError(f"[ERROR] '{v}' not found in temp_results for key '{k}'")
-                    obs_series_array_all[JJ] = self.operation_funcs_dict[self.obs_info["operations"][JJ]](*operands_outputs[JJ],series_output=True,**kwargs)
+                    obs_series_array_all[JJ] = operation_funcs_dict[self.obs_info["operations"][JJ]](*operands_outputs[JJ],series_output=True,**kwargs)
                 else:
-                    val_or_array = self.operation_funcs_dict[
+                    val_or_array = operation_funcs_dict[
                             self.obs_info["operations"][JJ]](*operands_outputs[JJ], **self.obs_info["operation_kwargs"][JJ])
                     if type(val_or_array) == float:
                         print("an operation func that returns a float (constant) "
@@ -2074,7 +2104,7 @@ class OpencorParamID():
                             else:
                                 raise KeyError(f"[ERROR] '{v}' not found in temp_results for key '{k}'")
                     #need to replace below sentence, otherwise will be print error
-                    obs = self.operation_funcs_dict[self.obs_info["operations"][JJ]](*operands_outputs[JJ], **kwargs)
+                    obs = operation_funcs_dict[self.obs_info["operations"][JJ]](*operands_outputs[JJ], **kwargs)
                     #each predict result saved into tmp array
                     self.temp_results[key_idxt] = obs
                 else:
@@ -2116,11 +2146,11 @@ class OpencorParamID():
 
                     time_domain_obs = operands_outputs[JJ][0]
                     # operations also apply to complex numbers
-                    complex_num = self.operation_funcs_dict[self.obs_info["operations"][JJ]](*complex_operands, **self.obs_info["operation_kwargs"][JJ]) 
+                    complex_num = operation_funcs_dict[self.obs_info["operations"][JJ]](*complex_operands, **self.obs_info["operation_kwargs"][JJ]) 
                     # TODO check this works for all cases
                     # I am checking the sign of the mean operated on time domain signal to ensure 
                     # the first amplitude is negative if it is a negative signal
-                    # sign_signal = np.sign(self.operation_funcs_dict[self.obs_info["operations"][JJ]](* \
+                    # sign_signal = np.sign(operation_funcs_dict[self.obs_info["operations"][JJ]](* \
                     #                             [np.mean(entry) for entry in operands_outputs[JJ]]))
 
                     amp = np.abs(complex_num)[0:len(time_domain_obs)]

--- a/tests/test_param_id.py
+++ b/tests/test_param_id.py
@@ -32,6 +32,43 @@ def test_casadi_differentiability_assert_passes_for_core_ops_and_costs():
     )
 
 
+@pytest.mark.unit
+def test_operation_and_cost_dicts_are_backend_independent():
+    """#315: building a casadi-mode registry must not change the backend of a numpy-mode one.
+
+    The built-in operation/cost funcs dispatch through a module-level ``mb`` backend, and each
+    registry build used to rebind that global -- so with a ``casadi_python`` model (which needs a
+    casadi registry for AD *and* a numpy registry for the numeric cost path) the numpy funcs
+    silently used the casadi backend and ``mean`` (``ca.sum(x)/x.numel()``) crashed on numpy
+    operands. bind_backend makes each registry independent regardless of build order.
+    """
+    from param_id.differentiable import is_circulatory_differentiable
+    from parsers.PrimitiveParsers import scriptFunctionParser
+    ca = pytest.importorskip("casadi")
+
+    sfp = scriptFunctionParser()
+    numpy_ops = sfp.get_operation_funcs_dict("numpy")
+    casadi_ops = sfp.get_operation_funcs_dict("casadi")  # built second; must not corrupt numpy_ops
+
+    x = np.array([1.0, 2.0, 3.0, 4.0])
+    # numpy-mode reductions must operate on numpy arrays (the #315 crash was numel() on ndarray).
+    assert float(numpy_ops["mean"](x)) == pytest.approx(2.5)
+    assert float(numpy_ops["max_minus_min"](x)) == pytest.approx(3.0)
+    # casadi-mode reductions still take a casadi symbol and stay symbolic.
+    s = ca.SX.sym("s", 4)
+    assert casadi_ops["mean"](s).shape == (1, 1)
+    # bind_backend preserves the @differentiable / series_to_constant markers used by the AD path.
+    assert is_circulatory_differentiable(numpy_ops["mean"])
+    assert getattr(numpy_ops["mean"], "series_to_constant", False)
+
+    # cost dicts share the same mechanism.
+    numpy_costs = sfp.get_cost_funcs_dict("numpy")
+    sfp.get_cost_funcs_dict("casadi")  # built second
+    ones = np.ones_like(x)
+    cost = numpy_costs["gaussian_MLE"](x, x, ones, ones)  # output == desired -> 0, and finite
+    assert np.isfinite(float(cost))
+
+
 def test_mcmc_and_laplace_require_is_mle_cost():
     from param_id.differentiable import assert_mle_cost_for_bayesian
     from parsers.PrimitiveParsers import scriptFunctionParser
@@ -408,6 +445,64 @@ def test_param_id_3compartment_genetic_algorithm_myokit_fast(
     })
 
     _ensure_cellml_model_generated(config, mpi_comm)
+    run_param_id(config)
+
+    if rank == 0:
+        out_dir = os.path.join(temp_output_dir,
+                               'genetic_algorithm_3compartment_3compartment_obs_data')
+        best_cost = float(np.load(os.path.join(out_dir, 'best_cost.npy')))
+        assert np.isfinite(best_cost) and best_cost >= 0, \
+            f'expected a finite, non-negative best cost, got {best_cost}'
+    mpi_comm.Barrier()
+
+
+@pytest.mark.integration
+@pytest.mark.mpi
+def test_param_id_3compartment_casadi_genetic_algorithm_fast(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
+    """Regression for #315: a gradient-free method (genetic algorithm) on a ``casadi_python``
+    model whose obs_data uses a backend-dispatched reduction (``mean`` / ``max_minus_min`` in
+    3compartment_obs_data.json).
+
+    The numeric cost path feeds numpy operands to the operation funcs; before the fix these were
+    built in casadi mode for casadi_python, so ``mean`` (``ca.sum(x)/x.numel()``) raised
+    ``'numpy.ndarray' object has no attribute 'numel'`` and the run crashed. The numeric path now
+    uses the numpy-mode funcs, so the run completes with a finite, non-negative best cost.
+
+    Deliberately small (short times, DEBUG population, few calls) so it stays in the fast
+    (`-m "not slow"`) suite alongside the Myokit variant above.
+    """
+    rank = mpi_comm.Get_rank()
+
+    config = base_user_inputs.copy()
+    config.update({
+        'file_prefix': '3compartment',
+        'input_param_file': '3compartment_parameters.csv',
+        'model_type': 'casadi_python',
+        'solver': 'casadi_integrator',
+        'param_id_method': 'genetic_algorithm',
+        'do_ad': False,
+        'pre_time': 2,
+        'sim_time': 1,
+        'dt': 0.01,
+        'DEBUG': True,
+        'do_mcmc': False,
+        'plot_predictions': False,
+        'do_ia': False,
+        'solver_info': {'method': 'bdf'},
+        'param_id_obs_path': os.path.join(resources_dir, '3compartment_obs_data.json'),
+        'param_id_output_dir': temp_output_dir,
+        'generated_models_dir': temp_generated_models_dir,
+        # num_calls must exceed the DEBUG genetic-algorithm population (28 for these 4 params).
+        'debug_optimiser_options': {'num_calls_to_function': 40, 'max_patience': 500},
+    })
+
+    # Generate the CasADi Python model on rank 0 (the numpy/casadi split is what #315 exercises).
+    if rank == 0:
+        success = generate_with_new_architecture(False, config)
+        assert success, "CasADi Python model generation should succeed for 3compartment"
+    mpi_comm.Barrier()
+
     run_param_id(config)
 
     if rank == 0:


### PR DESCRIPTION
Closes #315.

## Bug

A gradient-free method (genetic algorithm, CMA-ES, Bayesian) on a `casadi_python` model crashed on any observable using a backend-dispatched reduction (`mean`, `max_minus_min`, `max`/`min`):

```
AttributeError: 'numpy.ndarray' object has no attribute 'numel'
  operation_funcs.py: return mb.mean(x)
  math_backend.py:    return ca.sum(x) / x.numel()   # x is a numpy array
```

The numeric cost path feeds **numpy** operands to the operation/cost funcs, but for `casadi_python` those funcs ran in **casadi** mode, so a casadi reduction hit a numpy array. The symbolic/AD path (`sp_minimize` with `do_ad`) was unaffected because its operands are casadi symbols.

## Root cause — two coupled issues

1. **`is_symbolic` was derived from `model_type`, not the operands.** `get_cost_from_operands` marked *every* `casadi_python` evaluation `is_symbolic=True`, including gradient-free calibration whose operands are numpy. Fixed: `is_symbolic` now tracks the AD path (`do_ad and model_type == 'casadi_python'`), the only time operands are actually symbolic. `OpencorParamID` keeps both a numpy and a casadi operation/cost dict, and `get_obs_output_dict` / `cost_calc` select by `is_symbolic`.

2. **The funcs share a module-level `mb` backend.** The built-in / user / external operation and cost funcs dispatch through a module global `mb`, and each `register_*` hook rebinds it. So building the casadi registry silently changed the backend of the numpy one — even a correctly-selected numpy dict used the casadi backend. New **`math_backend.bind_backend`** binds each registered func to its backend so registries for different backends coexist independently, regardless of build order. Applied at all four register sites (core ops, core costs, user ops, external funcs); it preserves the `@differentiable` / `series_to_constant` / `is_MLE` markers via `functools.wraps`.

Both fixes are needed: (1) routes numeric operands to the numpy dict; (2) makes that numpy dict actually use the numpy backend.

## Scope / compatibility

- AD (`do_ad`) and AADC paths: unchanged.
- FD path on `casadi_python`: now evaluates through numpy funcs — same values (verified by the existing AD-vs-FD test).
- Non-casadi models: the numpy and symbolic dicts are the same object; behaviour unchanged.

## Tests

- `test_operation_and_cost_dicts_are_backend_independent` (unit): building the casadi registry after the numpy one must not corrupt the numpy funcs; markers preserved.
- `test_param_id_3compartment_casadi_genetic_algorithm_fast` (integration, fast): gradient-free `casadi_python` calibration with `mean`/`max_minus_min` observables — **crashed with the `numel` error before this change, finite best cost after**.

Verified green (OpenCOR python shell): the two new tests, plus the existing casadi_python regressions — Lotka-Volterra `sp_minimize` succeeds / AD-vs-FD / AD-vs-FD-AADC, `test_casadi_conditionals`, and the CasADi sensitivity-analysis agreement tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
