### PR TITLE
docs+fix(obs-data): document and harden per-data_item operation_kwargs

### DIFF
--- a/src/param_id/operation_funcs.py
+++ b/src/param_id/operation_funcs.py
@@ -1,5 +1,14 @@
-"""Built-in observable operations; dicts are built per mode via build_operation_funcs_dict."""
+"""Built-in observable operations; dicts are built per mode via build_operation_funcs_dict.
 
+This module also owns the ``operation_kwargs`` contract (issue #304): the helpers
+``resolve_operation_kwargs`` / ``validate_operation_kwargs`` are the single place that decides
+how a data_item's ``operation_kwargs`` mapping is checked and turned into the keyword arguments
+of an operation func, so param-id, MCMC/UQ and sensitivity analysis all behave identically.
+"""
+
+import difflib
+import inspect
+import math
 import os
 import sys
 
@@ -72,6 +81,205 @@ def division(x1, x2):
 
 
 ##
+## Below here is the `operation_kwargs` contract (issue #304).
+## These are public helpers, not observable operations, so they are excluded from registration.
+##
+
+# Keyword arguments that circulatory_autogen itself supplies to an operation func. A data_item's
+# `operation_kwargs` must not set them, otherwise the call raises a bare
+# "got multiple values for keyword argument".
+RESERVED_OPERATION_KWARGS = frozenset({"series_output"})
+
+
+def get_operation_kwarg_spec(func):
+    """Introspect an operation func's signature for the ``operation_kwargs`` contract.
+
+    Returns ``(accepted, from_operands, accepts_any)``:
+
+    - ``accepted``: ordered list of parameter names that may be given in ``operation_kwargs``.
+    - ``from_operands``: ordered list of parameters with no default, i.e. the ones
+      circulatory_autogen fills positionally from the data_item's ``operands``.
+    - ``accepts_any``: True when the func declares ``**kwargs``, in which case any key is
+      accepted (e.g. ``calculate_two_observable_difference``).
+
+    A func whose signature cannot be introspected is treated as ``accepts_any`` so that
+    validation never blocks a legitimate call.
+    """
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return [], [], True
+
+    accepted = []
+    from_operands = []
+    accepts_any = False
+    for name, param in sig.parameters.items():
+        if param.kind == param.VAR_KEYWORD:
+            accepts_any = True
+        elif param.kind == param.VAR_POSITIONAL:
+            # *args -> we cannot tell how many operands are consumed; don't second-guess.
+            accepts_any = True
+        elif param.kind == param.POSITIONAL_ONLY:
+            from_operands.append(name)
+        else:
+            accepted.append(name)
+            if param.default is param.empty:
+                from_operands.append(name)
+    return accepted, from_operands, accepts_any
+
+
+def _operation_kwarg_defaults(func):
+    """Map of parameter name -> default value for the keyword parameters of ``func``."""
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return {}
+    return {name: p.default for name, p in sig.parameters.items() if p.default is not p.empty}
+
+
+def _coerce_operation_kwarg(value, default):
+    """Basic numeric coercion of a JSON-sourced kwarg towards the type of the func's default.
+
+    JSON has a single number type, so a GUI (or a hand-edited obs_data.json) can easily write
+    ``20.0`` where the operation func's default is the int ``20`` (used as a slice index) or
+    ``1`` where the default is a float. Only these two integral<->float conversions are done;
+    everything else (strings, bools, lists, dicts, None) is passed through untouched.
+    """
+    if isinstance(value, bool) or isinstance(default, bool):
+        return value
+    if isinstance(default, int) and isinstance(value, float):
+        if math.isfinite(value) and float(value).is_integer():
+            return int(value)
+        return value
+    if isinstance(default, float) and isinstance(value, int):
+        return float(value)
+    return value
+
+
+def check_operation_kwargs(raw_kwargs, func, operation_name, data_item_name=None, num_operands=0):
+    """Validate a data_item's ``operation_kwargs`` against the chosen operation func's signature.
+
+    An unknown key is an **error**, not silently ignored: a stale or misspelled key would
+    otherwise change nothing and quietly calibrate against the wrong feature.
+
+    Raises:
+        ValueError: for a non-string key, a key reserved by circulatory_autogen, a key that
+            duplicates an argument already filled from ``operands``, or a key that is not a
+            parameter of ``func``.
+    """
+    if not raw_kwargs:
+        return
+    where = (f"data_item '{data_item_name}'" if data_item_name else "a data_item")
+    op_label = operation_name if operation_name is not None else getattr(func, "__name__", "<unknown>")
+    accepted, from_operands, accepts_any = get_operation_kwarg_spec(func)
+    positional_filled = set(from_operands[:num_operands])
+
+    for key in raw_kwargs:
+        if not isinstance(key, str):
+            raise ValueError(
+                f"Invalid 'operation_kwargs' in {where}: keys must be strings, got {key!r} "
+                f"({type(key).__name__}). 'operation_kwargs' maps keyword-argument names of the "
+                f"operation func '{op_label}' to values."
+            )
+        if key in RESERVED_OPERATION_KWARGS:
+            raise ValueError(
+                f"Invalid 'operation_kwargs' key '{key}' in {where}: '{key}' is set by "
+                f"circulatory_autogen when it calls the operation func '{op_label}' and must not "
+                f"be given in obs_data.json. Remove it from 'operation_kwargs'."
+            )
+        if key in positional_filled:
+            raise ValueError(
+                f"Invalid 'operation_kwargs' key '{key}' in {where}: the operation func "
+                f"'{op_label}' already receives '{key}' positionally from the data_item's "
+                f"'operands' (operands fill {list(from_operands[:num_operands])}). Remove '{key}' "
+                f"from 'operation_kwargs', or remove the corresponding entry from 'operands'."
+            )
+        if accepts_any or key in accepted:
+            continue
+        suggestions = difflib.get_close_matches(key, accepted, n=3, cutoff=0.6)
+        hint = f" Did you mean {' or '.join(repr(s) for s in suggestions)}?" if suggestions else ""
+        raise ValueError(
+            f"Invalid 'operation_kwargs' key '{key}' in {where}: the operation func '{op_label}' "
+            f"has no keyword argument '{key}'.{hint} Accepted keyword arguments are: "
+            f"{sorted(set(accepted) - RESERVED_OPERATION_KWARGS)}. Fix the key in the data_item's "
+            f"'operation_kwargs' in obs_data.json, or add '{key}' as a keyword argument of "
+            f"'{op_label}'."
+        )
+
+
+def resolve_operation_kwargs(raw_kwargs, func, operation_name=None, data_item_name=None,
+                             temp_results=None, num_operands=0):
+    """Validate and resolve a data_item's ``operation_kwargs`` into call keyword arguments.
+
+    Args:
+        raw_kwargs: the data_item's ``operation_kwargs`` value. A missing field parses to ``{}``,
+            but ``None``/``NaN``/any non-dict is tolerated and treated as "no kwargs".
+        func: the operation func that will be called.
+        operation_name: the data_item's ``operation`` (used in error messages).
+        data_item_name: the data_item's ``name_for_plotting`` (used in error messages).
+        temp_results: mapping of already-computed observable ``name_for_plotting`` -> value. Any
+            **string** kwarg value that matches a key here is replaced by that observable's value,
+            which is how an observable is built from earlier observables (see
+            ``calculate_two_observable_difference``). A string that matches nothing is passed
+            through unchanged, so plain string options still work.
+        num_operands: number of operands passed positionally, used to detect a kwarg that
+            duplicates a positional argument.
+
+    Returns:
+        A new dict safe to splat into ``func(*operands, **kwargs)``.
+    """
+    if not isinstance(raw_kwargs, dict) or not raw_kwargs:
+        # Covers the schema default {}, and a NaN/None left by a partially-filled obs_data file.
+        return {}
+
+    check_operation_kwargs(raw_kwargs, func, operation_name,
+                           data_item_name=data_item_name, num_operands=num_operands)
+
+    defaults = _operation_kwarg_defaults(func)
+    kwargs = {}
+    for key, value in raw_kwargs.items():
+        if isinstance(value, str) and temp_results is not None and value in temp_results:
+            # Reference to an earlier observable; substitute its value, never coerce it.
+            kwargs[key] = temp_results[value]
+        elif key in defaults:
+            kwargs[key] = _coerce_operation_kwarg(value, defaults[key])
+        else:
+            kwargs[key] = value
+    return kwargs
+
+
+def validate_operation_kwargs(obs_info, operation_funcs_dict):
+    """Eagerly validate every data_item's ``operation_kwargs`` in ``obs_info``.
+
+    Called once when the obs data is set so a stale obs_data.json fails immediately with a clear
+    message instead of part-way through a calibration / sensitivity run. Operations that are not
+    (yet) in ``operation_funcs_dict`` are skipped -- a user func may still be registered via
+    ``add_user_operation_func``, and an genuinely unknown operation is reported by the evaluation
+    path itself.
+    """
+    if not obs_info:
+        return
+    all_kwargs = obs_info.get("operation_kwargs") or []
+    operations = obs_info.get("operations") or []
+    operands = obs_info.get("operands") or []
+    names = obs_info.get("names_for_plotting") or []
+    for idx, raw_kwargs in enumerate(all_kwargs):
+        if not isinstance(raw_kwargs, dict) or not raw_kwargs:
+            continue
+        operation_name = operations[idx] if idx < len(operations) else None
+        func = operation_funcs_dict.get(operation_name) if operation_name is not None else None
+        if func is None:
+            continue
+        item_operands = operands[idx] if idx < len(operands) else []
+        num_operands = len(item_operands) if hasattr(item_operands, "__len__") else 0
+        check_operation_kwargs(
+            raw_kwargs, func, operation_name,
+            data_item_name=names[idx] if idx < len(names) else None,
+            num_operands=num_operands,
+        )
+
+
+##
 ## Below here are the organisational functions for building the operation functions dictionary
 ## They are not part of the public API
 ##
@@ -94,6 +302,11 @@ def register_core_operations(registry, backend):
             "register_core_operations",
             "build_operation_funcs_dict",
             "get_operation_funcs_dict_for_mode",
+            # operation_kwargs contract helpers (#304) -- public API of this module, not operations
+            "get_operation_kwarg_spec",
+            "check_operation_kwargs",
+            "resolve_operation_kwargs",
+            "validate_operation_kwargs",
         }
     )
     for name, obj in g.items():

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -65,6 +65,7 @@ from param_id.differentiable import (
     assert_mle_cost_for_bayesian,
     is_circulatory_differentiable,
 )
+from param_id.operation_funcs import resolve_operation_kwargs, validate_operation_kwargs
 from param_id.plot_outputs import ParamIDPlotOutputs
 from param_id import casadi_backend
 from param_id import fsa_backend
@@ -1269,6 +1270,8 @@ class OpencorParamID():
                 self.obs_info, self.cost_type,
                 self.operation_funcs_dict_symbolic, self.cost_funcs_dict_symbolic
             )
+        # Fail fast on a stale obs_data.json rather than part-way through an optimisation (#304).
+        validate_operation_kwargs(self.obs_info, self.operation_funcs_dict)
         self.DEBUG = DEBUG
 
         # Per (experiment, subexperiment) count of observables with non-zero weight. The sum
@@ -1364,6 +1367,7 @@ class OpencorParamID():
     def set_obs_info(self, obs_info):
         self.obs_info = obs_info
         self.cost_type = self.obs_info["cost_type"]
+        validate_operation_kwargs(self.obs_info, self.operation_funcs_dict)
         self._refresh_num_weighted_obs_tables()
 
     def set_optimiser_options(self, optimiser_options):
@@ -2014,6 +2018,28 @@ class OpencorParamID():
 
         return cost + series_cost + amp_cost + phase_cost + prob_dist_cost
 
+    def _resolve_operation_kwargs(self, JJ, operation_funcs_dict, operands_outputs,
+                                  num_operands=None):
+        """Keyword arguments for observable ``JJ``'s operation func, from its ``operation_kwargs``.
+
+        Single entry point for the ``operation_kwargs`` contract (#304) on the param-id / MCMC /
+        UQ path, so validation and the "string value naming an earlier observable" substitution
+        behave exactly as they do in sensitivity analysis. See
+        ``param_id.operation_funcs.resolve_operation_kwargs``.
+        """
+        operation_name = self.obs_info["operations"][JJ]
+        if num_operands is None:
+            operands_for_JJ = operands_outputs[JJ]
+            num_operands = len(operands_for_JJ) if hasattr(operands_for_JJ, '__len__') else 0
+        return resolve_operation_kwargs(
+            self.obs_info["operation_kwargs"][JJ],
+            operation_funcs_dict[operation_name],
+            operation_name=operation_name,
+            data_item_name=self.obs_info["names_for_plotting"][JJ],
+            temp_results=self.temp_results,
+            num_operands=num_operands,
+        )
+
     def get_obs_output_dict(self, operands_outputs, get_all_series=False, is_symbolic=False):
         #need to added an array to save tmp data, each calibration need to updated/re-initial
         self.temp_results = {}
@@ -2059,20 +2085,12 @@ class OpencorParamID():
                 if self.obs_info["operations"][JJ] is None:
                     obs_series_array_all[JJ] = operands_outputs[JJ][0]
                 elif hasattr(operation_funcs_dict[self.obs_info["operations"][JJ]], 'series_to_constant'):
-                    raw_kwargs = self.obs_info["operation_kwargs"][JJ]
-                    kwargs = raw_kwargs.copy() if isinstance(raw_kwargs, dict) else {}
-
-                    for k, v in list(kwargs.items()):
-                        if isinstance(v, str) and v in self.temp_results:
-                            #kwargs[k] = self.temp_results[v]
-                            if v in self.temp_results:
-                                kwargs[k] = self.temp_results[v]
-                            else:
-                                raise KeyError(f"[ERROR] '{v}' not found in temp_results for key '{k}'")
+                    kwargs = self._resolve_operation_kwargs(JJ, operation_funcs_dict, operands_outputs)
                     obs_series_array_all[JJ] = operation_funcs_dict[self.obs_info["operations"][JJ]](*operands_outputs[JJ],series_output=True,**kwargs)
                 else:
+                    kwargs = self._resolve_operation_kwargs(JJ, operation_funcs_dict, operands_outputs)
                     val_or_array = operation_funcs_dict[
-                            self.obs_info["operations"][JJ]](*operands_outputs[JJ], **self.obs_info["operation_kwargs"][JJ])
+                            self.obs_info["operations"][JJ]](*operands_outputs[JJ], **kwargs)
                     if type(val_or_array) == float:
                         print("an operation func that returns a float (constant) "
                               "Is present. This operation_func should have the header @series_to_constant"
@@ -2090,20 +2108,7 @@ class OpencorParamID():
             else:
                 if self.obs_info["data_types"][JJ] != 'frequency':
                     key_idxt = self.obs_info["names_for_plotting"][JJ]
-                    raw_kwargs = self.obs_info["operation_kwargs"][JJ]
-                    #every time check it and update to {} when not exist
-                    if isinstance(raw_kwargs, dict):
-                        kwargs = raw_kwargs.copy()
-                    else:
-                        kwargs = {}
-                    #if exist, extract value, convey it to participate in new cost_function
-                    for k, v in list(kwargs.items()):
-                        if isinstance(v, str) and v in self.temp_results:
-                            if v in self.temp_results:
-                                kwargs[k] = self.temp_results[v]
-                            else:
-                                raise KeyError(f"[ERROR] '{v}' not found in temp_results for key '{k}'")
-                    #need to replace below sentence, otherwise will be print error
+                    kwargs = self._resolve_operation_kwargs(JJ, operation_funcs_dict, operands_outputs)
                     obs = operation_funcs_dict[self.obs_info["operations"][JJ]](*operands_outputs[JJ], **kwargs)
                     #each predict result saved into tmp array
                     self.temp_results[key_idxt] = obs
@@ -2146,7 +2151,9 @@ class OpencorParamID():
 
                     time_domain_obs = operands_outputs[JJ][0]
                     # operations also apply to complex numbers
-                    complex_num = operation_funcs_dict[self.obs_info["operations"][JJ]](*complex_operands, **self.obs_info["operation_kwargs"][JJ]) 
+                    freq_kwargs = self._resolve_operation_kwargs(
+                        JJ, operation_funcs_dict, operands_outputs, num_operands=len(complex_operands))
+                    complex_num = operation_funcs_dict[self.obs_info["operations"][JJ]](*complex_operands, **freq_kwargs)
                     # TODO check this works for all cases
                     # I am checking the sign of the mean operated on time domain signal to ensure 
                     # the first amplitude is negative if it is a negative signal

--- a/src/sensitivity_analysis/sobolSA.py
+++ b/src/sensitivity_analysis/sobolSA.py
@@ -41,6 +41,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
 from parsers.PrimitiveParsers import scriptFunctionParser
+from param_id.operation_funcs import resolve_operation_kwargs, validate_operation_kwargs
 from mpi4py import MPI
 from parsers.PrimitiveParsers import CSVFileParser, ObsAndParamDataParser
 import csv
@@ -125,6 +126,8 @@ class sobol_SA():
             self.prediction_info = parsed_data["prediction_info"]
 
             self.obs_info = self.obs_and_param_parser.process_obs_info(gt_df=self.gt_df, output_dir=self.output_dir, dt=self.dt)
+            # Fail fast on a stale obs_data.json rather than part-way through the SA sweep (#304).
+            validate_operation_kwargs(self.obs_info, self.operation_funcs_dict)
             self.protocol_info = self.obs_and_param_parser.process_protocol_and_weights(
                 gt_df=self.gt_df,
                 protocol_info=self.protocol_info,
@@ -191,6 +194,7 @@ class sobol_SA():
         self.prediction_info = parsed_data["prediction_info"]
 
         self.obs_info = self.obs_and_param_parser.process_obs_info(gt_df=self.gt_df, output_dir=self.output_dir, dt=self.dt)
+        validate_operation_kwargs(self.obs_info, self.operation_funcs_dict)
         self.protocol_info = self.obs_and_param_parser.process_protocol_and_weights(
             gt_df=self.gt_df,
             protocol_info=self.protocol_info,
@@ -351,16 +355,16 @@ class sobol_SA():
                     operands_outputs = operands_outputs_dict.get((exp_idx, subexp_idx), None)
                     if operands_outputs is not None:
                         key_idxt = self.obs_info["names_for_plotting"][j]
-                        raw_kwargs = self.obs_info["operation_kwargs"][j]
-                        #every time check it and update to {} when not exist
-                        if isinstance(raw_kwargs, dict):
-                            kwargs = raw_kwargs.copy()
-                        else:
-                            kwargs = {}
-                        for k, v in list(kwargs.items()):
-                            if isinstance(v, str) and v in self.temp_results:
-                                kwargs[k] = self.temp_results[v]
-                        #also need to replace below sentence
+                        # Shared operation_kwargs contract (#304): same validation and
+                        # earlier-observable substitution as the param-id path.
+                        kwargs = resolve_operation_kwargs(
+                            self.obs_info["operation_kwargs"][j],
+                            func,
+                            operation_name=self.obs_info["operations"][j],
+                            data_item_name=key_idxt,
+                            temp_results=self.temp_results,
+                            num_operands=len(operands_outputs[j]),
+                        )
                         feature = func(*operands_outputs[j], **kwargs)
                         self.temp_results[key_idxt] = feature
                         if feature is None or (isinstance(feature, (float, int)) and np.isnan(feature)):

--- a/src/utilities/obs_data_helpers.py
+++ b/src/utilities/obs_data_helpers.py
@@ -137,12 +137,26 @@ class ObsDataCreator:
         """
         Add a data item to the dictionary.
         entry: dictionary containing the data item
+
+        ``operation_kwargs`` (optional, default ``{}``) is a dict of keyword arguments passed to
+        the ``operation`` func, on top of the ``operands`` it receives positionally, i.e.
+        ``operation(*operands, **operation_kwargs)``. Keys must be keyword arguments of that func
+        (an unknown key raises), and ``series_output`` is reserved for circulatory_autogen. A
+        string value that matches the ``name_for_plotting`` of an earlier data item is replaced at
+        run time by that observable's computed value. See issue #304 and the
+        parameter-identification tutorial page.
         """
-        required_keys = ['variable', 'name_for_plotting', 'operands', 
+        required_keys = ['variable', 'name_for_plotting', 'operands',
                          'unit', 'value', 'std']
         required_series_keys = ['obs_dt']
-        optional_keys = ['name_for_plotting', 'operation', 'weight', 'std', 'experiment_idx', 'subexperiment_idx']
-                         
+        optional_keys = ['name_for_plotting', 'operation', 'operation_kwargs', 'weight', 'std',
+                         'experiment_idx', 'subexperiment_idx']
+
+        if 'operation_kwargs' in entry and not isinstance(entry['operation_kwargs'], dict):
+            raise ValueError(
+                f"'operation_kwargs' must be a dict of keyword arguments for the 'operation' "
+                f"func, got {type(entry['operation_kwargs']).__name__}.")
+
         if 'name_for_plotting' not in entry:
             entry['name_for_plotting'] = entry['variable']
         # check that name_for_plotting only has one _ in it and remove if not

--- a/tests/test_operation_kwargs.py
+++ b/tests/test_operation_kwargs.py
@@ -1,0 +1,436 @@
+"""Unit tests for the per-``data_item`` ``operation_kwargs`` contract (issue #304).
+
+``operation_kwargs`` is the public obs_data.json field the CUFLynx GUI writes when a user tunes
+an operation func's keyword arguments. These tests lock in how it is validated and forwarded --
+``operation(*operands, **operation_kwargs)`` -- so calibration, MCMC/UQ and sensitivity analysis
+stay in step. No model, solver or MPI needed.
+"""
+import json
+import os
+import textwrap
+
+import numpy as np
+import pytest
+
+from param_id.operation_funcs import (
+    RESERVED_OPERATION_KWARGS,
+    check_operation_kwargs,
+    get_operation_kwarg_spec,
+    resolve_operation_kwargs,
+    validate_operation_kwargs,
+)
+from parsers.PrimitiveParsers import ObsAndParamDataParser, scriptFunctionParser
+
+
+# ---------------------------------------------------------------------------
+# Sample operation funcs (mirroring the shapes that exist in the real registries)
+# ---------------------------------------------------------------------------
+
+def op_windowed(x, start_frac=0.0, end_frac=1.0, series_output=False):
+    """Keyword-argument op: one operand + tunables (like ``mean_in_range``)."""
+    if series_output:
+        return x
+    start_idx = int(start_frac * (len(x) - 1))
+    end_idx = int(end_frac * (len(x) - 1))
+    return float(np.mean(x[start_idx:end_idx]))
+
+
+def op_index(x, window=10, series_output=False):
+    """Op whose kwarg default is an ``int`` and is used as a slice index."""
+    if series_output:
+        return x
+    return float(np.mean(x[:window]))
+
+
+def op_two_operands(x1, x2, scale=1.0):
+    return (x1 - x2) * scale
+
+
+def op_var_kwargs(x=None, series_output=False, **kwargs):
+    """``**kwargs`` op (like ``calculate_two_observable_difference``): accepts any key."""
+    if series_output:
+        return x
+    return kwargs["pred2"] - kwargs["pred1"]
+
+
+def op_no_kwargs(x):
+    return float(np.max(x))
+
+
+_X = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
+
+
+# ---------------------------------------------------------------------------
+# Signature introspection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_get_operation_kwarg_spec_separates_operands_from_kwargs():
+    accepted, from_operands, accepts_any = get_operation_kwarg_spec(op_windowed)
+    assert accepted == ['x', 'start_frac', 'end_frac', 'series_output']
+    assert from_operands == ['x']          # only 'x' has no default -> filled from operands
+    assert accepts_any is False
+
+
+@pytest.mark.unit
+def test_get_operation_kwarg_spec_detects_var_keyword():
+    _accepted, _from_operands, accepts_any = get_operation_kwarg_spec(op_var_kwargs)
+    assert accepts_any is True
+
+
+# ---------------------------------------------------------------------------
+# Default / empty case -- the overwhelmingly common one
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.parametrize('raw', [{}, None, float('nan'), np.nan, 'not a dict', 0.0])
+def test_missing_or_empty_operation_kwargs_resolves_to_empty_dict(raw):
+    """The schema default is ``{}``; a NaN/None left by a partially filled obs_data file must
+    also be tolerated rather than raising ``argument after ** must be a mapping``."""
+    kwargs = resolve_operation_kwargs(raw, op_windowed, operation_name='op_windowed')
+    assert kwargs == {}
+    # and the resulting call is the plain, default-valued one
+    assert op_windowed(_X, **kwargs) == pytest.approx(float(np.mean(_X[:9])))
+
+
+@pytest.mark.unit
+def test_op_with_no_kwargs_at_all_still_works_with_empty_operation_kwargs():
+    assert resolve_operation_kwargs({}, op_no_kwargs, operation_name='op_no_kwargs') == {}
+
+
+# ---------------------------------------------------------------------------
+# Scalar kwargs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_scalar_kwargs_are_forwarded():
+    raw = {'start_frac': 0.5, 'end_frac': 1.0}
+    kwargs = resolve_operation_kwargs(raw, op_windowed, operation_name='op_windowed',
+                                      num_operands=1)
+    assert kwargs == {'start_frac': 0.5, 'end_frac': 1.0}
+    assert op_windowed(_X, **kwargs) == pytest.approx(float(np.mean(_X[4:9])))
+    # the caller's dict is never mutated
+    assert raw == {'start_frac': 0.5, 'end_frac': 1.0}
+
+
+@pytest.mark.unit
+def test_kwargs_dict_is_a_copy_not_the_obs_info_entry():
+    raw = {'start_frac': 0.5}
+    kwargs = resolve_operation_kwargs(raw, op_windowed, operation_name='op_windowed')
+    kwargs['start_frac'] = 0.9
+    assert raw['start_frac'] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# String-valued kwargs (reference to an earlier observable)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_string_kwarg_matching_an_earlier_observable_is_substituted():
+    temp_results = {'v_{ARmean}': 2.0, 'v_{ARmax}': 5.0}
+    raw = {'pred1': 'v_{ARmean}', 'pred2': 'v_{ARmax}'}
+    kwargs = resolve_operation_kwargs(raw, op_var_kwargs, operation_name='op_var_kwargs',
+                                      temp_results=temp_results)
+    assert kwargs == {'pred1': 2.0, 'pred2': 5.0}
+    assert op_var_kwargs(**kwargs) == pytest.approx(3.0)
+
+
+@pytest.mark.unit
+def test_string_kwarg_matching_nothing_is_passed_through_unchanged():
+    """Plain string options must keep working; only names of earlier observables substitute."""
+    kwargs = resolve_operation_kwargs({'pred1': 'literal'}, op_var_kwargs,
+                                      operation_name='op_var_kwargs',
+                                      temp_results={'something_else': 1.0})
+    assert kwargs == {'pred1': 'literal'}
+
+
+@pytest.mark.unit
+def test_substituted_array_value_is_not_coerced():
+    series = np.arange(5.0)
+    kwargs = resolve_operation_kwargs({'window': 'earlier'}, op_index,
+                                      operation_name='op_index',
+                                      temp_results={'earlier': series})
+    assert kwargs['window'] is series
+
+
+# ---------------------------------------------------------------------------
+# series_output branch
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_series_output_is_reserved_and_rejected():
+    assert 'series_output' in RESERVED_OPERATION_KWARGS
+    with pytest.raises(ValueError) as excinfo:
+        resolve_operation_kwargs({'series_output': True}, op_windowed,
+                                 operation_name='op_windowed', data_item_name='u_{AR}')
+    msg = str(excinfo.value)
+    assert 'series_output' in msg
+    assert "u_{AR}" in msg
+    assert 'op_windowed' in msg
+
+
+@pytest.mark.unit
+def test_resolved_kwargs_compose_with_the_series_output_call():
+    """The plotting path calls ``func(*operands, series_output=True, **kwargs)``; the resolved
+    kwargs must never contain series_output so that call cannot get it twice."""
+    kwargs = resolve_operation_kwargs({'start_frac': 0.5}, op_windowed,
+                                      operation_name='op_windowed', num_operands=1)
+    assert 'series_output' not in kwargs
+    out = op_windowed(_X, series_output=True, **kwargs)
+    assert np.array_equal(out, _X)
+
+
+# ---------------------------------------------------------------------------
+# Error path: unknown / colliding keys
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_unknown_kwarg_raises_an_actionable_error():
+    with pytest.raises(ValueError) as excinfo:
+        resolve_operation_kwargs({'start_fraction': 0.5}, op_windowed,
+                                 operation_name='op_windowed', data_item_name='u_{AR}',
+                                 num_operands=1)
+    msg = str(excinfo.value)
+    assert 'start_fraction' in msg          # the offending key
+    assert 'op_windowed' in msg             # the operation func
+    assert "u_{AR}" in msg                  # the data item
+    assert 'start_frac' in msg              # the accepted keys / close-match suggestion
+    assert 'operation_kwargs' in msg        # where to fix it
+
+
+@pytest.mark.unit
+def test_unknown_kwarg_suggests_a_close_match():
+    with pytest.raises(ValueError, match="Did you mean 'end_frac'"):
+        resolve_operation_kwargs({'end_frak': 1.0}, op_windowed, operation_name='op_windowed')
+
+
+@pytest.mark.unit
+def test_kwarg_already_filled_from_operands_raises():
+    with pytest.raises(ValueError) as excinfo:
+        resolve_operation_kwargs({'x': [1.0]}, op_windowed, operation_name='op_windowed',
+                                 data_item_name='u_{AR}', num_operands=1)
+    assert 'operands' in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_second_operand_name_is_only_reserved_when_that_operand_is_supplied():
+    # only one operand given -> x2 is still a legitimate keyword argument
+    assert resolve_operation_kwargs({'x2': 3.0}, op_two_operands, operation_name='op_two_operands',
+                                    num_operands=1) == {'x2': 3.0}
+    # both operands given -> x2 comes from operands, so passing it again is an error
+    with pytest.raises(ValueError):
+        resolve_operation_kwargs({'x2': 3.0}, op_two_operands, operation_name='op_two_operands',
+                                 num_operands=2)
+
+
+@pytest.mark.unit
+def test_non_string_key_raises():
+    with pytest.raises(ValueError, match='keys must be strings'):
+        resolve_operation_kwargs({3: 0.5}, op_windowed, operation_name='op_windowed')
+
+
+@pytest.mark.unit
+def test_var_kwargs_func_accepts_any_key():
+    """An op that declares **kwargs opts out of the unknown-key check."""
+    kwargs = resolve_operation_kwargs({'anything_at_all': 1.0}, op_var_kwargs,
+                                      operation_name='op_var_kwargs')
+    assert kwargs == {'anything_at_all': 1.0}
+
+
+# ---------------------------------------------------------------------------
+# Basic type coercion
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_integral_float_is_coerced_to_int_when_the_default_is_an_int():
+    """JSON has one number type, so a GUI can write 3.0 where an int index is wanted."""
+    kwargs = resolve_operation_kwargs({'window': 3.0}, op_index, operation_name='op_index',
+                                      num_operands=1)
+    assert isinstance(kwargs['window'], int) and kwargs['window'] == 3
+    assert op_index(_X, **kwargs) == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_int_is_coerced_to_float_when_the_default_is_a_float():
+    kwargs = resolve_operation_kwargs({'start_frac': 0, 'end_frac': 1}, op_windowed,
+                                      operation_name='op_windowed', num_operands=1)
+    assert isinstance(kwargs['start_frac'], float)
+    assert isinstance(kwargs['end_frac'], float)
+
+
+@pytest.mark.unit
+def test_non_integral_float_is_not_coerced_to_int():
+    kwargs = resolve_operation_kwargs({'window': 3.5}, op_index, operation_name='op_index')
+    assert kwargs['window'] == 3.5
+
+
+@pytest.mark.unit
+def test_bools_and_other_types_are_not_coerced():
+    kwargs = resolve_operation_kwargs({'anything': True, 'other': None, 'l': [1, 2]},
+                                      op_var_kwargs, operation_name='op_var_kwargs')
+    assert kwargs == {'anything': True, 'other': None, 'l': [1, 2]}
+
+
+# ---------------------------------------------------------------------------
+# Eager validation over a whole obs_info
+# ---------------------------------------------------------------------------
+
+def _obs_info(operations, operands, operation_kwargs, names):
+    return {'operations': operations, 'operands': operands,
+            'operation_kwargs': operation_kwargs, 'names_for_plotting': names}
+
+
+@pytest.mark.unit
+def test_validate_operation_kwargs_flags_the_offending_data_item():
+    obs_info = _obs_info(['op_windowed', 'op_windowed'],
+                         [['main/x'], ['main/x']],
+                         [{'start_frac': 0.5}, {'start_frak': 0.5}],
+                         ['good', 'bad_item'])
+    with pytest.raises(ValueError) as excinfo:
+        validate_operation_kwargs(obs_info, {'op_windowed': op_windowed})
+    assert 'bad_item' in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_validate_operation_kwargs_accepts_a_valid_obs_info():
+    obs_info = _obs_info(['op_windowed', None, 'op_var_kwargs'],
+                         [['main/x'], ['main/y'], []],
+                         [{'start_frac': 0.5}, {}, {'pred1': 'good', 'pred2': 'good'}],
+                         ['good', 'plain', 'delta'])
+    validate_operation_kwargs(obs_info, {'op_windowed': op_windowed,
+                                         'op_var_kwargs': op_var_kwargs})
+
+
+@pytest.mark.unit
+def test_validate_operation_kwargs_skips_ops_not_yet_registered():
+    """A user func may be registered later via add_user_operation_func; eager validation must not
+    pre-emptively fail on it."""
+    obs_info = _obs_info(['not_registered_yet'], [['main/x']], [{'foo': 1.0}], ['item'])
+    validate_operation_kwargs(obs_info, {'op_windowed': op_windowed})
+
+
+@pytest.mark.unit
+def test_validate_operation_kwargs_tolerates_empty_obs_info():
+    validate_operation_kwargs(None, {})
+    validate_operation_kwargs({}, {})
+
+
+# ---------------------------------------------------------------------------
+# The contract helpers must not be registered as observable operations
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_contract_helpers_are_not_registered_as_operations():
+    ops = scriptFunctionParser().get_operation_funcs_dict('numpy')
+    for name in ['resolve_operation_kwargs', 'check_operation_kwargs',
+                 'validate_operation_kwargs', 'get_operation_kwarg_spec']:
+        assert name not in ops
+    assert 'mean' in ops        # sanity: the real operations are still registered
+
+
+# ---------------------------------------------------------------------------
+# Regression: a user op with kwargs driven from an obs_data.json file (issue #304 request 4)
+# ---------------------------------------------------------------------------
+
+_EXTERNAL_OPS = textwrap.dedent('''
+    from param_id.operation_funcs import series_to_constant
+    from param_id.differentiable import differentiable
+    from param_id.math_backend import make_math_backend
+    mb = make_math_backend("numpy")
+
+    @differentiable
+    @series_to_constant
+    def scaled_mean(x, scale=1.0, offset=0.0, series_output=False):
+        if series_output:
+            return x
+        return mb.mean(x) * scale + offset
+''')
+
+
+def _obs_data_json(operation_kwargs_for_second_item):
+    return {
+        "protocol_info": {"pre_times": [0.0], "sim_times": [[1.0]], "params_to_change": {}},
+        "data_items": [
+            {"variable": "x", "name_for_plotting": "x_{plain}", "data_type": "constant",
+             "operation": "scaled_mean", "operands": ["main/x"], "unit": "dimensionless",
+             "weight": 1.0, "value": 1.0, "std": 0.1},
+            {"variable": "x", "name_for_plotting": "x_{scaled}", "data_type": "constant",
+             "operation": "scaled_mean", "operands": ["main/x"], "unit": "dimensionless",
+             "operation_kwargs": operation_kwargs_for_second_item,
+             "weight": 1.0, "value": 1.0, "std": 0.1},
+        ],
+    }
+
+
+def _parse_obs_info(obs_data_dict, tmp_path):
+    parser = ObsAndParamDataParser()
+    parsed = parser.parse_obs_data_json(obs_data_dict=obs_data_dict, pre_time=0.0, sim_time=1.0)
+    return parser.process_obs_info(gt_df=parsed["gt_df"], output_dir=str(tmp_path), dt=0.01)
+
+
+@pytest.mark.unit
+def test_external_user_op_receives_operation_kwargs_from_obs_data_json(tmp_path):
+    """End-to-end for the field: obs_data.json -> parser -> obs_info -> operation call, using a
+    user op loaded through ``operation_funcs_external_path`` (#303)."""
+    op_path = os.path.join(str(tmp_path), 'my_ops.py')
+    with open(op_path, 'w') as fh:
+        fh.write(_EXTERNAL_OPS)
+    ops = scriptFunctionParser(operation_funcs_external_path=op_path).get_operation_funcs_dict('numpy')
+    assert 'scaled_mean' in ops
+
+    obs_info = _parse_obs_info(_obs_data_json({"scale": 3.0, "offset": 1.0}), tmp_path)
+
+    # the parser gives the first (kwarg-free) item the schema default {}
+    assert obs_info["operation_kwargs"][0] == {}
+    assert obs_info["operation_kwargs"][1] == {"scale": 3.0, "offset": 1.0}
+
+    # ...and it validates cleanly and forwards through to the external func
+    validate_operation_kwargs(obs_info, ops)
+    x = np.array([1.0, 2.0, 3.0])
+    results = []
+    for idx in range(len(obs_info["operations"])):
+        func = ops[obs_info["operations"][idx]]
+        kwargs = resolve_operation_kwargs(
+            obs_info["operation_kwargs"][idx], func,
+            operation_name=obs_info["operations"][idx],
+            data_item_name=obs_info["names_for_plotting"][idx],
+            temp_results={}, num_operands=1)
+        results.append(func(x, **kwargs))
+    assert results[0] == pytest.approx(2.0)
+    assert results[1] == pytest.approx(2.0 * 3.0 + 1.0)
+
+
+@pytest.mark.unit
+def test_stale_operation_kwargs_in_obs_data_json_fails_with_a_clear_error(tmp_path):
+    op_path = os.path.join(str(tmp_path), 'my_ops.py')
+    with open(op_path, 'w') as fh:
+        fh.write(_EXTERNAL_OPS)
+    ops = scriptFunctionParser(operation_funcs_external_path=op_path).get_operation_funcs_dict('numpy')
+
+    obs_info = _parse_obs_info(_obs_data_json({"scaling": 3.0}), tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        validate_operation_kwargs(obs_info, ops)
+    msg = str(excinfo.value)
+    assert 'scaling' in msg and 'scaled_mean' in msg and 'x_{scaled}' in msg
+    assert 'scale' in msg
+
+
+@pytest.mark.unit
+def test_shipped_extra_ops_obs_data_json_still_validates(tmp_path):
+    """resources/3compartment_extra_ops_obs_data.json uses operation_kwargs with a **kwargs op;
+    the new validation must not reject it."""
+    resources_dir = os.path.join(os.path.dirname(__file__), '..', 'resources')
+    obs_path = os.path.join(resources_dir, '3compartment_extra_ops_obs_data.json')
+    with open(obs_path, encoding='utf-8-sig') as fh:
+        data_items = json.load(fh)
+
+    parser = ObsAndParamDataParser()
+    parsed = parser.parse_obs_data_json(obs_data_dict=data_items, pre_time=0.0, sim_time=1.0)
+    obs_info = parser.process_obs_info(gt_df=parsed["gt_df"], output_dir=str(tmp_path), dt=0.01)
+    validate_operation_kwargs(obs_info, scriptFunctionParser().get_operation_funcs_dict('numpy'))
+
+
+@pytest.mark.unit
+def test_check_operation_kwargs_is_a_noop_for_empty_kwargs():
+    check_operation_kwargs({}, op_windowed, 'op_windowed')
+    check_operation_kwargs(None, op_windowed, 'op_windowed')

--- a/tutorial/docs/parameter-identification.md
+++ b/tutorial/docs/parameter-identification.md
@@ -117,12 +117,85 @@ If `obs_dt` is omitted, it is estimated from the mean step in `t_path`. For `std
     The `dt` or `sample_rate` fields are deprecated for series data. Use `obs_dt` instead.
 Not to be confused with the dt for the model simulation outputs.
 - **operation**: This defines the operation that will be done on the operands/variable. The possible operations to be done on model outputs are defined in `[CA_dir]/src/param_id/operation_funcs.py` and in `[CA_dir]/funcs_user/operation_funcs_user.py` for user defined operations.
-- **operation_kwargs**: This is a dictionary of key word arguments (kwargs) and their values that links to the kwargs in the chosen python operation function.
+- **operation_kwargs**: An optional dictionary of keyword arguments (kwargs) and their values, passed to the chosen python operation function on top of the operands. Defaults to `{}`. See [operation_kwargs](#operation_kwargs) below for the full contract.
 - **operands**: The above defined "operation" can take in multiple variables. If operands is defined, then the "variable" entry will be a placeholder name for the calculated variable and the operands will define the model variables that are used to calculate the final feature that will be compared to the observable value entry/s.
 - **experiment_idx** and **subexperiment_idx**: Optional indices to link a data item to a specific experiment/subexperiment in `protocol_info`.
 
 !!! warning
     **obs_type**: Deprecated in favor of **operation**.
+
+### operation_kwargs
+
+`operation_kwargs` is an optional, per-`data_item` dictionary of keyword arguments for that item's
+`operation` func. It is a supported public field of `obs_data.json` (it is what the
+[CUFLynx](https://github.com/physiomelinks/CUFLynx) editor writes when you tune an operation's
+options in the GUI), and it behaves identically in calibration, MCMC/UQ and sensitivity analysis.
+
+At run time Circulatory Autogen calls:
+
+```python
+operation(*operands, **operation_kwargs)
+```
+
+so the `operands` fill the operation func's leading positional arguments and `operation_kwargs`
+fills its keyword arguments. For example, with the user operation
+
+```python
+@series_to_constant
+def mean_in_range(x, start_frac=0.0, end_frac=1.0, series_output=False):
+    ...
+```
+
+a `data_item` can ask for the mean over the last 20% of the sub-experiment:
+
+```json
+{
+  "variable": "P aortic root",
+  "name_for_plotting": "u_{ARlate}",
+  "data_type": "constant",
+  "operation": "mean_in_range",
+  "operands": ["aortic_root/u"],
+  "operation_kwargs": { "start_frac": 0.8, "end_frac": 1.0 },
+  "unit": "J_per_m3",
+  "weight": 1.0,
+  "value": 12000,
+  "std": 1200
+}
+```
+
+The rules are:
+
+- **Optional, default `{}`.** Omitting `operation_kwargs` (or leaving it empty/null) calls the
+  operation func with its own defaults, exactly as before.
+- **Keys must be keyword arguments of the operation func.** An unknown or misspelled key is an
+  **error**, not silently ignored -- otherwise a stale obs_data file would quietly calibrate against
+  a different feature than you asked for. The error names the data item, the operation func, the
+  offending key and the accepted keys, and it is raised as soon as the observation data is set,
+  before any simulation runs. A func that declares `**kwargs` (like
+  `calculate_two_observable_difference`) accepts any key.
+- **Keys already filled from `operands` are rejected.** If `operands` supplies the operation's
+  first argument `x`, you cannot also pass `"x"` in `operation_kwargs`.
+- **`series_output` is reserved.** Circulatory Autogen sets it itself when it needs the trace for
+  plotting, so a `data_item` must not set it.
+- **String values can reference an earlier observable.** A string value that matches the
+  `name_for_plotting` of an earlier `data_item` is replaced, at run time, by that observable's
+  computed value. This is how an observable is built from other observables -- see
+  `calculate_two_observable_difference` in `funcs_user/operation_funcs_user.py` and
+  `resources/3compartment_extra_ops_obs_data.json`. A string that matches no earlier observable is
+  passed through unchanged, so plain string options still work. Note that the referenced item must
+  appear **earlier** in `data_items` than the item that references it.
+- **Type coercion is minimal.** JSON has a single number type, so a value written as `20.0` where
+  the func's default is the integer `20` is converted to `int`, and an integer written where the
+  default is a float is converted to `float`. Nothing else is coerced: strings, booleans, lists and
+  `null` reach the operation func as-is.
+
+User-defined operation funcs receive `operation_kwargs` exactly like the built-ins. This includes
+funcs in `funcs_user/operation_funcs_user.py`, funcs in a file pointed to by
+`operation_funcs_external_path` in `user_inputs.yaml`, and funcs registered from python with
+`add_user_operation_func()`.
+
+When building obs data in python rather than as a file, pass the same field through
+`ObsDataCreator.add_data_item({... , "operation_kwargs": {...}})`.
 
 ### prediction items (optional)
 

--- a/tutorial/docs/sensitivity-analysis.md
+++ b/tutorial/docs/sensitivity-analysis.md
@@ -91,7 +91,7 @@ important notice: this experimental unit must be placed after the unit from whic
 
 "operands": "", current experimental unit calculate results by extracted predicted results, so could be set as empty.
 
-"operation_kwargs", this data used to point which experiment predicted results need to be added, then convey the value to participate in the cost function calculation.
+"operation_kwargs", this data used to point which experiment predicted results need to be added, then convey the value to participate in the cost function calculation. It is the same per-`data_item` field used in calibration -- see [operation_kwargs](parameter-identification.md#operation_kwargs) for the full contract (which keys are accepted, what happens to an unknown key, and how a string value references an earlier observable).
 
 "v_{ARmean}" and "v_{ARmax}", important strings, specifies which experiment predicts results will be conveyed to the current experiment.
 
@@ -101,14 +101,12 @@ important notice: this experimental unit must be placed after the unit from whic
 
 ![Example of operation file](images/SensitivityAnalysis_Operationexample.png)
 
--Notice: sometimes will report an error similar to the following:
-
-```
-obs_series_array_all[JJ] = self.operation_funcs_dict[
-                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
-TypeError: operation_funcs.mean() argument after ** must be a mapping, not float
-```
-
-please just change `**self.obs_info["operation_kwargs"][JJ]` to `**kwargs`.
+!!! note
+    Older versions could fail with `TypeError: operation_funcs.mean() argument after ** must be a
+    mapping, not float` when a `data_item` had no `operation_kwargs`. This is fixed: every place
+    that forwards `operation_kwargs` now goes through
+    `param_id.operation_funcs.resolve_operation_kwargs`, which treats a missing/null/NaN value as
+    "no kwargs" and raises a descriptive `ValueError` (naming the data item, the operation and the
+    accepted keys) for a key the operation func does not accept.
 
 If there is any other issue, please contact Changqing Dong, email: cdon822@aucklanduni.ac.nz. 


### PR DESCRIPTION
Closes #304.

`operation_kwargs` already worked end to end on `master`, so this PR is about locking in the contract that the CUFLynx editor (physiomelinks/CUFLynx#112) now depends on: one implementation, clear errors, docs, tests.

## What was actually wrong

Each of the five places that forwarded `operation_kwargs` reimplemented it slightly differently:

- `paramID.get_obs_output_dict` had three branches — the `series_output=True` plotting branch and the main branch each hand-rolled the "copy the dict, substitute string values from `temp_results`" logic (with a dead `else: raise KeyError` inside an `if v in temp_results`), while the `get_all_series` non-`series_to_constant` branch and the frequency branch splatted `**self.obs_info["operation_kwargs"][JJ]` raw — which is exactly the `TypeError: argument after ** must be a mapping, not float` the sensitivity-analysis tutorial page told users to patch out by hand.
- `sobolSA` had yet another copy, without the paramID error handling.

And in all of them a misspelled key surfaced as a bare `TypeError: op() got an unexpected keyword argument 'start_frak'` from deep inside the call, mid-optimisation.

## Changes

**Validation (`src/param_id/operation_funcs.py`)** — new `resolve_operation_kwargs` / `check_operation_kwargs` / `validate_operation_kwargs`, now the single entry point used by all five call sites. The decided-and-documented contract:

- optional, default `{}`; a `null`/`NaN` left by a partially-filled obs_data file is tolerated as "no kwargs" (so the stale tutorial workaround is no longer needed)
- **an unknown key is an error, not silently ignored** — otherwise a stale obs_data file quietly calibrates against a different feature than the user asked for. The message names the data_item, the operation func, the offending key, a close-match suggestion and the accepted keys. A func declaring `**kwargs` (e.g. `calculate_two_observable_difference`) still accepts anything.
- a key that duplicates an argument already filled positionally from `operands` is rejected, as is the CA-managed `series_output`
- a **string** value matching an earlier observable's `name_for_plotting` is substituted with that observable's computed value (existing behaviour, now documented); a string matching nothing passes through unchanged
- **type coercion is minimal**: integral-float → `int` and `int` → `float` when the func's default says so, since JSON has a single number type and a GUI spin box can easily emit `20.0` for an `int` slice index. Nothing else is coerced.

Validation also runs **eagerly** when the obs data is set (`OpencorParamID.__init__` / `set_obs_info`, `sobol_SA.__init__` / `set_ground_truth_data`), so a stale file fails before any simulation rather than part-way through. Operations not yet in the registry are skipped, so `add_user_operation_func()` registered after the obs data still works.

Confirms issue request 3: funcs from `funcs_user/`, from `operation_funcs_external_path` (#303) and from `add_user_operation_func()` all go through the same registry and receive `operation_kwargs` identically to the built-ins — there is a test for the external-file case.

**Docs**
- `tutorial/docs/parameter-identification.md`: new `### operation_kwargs` section under `data items` (the existing one-line bullet now links to it) with a worked example and the full rule list.
- `tutorial/docs/sensitivity-analysis.md`: cross-links the new section, and the stale "please just change `**self.obs_info["operation_kwargs"][JJ]` to `**kwargs`" workaround is replaced with a note that it is fixed.
- `ObsDataCreator.add_data_item`: `operation_kwargs` added to the optional keys and the docstring, with a type check.

**Tests** — `tests/test_operation_kwargs.py`, 35 unit tests: signature introspection, scalar kwargs, string-valued kwargs (substituted and pass-through), the `series_output` branch, the default-empty / `None` / `NaN` / non-dict cases, `**kwargs` funcs, minimal type coercion, and every error path (unknown key, close-match suggestion, operand collision, reserved key, non-string key). Plus a regression test driving a user op with kwargs from an obs_data.json dict through the real parser to the call (issue request 4), and a guard that the shipped `resources/3compartment_extra_ops_obs_data.json` still validates.

## Testing

Run under the OpenCOR python shell (`./run_pytest.sh`), 1 MPI rank:

- `tests/test_operation_kwargs.py` — **35 passed**
- `tests/test_external_user_funcs.py tests/test_solver_info_validation.py` — **33 passed**
- `-k extra_ops` (autogen + param-id + SA on the model that actually uses `operation_kwargs`) — **4 passed, 1 skipped**
- `-k test_fft` (exercises the frequency branch) — **2 passed, 1 skipped**
- `-k SN_simple_CVODE_myokit_ga_smoke` (exercises the `series_to_constant` / plotting branch) — **1 passed, 1 skipped**
- `tests/test_sensitivity_analysis.py tests/test_python_user_defined.py` — **11 passed**

The full suite was not run.

## Note on scope

Issue request 2 asks to "decide and document behaviour for an `operation_kwargs` key that isn't a parameter of the chosen operation (ignore vs. error)". This PR chooses **error**. Ignoring would let a stale or misspelled key silently change nothing while the user believes it took effect — a wrong calibration that looks successful. Funcs that genuinely want open-ended keys can declare `**kwargs` and opt out.

Note this makes previously-tolerated (but already broken) obs_data files fail loudly at setup. That is intentional; the message says exactly which data_item and key to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)