### PR TITLE
fix(param-id): save best_param_vals.npy incrementally in the gradient optimisers

### DIFF
--- a/src/param_id/optimisers.py
+++ b/src/param_id/optimisers.py
@@ -839,6 +839,11 @@ class SciPyMinimizeOptimiser(Optimiser):
         comm = self.comm
         rank = self.rank
 
+        # Fresh running best (updated and saved incrementally by the callback below), so a
+        # re-run on the same object isn't gated by the previous run's best.
+        self.best_cost = np.inf
+        self.best_param_vals = None
+
         best_param_vals = np.empty(self.num_params, dtype=float)
         best_gradient_vals = np.empty(self.num_params, dtype=float)
         best_cost_array = np.empty(1, dtype=float)
@@ -954,10 +959,29 @@ class SciPyMinimizeOptimiser(Optimiser):
                         np.savetxt(file, np.asarray(grad_real, dtype=float).reshape(1, -1),
                                    fmt='%.9e', delimiter=', ')
 
+                def _update_running_best(cost_val, param_vals):
+                    # Keep best_cost.npy / best_param_vals.npy current *during* the run, the way
+                    # the population-based optimisers (GA, CMA-ES, Bayesian) do, so a run that is
+                    # cancelled partway still leaves a recoverable best-so-far (issue #300).
+                    # best_param_vals_history.csv is no substitute: it stores NORMALISED values.
+                    # param_vals is therefore the actual (unnormalised) parameter vector, and
+                    # cost_val comes from the same cost the minimiser is driving (min_cost_fun),
+                    # so it is directly comparable to the final res.fun recorded at the end.
+                    cost_val = float(cost_val)
+                    if not np.isfinite(cost_val) or cost_val >= self.best_cost:
+                        return
+                    self.best_cost = cost_val
+                    self.best_param_vals = np.asarray(param_vals, dtype=float).flatten()
+                    # rank-0-guarded inside; only rank 0 gets here anyway.
+                    self._save_best_params()
+
                 # Record the starting point so the progress curves begin at the
                 # pre-optimisation cost and gradient.
                 _append_history(init_cost, self.param_norm_obj.normalise(init_param_vals),
                                 init_gradient)
+                # ... and as the initial best-so-far, so even a run stopped before the first
+                # accepted iterate leaves a usable best_param_vals.npy.
+                _update_running_best(init_cost, init_param_vals)
 
                 step_counter = [0]
                 last_iterate = {"x_norm": None, "cost": None}
@@ -979,6 +1003,8 @@ class SciPyMinimizeOptimiser(Optimiser):
                     grad_real = _grad_real_at(x_norm)
                     # Live progress: one history row per accepted iteration.
                     _append_history(cost_val, x_norm, grad_real)
+                    # ... and keep the saved best-so-far (actual parameter values) current.
+                    _update_running_best(cost_val, param_vals)
                     if self.DEBUG:
                         print(f'[sp_minimize] step {step_counter[0]}: cost = {cost_val:.6e}')
                         for i, names in enumerate(self.param_id_info["param_names"]):
@@ -1336,6 +1362,31 @@ class MultiStartSciPyMinimizeOptimiser(Optimiser):
         except OSError:
             pass
 
+    def _update_running_best(self, cost_val, x_norm):
+        """Update the running *global* best across all starts and persist it immediately.
+
+        Mirrors the incremental saves of the population-based optimisers (GA, CMA-ES, Bayesian)
+        so a multi-start run that is cancelled partway still leaves a recoverable
+        best_param_vals.npy / best_cost.npy (issue #300). The per-start streams are no
+        substitute for the cost/params pair, and best_param_vals_history.csv stores NORMALISED
+        values, so the actual (unnormalised) parameter vector is written here.
+
+        cost_val comes from the same cost_fun the descents minimise (so it is directly
+        comparable to the final best_result['final_cost'] recorded at the end of run()).
+        Only rank 0 writes -- _save_best_params is rank-0-guarded -- so a best found on another
+        rank is only persisted at the end of the run, when the results are gathered.
+        """
+        cost_val = float(cost_val)
+        if not np.isfinite(cost_val) or cost_val >= self.best_cost:
+            return
+        self.best_cost = cost_val
+        self.best_param_vals = np.asarray(
+            self.param_norm_obj.unnormalise(np.asarray(x_norm, dtype=float)),
+            dtype=float).flatten()
+        # No output dir configured at all (as for the live streams) -> nothing to save.
+        if self.output_dir is not None:
+            self._save_best_params()
+
     def _run_one_start(self, start_idx, x0_norm, cost_fun, gradient_func, bounds_norm):
         """Run a single bounded L-BFGS-B descent. Returns a result dict (never raises for a
         cost-converged early stop)."""
@@ -1366,6 +1417,9 @@ class MultiStartSciPyMinimizeOptimiser(Optimiser):
         self._append_start_cost(start_idx, 0, init_cost)
         self._append_start_params(start_idx, 0, x0_norm)
         self._append_start_gradient(start_idx, 0, grad_real_at(x0_norm))
+        # The start point itself is a candidate for the running global best, so even a run
+        # cancelled before the first accepted iterate leaves a usable best_param_vals.npy.
+        self._update_running_best(init_cost, x0_norm)
 
         last_iterate = {"x_norm": None, "cost": None}
 
@@ -1379,6 +1433,8 @@ class MultiStartSciPyMinimizeOptimiser(Optimiser):
             self._append_start_cost(start_idx, len(iterates) - 1, cost_val)
             self._append_start_params(start_idx, len(iterates) - 1, x_norm)
             self._append_start_gradient(start_idx, len(iterates) - 1, grad_real_at(x_norm))
+            # Keep the saved best-so-far (actual parameter values) current across all starts.
+            self._update_running_best(cost_val, x_norm)
             if self.DEBUG:
                 print(f'[multi_start_sp_minimize] rank {self.rank} start {start_idx}: '
                       f'cost = {cost_val:.6e}')
@@ -1419,6 +1475,11 @@ class MultiStartSciPyMinimizeOptimiser(Optimiser):
         comm = self.comm
         rank = self.rank
         num_procs = self.num_procs
+
+        # Fresh running global best (updated and saved incrementally by _update_running_best as
+        # the starts run), so a re-run on the same object isn't gated by the previous run's best.
+        self.best_cost = np.inf
+        self.best_param_vals = None
 
         # Live per-start streams: cost (multi_start_cost_history.csv), parameter values
         # (multi_start_param_vals_history.csv) and gradient (multi_start_gradient_history.csv), one

--- a/tests/test_param_id.py
+++ b/tests/test_param_id.py
@@ -3664,6 +3664,178 @@ def test_multi_start_no_new_starts_on_convergence_false_runs_every_start(temp_ou
                 f'converged starts should be in the -1 well, got {cluster["params"]}'
 
 
+# ---------------------------------------------------------------------------
+# best_param_vals.npy must be kept current DURING a gradient run (issue #300), so a
+# calibration that is cancelled partway still leaves a recoverable best-so-far -- the way
+# GA / CMA-ES / Bayesian already behave. best_param_vals_history.csv is not a substitute:
+# it stores normalised values.
+# ---------------------------------------------------------------------------
+
+class _RunCancelled(Exception):
+    """Stands in for a user cancelling a calibration partway through."""
+
+
+class _CancellingTwoWellParamId(_TwoWellParamId):
+    """Two-well cost that aborts the run after a fixed number of cost evaluations."""
+
+    def __init__(self, cancel_after, **kwargs):
+        super().__init__(**kwargs)
+        self.cancel_after = cancel_after
+
+    def get_cost(self, p):
+        if self.num_cost_calls >= self.cancel_after:
+            raise _RunCancelled(f'cancelled after {self.num_cost_calls} cost evaluations')
+        return super().get_cost(p)
+
+
+def _read_history_rows(path):
+    """Rows of a plain numeric history csv (no header), as a list of float lists."""
+    rows = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append([float(v) for v in line.split(',')])
+    return rows
+
+
+def _read_keyed_stream_rows(path):
+    """Rows of a multi_start_*_history.csv (header + 'start_idx, iteration, values...')."""
+    rows = []
+    with open(path) as f:
+        next(f, None)  # header
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            vals = [float(v) for v in line.split(',')]
+            rows.append((int(vals[0]), int(vals[1]), vals[2:]))
+    return rows
+
+
+@pytest.mark.unit
+def test_sp_minimize_saves_best_params_before_the_run_finishes(temp_output_dir):
+    """A cancelled sp_minimize run must leave a best_param_vals.npy holding the best-so-far in
+    ACTUAL (unnormalised) parameter space, not just write one at the very end (issue #300)."""
+    from param_id.optimisers import SciPyMinimizeOptimiser
+
+    # The full descent from (1.9, 1.9) takes ~13 cost evaluations, so cancelling after 8 lands
+    # partway through, several accepted L-BFGS-B iterations in.
+    param_id_obj = _CancellingTwoWellParamId(cancel_after=8, param_init=(1.9, 1.9))
+    init_cost = _two_well_cost(param_id_obj.param_init)
+
+    opt = SciPyMinimizeOptimiser(
+        param_id_obj=param_id_obj, param_id_info=_two_well_param_id_info(),
+        param_norm_obj=_TwoWellNorm(), num_params=2, output_dir=temp_output_dir,
+        optimiser_options={'cost_convergence': 1e-12}, do_ad=True, DEBUG=False,
+    )
+
+    # The cancellation propagates as the RuntimeError run() raises on every rank for a rank-0
+    # failure -- i.e. run() never reaches its end-of-run _save_best_params().
+    with pytest.raises(RuntimeError):
+        opt.run()
+
+    if MPI.COMM_WORLD.Get_rank() != 0:
+        return
+
+    cost_path = os.path.join(temp_output_dir, 'best_cost.npy')
+    params_path = os.path.join(temp_output_dir, 'best_param_vals.npy')
+    assert os.path.isfile(cost_path), \
+        'a cancelled sp_minimize run left no best_cost.npy to continue from'
+    assert os.path.isfile(params_path), \
+        'a cancelled sp_minimize run left no best_param_vals.npy to continue from'
+
+    saved_cost = float(np.load(cost_path))
+    saved_params = np.load(params_path)
+    assert saved_params.shape == (2,)
+    assert np.all(np.isfinite(saved_params))
+
+    # The descent got somewhere before it was cancelled, and that progress was saved -- not
+    # merely the starting point.
+    assert saved_cost < init_cost, \
+        (f'saved best cost {saved_cost} should improve on the initial cost {init_cost}, '
+         f'i.e. the mid-run best must be kept up to date')
+
+    # It is up to date with the streamed history: the saved cost is the best cost recorded so
+    # far, and the saved parameters are that iterate in ACTUAL parameter space (the history csv
+    # holds normalised values, which is why it cannot stand in for this file).
+    cost_rows = _read_history_rows(os.path.join(temp_output_dir, 'best_cost_history.csv'))
+    param_rows = _read_history_rows(os.path.join(temp_output_dir,
+                                                 'best_param_vals_history.csv'))
+    assert len(cost_rows) == len(param_rows) >= 2
+    costs = [row[0] for row in cost_rows]
+    best_idx = int(np.argmin(costs))
+    assert saved_cost == pytest.approx(costs[best_idx], rel=1e-6, abs=1e-9)
+    expected_params = _TwoWellNorm().unnormalise(np.asarray(param_rows[best_idx]))
+    assert saved_params == pytest.approx(expected_params, rel=1e-4, abs=1e-6)
+    # and they really are unnormalised (the two differ for this best iterate)
+    assert not np.allclose(saved_params, np.asarray(param_rows[best_idx])), \
+        'best_param_vals.npy must hold actual parameter values, not normalised ones'
+
+    # the cost really is the same quantity the optimiser is minimising
+    assert saved_cost == pytest.approx(_two_well_cost(saved_params), rel=1e-6, abs=1e-9)
+
+
+@pytest.mark.unit
+def test_multi_start_sp_minimize_saves_best_params_before_the_run_finishes(temp_output_dir):
+    """A cancelled multi_start_sp_minimize run must likewise leave the running global best in
+    best_param_vals.npy / best_cost.npy (issue #300)."""
+    # Start 0 is the initial point and is always run by rank 0; on its own it takes ~18 cost
+    # evaluations, so cancelling after 8 always lands inside it, past its first accepted
+    # iteration -- whatever the rank count.
+    param_id_obj = _CancellingTwoWellParamId(cancel_after=8, param_init=(1.9, 1.9))
+    init_cost = _two_well_cost(param_id_obj.param_init)
+
+    opt = _make_multi_start_optimiser(
+        temp_output_dir, param_id_obj,
+        {'num_starts': 8, 'start_sampling': 'sobol', 'seed': 0, 'include_init_point': True,
+         'cost_convergence': 1e-12})
+
+    # Every rank runs starts, so every rank hits the cancellation and run() raises before its
+    # end-of-run _save_best_params().
+    with pytest.raises(RuntimeError):
+        opt.run()
+
+    if MPI.COMM_WORLD.Get_rank() != 0:
+        return
+
+    cost_path = os.path.join(temp_output_dir, 'best_cost.npy')
+    params_path = os.path.join(temp_output_dir, 'best_param_vals.npy')
+    assert os.path.isfile(cost_path), \
+        'a cancelled multi_start_sp_minimize run left no best_cost.npy to continue from'
+    assert os.path.isfile(params_path), \
+        'a cancelled multi_start_sp_minimize run left no best_param_vals.npy to continue from'
+
+    saved_cost = float(np.load(cost_path))
+    saved_params = np.load(params_path)
+    assert saved_params.shape == (2,)
+    assert np.all(np.isfinite(saved_params))
+
+    # start 0 is the initial point (include_init_point), and it is run by rank 0, so the saved
+    # best must have improved on it before the run was cancelled.
+    assert saved_cost < init_cost, \
+        (f'saved best cost {saved_cost} should improve on the initial cost {init_cost}, '
+         f'i.e. the running global best must be kept up to date')
+
+    # The saved pair matches an iterate that was actually streamed by this rank, in ACTUAL
+    # parameter space, and is the best of the ones rank 0 saw (only rank 0 writes the file).
+    cost_rows = _read_keyed_stream_rows(
+        os.path.join(temp_output_dir, 'multi_start_cost_history.csv'))
+    param_rows = _read_keyed_stream_rows(
+        os.path.join(temp_output_dir, 'multi_start_param_vals_history.csv'))
+    assert cost_rows and param_rows
+    match = [(s, it) for s, it, vals in cost_rows
+             if vals[0] == pytest.approx(saved_cost, rel=1e-6, abs=1e-9)]
+    assert match, \
+        f'saved best cost {saved_cost} is not one of the streamed per-start costs'
+    key = match[0]
+    streamed_params = [vals for s, it, vals in param_rows if (s, it) == key]
+    assert streamed_params
+    assert saved_params == pytest.approx(np.asarray(streamed_params[0]), rel=1e-4, abs=1e-6)
+    assert saved_cost == pytest.approx(_two_well_cost(saved_params), rel=1e-6, abs=1e-9)
+
+
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.mpi


### PR DESCRIPTION
## Problem

`best_cost.npy` / `best_param_vals.npy` are written **incrementally** by the population-based optimisers (`GeneticAlgorithmOptimiser`, `BayesianOptimiser`, `CMAESOptimiser`) every time a new best is found, but the gradient optimisers `SciPyMinimizeOptimiser` (`sp_minimize`) and `MultiStartSciPyMinimizeOptimiser` (`multi_start_sp_minimize`) only called `_save_best_params()` **once, at the end** of `run()`.

A gradient run that is cancelled partway therefore leaves no actual best-so-far to continue from, which breaks "cancel a calibration and continue from where it reached" (CUFLynx #83). `best_param_vals_history.csv` is not a substitute: it stores **normalised** values.

## Change (`src/param_id/optimisers.py`)

Both gradient optimisers now track the running best in **actual (unnormalised)** parameter space and call `self._save_best_params()` whenever it improves:

- **`sp_minimize`**: a local `_update_running_best(cost_val, param_vals)` seeded with the initial point and called from the existing L-BFGS-B `lbfgsb_callback`, right next to the per-iteration `_append_history(...)`. The callback's `cost_val` is the same cost the minimiser drives (`min_cost_fun`), so the mid-run best is directly comparable to the final `res.fun`.
- **`multi_start_sp_minimize`**: a `_update_running_best(cost_val, x_norm)` method called from `_run_one_start` — at the start point and in the per-iteration callback — tracking the running **global** best across all starts. `_save_best_params()` is rank-0-guarded (verified), so only rank 0 writes; a best found on another rank is still persisted at the end of the run when the results are gathered.

Everything else is unchanged: the end-of-run `_save_best_params()` calls stay, as does all history/summary writing (`best_cost_history.csv`, `best_param_vals_history.csv`, `best_gradient_history.csv`, the `multi_start_*_history.csv` live streams, `multi_start_summary.csv`) and the final-result bookkeeping. Both `run()` methods now reset the running best at entry so a re-run on the same object isn't gated by the previous run's best. Additive, no format change.

## Tests (`tests/test_param_id.py`)

Two new `unit`-marked tests (no new markers), built on the existing two-well fakes (`_TwoWellParamId` / `_TwoWellNorm` / `_make_multi_start_optimiser`):

- `test_sp_minimize_saves_best_params_before_the_run_finishes`
- `test_multi_start_sp_minimize_saves_best_params_before_the_run_finishes`

Each cancels the run partway (the stub `param_id_obj` raises after a fixed number of cost evaluations, well before the descent finishes), then asserts that `best_cost.npy` / `best_param_vals.npy` exist, that the saved cost **improves on the initial cost** (i.e. mid-descent progress was saved, not just the starting point), that the saved pair matches the corresponding streamed history row in **actual** parameter space (and is explicitly *not* the normalised vector), and that the saved cost is the same quantity the optimiser minimises.

Both tests **fail before the fix** with `AssertionError: a cancelled sp_minimize run left no best_cost.npy to continue from` (and the multi-start equivalent).

### What was run (OpenCOR pythonshell, `./run_pytest.sh`, 1 MPI rank)

- `-k "saves_best_params_before_the_run_finishes"` → **2 passed** (and **2 failed** on the same selection with the `optimisers.py` change stashed).
- `-m unit -k "multi_start or sp_minimize"` → **10 passed** (all existing optimiser unit tests still pass).
- `-k test_param_id_lotka_volterra_sp_minimize_succeeds` → **1 passed** (end-to-end `sp_minimize` calibration).
- `-k test_multi_start_reports_both_minima_of_a_two_minimum_model` → **1 passed** (end-to-end multi-start calibration).

Not run: the full suite, and multi-rank (`-n 4`) runs of these tests — a narrow `-k` selection under multiple ranks hits the pre-existing `wait_for_autogen_if_needed` gate in `tests/conftest.py` (it times out waiting for autogen completion lines from the deselected autogen tests). The change adds no MPI calls, only rank-local state updates and rank-0-guarded file writes.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)
