### PR TITLE
feat(solvers): set_param_vals updates state initial values by default

### DIFF
--- a/src/protocol_runners/protocol_executor.py
+++ b/src/protocol_runners/protocol_executor.py
@@ -135,10 +135,18 @@ class ProtocolExecutor:
                     )
 
                 if params_to_change:
+                    # change_states re-derives every state initial value from the model. That is
+                    # right for the first sub-experiment (reset_states() above has just put the
+                    # states at their initial values anyway, so a state-init parameter here must
+                    # take effect), but for every later sub-experiment it would throw away the
+                    # state the previous one evolved into and break continuity -- so the flag is
+                    # off there. A params_to_change entry naming a state directly is therefore
+                    # only honoured in the first sub-experiment and raises after that.
                     self.sim_helper.set_param_vals(
                         list(params_to_change.keys()),
                         [params_to_change[k][exp_idx][sub_idx]
                          for k in params_to_change],
+                        change_states=(sub_idx == 0),
                     )
 
                 success = self.sim_helper.run()

--- a/src/solver_wrappers/aadc_python_solver_helper.py
+++ b/src/solver_wrappers/aadc_python_solver_helper.py
@@ -235,7 +235,27 @@ class SimulationHelper:
             vals.append(sub if len(sub) > 1 else sub[0])
         return vals
 
-    def set_param_vals(self, param_names, param_vals):
+    def set_param_vals(self, param_names, param_vals, change_states=True):
+        """Set parameter values, by default including any state initial values they drive.
+
+        ``change_states=False`` is for mid-protocol updates that must preserve the state the
+        previous sub-experiment evolved into; naming a state there is an error.
+        """
+        if not change_states:
+            offenders = []
+            for _n_or_l in param_names:
+                for _n in (_n_or_l if isinstance(_n_or_l, (list, tuple)) else [_n_or_l]):
+                    try:
+                        _kind, _ = self._resolve_name(_n)
+                    except Exception:
+                        continue
+                    if _kind == "state":
+                        offenders.append(str(_n))
+            if offenders:
+                raise ValueError(
+                    "set_param_vals(change_states=False) cannot set states directly, but was "
+                    f"given: {', '.join(offenders)}. change_states=False exists for mid-protocol "
+                    "updates that must preserve the evolved state.")
         for idx, name_or_list in enumerate(param_names):
             vals = param_vals[idx]
             if not isinstance(name_or_list, (list, tuple)):
@@ -261,7 +281,7 @@ class SimulationHelper:
                     self.variables[self._var_idx_to_const_pos(idx_res)] = val
                     var_name = self.var_idx_to_name.get(idx_res, "")
                     var_part = var_name.split("/")[-1] if "/" in var_name else var_name
-                    if var_part.endswith("_init"):
+                    if change_states and var_part.endswith("_init"):
                         state_var = var_part[:-5]
                         state_kind, state_idx = self._resolve_name(state_var)
                         if state_kind == "state":

--- a/src/solver_wrappers/casadi_python_solver_helper.py
+++ b/src/solver_wrappers/casadi_python_solver_helper.py
@@ -293,7 +293,27 @@ class SimulationHelper:
             vals.append(sub if len(sub) > 1 else sub[0])
         return vals
 
-    def set_param_vals(self, param_names, param_vals):
+    def set_param_vals(self, param_names, param_vals, change_states=True):
+        """Set parameter values, by default including any state initial values they drive.
+
+        ``change_states=False`` is for mid-protocol updates that must preserve the state the
+        previous sub-experiment evolved into; naming a state there is an error.
+        """
+        if not change_states:
+            offenders = []
+            for _n_or_l in param_names:
+                for _n in (_n_or_l if isinstance(_n_or_l, (list, tuple)) else [_n_or_l]):
+                    try:
+                        _kind, _ = self._resolver.resolve(_n)
+                    except Exception:
+                        continue
+                    if _kind == "state":
+                        offenders.append(str(_n))
+            if offenders:
+                raise ValueError(
+                    "set_param_vals(change_states=False) cannot set states directly, but was "
+                    f"given: {', '.join(offenders)}. change_states=False exists for mid-protocol "
+                    "updates that must preserve the evolved state.")
         for idx, name_or_list in enumerate(param_names):
             vals = param_vals[idx]
 
@@ -330,7 +350,8 @@ class SimulationHelper:
                 elif kind == "var":
                     self.variables[self._var_idx_to_const_pos(idx_res)] = val
                     self.variables_model[idx_res] = val
-                    self._sync_numeric_state_for_init_var(idx_res, val)
+                    if change_states:
+                        self._sync_numeric_state_for_init_var(idx_res, val)
                 else:
                     raise ValueError(f"parameter name {name} not found in states or variables")
         self.model.compute_computed_constants(self.variables_model)

--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -604,17 +604,9 @@ class SimulationHelper:
         # NOTE: if an offline warm-up using pre() is ever reinstated, that pollution returns and
         # this restore must come back with it (see run_offline_pre_and_set_default_state).
         self.simulation.reset()
-        if self._offline_default_state is not None:
-            self.simulation.set_state(self._offline_default_state)
-        else:
-            updated_initial_state = self._get_simulation_model().initial_values(as_floats=True)
-            self.simulation.set_state(updated_initial_state)
-        for qname, val in self._state_overrides.items():
-            if qname in self.state_index:
-                self._set_state_value(qname, float(val))
-        state = list(self.simulation.state())
-        self.simulation.set_default_state(state)
-        self.default_states = state
+        # Same refresh set_param_vals(change_states=True) performs -- kept in one place so the
+        # two paths cannot drift (offline warm-up precedence, state overrides, default_state).
+        self._refresh_initial_states_from_model()
         self.last_log = None
 
     def get_all_variable_names(self):
@@ -722,7 +714,111 @@ class SimulationHelper:
         state[idx] = float(val)
         self.simulation.set_state(state)
 
-    def set_param_vals(self, param_names, param_vals):
+    def _refresh_initial_states_from_model(self):
+        """Push the model's (re-evaluated) initial values into the Simulation.
+
+        A Myokit ``Simulation`` keeps its own ``state``/``default_state`` arrays, snapshotted at
+        construction. ``set_constant()`` updates the *model* -- so a state whose CellML
+        ``initial_value`` references a constant (``q_lv`` -> ``q_lv_init``) re-evaluates
+        correctly there -- but it never touches those arrays, and ``reset()`` restores *from*
+        ``default_state``. Without this refresh the simulation keeps the initial condition it was
+        built with, silently ignoring any change to a state-init parameter.
+
+        Mirrors ``reset_states()``: an offline warm-up state, when present, still wins over the
+        model's initial values, and explicit state overrides are re-applied on top.
+        """
+        if self._offline_default_state is not None:
+            self.simulation.set_state(list(self._offline_default_state))
+        else:
+            self.simulation.set_state(self._get_simulation_model().initial_values(as_floats=True))
+        for qname, val in self._state_overrides.items():
+            if qname in self.state_index:
+                self._set_state_value(qname, float(val))
+        state = list(self.simulation.state())
+        self.simulation.set_default_state(state)
+        self.default_states = state
+
+    def _states_initialised_by(self, changed_qnames):
+        """States whose CellML initial value references any of ``changed_qnames``.
+
+        Only these can be affected by the constants just written, so only these are refreshed --
+        re-deriving *every* state would reset the whole vector and destroy the state a running
+        multi-sub-experiment protocol has evolved into.
+        """
+        affected = []
+        if not changed_qnames:
+            return affected
+        for s in self._get_simulation_model().states():
+            initial = s.initial_value()
+            if initial is None:
+                continue
+            try:
+                refs = {n.var().qname() for n in initial.references()}
+            except Exception:
+                continue  # a literal initial value has nothing to depend on
+            if refs & changed_qnames:
+                affected.append(s)
+        return affected
+
+    def _refresh_initial_states_for(self, changed_qnames):
+        """Re-evaluate and apply the initial values driven by ``changed_qnames``.
+
+        A Myokit ``Simulation`` keeps its own ``state``/``default_state`` arrays, snapshotted at
+        construction. ``set_constant()`` updates the *model* -- so a state whose CellML
+        ``initial_value`` references a constant (``q_lv`` -> ``q_lv_init``) re-evaluates correctly
+        there -- but never touches those arrays, and ``reset()`` restores *from* ``default_state``.
+        Without this the simulation silently keeps the initial condition it was built with.
+        """
+        affected = self._states_initialised_by(changed_qnames)
+        if not affected:
+            return
+        state = list(self.simulation.state())
+        for s in affected:
+            try:
+                state[self.state_index[s.qname()]] = float(s.initial_value().eval())
+            except Exception:
+                continue
+        for qname, val in self._state_overrides.items():
+            if qname in self.state_index:
+                state[self.state_index[qname]] = float(val)
+        self.simulation.set_state(state)
+        self.simulation.set_default_state(list(state))
+        self.default_states = list(state)
+
+    def set_param_vals(self, param_names, param_vals, change_states=True):
+        """Set parameter values, by default including any state initial values they drive.
+
+        Args:
+            param_names: names to set; each entry may be a list sharing one value.
+            param_vals: matching values.
+            change_states: when True (default), state initial values are re-derived from the
+                model after the parameters are applied, so setting a state-init parameter
+                (``q_lv_init``) actually moves the state it initialises. Set False for
+                mid-protocol updates, where re-deriving initial values would discard the state
+                the previous sub-experiment evolved into and break continuity. With
+                ``change_states=False`` it is an error to name a state directly, since that
+                request cannot be honoured without disturbing exactly that continuity.
+        """
+        # Phase 0: with change_states=False the caller is asserting "do not touch the state
+        # vector". Naming a state contradicts that, so fail loudly rather than half-applying.
+        if not change_states:
+            offenders = []
+            for name_or_list in param_names:
+                for name in (name_or_list if isinstance(name_or_list, list) else [name_or_list]):
+                    try:
+                        kind, qname = self._resolve_name(name)
+                    except Exception:
+                        continue
+                    if kind == "state":
+                        offenders.append(f"{name} (state {qname})")
+            if offenders:
+                raise ValueError(
+                    "set_param_vals(change_states=False) cannot set states directly, but was "
+                    f"given: {', '.join(offenders)}. change_states=False exists for mid-protocol "
+                    "updates that must preserve the evolved state; writing a state there would "
+                    "destroy sub-experiment continuity. Either call with change_states=True (the "
+                    "default) or remove the state from this call.")
+
         # Phase 1: Pre-scan for any string trace value and rebind pace if the target
         # variable differs from the currently bound one.  This ensures set_constant
         # calls made later in the same invocation are not lost to a mid-loop recreate.
@@ -730,7 +826,9 @@ class SimulationHelper:
         if new_paced_qname is not None and new_paced_qname != self.paced_parameter_qname:
             self._rebind_pace_to(new_paced_qname)
 
-        # Phase 2: Apply all parameter values.
+        # Phase 2: Apply all parameter values, recording which constants changed so only the
+        # states they initialise are refreshed afterwards.
+        changed_var_qnames = set()
         for idx, name_or_list in enumerate(param_names):
             names = name_or_list if isinstance(name_or_list, list) else [name_or_list]
             vals = param_vals[idx]
@@ -800,6 +898,7 @@ class SimulationHelper:
                             self.simulation.set_protocol(protocol, label='pace')
                         else:
                             self.simulation.set_constant(qname, float(val))
+                            changed_var_qnames.add(qname)
                             # Keep self.model in sync with every set_constant call.
                             # _rebind_pace_to calls _recreate_simulation(), which clones
                             # self.model fresh (Myokit docs: "changes to the original model
@@ -816,8 +915,13 @@ class SimulationHelper:
                                 pass
                 else:
                     raise ValueError(f"parameter {name} not found")
-        # Keep state defaults consistent with model-defined initial values.
-        self.default_states = list(self._get_simulation_model().initial_values(as_floats=True))
+        # Keep state defaults consistent with model-defined initial values. With change_states
+        # the re-derived values are pushed into the Simulation too, not just recorded here --
+        # otherwise self.default_states and simulation.default_state() silently disagree.
+        if change_states:
+            self._refresh_initial_states_for(changed_var_qnames)
+        self.default_states = list(
+            self._get_simulation_model().initial_values(as_floats=True))
 
     def _find_required_paced_qname(self, param_names, param_vals):
         """

--- a/src/solver_wrappers/opencor_helper.py
+++ b/src/solver_wrappers/opencor_helper.py
@@ -207,8 +207,31 @@ class SimulationHelper():
 
         return param_init
 
-    def set_param_vals(self, param_names, param_vals):
-            
+    def set_param_vals(self, param_names, param_vals, change_states=True):
+        """Set parameter values, by default including any state initial values they drive.
+
+        ``change_states=False`` is for mid-protocol updates that must preserve the state the
+        previous sub-experiment evolved into; naming a state there is an error (see the Myokit
+        backend for the full rationale).
+        """
+        if not change_states:
+            offenders = []
+            for param_name_or_list in param_names:
+                names = (param_name_or_list if isinstance(param_name_or_list, list)
+                         else [param_name_or_list])
+                for param_name in names:
+                    try:
+                        kind, _ = self._resolve_name(param_name)
+                    except Exception:
+                        continue
+                    if kind == "state":
+                        offenders.append(param_name)
+            if offenders:
+                raise ValueError(
+                    "set_param_vals(change_states=False) cannot set states directly, but was "
+                    f"given: {', '.join(offenders)}. change_states=False exists for mid-protocol "
+                    "updates that must preserve the evolved state.")
+
         # ensure param_vals stores state values first, then constant values
         for JJ, param_name_or_list in enumerate(param_names):
             if type(param_vals[JJ]) == str:
@@ -226,10 +249,35 @@ class SimulationHelper():
                     self.data.states()[resolved] = param_vals[JJ]
                 elif kind == "const":
                     self.data.constants()[resolved] = param_vals[JJ]
+                    # A constant following the "<state>_init" convention initialises a state;
+                    # keep that state in step so setting it actually moves the trajectory.
+                    if change_states:
+                        self._sync_state_for_init_const(param_name, param_vals[JJ])
                 else:
                     raise ValueError(
                         f"parameter name {param_name} not found in OpenCOR states/constants"
                     )
+
+    def _sync_state_for_init_const(self, param_name, val):
+        """If ``param_name`` is a ``<state>_init`` constant, write ``val`` to that state too.
+
+        Mirrors the python/CasADi/AADC backends, which already do this. Silently does nothing
+        when the name does not follow the convention or the state cannot be resolved -- the
+        constant has still been set either way.
+        """
+        var_part = param_name.split("/")[-1] if "/" in param_name else param_name
+        if not var_part.endswith("_init"):
+            return
+        state_var = var_part[:-len("_init")]
+        for candidate in (state_var, param_name.rsplit("/", 1)[0] + "/" + state_var
+                          if "/" in param_name else state_var):
+            try:
+                kind, resolved = self._resolve_name(candidate)
+            except Exception:
+                continue
+            if kind == "state":
+                self.data.states()[resolved] = val
+                return
 
     def modify_params_and_run_and_get_results(self, param_names, mod_factors, obs_names, absolute=False):
 

--- a/src/solver_wrappers/python_solver_helper.py
+++ b/src/solver_wrappers/python_solver_helper.py
@@ -294,7 +294,7 @@ class SimulationHelper:
             vals.append(sub if len(sub) > 1 else sub[0])
         return vals
 
-    def set_param_vals(self, param_names, param_vals):
+    def set_param_vals(self, param_names, param_vals, change_states=True):
         """Set the values of the named parameters.
 
         Args:
@@ -302,6 +302,21 @@ class SimulationHelper:
                 names sharing a value).
             param_vals: Matching list of values to assign.
         """
+        if not change_states:
+            offenders = []
+            for _n_or_l in param_names:
+                for _n in (_n_or_l if isinstance(_n_or_l, (list, tuple)) else [_n_or_l]):
+                    try:
+                        _kind, _ = self._resolve_name(_n)
+                    except Exception:
+                        continue
+                    if _kind == "state":
+                        offenders.append(str(_n))
+            if offenders:
+                raise ValueError(
+                    "set_param_vals(change_states=False) cannot set states directly, but was "
+                    f"given: {', '.join(offenders)}. change_states=False exists for mid-protocol "
+                    "updates that must preserve the evolved state.")
         for idx, name_or_list in enumerate(param_names):
             vals = param_vals[idx]
 
@@ -340,7 +355,7 @@ class SimulationHelper:
                     # keep the corresponding state/default-init synchronized.
                     # Use just the variable part (after '/') for the _init lookup.
                     var_part = resolved_name.split("/")[-1] if "/" in resolved_name else resolved_name
-                    if var_part.endswith("_init"):
+                    if change_states and var_part.endswith("_init"):
                         state_var = var_part[:-5]
                         # Try component/state_var first, then bare state_var
                         state_idx = self.state_name_to_idx.get(state_var)

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1648,3 +1648,66 @@ def test_van_der_pol_stiff_semi_implicit_euler_convergence(
     assert errors[0] > errors[1] > errors[2], f"not converging with dt: {errors}"
     # And the finest dt is well-converged (so the scheme is correct, just dt-sensitive).
     assert errors[-1] < 2.0, f"finest-dt error {errors[-1]:.3f}% too high"
+
+
+@pytest.mark.integration
+@pytest.mark.solver
+def test_set_param_vals_changes_state_init_without_explicit_reset(generated_cellml_model_factory):
+    """set_param_vals(change_states=True) must move a state-init parameter's state on its own.
+
+    Before change_states existed, a Myokit Simulation kept the state/default_state arrays it was
+    built with: set_constant updated the *model* (so the symbolic initial value q_lv -> q_lv_init
+    re-evaluated) but nothing pushed that into the simulation, and reset() restored the stale
+    default_state. Only reset_states() closed the gap, so `set_param_vals(); run()` -- the
+    documented programmatic API -- silently simulated the old initial condition.
+    """
+    model_path = generated_cellml_model_factory(
+        "3compartment", "3compartment_parameters.csv", solver="CVODE_myokit")
+    helper = get_simulation_helper(
+        model_path=model_path, model_type="cellml_only", solver="CVODE_myokit",
+        dt=0.01, sim_time=0.1, pre_time=0.0,
+        solver_info={"MaximumStep": 0.001, "MaximumNumberOfSteps": 5000})
+    q_name = _find_state_series_name(helper, "q_lv")
+
+    # NOTE: deliberately no reset_states() call -- that is the whole point of this test.
+    helper.set_param_vals(["global/q_lv_init"], [2e-4])
+    q0_lo = _run_and_get_initial_state(helper, q_name)
+    helper.set_param_vals(["global/q_lv_init"], [8e-4])
+    q0_hi = _run_and_get_initial_state(helper, q_name)
+
+    assert np.isclose(q0_lo, 2e-4, rtol=0.0, atol=1e-10), f"expected q_lv(0)=2e-4, got {q0_lo}"
+    assert np.isclose(q0_hi, 8e-4, rtol=0.0, atol=1e-10), f"expected q_lv(0)=8e-4, got {q0_hi}"
+    # the helper's bookkeeping and the simulation must agree, not silently diverge
+    idx = helper.state_index[_resolve_state_qname(helper, "q_lv")]
+    assert np.isclose(helper.default_states[idx], 8e-4, rtol=0.0, atol=1e-10)
+    assert np.isclose(helper.simulation.default_state()[idx], 8e-4, rtol=0.0, atol=1e-10)
+
+
+@pytest.mark.integration
+@pytest.mark.solver
+def test_set_param_vals_change_states_false_rejects_states(generated_cellml_model_factory):
+    """change_states=False promises not to touch the state vector, so naming a state must raise.
+
+    Mid-protocol updates rely on that promise to preserve sub-experiment continuity; silently
+    skipping the write (or applying it anyway) would both be worse than failing loudly.
+    """
+    model_path = generated_cellml_model_factory(
+        "3compartment", "3compartment_parameters.csv", solver="CVODE_myokit")
+    helper = get_simulation_helper(
+        model_path=model_path, model_type="cellml_only", solver="CVODE_myokit",
+        dt=0.01, sim_time=0.1, pre_time=0.0,
+        solver_info={"MaximumStep": 0.001, "MaximumNumberOfSteps": 5000})
+
+    state_name = _resolve_state_qname(helper, "q_lv")
+    with pytest.raises(ValueError, match="cannot set states directly"):
+        helper.set_param_vals([state_name], [3e-4], change_states=False)
+
+    # a plain constant is still settable with change_states=False
+    helper.set_param_vals(["global/q_lv_init"], [3e-4], change_states=False)
+
+
+def _resolve_state_qname(helper, basename):
+    for qname in helper.state_index:
+        if qname.endswith(f".{basename}") or qname == basename:
+            return qname
+    raise AssertionError(f"state '{basename}' not found in {list(helper.state_index)[:10]}")


### PR DESCRIPTION
## Problem

A state whose CellML `initial_value` references a constant — `<variable name="q_lv" initial_value="q_lv_init"/>` — did not move when that constant was set through the Myokit backend.

The model was fine and `set_constant` did update it: the symbolic initial value re-evaluates correctly, and `heart_module.q_lv` really does carry `initial_value = parameters_global.q_lv_init`. But a Myokit `Simulation` keeps its own `state`/`default_state` arrays, snapshotted at construction. `set_constant()` never touches them, and `reset()` restores *from* `default_state`, so it cannot recover the new value either. Traced precisely:

| after | model's re-derived init | `sim.state()` | `sim.default_state()` | `helper.default_states` |
|---|---|---|---|---|
| construction | 0.002 | 0.002 | 0.002 | 0.002 |
| `set_param_vals(8e-4)` | **0.0008** | 0.002 | 0.002 | **0.0008** |
| `simulation.reset()` | 0.0008 | 0.002 | 0.002 | 0.0008 |
| `reset_states()` | 0.0008 | **0.0008** | **0.0008** | 0.0008 |

Only `reset_states()` closed the gap. Calibration was therefore correct — `protocol_executor.py:119` always calls it — but the documented programmatic API (`set_param_vals(); run()`) silently simulated the old initial condition, and row 2 shows `helper.default_states` disagreeing with the simulation it wraps.

## Change

`set_param_vals` takes `change_states` (default `True`). It records which constants it wrote and refreshes **only** the states whose initial-value expression references them, resolved through the Myokit expression's `references()`:

```
heart_module.q_lv    <- [parameters_global.q_lv_init]
systemic_T_module.q  <- [parameters.q_init_systemic_T]
```

That scoping is load-bearing. An earlier draft re-derived *every* state and broke `test_trace_step_input_equals_discrete_subexperiment_change`, which steps `gamma` — a constant no state depends on — across two sub-experiments via direct `set_param_vals` calls; resetting the whole vector destroyed the carried state. Scoped to actual dependencies, that test passes untouched.

`change_states=False` additionally refuses to set a state at all, for callers that must guarantee the state vector is untouched. `protocol_executor` passes `change_states=(sub_idx == 0)`, so a `params_to_change` entry naming a state is still honoured in the first sub-experiment (states were just reset there anyway) but raises after that rather than silently breaking continuity.

The python, CasADi and AADC backends already synced `<state>_init` constants to their states and now honour the flag; OpenCOR gains the same sync.

## Risks

- **Narrows a supported capability.** `params_to_change` may name a state (`myokit_helper.py` has dedicated FSA handling for it); that is now rejected in sub-experiments after the first. No shipped obs_data does this — `flag_0`, `I_in`, `g_M` are all constants — but downstream user models might.
- `modify_params_and_run_and_get_results` (Myokit and OpenCOR) picks up the new default, so its results change for `*_init` parameters — correctly, but they do change.
- OpenCOR's new sync uses the `<state>_init` naming convention the python/CasADi/AADC backends rely on, so an init parameter not following that convention still will not sync there. Myokit is exact, resolving the real symbolic dependency.

## Testing

Two new tests: one asserts `set_param_vals(); run()` moves `q_lv(0)` with no explicit `reset_states()` and that `helper.default_states` and `simulation.default_state()` agree; the other asserts `change_states=False` raises on a state and still accepts a constant.

13 passed covering state-init, protocol continuity, `params_to_change`, multi-trace, pace rebind and CasADi sub-experiment state carry — including `test_trace_step_input_equals_discrete_subexperiment_change`. Two failures elsewhere in `test_solvers.py` (`python_BDF_solver[SN_simple]`, `test_aadc_semi_implicit_vs_cvode_3compartment`) were verified to fail identically on pristine master and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)