### PR TITLE
fix(solver_info): CVODE_myokit does not accept MaximumNumberOfSteps

### DIFF
--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -872,9 +872,15 @@ class YamlFileParser(object):
         
 
         if 'solver_info' in inp_data_dict:
-            inp_data_dict['solver_info'] = migrate_legacy_solver_info_keys(
-                solver_name, inp_data_dict['solver_info']
-            )
+            try:
+                inp_data_dict['solver_info'] = migrate_legacy_solver_info_keys(
+                    solver_name, inp_data_dict['solver_info']
+                )
+            except ValueError as exc:
+                # Same failure mode as validate_solver_info below: the config is
+                # wrong and no guess about which value was meant is safe.
+                print(exc)
+                exit()
 
         if 'solver_info' not in inp_data_dict.keys():
             inp_data_dict['solver_info'] = _solver_info_default_for(
@@ -1203,24 +1209,33 @@ _SOLVER_INTEGRATOR_KEYS = {
 }
 
 
-def _warn_renamed_solver_info_key(solver_name, old_key, new_key, renamed):
-    """Tell the user which key to use instead, and whether the value carried over.
+def _warn_renamed_solver_info_key(solver_name, old_key, new_key):
+    """Tell the user which key the value was moved to, and to rename it.
 
     Migration used to be silent, so a config could keep a key that had quietly
     stopped doing anything and nothing said which key had replaced it.
     """
-    if renamed:
-        print(
-            f'WARNING: solver_info key {old_key!r} is not used by solver '
-            f'{solver_name!r}; its value was applied to {new_key!r} instead. '
-            f'Rename it in your user_inputs to silence this.'
-        )
-    else:
-        print(
-            f'WARNING: solver_info key {old_key!r} is not used by solver '
-            f'{solver_name!r} and was ignored; use {new_key!r} instead. '
-            f'(Your {new_key!r} setting was kept.)'
-        )
+    print(
+        f'WARNING: solver_info key {old_key!r} is not used by solver '
+        f'{solver_name!r}; its value was applied to {new_key!r} instead. '
+        f'Rename it in your user_inputs to silence this.'
+    )
+
+
+def _raise_duplicate_solver_info_key(solver_name, old_key, new_key, solver_info):
+    """One setting, specified twice, under two names.
+
+    Not a warning: picking a winner would silently discard the other value, and
+    there is no way to tell which one the user meant -- if the two disagree, one
+    of them is what they think the run is using. Refuse and make them delete one.
+    """
+    raise ValueError(
+        f'solver_info sets both {old_key!r} ({solver_info[old_key]!r}) and '
+        f'{new_key!r} ({solver_info[new_key]!r}) for solver {solver_name!r}. '
+        f'These are the same setting: {old_key!r} is the legacy name for '
+        f'{new_key!r}, which is the one this solver uses. Remove {old_key!r} '
+        f'(keeping {new_key!r}) so there is one value, not two.'
+    )
 
 
 def _warn_dropped_solver_info_key(solver_name, key, reason):
@@ -1239,6 +1254,10 @@ def migrate_legacy_solver_info_keys(solver_name, solver_info):
     that there is none), so a setting can never stop taking effect silently.
     Migrating rather than rejecting keeps configs written for another backend --
     or for an older CA -- working.
+
+    Raises ValueError when a config sets both names for one setting: that is not
+    a stale key to migrate but a contradiction, and no choice between the two
+    values can be made on the user's behalf.
     """
     solver_info = dict(solver_info)
 
@@ -1246,14 +1265,15 @@ def migrate_legacy_solver_info_keys(solver_name, solver_info):
         """Move ``old_key`` onto ``new_key`` (unless already set), then drop it."""
         if old_key not in solver_info and fallback_key not in solver_info:
             return
+        if new_key in solver_info and old_key in solver_info:
+            # One setting under two names. Silently preferring either would hide
+            # the other value from a user who believes it is in effect.
+            _raise_duplicate_solver_info_key(solver_name, old_key, new_key, solver_info)
         if new_key not in solver_info:
             source = old_key if old_key in solver_info else fallback_key
             solver_info[new_key] = solver_info[source]
             if source == old_key:
-                _warn_renamed_solver_info_key(solver_name, old_key, new_key, True)
-        elif old_key in solver_info:
-            # An explicit new_key wins; say so rather than dropping in silence.
-            _warn_renamed_solver_info_key(solver_name, old_key, new_key, False)
+                _warn_renamed_solver_info_key(solver_name, old_key, new_key)
         solver_info.pop(old_key, None)
 
     if solver_name == 'solve_ivp':

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -138,12 +138,25 @@ _SI_RTOL = {'name': 'rtol', 'type': 'float', 'default': 1e-8, 'required': False,
             'description': 'Relative integration tolerance.'}
 _SI_ATOL = {'name': 'atol', 'type': 'float', 'default': 1e-8, 'required': False,
             'description': 'Absolute integration tolerance.'}
-# CVODE-family backends (opencor/myokit, and the cpp CVODE/RK4/PETSC) share the same fields.
+# CVODE-family backends (opencor, and the cpp CVODE/RK4/PETSC) share the same fields.
 _CVODE_FAMILY_SOLVER_INFO = [
     {'name': 'MaximumStep', 'type': 'float', 'default': 0.001, 'required': False,
      'description': 'Maximum integrator step size.'},
     {'name': 'MaximumNumberOfSteps', 'type': 'int', 'default': 5000, 'required': False,
      'description': 'Maximum number of internal integrator steps per output step.'},
+    _SI_RTOL, _SI_ATOL,
+]
+
+# CVODE_myokit is deliberately NOT in that family. myokit.Simulation exposes only
+# set_max_step_size / set_min_step_size / set_tolerance -- there is no max-step-count
+# knob, so myokit_helper never reads MaximumNumberOfSteps. Advertising a setting the
+# code never reads makes a downstream tool (e.g. CUFLynx) render a control that
+# silently does nothing -- the same reasoning as the note on 'aadc_semi_implicit'
+# below. Configs that already set it are migrated with a warning, not rejected; see
+# migrate_legacy_solver_info_keys.
+_MYOKIT_SOLVER_INFO = [
+    {'name': 'MaximumStep', 'type': 'float', 'default': 0.001, 'required': False,
+     'description': 'Maximum integrator step size (myokit Simulation.set_max_step_size).'},
     _SI_RTOL, _SI_ATOL,
 ]
 
@@ -164,7 +177,7 @@ _SOLVE_IVP_SOLVER_INFO = [
 
 SOLVER_INFO_FIELDS = {
     'CVODE_opencor': _CVODE_FAMILY_SOLVER_INFO,
-    'CVODE_myokit': _CVODE_FAMILY_SOLVER_INFO,
+    'CVODE_myokit': _MYOKIT_SOLVER_INFO,
     'CVODE': _CVODE_FAMILY_SOLVER_INFO,
     'RK4': _CVODE_FAMILY_SOLVER_INFO,
     'PETSC': _CVODE_FAMILY_SOLVER_INFO,
@@ -863,10 +876,12 @@ class YamlFileParser(object):
                 solver_name, inp_data_dict['solver_info']
             )
 
-        if 'solver_info' not in inp_data_dict.keys(): 
-            inp_data_dict['solver_info'] = get_solver_info_default(inp_data_dict['model_type'])
+        if 'solver_info' not in inp_data_dict.keys():
+            inp_data_dict['solver_info'] = _solver_info_default_for(
+                inp_data_dict['model_type'], solver_name
+            )
         else:
-            defaults = get_solver_info_default(inp_data_dict['model_type'])
+            defaults = _solver_info_default_for(inp_data_dict['model_type'], solver_name)
             if inp_data_dict.get('model_type') == 'casadi_python':
                 if 'max_num_steps' not in inp_data_dict['solver_info']:
                     inp_data_dict['solver_info']['max_num_steps'] = defaults.get('max_num_steps', 5000)
@@ -877,7 +892,8 @@ class YamlFileParser(object):
                 pass  # AADC solver handles its own defaults
             elif inp_data_dict.get('model_type') == 'python_user_defined':
                 pass  # user wrapper handles its own integration
-            elif 'MaximumNumberOfSteps' not in inp_data_dict['solver_info']:
+            elif ('MaximumNumberOfSteps' in defaults
+                  and 'MaximumNumberOfSteps' not in inp_data_dict['solver_info']):
                 inp_data_dict['solver_info']['MaximumNumberOfSteps'] = defaults['MaximumNumberOfSteps']
         if 'solver' not in inp_data_dict['solver_info'].keys():
             inp_data_dict['solver_info']['solver'] = solver_name
@@ -1187,31 +1203,81 @@ _SOLVER_INTEGRATOR_KEYS = {
 }
 
 
+def _warn_renamed_solver_info_key(solver_name, old_key, new_key, renamed):
+    """Tell the user which key to use instead, and whether the value carried over.
+
+    Migration used to be silent, so a config could keep a key that had quietly
+    stopped doing anything and nothing said which key had replaced it.
+    """
+    if renamed:
+        print(
+            f'WARNING: solver_info key {old_key!r} is not used by solver '
+            f'{solver_name!r}; its value was applied to {new_key!r} instead. '
+            f'Rename it in your user_inputs to silence this.'
+        )
+    else:
+        print(
+            f'WARNING: solver_info key {old_key!r} is not used by solver '
+            f'{solver_name!r} and was ignored; use {new_key!r} instead. '
+            f'(Your {new_key!r} setting was kept.)'
+        )
+
+
+def _warn_dropped_solver_info_key(solver_name, key, reason):
+    print(
+        f'WARNING: solver_info key {key!r} is not supported by solver '
+        f'{solver_name!r} and was ignored. {reason}'
+    )
+
+
 def migrate_legacy_solver_info_keys(solver_name, solver_info):
     """
     Map legacy CVODE-style solver_info keys to backend-specific names and drop
     keys that the selected integrator does not accept.
+
+    Every rename and every drop warns, naming the key to use instead (or saying
+    that there is none), so a setting can never stop taking effect silently.
+    Migrating rather than rejecting keeps configs written for another backend --
+    or for an older CA -- working.
     """
     solver_info = dict(solver_info)
 
+    def migrate(old_key, new_key, fallback_key=None):
+        """Move ``old_key`` onto ``new_key`` (unless already set), then drop it."""
+        if old_key not in solver_info and fallback_key not in solver_info:
+            return
+        if new_key not in solver_info:
+            source = old_key if old_key in solver_info else fallback_key
+            solver_info[new_key] = solver_info[source]
+            if source == old_key:
+                _warn_renamed_solver_info_key(solver_name, old_key, new_key, True)
+        elif old_key in solver_info:
+            # An explicit new_key wins; say so rather than dropping in silence.
+            _warn_renamed_solver_info_key(solver_name, old_key, new_key, False)
+        solver_info.pop(old_key, None)
+
     if solver_name == 'solve_ivp':
-        if 'max_step' not in solver_info:
-            if 'MaximumStep' in solver_info:
-                solver_info['max_step'] = solver_info['MaximumStep']
-            elif 'dt_solver' in solver_info:
-                solver_info['max_step'] = solver_info['dt_solver']
-        solver_info.pop('MaximumStep', None)
-        solver_info.pop('MaximumNumberOfSteps', None)
+        migrate('MaximumStep', 'max_step', fallback_key='dt_solver')
+        if 'MaximumNumberOfSteps' in solver_info:
+            _warn_dropped_solver_info_key(
+                solver_name, 'MaximumNumberOfSteps',
+                'scipy.integrate.solve_ivp has no step-count limit.',
+            )
+            solver_info.pop('MaximumNumberOfSteps', None)
     elif solver_name == 'casadi_integrator':
-        if 'max_step_size' not in solver_info:
-            if 'MaximumStep' in solver_info:
-                solver_info['max_step_size'] = solver_info['MaximumStep']
-            elif 'dt_solver' in solver_info:
-                solver_info['max_step_size'] = solver_info['dt_solver']
-        if 'max_num_steps' not in solver_info and 'MaximumNumberOfSteps' in solver_info:
-            solver_info['max_num_steps'] = solver_info['MaximumNumberOfSteps']
-        solver_info.pop('MaximumStep', None)
-        solver_info.pop('MaximumNumberOfSteps', None)
+        migrate('MaximumStep', 'max_step_size', fallback_key='dt_solver')
+        migrate('MaximumNumberOfSteps', 'max_num_steps')
+    elif solver_name == 'CVODE_myokit':
+        # No equivalent to migrate onto: myokit.Simulation exposes only
+        # set_max_step_size / set_min_step_size / set_tolerance.
+        if 'MaximumNumberOfSteps' in solver_info:
+            _warn_dropped_solver_info_key(
+                solver_name, 'MaximumNumberOfSteps',
+                "Myokit's integrator has no maximum-step-count setting; use "
+                "'MaximumStep' to bound the step size, or 'rtol'/'atol' to "
+                'control accuracy.',
+            )
+            solver_info.pop('MaximumNumberOfSteps', None)
 
     return solver_info
 
@@ -1264,6 +1330,24 @@ def validate_solver_info(solver_name, solver_info):
         f'Allowed framework keys: {framework_keys}. '
         f'Allowed integrator keys for {solver_name}: {integrator_keys}.{hint_text}'
     )
+
+
+def _solver_info_default_for(model_type, solver_name):
+    """``get_solver_info_default`` narrowed to the keys ``solver_name`` accepts.
+
+    The defaults are per model_type, but a model_type can host backends with
+    different settings: cellml_only covers both CVODE_opencor (which takes
+    MaximumNumberOfSteps) and CVODE_myokit (which has no such knob). Seeding the
+    whole default set would put back exactly what
+    migrate_legacy_solver_info_keys just removed, and validate_solver_info would
+    then reject CA's own default.
+    """
+    defaults = get_solver_info_default(model_type)
+    allowed = _SOLVER_INTEGRATOR_KEYS.get(solver_name)
+    if allowed is None:
+        return defaults
+    allowed = allowed | _FRAMEWORK_SOLVER_INFO_KEYS
+    return {k: v for k, v in defaults.items() if k in allowed}
 
 
 def get_solver_info_default(model_type):

--- a/src/protocol_runners/protocol_runner.py
+++ b/src/protocol_runners/protocol_runner.py
@@ -28,6 +28,21 @@ from solver_wrappers import get_simulation_helper
 from protocol_runners.protocol_executor import ProtocolExecutor
 
 
+def _solver_accepts(solver, key):
+    """Whether ``solver``'s backend honours the solver_info ``key``.
+
+    Imported lazily so this module keeps working if the parsers package is
+    unavailable; an unknown solver is assumed to accept the key, which preserves
+    the previous behaviour rather than silently dropping a setting.
+    """
+    try:
+        from parsers.PrimitiveParsers import solver_info_fields
+    except Exception:
+        return True
+    fields = solver_info_fields(solver)
+    return True if not fields else any(f['name'] == key for f in fields)
+
+
 class ProtocolRunner:
     """Standalone, user-facing runner for model protocols.
 
@@ -81,8 +96,15 @@ class ProtocolRunner:
         # Preserve all solver_info keys (e.g. rtol/atol/method) and only fill in
         # MaximumStep / MaximumNumberOfSteps defaults — previously the extra keys
         # were silently dropped, so tight tolerances passed by callers were ignored.
+        #
+        # The MaximumNumberOfSteps default is conditional: this relays solver_info
+        # to the backend rather than consuming it, so seeding it unconditionally
+        # put the key back for solvers whose helper ignores it (CVODE_myokit) --
+        # undoing migrate_legacy_solver_info_keys and re-creating a setting that
+        # looks live but does nothing.
         full_solver_info = dict(solver_info)
-        full_solver_info.setdefault('MaximumNumberOfSteps', self.MaximumNumberOfSteps)
+        if _solver_accepts(solver, 'MaximumNumberOfSteps'):
+            full_solver_info.setdefault('MaximumNumberOfSteps', self.MaximumNumberOfSteps)
         full_solver_info.setdefault('MaximumStep', self.MaximumStep)
         # sim_time=1.0 is a placeholder — overridden per protocol_info in run_protocols
         self.sim_helper = get_simulation_helper(

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -110,7 +110,10 @@ def test_solver_integrator_keys_derived_from_schema():
         assert _SOLVER_INTEGRATOR_KEYS[solver] == {f['name'] for f in fields}
     cvode = {'MaximumStep', 'MaximumNumberOfSteps', 'rtol', 'atol'}
     assert _SOLVER_INTEGRATOR_KEYS['CVODE_opencor'] == cvode
-    assert _SOLVER_INTEGRATOR_KEYS['CVODE_myokit'] == cvode
+    # CVODE_myokit is deliberately not in that family: myokit.Simulation exposes only
+    # set_max_step_size / set_min_step_size / set_tolerance, so myokit_helper never reads
+    # MaximumNumberOfSteps and advertising it would render a dead control downstream.
+    assert _SOLVER_INTEGRATOR_KEYS['CVODE_myokit'] == {'MaximumStep', 'rtol', 'atol'}
     assert _SOLVER_INTEGRATOR_KEYS['solve_ivp'] == {
         'rtol', 'atol', 'max_step', 'vectorized', 'dense_output', 'jac'}
     assert _SOLVER_INTEGRATOR_KEYS['casadi_integrator'] == {
@@ -131,9 +134,17 @@ def test_schema_settings_are_actually_read_by_the_code():
     it). Check the schema against the source instead.
 
     The search is deliberately repo-wide rather than per-solver-file, because a setting is not
-    always consumed by its own helper: CVODE_myokit's MaximumNumberOfSteps is read in
-    protocol_runner.py, not myokit_helper.py. PrimitiveParsers.py is excluded because that is
-    where the schema declares the names in the first place.
+    always consumed by its own helper. PrimitiveParsers.py is excluded because that is where the
+    schema declares the names in the first place.
+
+    KNOWN LIMITATION -- this check is per *setting*, not per *solver*, and a name that merely
+    passes through counts as "read". Both together let CVODE_myokit advertise
+    MaximumNumberOfSteps for a long time: the name appears in protocol_runner.py, but only to be
+    relayed into get_simulation_helper's solver_info, and myokit_helper drops it on the floor
+    (myokit.Simulation exposes only set_max_step_size / set_min_step_size / set_tolerance). This
+    docstring previously cited that relay as proof the setting was read, which is exactly the
+    reasoning to distrust. Tightening this to per-solver, consumption-aware checking is the real
+    fix; until then, a name appearing in the corpus is necessary but NOT sufficient.
     """
     src_dir = pathlib.Path(__file__).resolve().parent.parent / 'src'
     corpus = '\n'.join(
@@ -374,8 +385,23 @@ def test_cellml_solver_accepts_maximum_step_keys():
         'solver': 'CVODE_myokit',
         'method': 'CVODE',
         'MaximumStep': 0.001,
+    })
+    validate_solver_info('CVODE_opencor', {
+        'solver': 'CVODE_opencor',
+        'method': 'CVODE',
+        'MaximumStep': 0.001,
         'MaximumNumberOfSteps': 5000,
     })
+
+
+def test_myokit_rejects_maximum_number_of_steps_after_migration():
+    """It has no such knob, so a config that still carries it is migrated (with a
+    warning) rather than validated -- reaching validation means it was set anew."""
+    with pytest.raises(ValueError, match='MaximumNumberOfSteps'):
+        validate_solver_info('CVODE_myokit', {
+            'solver': 'CVODE_myokit',
+            'MaximumNumberOfSteps': 5000,
+        })
 
 
 def test_cpp_rk4_accepts_maximum_number_of_steps():
@@ -418,6 +444,70 @@ def test_migrate_legacy_solver_info_keys_for_casadi_integrator():
         'max_num_steps': 5000,
     }
     validate_solver_info('casadi_integrator', {'solver': 'casadi_integrator', **migrated})
+
+
+def test_migrate_drops_maximum_number_of_steps_for_myokit(capsys):
+    """myokit has no max-step-count knob, so the key is dropped rather than renamed --
+    but never in silence: a setting that stops taking effect must say so."""
+    migrated = migrate_legacy_solver_info_keys('CVODE_myokit', {
+        'MaximumStep': 0.0001,
+        'MaximumNumberOfSteps': 5000,
+        'rtol': 1e-8,
+    })
+    assert migrated == {'MaximumStep': 0.0001, 'rtol': 1e-8}
+    validate_solver_info('CVODE_myokit', {'solver': 'CVODE_myokit', **migrated})
+
+    warning = capsys.readouterr().out
+    assert 'WARNING' in warning
+    assert 'MaximumNumberOfSteps' in warning
+    assert 'CVODE_myokit' in warning
+    # Names what to use instead, since there is no direct replacement.
+    assert 'MaximumStep' in warning
+    assert 'rtol' in warning
+
+
+def test_migrate_is_silent_when_there_is_nothing_to_migrate(capsys):
+    """A config already using the right keys must not be nagged."""
+    migrate_legacy_solver_info_keys('CVODE_myokit', {'MaximumStep': 0.0001, 'atol': 1e-8})
+    assert capsys.readouterr().out == ''
+
+
+def test_migrate_names_the_replacement_key_when_renaming(capsys):
+    migrate_legacy_solver_info_keys('solve_ivp', {'MaximumStep': 0.0001})
+    out = capsys.readouterr().out
+    assert 'MaximumStep' in out and 'max_step' in out
+
+    migrate_legacy_solver_info_keys('casadi_integrator', {'MaximumNumberOfSteps': 500})
+    out = capsys.readouterr().out
+    assert 'MaximumNumberOfSteps' in out and 'max_num_steps' in out
+
+
+def test_an_explicit_new_key_wins_over_the_legacy_one(capsys):
+    """And the user is told which of the two took effect, rather than one being
+    dropped silently."""
+    migrated = migrate_legacy_solver_info_keys('casadi_integrator', {
+        'MaximumNumberOfSteps': 500,
+        'max_num_steps': 999,
+    })
+    assert migrated == {'max_num_steps': 999}
+    out = capsys.readouterr().out
+    assert 'max_num_steps' in out and 'was kept' in out
+
+
+def test_myokit_default_solver_info_needs_no_migration():
+    """CA's own cellml_only default must validate for myokit, not just opencor --
+    otherwise the default config would be rejected by its own validator."""
+    from parsers.PrimitiveParsers import _solver_info_default_for
+
+    defaults = _solver_info_default_for('cellml_only', 'CVODE_myokit')
+    assert 'MaximumNumberOfSteps' not in defaults
+    assert defaults['MaximumStep'] == 0.001
+    validate_solver_info('CVODE_myokit', defaults)
+
+    # opencor keeps it: it is a real setting there.
+    opencor = _solver_info_default_for('cellml_only', 'CVODE_opencor')
+    assert opencor['MaximumNumberOfSteps'] == 5000
+    validate_solver_info('CVODE_opencor', opencor)
 
 
 def test_parse_user_inputs_migrates_legacy_keys_for_python_model():

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -482,16 +482,46 @@ def test_migrate_names_the_replacement_key_when_renaming(capsys):
     assert 'MaximumNumberOfSteps' in out and 'max_num_steps' in out
 
 
-def test_an_explicit_new_key_wins_over_the_legacy_one(capsys):
-    """And the user is told which of the two took effect, rather than one being
-    dropped silently."""
-    migrated = migrate_legacy_solver_info_keys('casadi_integrator', {
-        'MaximumNumberOfSteps': 500,
-        'max_num_steps': 999,
+def test_setting_both_names_for_one_setting_is_an_error():
+    """Not a warning: preferring either value would hide the other from a user who
+    believes it is in effect, and nothing can tell which one they meant."""
+    with pytest.raises(ValueError) as exc:
+        migrate_legacy_solver_info_keys('casadi_integrator', {
+            'MaximumNumberOfSteps': 500,
+            'max_num_steps': 999,
+        })
+    msg = str(exc.value)
+    # Both names, both values, and which one to delete.
+    assert 'MaximumNumberOfSteps' in msg and 'max_num_steps' in msg
+    assert '500' in msg and '999' in msg
+    assert 'Remove' in msg
+
+    with pytest.raises(ValueError, match='MaximumStep'):
+        migrate_legacy_solver_info_keys('solve_ivp', {
+            'MaximumStep': 0.001,
+            'max_step': 0.002,
+        })
+
+
+def test_duplicate_names_error_even_when_the_values_agree():
+    """The config still says one thing twice; leaving it means the next edit to
+    either name silently does nothing."""
+    with pytest.raises(ValueError):
+        migrate_legacy_solver_info_keys('casadi_integrator', {
+            'MaximumNumberOfSteps': 500,
+            'max_num_steps': 500,
+        })
+
+
+def test_dt_solver_alongside_the_new_key_is_not_a_duplicate(capsys):
+    """dt_solver is a framework key used only as a *fallback* source, not another
+    spelling of max_step, so pairing the two is legitimate and silent."""
+    migrated = migrate_legacy_solver_info_keys('solve_ivp', {
+        'dt_solver': 0.01,
+        'max_step': 0.002,
     })
-    assert migrated == {'max_num_steps': 999}
-    out = capsys.readouterr().out
-    assert 'max_num_steps' in out and 'was kept' in out
+    assert migrated == {'dt_solver': 0.01, 'max_step': 0.002}
+    assert capsys.readouterr().out == ''
 
 
 def test_myokit_default_solver_info_needs_no_migration():


### PR DESCRIPTION
## The problem

`SOLVER_INFO_FIELDS` gives `CVODE_myokit` the shared `_CVODE_FAMILY_SOLVER_INFO` list, which carries `MaximumNumberOfSteps`. That is correct for `CVODE_opencor` and the cpp `CVODE`/`RK4`/`PETSC` — but Myokit has no such knob:

```
myokit.Simulation → set_max_step_size, set_min_step_size, set_tolerance
```

`myokit_helper` accordingly never reads it. Downstream tools build their settings forms from this schema, so CUFLynx rendered a control the user could change with no effect and no way to tell — precisely what the existing comment on `aadc_semi_implicit` warns against.

Found while making CUFLynx report *why* a simulation failed: the "raise MaximumNumberOfSteps" advice would have pointed users at a dead control.

## The fix

`CVODE_myokit` gets its own field list. Because `_SOLVER_INTEGRATOR_KEYS` is derived from `SOLVER_INFO_FIELDS`, `validate_solver_info` follows for free.

**Existing configs are migrated, not rejected** — a `user_inputs` that already sets the key keeps working.

## Migration warns, and names the replacement

`solve_ivp` and `casadi_integrator` were already dropping and renaming keys in **complete silence**, so a setting could stop taking effect with nothing said. Every migration now warns:

```
WARNING: solver_info key 'MaximumNumberOfSteps' is not supported by solver
'CVODE_myokit' and was ignored. Myokit's integrator has no maximum-step-count
setting; use 'MaximumStep' to bound the step size, or 'rtol'/'atol' to control accuracy.

WARNING: solver_info key 'MaximumStep' is not used by solver 'solve_ivp'; its value
was applied to 'max_step' instead. Rename it in your user_inputs to silence this.
```

A config already using the right keys stays silent.

## ...but one setting under two names is an **error**

Setting both `MaximumNumberOfSteps` and `max_num_steps` is not a stale key to migrate — it is a contradiction. The two values can disagree, and whichever loses would be silently discarded from a config whose author believes it is in effect. A warning scrolls past; the run then uses a number nobody intended.

```
solver_info sets both 'MaximumNumberOfSteps' (500) and 'max_num_steps' (999) for
solver 'casadi_integrator'. These are the same setting: 'MaximumNumberOfSteps' is
the legacy name for 'max_num_steps', which is the one this solver uses. Remove
'MaximumNumberOfSteps' (keeping 'max_num_steps') so there is one value, not two.
```

`parse_user_inputs_file` reports it the same way it already reports `validate_solver_info` failures. It errors even when the two values *agree* — the config still says one thing twice, so a later edit to the legacy name would silently do nothing.

`dt_solver` alongside `max_step` is **not** a duplicate: `dt_solver` is a framework key used only as a fallback *source*, not another spelling. That pairing stays legitimate and silent.

## Two places put the key back, and had to follow

Without these the migration would have been cosmetic:

- **`get_solver_info_default`** is keyed by *model_type*, but `cellml_only` hosts both opencor (takes the key) and myokit (does not). Seeding the whole default set restored exactly what the migration removed — and `validate_solver_info` would then have rejected CA's own default. `_solver_info_default_for` narrows it to what the solver accepts.
- **`ProtocolRunner`** `setdefault`s it into the `solver_info` it hands to `get_simulation_helper`. It only relays the value rather than consuming it, so this is now conditional on the backend accepting it.

## Why the schema test missed this

`test_schema_settings_are_actually_read_by_the_code` greps `src/` for each advertised setting — but it checks per **setting**, not per **solver**, and a name that merely *passes through* counts as read. `protocol_runner.py` reads `MaximumNumberOfSteps` only to relay it to a helper that drops it.

The test's docstring cited that relay as proof the setting was read — the exact reasoning that let this survive. It now records the limitation instead. Tightening it to per-solver, consumption-aware checking is #330.

## Tests

`tests/test_solver_info_validation.py`, 36 passing, 8 new:

- the myokit drop warns, names `MaximumStep`/`rtol`/`atol` as the alternatives, and the result validates
- migration is silent when there is nothing to migrate
- renames name their replacement key (`solve_ivp`, `casadi_integrator`)
- both names for one setting raises, naming both values and which to delete — for `casadi_integrator` and `solve_ivp`
- ...and raises even when the values agree
- `dt_solver` + `max_step` is not treated as a duplicate
- CA's own `cellml_only` default validates for myokit as well as opencor

Two existing tests updated where they asserted `CVODE_myokit` shared the family key set.

`tests/test_solvers.py::test_python_BDF_solver[SN_simple]` fails — a libcellml Python-generation issue, **pre-existing**: verified identical on `master` with these changes stashed.

Verified downstream: CUFLynx's form drops to `['method', 'dt', 'MaximumStep', 'rtol', 'atol']`, with 436 unit + 34 integration tests passing against this branch.

Follow-up: #330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
