### PR TITLE
feat(schema): advertise which AADC methods the tape can record (#336)

### DIFF
--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -17,10 +17,11 @@ machine without AADC.
 """
 import numpy as np
 
-# AADC solver methods whose forward integration the tape can record step-for-step. An adaptive
-# integrator picks its step sizes from the state, so the sequence of operations changes with the
-# parameters and cannot be replayed from a tape.
-TAPE_CONSISTENT_METHODS = ('rk4', 'implicit_euler_ift', 'semi_implicit')
+# The methods whose forward integration the tape can record step-for-step. Defined in
+# parsers.PrimitiveParsers alongside SOLVER_SCHEMA['ad_suitable_methods'], which is derived from
+# it, so the advertised menu and the check enforced here cannot drift (issue #336). Re-exported
+# under the original name for callers that already import it from this module.
+from parsers.PrimitiveParsers import AADC_TAPE_CONSISTENT_METHODS as TAPE_CONSISTENT_METHODS
 
 
 def cost_and_grad(pid, param_vals):

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -42,6 +42,13 @@ sys.path.append(os.path.join(root_dir, 'src'))
 # and SOLVER_SCHEMA['ad_suitable_methods'] below, so the two cannot drift.
 _CASADI_ADJOINT_METHODS = ('cvodes', 'idas')
 
+# AADC solver methods whose forward integration the tape can record step-for-step. An adaptive
+# integrator picks its step sizes from the state, so the sequence of operations changes with the
+# parameters and cannot be replayed from a tape. Lives here (not in param_id/aadc_backend.py,
+# which imports it) so the schema and the check that enforces it cannot drift, and so the
+# dependency points one way: the backend depends on the schema, not the reverse.
+AADC_TAPE_CONSISTENT_METHODS = ('rk4', 'implicit_euler_ift', 'semi_implicit')
+
 # Single source of truth for which generated model_types exist, which solvers are
 # valid for each, and which methods/plugins are valid for each solver. Used for
 # input validation here AND surfaced to downstream tools (e.g. the CUFLynx
@@ -105,9 +112,15 @@ SOLVER_SCHEMA = {
 # (cvodes/idas), whose adjoint integration fails on a long warmup (CV_TOO_MUCH_WORK); the symbolic
 # methods (collocation, rk, semi_implicit_euler, bdf) are differentiated by reverse mode and fully
 # support CasADi AD. Derived from _CASADI_ADJOINT_METHODS so the flag and the warning cannot drift.
+# AD-suitable aadc_semi_implicit methods are exactly the fixed-step ones the tape can replay;
+# 'adaptive_rk45' chooses its steps from the state, so the forward solve and the gradient would
+# integrate different systems. Derived from AADC_TAPE_CONSISTENT_METHODS, which aadc_backend
+# enforces, so the schema and the runtime check cannot drift (issue #336).
 SOLVER_SCHEMA['ad_suitable_methods'] = {
     'casadi_integrator': [m for m in SOLVER_SCHEMA['methods_by_solver']['casadi_integrator']
                           if m not in _CASADI_ADJOINT_METHODS],
+    'aadc_semi_implicit': [m for m in SOLVER_SCHEMA['methods_by_solver']['aadc_semi_implicit']
+                           if m in AADC_TAPE_CONSISTENT_METHODS],
 }
 # Myokit CVODES forward-sensitivity (FSA) is the analytic gradient for stiff cellml_only models;
 # its method is 'CVODE' on the CVODE solvers. (CA's get_gradient currently produces FSA only for
@@ -123,6 +136,10 @@ SOLVER_SCHEMA['fsa_suitable_methods'] = {
 # internal fallback (a plain run without a method still uses the helper's default).
 SOLVER_SCHEMA['default_method_by_solver'] = {
     'casadi_integrator': 'bdf',
+    # 'rk4' rather than the first entry in methods_by_solver ('adaptive_rk45'): a tool defaulting
+    # to "first offered" would pick the one method the tape can never record, on a backend whose
+    # whole purpose is tape-based gradients (issue #336).
+    'aadc_semi_implicit': 'rk4',
 }
 
 
@@ -429,6 +446,12 @@ def gradient_sources(model_type, solver=None, method=None):
                                 'model to be differentiable.'),
             })
     elif model_type == 'aadc_python':
+        aadc_methods = SOLVER_SCHEMA['methods_by_solver']['aadc_semi_implicit']
+        aadc_ad_suitable = SOLVER_SCHEMA['ad_suitable_methods']['aadc_semi_implicit']
+        # Gate only a *known* aadc method the tape cannot record (adaptive_rk45); an unknown or
+        # unspecified method leaves AD offered, matching the casadi branch above.
+        if method is not None and method in aadc_methods and method not in aadc_ad_suitable:
+            return sources
         sources.append({
             'value': 'AD', 'label': 'Automatic differentiation (AADC)', 'do_ad': True,
             'requires_all_differentiable': False,

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -695,3 +695,55 @@ def test_gradient_sources_gates_analytic_source_on_integrator_method():
 
     # AADC AD has no per-integrator gate (its tape method is independent of this menu).
     assert 'AD' in [s['value'] for s in gradient_sources('aadc_python', method='semi_implicit')]
+
+
+@pytest.mark.unit
+def test_aadc_ad_suitable_methods_match_what_the_tape_enforces():
+    """The advertised AD-suitable AADC methods must be exactly those aadc_backend accepts.
+
+    Before issue #336 the schema had no aadc_semi_implicit entry at all, so a tool reading it
+    could not tell which methods the tape can record -- and since methods_by_solver lists
+    'adaptive_rk45' first, a front-end defaulting to "first offered" picked the one method AD can
+    never use, failing only once a calibration had started.
+    """
+    from parsers.PrimitiveParsers import AADC_TAPE_CONSISTENT_METHODS
+
+    all_methods = SOLVER_SCHEMA['methods_by_solver']['aadc_semi_implicit']
+    advertised = SOLVER_SCHEMA['ad_suitable_methods']['aadc_semi_implicit']
+
+    # derived from the enforced tuple, so the two cannot drift
+    assert advertised == [m for m in all_methods if m in AADC_TAPE_CONSISTENT_METHODS]
+    assert set(advertised) <= set(all_methods), (advertised, all_methods)
+    # the adaptive integrator is the one that must NOT be advertised
+    assert 'adaptive_rk45' in all_methods and 'adaptive_rk45' not in advertised
+
+    # and the runtime check enforces precisely this set
+    from param_id.aadc_backend import TAPE_CONSISTENT_METHODS
+    assert tuple(TAPE_CONSISTENT_METHODS) == tuple(AADC_TAPE_CONSISTENT_METHODS)
+
+
+@pytest.mark.unit
+def test_aadc_default_method_is_ad_suitable():
+    """A default the AD path cannot use is a poor default for a tape-gradient backend."""
+    default = SOLVER_SCHEMA['default_method_by_solver']['aadc_semi_implicit']
+    assert default in SOLVER_SCHEMA['ad_suitable_methods']['aadc_semi_implicit'], default
+    assert default in SOLVER_SCHEMA['methods_by_solver']['aadc_semi_implicit'], default
+
+
+@pytest.mark.unit
+def test_gradient_sources_gates_aadc_ad_on_a_tape_consistent_method():
+    """AD must not be offered for an AADC method the tape cannot record."""
+    from parsers.PrimitiveParsers import gradient_sources
+
+    def values(method):
+        return [s['value'] for s in gradient_sources('aadc_python', 'aadc_semi_implicit',
+                                                     method=method)]
+
+    # the adaptive integrator: FD only, no AD
+    assert values('adaptive_rk45') == ['FD']
+    # every tape-consistent method still offers AD
+    for m in SOLVER_SCHEMA['ad_suitable_methods']['aadc_semi_implicit']:
+        assert 'AD' in values(m), m
+    # unspecified or unknown method leaves AD offered, matching the casadi branch
+    assert 'AD' in values(None)
+    assert 'AD' in values('some_unknown_method')


### PR DESCRIPTION
Closes #336.

`SOLVER_SCHEMA['ad_suitable_methods']` had no `aadc_semi_implicit` entry, so nothing downstream could tell which of its methods the AADC tape can record. The constraint existed and was enforced in `param_id/aadc_backend.py`, but was invisible to any tool reading the schema — and since `methods_by_solver` lists `adaptive_rk45` **first**, a front-end defaulting to "the first method CA offers" picked the one method AD can never use, failing only once a calibration had been configured and started.

## Change

`AADC_TAPE_CONSISTENT_METHODS` moves to `parsers/PrimitiveParsers.py`, next to the schema, and `aadc_backend` imports it (re-exported under its original name, so existing callers such as `paramID.TAPE_CONSISTENT_AADC_METHODS` are unaffected). This is the import direction the issue asked for: the backend depends on the schema, not the reverse.

```python
SOLVER_SCHEMA['ad_suitable_methods'] = {
    'casadi_integrator': [...],
    'aadc_semi_implicit': [m for m in SOLVER_SCHEMA['methods_by_solver']['aadc_semi_implicit']
                           if m in AADC_TAPE_CONSISTENT_METHODS],
}
```

Derived from the tuple the runtime check enforces, so the advertised menu and the check cannot drift — the same pattern `_CASADI_ADJOINT_METHODS` established in #298.

## Also, per the issue's closing suggestions

- **`default_method_by_solver`** gains `'aadc_semi_implicit': 'rk4'`. Without it, "first in the list" wins and that is `adaptive_rk45` — a default the AD path cannot use, on a backend whose whole purpose is tape-based gradients.
- **`gradient_sources()`** now gates the AADC AD source on the method, mirroring what it already did for `casadi_integrator`. It previously offered AD for `aadc_python` **unconditionally**, including for `adaptive_rk45`, which is the same class of bug one level up.

Resulting behaviour:

```
ad_suitable aadc : ['semi_implicit', 'implicit_euler_ift', 'rk4']
default aadc     : rk4
gradient_sources(method='adaptive_rk45') -> ['FD']
gradient_sources(method='rk4')           -> ['FD', 'AD']
gradient_sources(method=None)            -> ['FD', 'AD']
```

An unknown or unspecified method leaves AD offered, matching the CasADi branch — only a *known* unsuitable method is gated.

## Testing

Three unit tests in `tests/test_solver_info_validation.py`: the advertised set is exactly what `aadc_backend` enforces (and excludes `adaptive_rk45`), the default method is itself AD-suitable, and `gradient_sources` withholds AD for `adaptive_rk45` while offering it for every tape-consistent method and for an unknown/unspecified one. 42 tests in the file pass.

Once this lands, CUFLynx's stopgap of reading `TAPE_CONSISTENT_METHODS` directly becomes inert, since it defers to `ad_suitable_methods` whenever CA advertises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)