### PR TITLE
feat(protocol): declare pacing as events, not as a table of points

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,13 +112,18 @@ User-extensible (kept outside `src/`): `module_config_user/` (custom CellML modu
     "pre_times":  [0.0, 0.0],
     "sim_times":  [[5], [5]],
     "params_to_change": { "component/param": [[exp0_sub0, …], [exp1_sub0, …]] },
-    "protocol_traces": { "trace_key": {"t": [...], "values": [...]} }
+    "protocol_traces": { "trace_key": {"t": [...], "values": [...]} },
+    "protocol_shapes": { "trace_key": {"events": [{"level": 1.0, "start": 100,
+                                                   "length": 2, "period": 1000,
+                                                   "multiplier": 0}]} }
   },
   "data_items": [...],
   "prediction_items": [...]
 }
 ```
 A `params_to_change` value is a **float** (constant) or a **string** (trace key into `protocol_traces`). Series entries currently must have a `std` set (single-likelihood assumption — see commit history).
+
+`protocol_shapes` is the **same waveform written as Myokit `[[protocol]]` events** rather than as a table of points, in Myokit's own field names (`level` / `start` / `length` / `period` / `multiplier`, plus an optional `baseline`) — so a protocol imported from a `.mmt` needs no translation. `utilities/protocol_shapes.materialise_shapes` expands them **into `protocol_traces`** at parse time (and again, idempotently, in `set_protocol_info`), so **nothing downstream needs to know shapes exist** — keep it that way and add new shape types there rather than teaching the solvers about them. A shape is sized by the sub-experiment that references it unless it names its own `duration`; a name belongs to `protocol_traces` **or** `protocol_shapes`, not both.
 
 **Timeline conventions** (subtle — get these right):
 - `pre_times[j]` is the **unlogged pre-pass** before the first sub-experiment of experiment `j`; `sim_times[j][k]` is the duration of sub-experiment `(j, k)`.

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -20,6 +20,8 @@ except Exception:
 import re
 from datetime import date
 
+from utilities.protocol_shapes import materialise_shapes, validate_trace_references
+
 try:
     from mpi4py import MPI
     mpi_available = True
@@ -1982,6 +1984,9 @@ class ObsAndParamDataParser(object):
                 "experiment_colors": {"types": (list, tuple, np.ndarray), "default": None},
                 "comment": {"types": (str,), "default": None},
                 "protocol_traces": {"types": (dict,), "default": {}},
+                # The same waveforms written as Myokit-style events rather than
+                # point tables; expanded into protocol_traces below.
+                "protocol_shapes": {"types": (dict,), "default": {}},
             }
 
             unknown_protocol_keys = sorted(set(protocol_info.keys()) - set(protocol_schema.keys()))
@@ -2018,6 +2023,11 @@ class ObsAndParamDataParser(object):
                 )
 
             validate_params_to_change(protocol_info)
+            # Shapes become traces here, once, so every consumer downstream --
+            # solver helpers, plotting, anything added later -- keeps seeing only
+            # protocol_traces and needs no knowledge of shapes.
+            materialise_shapes(protocol_info)
+            validate_trace_references(protocol_info)
 
             # Load Prediction Info
             if 'prediction_items' in json_obj.keys():
@@ -2128,7 +2138,13 @@ class ObsAndParamDataParser(object):
 
             type_errors = []
             missing_required_cols = []
-            for col, rules in schema.items():
+            # No data items at all is a valid obs_data: a protocol-only file says
+            # how to drive the model without yet saying what to measure, which is
+            # what an obs_data generated from a model's own protocol looks like
+            # before its targets are added. There is nothing to validate, and the
+            # column defaults below are derived from other columns -- so on an
+            # empty frame they raised KeyError: 'variable' instead.
+            for col, rules in ({} if len(gt_df) == 0 else schema).items():
                 allowed = rules["types"]
                 default = rules["default"]
 

--- a/src/protocol_runners/protocol_runner.py
+++ b/src/protocol_runners/protocol_runner.py
@@ -157,6 +157,22 @@ class ProtocolRunner:
                 json_obj = json.load(fh)
             protocol_info = json_obj['protocol_info']
 
+        # Hand the protocol to the helper before running it. Without this a
+        # params_to_change entry naming a trace (or a shape) failed here with
+        # "protocol_traces not found in protocol_info" -- the helper had never
+        # been told the protocol it was executing. Guarded on identity because
+        # for the Myokit backend this rebinds `pace` and recreates the
+        # simulation, which is not something to redo on every call.
+        if hasattr(self.sim_helper, 'set_protocol_info'):
+            if getattr(self, '_applied_protocol_info', None) is not protocol_info:
+                self.sim_helper.set_protocol_info(protocol_info)
+                self._applied_protocol_info = protocol_info
+                # Binding `pace` rebuilds the simulation, and the result rows are
+                # ordered by the rebuilt model's variables -- so the map captured
+                # in __init__ no longer indexes what get_results returns. Left
+                # stale, every variable silently reads as its neighbour.
+                self.variable_names = self.sim_helper.get_all_variable_names()
+
         sim_times = protocol_info['sim_times']
         pre_times = protocol_info['pre_times']
         num_experiments = len(sim_times)

--- a/src/solver_wrappers/aadc_python_solver_helper.py
+++ b/src/solver_wrappers/aadc_python_solver_helper.py
@@ -238,6 +238,17 @@ class SimulationHelper:
             if not isinstance(vals, (list, tuple)):
                 vals = [vals]
             for name, val in zip(name_or_list, vals):
+                if isinstance(val, str):
+                    # See the CasADi backend: an unchecked string silently corrupts the
+                    # parameter vector rather than failing where the mistake is.
+                    raise NotImplementedError(
+                        f"'{name}' was given the protocol trace name '{val}', but the "
+                        f"AADC backend cannot drive a variable from a time series. "
+                        f"protocol_traces (and the protocol_shapes that expand into them) are "
+                        f"only implemented for solver 'CVODE_myokit'. Use that solver for a "
+                        f"paced model, or replace the trace with a per-sub-experiment constant "
+                        f"in params_to_change."
+                    )
                 kind, idx_res = self._resolve_name(name)
                 if kind == "state":
                     self.states[idx_res] = val

--- a/src/solver_wrappers/casadi_python_solver_helper.py
+++ b/src/solver_wrappers/casadi_python_solver_helper.py
@@ -312,6 +312,18 @@ class SimulationHelper:
             vals = _to_list(vals)
 
             for name, val in zip(name_or_list, vals):
+                if isinstance(val, str):
+                    # Without this the string is assigned straight into self.variables and
+                    # corrupts the parameter vector silently -- the failure then surfaces
+                    # somewhere numeric, far from the protocol that caused it.
+                    raise NotImplementedError(
+                        f"'{name}' was given the protocol trace name '{val}', but the "
+                        f"CasADi backend cannot drive a variable from a time series. "
+                        f"protocol_traces (and the protocol_shapes that expand into them) are "
+                        f"only implemented for solver 'CVODE_myokit'. Use that solver for a "
+                        f"paced model, or replace the trace with a per-sub-experiment constant "
+                        f"in params_to_change."
+                    )
                 kind, idx_res = self._resolver.resolve(name)
                 if kind == "state":
                     self.states[idx_res] = val

--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -7,6 +7,7 @@ from myokit.formats import cellml as cellml_format
 # sys.path.append(src_dir)
 import utilities.libcellml_helper_funcs as cellml
 from solver_wrappers.name_resolver import VariableNameResolver
+from utilities.protocol_shapes import materialise_shapes, validate_trace_references
 import xml.etree.ElementTree as ET
 import tempfile
 import re
@@ -77,6 +78,13 @@ class SimulationHelper:
         """
         Store protocol metadata and (if needed) recreate Simulation with pace binding.
         """
+        # Any protocol_shapes become protocol_traces here, so the trace lookup
+        # further down sees one representation regardless of which the user
+        # wrote. In place and idempotent: the caller keeps the dict it passed
+        # (plot_outputs reads protocol_info back off the helper), and a
+        # protocol_info that came through the parser is already expanded.
+        materialise_shapes(protocol_info)
+        validate_trace_references(protocol_info)
         self.protocol_info = protocol_info
         paced_param_name = self._find_paced_parameter_name(protocol_info)
         if paced_param_name is None:

--- a/src/solver_wrappers/python_solver_helper.py
+++ b/src/solver_wrappers/python_solver_helper.py
@@ -321,7 +321,12 @@ class SimulationHelper:
 
             for name, val in zip(name_or_list, vals):
                 if type(val) == str:
-                    raise NotImplementedError("Setting parameter values by name of protocol trace is not implemented for OpenCOR")
+                    raise NotImplementedError(
+                        f"'{name}' was given the protocol trace name '{val}', but the "
+                        f"python (solve_ivp) backend cannot drive a variable from a time "
+                        f"series. protocol_traces (and the protocol_shapes that expand "
+                        f"into them) are only implemented for solver 'CVODE_myokit'."
+                    )
                 elif type(val) not in [float, np.float64, int]:
                     raise ValueError(f"Parameter value {param_vals[JJ]} is not a valid type. {type(param_vals[JJ])}" + \
                                     "must be a float, np.float64, or int.")

--- a/src/utilities/protocol_shapes.py
+++ b/src/utilities/protocol_shapes.py
@@ -32,17 +32,20 @@ not have to learn a second name for ``Length``.
 
 from __future__ import annotations
 
-# Recognised shape types. Only pacing today; the key exists so a later shape
-# (ramp, sine) is an addition rather than a breaking change to the format.
+# Recognised shape types. `pacing` covers everything built from square events --
+# a stimulus train, a step, a single pulse -- because those differ only in how
+# many times the event repeats. `ramp` is separate because a linear sweep is not
+# a square event and cannot be written as one.
 PACING = "pacing"
-SHAPE_TYPES = (PACING,)
+RAMP = "ramp"
+SHAPE_TYPES = (PACING, RAMP)
 
 # `Length` in a .mmt's column header, `duration` in Myokit's Python API. Both are
 # accepted: a user coming from either should not have to look this up.
 LENGTH_KEYS = ("length", "duration")
 
 EVENT_KEYS = {"level", "start", "period", "multiplier", *LENGTH_KEYS}
-SHAPE_KEYS = {"type", "events", "baseline", "duration"}
+SHAPE_KEYS = {"type", "events", "baseline", "duration", "from", "to"}
 
 # A generated trace is square, but myokit.TimeSeriesProtocol interpolates
 # linearly between the points it is given -- so an edge is a very short ramp
@@ -92,6 +95,9 @@ def normalise_shape(shape, *, name):
             f"protocol_shapes['{name}'] has type '{shape_type}'; "
             f"expected one of {list(SHAPE_TYPES)}"
         )
+
+    if shape_type == RAMP:
+        return _normalise_ramp(shape, name=name)
 
     events = shape.get("events")
     if not isinstance(events, (list, tuple)) or not events:
@@ -172,6 +178,40 @@ def normalise_shape(shape, *, name):
     return canonical
 
 
+def _normalise_ramp(shape, *, name):
+    """A linear sweep across the sub-experiment: ``from`` at its start, ``to`` at
+    its end.
+
+    Kept deliberately plain. A ramp holding at a value before it starts, or
+    sweeping only part of the way through, is a ramp plus a step -- and the
+    format already has a way to say that, by giving the parameter its own
+    sub-experiments.
+    """
+    for key in ("from", "to"):
+        if key not in shape:
+            raise ProtocolShapeError(
+                f"protocol_shapes['{name}'] is a ramp, so it needs '{key}'"
+            )
+    unused = sorted({"events", "baseline"} & set(shape))
+    if unused:
+        raise ProtocolShapeError(
+            f"protocol_shapes['{name}'] is a ramp, so {unused} does not apply to it"
+        )
+    canonical = {
+        "type": RAMP,
+        "from": _number(shape["from"], f"protocol_shapes['{name}']['from']"),
+        "to": _number(shape["to"], f"protocol_shapes['{name}']['to']"),
+    }
+    if "duration" in shape:
+        duration = _number(shape["duration"], f"protocol_shapes['{name}']['duration']")
+        if duration <= 0:
+            raise ProtocolShapeError(
+                f"protocol_shapes['{name}'] has duration {duration}; it must be positive"
+            )
+        canonical["duration"] = duration
+    return canonical
+
+
 def _occurrences(event, duration):
     """When the event fires, within ``[0, duration)``.
 
@@ -224,6 +264,9 @@ def expand_shape(shape, duration, *, name):
             f"protocol_shapes['{name}'] is used over a sub-experiment of length "
             f"{duration:g}; there is no time to pace anything in"
         )
+
+    if shape["type"] == RAMP:
+        return {"t": [0.0, duration], "values": [shape["from"], shape["to"]]}
 
     baseline = shape["baseline"]
     spans = _intervals(shape["events"], duration, name=name)

--- a/src/utilities/protocol_shapes.py
+++ b/src/utilities/protocol_shapes.py
@@ -1,0 +1,392 @@
+"""Declarative pacing shapes that expand into ``protocol_traces``.
+
+``protocol_traces`` lets a ``params_to_change`` entry be a string key naming an
+arbitrary ``{t, values}`` waveform. That is completely general and completely
+unwritable by hand: a 1 Hz stimulus over ten beats is a forty-point table in
+which every number has to be right, and changing the period means rebuilding the
+table rather than editing a field.
+
+``protocol_shapes`` is the same waveform written the way Myokit's ``[[protocol]]``
+section writes it -- one line per event, in the same five columns::
+
+    # Level  Start  Length  Period  Multiplier
+    1.0      100    2       1000    0
+
+becomes::
+
+    "protocol_shapes": {
+        "stim": {"events": [{"level": 1.0, "start": 100, "length": 2,
+                             "period": 1000, "multiplier": 0}]}
+    }
+
+The two are alternatives, not layers: a name is defined in one or the other, and
+whichever you use, ``params_to_change`` refers to it the same way. Shapes are
+expanded into ``protocol_traces`` before anything downstream looks at them, so
+solvers, plotting and the rest of the pipeline keep seeing the traces they
+already understand and need no knowledge of shapes at all.
+
+The field names are Myokit's on purpose. A model imported from a ``.mmt`` carries
+its protocol in exactly this vocabulary, and a user who has written one should
+not have to learn a second name for ``Length``.
+"""
+
+from __future__ import annotations
+
+# Recognised shape types. Only pacing today; the key exists so a later shape
+# (ramp, sine) is an addition rather than a breaking change to the format.
+PACING = "pacing"
+SHAPE_TYPES = (PACING,)
+
+# `Length` in a .mmt's column header, `duration` in Myokit's Python API. Both are
+# accepted: a user coming from either should not have to look this up.
+LENGTH_KEYS = ("length", "duration")
+
+EVENT_KEYS = {"level", "start", "period", "multiplier", *LENGTH_KEYS}
+SHAPE_KEYS = {"type", "events", "baseline", "duration"}
+
+# A generated trace is square, but myokit.TimeSeriesProtocol interpolates
+# linearly between the points it is given -- so an edge is a very short ramp
+# rather than a discontinuity. This is the fraction of the shortest interval in
+# the waveform that an edge is allowed to take.
+EDGE_FRACTION = 1e-3
+
+
+class ProtocolShapeError(ValueError):
+    """A protocol_shapes entry that cannot be turned into a trace."""
+
+
+def _number(value, what):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ProtocolShapeError(f"{what} must be a number, got {value!r}")
+    value = float(value)
+    if value != value or value in (float("inf"), float("-inf")):
+        raise ProtocolShapeError(f"{what} must be finite, got {value!r}")
+    return value
+
+
+def normalise_shape(shape, *, name):
+    """Validate one ``protocol_shapes`` entry and return it in canonical form.
+
+    Accepts the canonical ``{"events": [...]}`` mapping and, as a shorthand, a
+    bare list of events -- which is what a ``.mmt`` protocol table looks like
+    when transcribed directly.
+    """
+    if isinstance(shape, (list, tuple)):
+        shape = {"events": list(shape)}
+    if not isinstance(shape, dict):
+        raise ProtocolShapeError(
+            f"protocol_shapes['{name}'] must be a mapping or a list of events, "
+            f"got {type(shape).__name__}"
+        )
+
+    unknown = sorted(set(shape) - SHAPE_KEYS)
+    if unknown:
+        raise ProtocolShapeError(
+            f"protocol_shapes['{name}'] has unknown keys {unknown}; "
+            f"expected any of {sorted(SHAPE_KEYS)}"
+        )
+
+    shape_type = shape.get("type", PACING)
+    if shape_type not in SHAPE_TYPES:
+        raise ProtocolShapeError(
+            f"protocol_shapes['{name}'] has type '{shape_type}'; "
+            f"expected one of {list(SHAPE_TYPES)}"
+        )
+
+    events = shape.get("events")
+    if not isinstance(events, (list, tuple)) or not events:
+        raise ProtocolShapeError(
+            f"protocol_shapes['{name}'] needs a non-empty 'events' list -- one "
+            f"entry per line of a .mmt [[protocol]] table"
+        )
+
+    normalised = []
+    for i, raw in enumerate(events):
+        if not isinstance(raw, dict):
+            raise ProtocolShapeError(
+                f"protocol_shapes['{name}'].events[{i}] must be a mapping, "
+                f"got {type(raw).__name__}"
+            )
+        unknown = sorted(set(raw) - EVENT_KEYS)
+        if unknown:
+            raise ProtocolShapeError(
+                f"protocol_shapes['{name}'].events[{i}] has unknown keys {unknown}; "
+                f"expected any of {sorted(EVENT_KEYS)}"
+            )
+        where = f"protocol_shapes['{name}'].events[{i}]"
+
+        given_length = [k for k in LENGTH_KEYS if k in raw]
+        if not given_length:
+            raise ProtocolShapeError(f"{where} needs a 'length' (the .mmt column) or 'duration'")
+        if len(given_length) > 1:
+            raise ProtocolShapeError(
+                f"{where} gives both 'length' and 'duration'; they are the same "
+                f"field under two names, so give only one"
+            )
+        length = _number(raw[given_length[0]], f"{where}['{given_length[0]}']")
+        if length <= 0:
+            raise ProtocolShapeError(f"{where} has length {length}; an event must last some time")
+
+        if "level" not in raw:
+            raise ProtocolShapeError(f"{where} needs a 'level'")
+        level = _number(raw["level"], f"{where}['level']")
+        start = _number(raw.get("start", 0.0), f"{where}['start']")
+        if start < 0:
+            raise ProtocolShapeError(f"{where} has start {start}; it cannot be before the run")
+        period = _number(raw.get("period", 0.0), f"{where}['period']")
+        if period < 0:
+            raise ProtocolShapeError(f"{where} has period {period}; it cannot be negative")
+        multiplier = _number(raw.get("multiplier", 0.0), f"{where}['multiplier']")
+        if multiplier < 0 or multiplier != int(multiplier):
+            raise ProtocolShapeError(
+                f"{where} has multiplier {multiplier}; it must be a non-negative whole number "
+                f"(0 means repeat for as long as the sub-experiment lasts)"
+            )
+        if period == 0 and multiplier > 1:
+            raise ProtocolShapeError(
+                f"{where} repeats {int(multiplier)} times but has no period, so every "
+                f"repeat would land on top of the first one"
+            )
+        normalised.append(
+            {
+                "level": level,
+                "start": start,
+                "length": length,
+                "period": period,
+                "multiplier": int(multiplier),
+            }
+        )
+
+    canonical = {
+        "type": shape_type,
+        "events": normalised,
+        "baseline": _number(shape.get("baseline", 0.0), f"protocol_shapes['{name}']['baseline']"),
+    }
+    if "duration" in shape:
+        duration = _number(shape["duration"], f"protocol_shapes['{name}']['duration']")
+        if duration <= 0:
+            raise ProtocolShapeError(
+                f"protocol_shapes['{name}'] has duration {duration}; it must be positive"
+            )
+        canonical["duration"] = duration
+    return canonical
+
+
+def _occurrences(event, duration):
+    """When the event fires, within ``[0, duration)``.
+
+    Myokit's rules: no period means it happens once; multiplier 0 with a period
+    means it repeats indefinitely, which here means "for as long as this
+    sub-experiment runs".
+    """
+    start, period, multiplier = event["start"], event["period"], event["multiplier"]
+    if period == 0:
+        return [start] if start < duration else []
+
+    times = []
+    when = start
+    # An indefinite event is bounded by the sub-experiment; a counted one by its
+    # multiplier. The `len(times)` guard also stops a pathologically small period
+    # from generating an unbounded list.
+    limit = multiplier if multiplier else None
+    max_points = int(duration / period) + 2
+    while when < duration and (limit is None or len(times) < limit):
+        times.append(when)
+        when += period
+        if limit is None and len(times) > max_points:
+            break
+    return times
+
+
+def _intervals(events, duration, *, name):
+    """``(start, end, level)`` for every occurrence, checked for overlap."""
+    spans = []
+    for event in events:
+        for start in _occurrences(event, duration):
+            spans.append((start, min(start + event["length"], duration), event["level"]))
+    spans.sort()
+    for (a_start, a_end, _), (b_start, _, _) in zip(spans, spans[1:]):
+        if b_start < a_end:
+            raise ProtocolShapeError(
+                f"protocol_shapes['{name}'] has events that overlap: one runs from "
+                f"{a_start:g} to {a_end:g} while another starts at {b_start:g}. "
+                f"Myokit rejects overlapping events too -- the value during the "
+                f"overlap would be ambiguous."
+            )
+    return spans
+
+
+def expand_shape(shape, duration, *, name):
+    """Turn a normalised shape into a ``{"t": [...], "values": [...]}`` trace."""
+    duration = _number(duration, f"duration for protocol_shapes['{name}']")
+    if duration <= 0:
+        raise ProtocolShapeError(
+            f"protocol_shapes['{name}'] is used over a sub-experiment of length "
+            f"{duration:g}; there is no time to pace anything in"
+        )
+
+    baseline = shape["baseline"]
+    spans = _intervals(shape["events"], duration, name=name)
+    if not spans:
+        # Every occurrence fell outside the run. Say so rather than returning a
+        # flat line that looks like a protocol and does nothing.
+        raise ProtocolShapeError(
+            f"protocol_shapes['{name}'] fires nothing within the {duration:g} it is "
+            f"run over -- check 'start' against the sub-experiment's sim_time"
+        )
+
+    # An edge has to be short relative to the shortest feature in the waveform,
+    # or a 2 ms stimulus in a 2000 ms beat gets ramped away.
+    features = [end - start for start, end, _ in spans]
+    features += [b[0] - a[1] for a, b in zip(spans, spans[1:]) if b[0] > a[1]]
+    features += [spans[0][0]] if spans[0][0] > 0 else []
+    features += [duration - spans[-1][1]] if spans[-1][1] < duration else []
+    smallest = min(f for f in features if f > 0)
+    eps = max(smallest * EDGE_FRACTION, duration * 1e-12)
+
+    t = [0.0]
+    values = [baseline]
+
+    def push(when, value):
+        when = min(max(when, 0.0), duration)
+        if when > t[-1]:
+            t.append(when)
+            values.append(value)
+        else:
+            # Two edges landing on the same instant: the later one wins, which is
+            # what a square wave means at a transition.
+            values[-1] = value
+
+    for start, end, level in spans:
+        if start > 0:
+            push(start, baseline)
+        push(min(start + eps, duration), level)
+        if end > start + eps:
+            push(end, level)
+        if end < duration:
+            push(min(end + eps, duration), baseline)
+    push(duration, baseline if spans[-1][1] < duration else spans[-1][2])
+    return {"t": t, "values": values}
+
+
+def _string_leaves(value):
+    """Every string leaf of a params_to_change entry, with its (exp, sub) index."""
+    found = []
+    if isinstance(value, (list, tuple)):
+        for exp_idx, row in enumerate(value):
+            if isinstance(row, (list, tuple)):
+                for sub_idx, leaf in enumerate(row):
+                    if isinstance(leaf, str):
+                        found.append((exp_idx, sub_idx, leaf))
+            elif isinstance(row, str):
+                found.append((exp_idx, 0, row))
+    return found
+
+
+def materialise_shapes(protocol_info):
+    """Expand ``protocol_shapes`` into ``protocol_traces``, in place.
+
+    Called before anything reads the traces, so the rest of the pipeline never
+    has to know shapes exist. Idempotent: a protocol_info that has already been
+    expanded passes through untouched, which matters because it is handed around
+    between the parser, the runner and the solver helpers.
+
+    A shape is expanded over the sub-experiment that refers to it, so its length
+    comes from ``sim_times`` rather than having to be repeated in the shape. A
+    shape used by sub-experiments of different lengths is ambiguous and is
+    refused unless it names its own ``duration``.
+    """
+    if not isinstance(protocol_info, dict):
+        return protocol_info
+
+    shapes_raw = protocol_info.get("protocol_shapes") or {}
+    if not shapes_raw:
+        return protocol_info
+    if not isinstance(shapes_raw, dict):
+        raise ProtocolShapeError(
+            f"protocol_shapes must be a mapping of name -> shape, got {type(shapes_raw).__name__}"
+        )
+
+    traces = protocol_info.get("protocol_traces")
+    if not isinstance(traces, dict):
+        traces = {}
+
+    shapes = {name: normalise_shape(shape, name=name) for name, shape in shapes_raw.items()}
+
+    sim_times = protocol_info.get("sim_times") or []
+    durations = {}
+    for param, value in (protocol_info.get("params_to_change") or {}).items():
+        for exp_idx, sub_idx, leaf in _string_leaves(value):
+            if leaf not in shapes:
+                continue
+            try:
+                duration = float(sim_times[exp_idx][sub_idx])
+            except (IndexError, TypeError, ValueError):
+                raise ProtocolShapeError(
+                    f"params_to_change['{param}'][{exp_idx}][{sub_idx}] uses shape "
+                    f"'{leaf}', but sim_times has no matching sub-experiment"
+                ) from None
+            durations.setdefault(leaf, {}).setdefault(duration, []).append(
+                f"{param}[{exp_idx}][{sub_idx}]"
+            )
+
+    for name, shape in shapes.items():
+        if "duration" in shape:
+            duration = shape["duration"]
+        else:
+            seen = durations.get(name)
+            if not seen:
+                raise ProtocolShapeError(
+                    f"protocol_shapes['{name}'] is never used by params_to_change, so "
+                    f"there is no sub-experiment to size it against. Reference it, "
+                    f"remove it, or give it an explicit 'duration'."
+                )
+            if len(seen) > 1:
+                lengths = ", ".join(
+                    f"{d:g} (from {', '.join(refs)})" for d, refs in sorted(seen.items())
+                )
+                raise ProtocolShapeError(
+                    f"protocol_shapes['{name}'] is used over sub-experiments of "
+                    f"different lengths: {lengths}. Give it an explicit 'duration', "
+                    f"or split it into one shape per length."
+                )
+            duration = next(iter(seen))
+        generated = expand_shape(shape, duration, name=name)
+        # A name defined as both a shape and a hand-written trace is ambiguous --
+        # except when the "hand-written" one is this function's own output from an
+        # earlier pass, which is how expansion stays idempotent across the parser,
+        # the runner and the solver helper all calling it on the same dict.
+        if name in traces and traces[name] != generated:
+            raise ProtocolShapeError(
+                f"'{name}' is defined in both protocol_shapes and protocol_traces, "
+                f"and they disagree. They are alternatives -- define each name in "
+                f"one or the other."
+            )
+        traces[name] = generated
+
+    protocol_info["protocol_traces"] = traces
+    return protocol_info
+
+
+def validate_trace_references(protocol_info):
+    """Fail early on a ``params_to_change`` string that names nothing.
+
+    Without this the mistake surfaces at solve time, inside whichever
+    sub-experiment happens to reach it first, long after the file was read.
+    """
+    if not isinstance(protocol_info, dict):
+        return
+    traces = protocol_info.get("protocol_traces") or {}
+    shapes = protocol_info.get("protocol_shapes") or {}
+    known = set(traces) | set(shapes)
+    missing = []
+    for param, value in (protocol_info.get("params_to_change") or {}).items():
+        for exp_idx, sub_idx, leaf in _string_leaves(value):
+            if leaf not in known:
+                missing.append(f"  params_to_change['{param}'][{exp_idx}][{sub_idx}] -> '{leaf}'")
+    if missing:
+        raise ProtocolShapeError(
+            "params_to_change refers to traces that are defined nowhere:\n"
+            + "\n".join(missing)
+            + f"\nDefined names: {sorted(known) if known else 'none'}"
+        )

--- a/tests/test_protocol_shapes.py
+++ b/tests/test_protocol_shapes.py
@@ -452,3 +452,36 @@ def test_the_runner_reports_the_variables_it_returns_after_a_pace_rebind(paced_c
     # itself only ever sits between 0 and 1, so reading the wrong row is obvious.
     assert np.min(v) < -1.0
     assert np.max(v) > 1.0
+
+
+# ---------------------------------------------------------------------------
+# ramp -- the one editor shape that is not a square event
+# ---------------------------------------------------------------------------
+def test_a_ramp_sweeps_across_the_subexperiment():
+    info = materialise_shapes(_protocol({"type": "ramp", "from": 0.0, "to": 5.0}))
+    trace = info["protocol_traces"]["stim"]
+    assert trace == {"t": [0.0, 2000.0], "values": [0.0, 5.0]}
+
+
+def test_a_ramp_is_sized_by_its_subexperiment_too():
+    info = materialise_shapes(
+        _protocol({"type": "ramp", "from": 1.0, "to": 2.0}, sim_times=[[7.5]])
+    )
+    assert info["protocol_traces"]["stim"]["t"] == [0.0, 7.5]
+
+
+def test_a_ramp_can_go_downwards():
+    info = materialise_shapes(_protocol({"type": "ramp", "from": 10.0, "to": -10.0}))
+    assert _levels_at(info["protocol_traces"]["stim"], [0, 1000, 2000]) == [10.0, 0.0, -10.0]
+
+
+def test_a_ramp_needs_both_ends():
+    with pytest.raises(ProtocolShapeError, match="needs 'to'"):
+        normalise_shape({"type": "ramp", "from": 0.0}, name="s")
+
+
+def test_a_ramp_rejects_the_pacing_fields_rather_than_ignoring_them():
+    """Silently dropping 'events' would give a ramp where the user wrote a
+    stimulus and expected one."""
+    with pytest.raises(ProtocolShapeError, match="does not apply"):
+        normalise_shape({"type": "ramp", "from": 0.0, "to": 1.0, "events": [STIM]}, name="s")

--- a/tests/test_protocol_shapes.py
+++ b/tests/test_protocol_shapes.py
@@ -485,3 +485,108 @@ def test_a_ramp_rejects_the_pacing_fields_rather_than_ignoring_them():
     stimulus and expected one."""
     with pytest.raises(ProtocolShapeError, match="does not apply"):
         normalise_shape({"type": "ramp", "from": 0.0, "to": 1.0, "events": [STIM]}, name="s")
+
+
+# ----------------------------------------------------------------------------------------
+# Mixing a hand-written trace and a shape, and the one-paced-variable limit
+# ----------------------------------------------------------------------------------------
+
+def test_a_trace_and_a_shape_can_drive_different_variables():
+    """One variable driven by a hand-written trace, another by a shape, in one protocol.
+
+    The two forms are alternatives *per name*, not mutually exclusive per file: a name is
+    defined in protocol_traces or protocol_shapes, but a protocol may use both for different
+    variables. Expansion merges the shape-derived traces into whatever traces are already
+    there, so params_to_change can refer to either kind the same way.
+    """
+    info = {
+        "pre_times": [0.0],
+        "sim_times": [[2000.0], [2000.0]],
+        "params_to_change": {
+            "engine/pace": [["stim"], [0.0]],        # sub-exp 0: shape-derived
+            "membrane/i_ext": [[0.0], ["ramp"]],     # sub-exp 1: hand-written trace
+        },
+        "protocol_shapes": {"stim": _shape()},
+        "protocol_traces": {"ramp": {"t": [0.0, 1000.0, 2000.0],
+                                     "values": [0.0, 1.0, 0.0]}},
+    }
+    out = materialise_shapes(info)
+    traces = out["protocol_traces"]
+
+    assert set(traces) == {"stim", "ramp"}
+    # the hand-written one is untouched
+    assert traces["ramp"] == {"t": [0.0, 1000.0, 2000.0], "values": [0.0, 1.0, 0.0]}
+    # the shape expanded into a real waveform, distinct from it
+    assert traces["stim"]["t"] and traces["stim"] != traces["ramp"]
+    # and neither reference is reported as dangling
+    validate_trace_references(out)
+
+
+def test_a_shape_and_a_trace_may_drive_the_same_variable_in_different_subexperiments():
+    """Switching which waveform drives one variable between sub-experiments is allowed.
+
+    Only *concurrent* pacing of two different variables is limited (see the Myokit test
+    below); driving one variable from a shape in one sub-experiment and a hand-written trace
+    in the next is a single paced variable at any moment.
+    """
+    info = {
+        "pre_times": [0.0],
+        "sim_times": [[2000.0, 2000.0]],
+        "params_to_change": {"engine/pace": [["stim", "ramp"]]},
+        "protocol_shapes": {"stim": _shape()},
+        "protocol_traces": {"ramp": {"t": [0.0, 2000.0], "values": [0.0, 1.0]}},
+    }
+    out = materialise_shapes(info)
+    assert set(out["protocol_traces"]) == {"stim", "ramp"}
+    validate_trace_references(out)
+
+
+@pytest.mark.integration
+@pytest.mark.solver
+def test_myokit_refuses_two_paced_variables_in_one_subexperiment(
+        generated_cellml_model_factory):
+    """Myokit binds a single 'pace' label per simulation segment, so two variables cannot be
+    driven from time series at the same instant. Driving different variables in *different*
+    sub-experiments is fine; this is only about one sub-experiment."""
+    import sys, os
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src'))
+    from solver_wrappers import get_simulation_helper
+
+    model_path = generated_cellml_model_factory(
+        "Lotka_Volterra", "Lotka_Volterra_parameters.csv", solver="CVODE_myokit")
+    h = get_simulation_helper(
+        model_path=model_path, model_type="cellml_only", solver="CVODE_myokit",
+        dt=0.01, sim_time=1.0, pre_time=0.0,
+        solver_info={"MaximumStep": 0.01, "MaximumNumberOfSteps": 5000})
+    h.set_protocol_info({
+        "pre_times": [0.0], "sim_times": [[1.0]],
+        "params_to_change": {"Lotka_Volterra/alpha": [["a"]],
+                             "Lotka_Volterra/beta": [["b"]]},
+        "protocol_traces": {"a": {"t": [0.0, 1.0], "values": [1.0, 1.0]},
+                            "b": {"t": [0.0, 1.0], "values": [1.0, 1.0]}},
+    })
+    with pytest.raises(ValueError, match="only one paced variable"):
+        h.set_param_vals([["Lotka_Volterra/alpha"], ["Lotka_Volterra/beta"]], [["a"], ["b"]])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name,backend_label", [
+    ("solver_wrappers.casadi_python_solver_helper", "CasADi"),
+    ("solver_wrappers.aadc_python_solver_helper", "AADC"),
+    ("solver_wrappers.python_solver_helper", "python"),
+])
+def test_non_myokit_backends_refuse_protocol_traces_explicitly(module_name, backend_label):
+    """Only the Myokit backend implements protocol_traces.
+
+    The others previously assigned the trace *name* straight into their numeric parameter
+    vector (CasADi and AADC) or named the wrong backend in the error (python said 'OpenCOR').
+    A silently corrupted parameter vector surfaces somewhere numeric, far from the protocol
+    that caused it, so each backend now refuses a string value where the mistake is made.
+    """
+    import importlib, inspect
+    src = inspect.getsource(importlib.import_module(module_name).SimulationHelper.set_param_vals)
+    assert "isinstance(val, str)" in src or "type(val) == str" in src, (
+        f"{backend_label} backend does not check for a protocol trace name")
+    assert "NotImplementedError" in src
+    assert "CVODE_myokit" in src, (
+        f"{backend_label} error should point at the solver that does support traces")

--- a/tests/test_protocol_shapes.py
+++ b/tests/test_protocol_shapes.py
@@ -1,0 +1,454 @@
+"""Tests for protocol_shapes -- Myokit-style pacing events as an alternative to
+hand-written protocol_traces.
+
+The interesting assertions are the ones tying the expansion to Myokit itself: a
+shape written with the same five numbers as a .mmt [[protocol]] line has to
+produce the same waveform Myokit would, or the two representations agree only by
+coincidence.
+"""
+
+import pytest
+from bisect import bisect_right as _bisect
+
+from utilities.protocol_shapes import (
+    ProtocolShapeError,
+    expand_shape,
+    materialise_shapes,
+    normalise_shape,
+    validate_trace_references,
+)
+
+# The stimulus from resources/br-1977.mmt: 1 unit, 2 long, every 1000, forever.
+STIM = {"level": 1.0, "start": 100, "length": 2, "period": 1000, "multiplier": 0}
+
+
+def _shape(**over):
+    event = dict(STIM)
+    event.update(over)
+    return {"events": [event]}
+
+
+def _protocol(shape=None, sim_times=None, **extra):
+    info = {
+        "pre_times": [0.0],
+        "sim_times": sim_times or [[2000.0]],
+        "params_to_change": {"engine/pace": [["stim"]]},
+        "protocol_shapes": {"stim": shape if shape is not None else _shape()},
+    }
+    info.update(extra)
+    return info
+
+
+def _levels_at(trace, times):
+    """Sample the trace the way myokit.TimeSeriesProtocol would: linearly."""
+    import numpy as np
+
+    return list(np.interp(times, trace["t"], trace["values"]))
+
+
+# ---------------------------------------------------------------------------
+# The waveform
+# ---------------------------------------------------------------------------
+def test_a_periodic_event_repeats_for_as_long_as_the_subexperiment_runs():
+    info = materialise_shapes(_protocol())
+    trace = info["protocol_traces"]["stim"]
+    # Two beats in 2000 with a period of 1000.
+    assert _levels_at(trace, [50, 101, 500, 1101, 1500]) == [0.0, 1.0, 0.0, 1.0, 0.0]
+
+
+def test_the_stimulus_sits_exactly_where_the_event_says():
+    trace = materialise_shapes(_protocol())["protocol_traces"]["stim"]
+    assert _levels_at(trace, [99.9, 100.5, 101.9, 102.5]) == [0.0, 1.0, 1.0, 0.0]
+
+
+def test_a_multiplier_bounds_the_repeats():
+    info = materialise_shapes(_protocol(_shape(multiplier=1)))
+    trace = info["protocol_traces"]["stim"]
+    assert _levels_at(trace, [101, 1101]) == [1.0, 0.0]  # first beat only
+
+
+def test_no_period_means_a_single_event():
+    info = materialise_shapes(_protocol(_shape(period=0, multiplier=0)))
+    trace = info["protocol_traces"]["stim"]
+    assert _levels_at(trace, [101, 1101]) == [1.0, 0.0]
+
+
+def test_the_baseline_is_the_value_outside_every_event():
+    info = materialise_shapes(_protocol({"events": [STIM], "baseline": -80.0}))
+    trace = info["protocol_traces"]["stim"]
+    assert _levels_at(trace, [50, 101, 500]) == [-80.0, 1.0, -80.0]
+
+
+def test_the_trace_covers_the_whole_subexperiment():
+    trace = materialise_shapes(_protocol())["protocol_traces"]["stim"]
+    assert trace["t"][0] == 0.0
+    assert trace["t"][-1] == pytest.approx(2000.0)
+
+
+def test_the_times_strictly_increase():
+    """myokit.TimeSeriesProtocol requires it, and a duplicate instant is what a
+    naive square-wave expansion produces."""
+    trace = materialise_shapes(_protocol())["protocol_traces"]["stim"]
+    assert all(b > a for a, b in zip(trace["t"], trace["t"][1:]))
+
+
+def test_edges_stay_short_next_to_a_brief_stimulus():
+    """TimeSeriesProtocol interpolates linearly, so an edge is a ramp. A 2-long
+    stimulus inside a 2000-long beat must not be ramped away."""
+    trace = materialise_shapes(_protocol())["protocol_traces"]["stim"]
+    rise = [b - a for a, b in zip(trace["t"], trace["t"][1:])]
+    assert min(rise) <= 2 * 1e-3 * 1.01
+    # Full amplitude is reached well inside the event, not at its end.
+    assert _levels_at(trace, [100.1]) == [1.0]
+
+
+def test_several_events_in_one_shape():
+    """A .mmt [[protocol]] table can have many lines."""
+    shape = {
+        "events": [
+            {"level": 1.0, "start": 100, "length": 2, "period": 0, "multiplier": 0},
+            {"level": 2.0, "start": 500, "length": 5, "period": 0, "multiplier": 0},
+        ]
+    }
+    trace = materialise_shapes(_protocol(shape))["protocol_traces"]["stim"]
+    assert _levels_at(trace, [101, 300, 502, 800]) == [1.0, 0.0, 2.0, 0.0]
+
+
+# ---------------------------------------------------------------------------
+# Agreement with Myokit -- the point of using its vocabulary
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "event,duration",
+    [
+        (STIM, 2000.0),
+        ({"level": 1.0, "start": 100, "length": 2, "period": 1000, "multiplier": 3}, 5000.0),
+        ({"level": -2.5, "start": 0, "length": 0.5, "period": 30, "multiplier": 0}, 120.0),
+        ({"level": 1.0, "start": 10, "length": 5, "period": 0, "multiplier": 0}, 50.0),
+    ],
+)
+def test_the_waveform_is_the_one_myokit_would_produce(event, duration):
+    """Same five numbers, same stimulus. Built independently: Myokit expands its
+    own Protocol, we expand ours, and the two are sampled at the same instants."""
+    myokit = pytest.importorskip("myokit")
+
+    protocol = myokit.Protocol()
+    protocol.schedule(
+        event["level"], event["start"], event["length"], event["period"], event["multiplier"]
+    )
+    log_for_interval = getattr(protocol, "log_for_interval", None)
+    if log_for_interval is None:  # older Myokit
+        log_for_interval = protocol.create_log_for_interval
+    reference = log_for_interval(0, duration, for_drawing=False)
+
+    ours = expand_shape(normalise_shape({"events": [event]}, name="s"), duration, name="s")
+
+    # Sample midway through every stretch Myokit reports, where both
+    # representations are unambiguously at their held value. Myokit's log is a
+    # list of change points -- a step function, held forward -- so it is sampled
+    # as one; ours is a point table for linear interpolation.
+    times = list(reference["time"])
+    levels = list(reference["pace"])
+    midpoints = [(a + b) / 2 for a, b in zip(times, times[1:])]
+    held = [levels[max(0, _bisect(times, t) - 1)] for t in midpoints]
+
+    assert midpoints, "the reference protocol produced no stretches to compare"
+    assert _levels_at(ours, midpoints) == pytest.approx(held, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Sizing: a shape takes its length from the sub-experiment that uses it
+# ---------------------------------------------------------------------------
+def test_the_shape_is_sized_by_the_subexperiment_that_uses_it():
+    info = materialise_shapes(_protocol(sim_times=[[5000.0]]))
+    assert info["protocol_traces"]["stim"]["t"][-1] == pytest.approx(5000.0)
+    # 5000 with a period of 1000 is five beats.
+    assert _levels_at(info["protocol_traces"]["stim"], [101, 1101, 2101, 3101, 4101]) == [1.0] * 5
+
+
+def test_an_explicit_duration_overrides_the_subexperiment():
+    shape = {"events": [STIM], "duration": 1500.0}
+    info = materialise_shapes(_protocol(shape))
+    assert info["protocol_traces"]["stim"]["t"][-1] == pytest.approx(1500.0)
+
+
+def test_a_shape_used_at_two_different_lengths_is_refused():
+    """Silently picking one of them would give a protocol that is wrong in half
+    the experiments and looks right in the file."""
+    info = _protocol(sim_times=[[2000.0], [3000.0]])
+    info["pre_times"] = [0.0, 0.0]
+    info["params_to_change"] = {"engine/pace": [["stim"], ["stim"]]}
+    with pytest.raises(ProtocolShapeError, match="different lengths"):
+        materialise_shapes(info)
+
+
+def test_a_shape_nobody_uses_is_refused_rather_than_guessed_at():
+    info = _protocol()
+    info["params_to_change"] = {}
+    with pytest.raises(ProtocolShapeError, match="never used"):
+        materialise_shapes(info)
+
+
+# ---------------------------------------------------------------------------
+# Shapes and traces are alternatives
+# ---------------------------------------------------------------------------
+def test_a_name_defined_as_both_a_shape_and_a_trace_is_refused():
+    info = _protocol()
+    info["protocol_traces"] = {"stim": {"t": [0, 1], "values": [0, 1]}}
+    with pytest.raises(ProtocolShapeError, match="both"):
+        materialise_shapes(info)
+
+
+def test_hand_written_traces_are_left_alone():
+    info = _protocol()
+    info["protocol_traces"] = {"other": {"t": [0.0, 1.0], "values": [0.0, 1.0]}}
+    out = materialise_shapes(info)
+    assert out["protocol_traces"]["other"] == {"t": [0.0, 1.0], "values": [0.0, 1.0]}
+    assert "stim" in out["protocol_traces"]
+
+
+def test_expanding_twice_changes_nothing():
+    """protocol_info is passed between the parser, the runner and the helper, so
+    each of them expanding it must be safe."""
+    first = materialise_shapes(_protocol())
+    once = dict(first["protocol_traces"]["stim"])
+    twice = materialise_shapes(first)["protocol_traces"]["stim"]
+    assert twice == once
+
+
+def test_a_protocol_with_no_shapes_is_untouched():
+    info = {"pre_times": [0.0], "sim_times": [[1.0]], "params_to_change": {"a/b": [[1.0]]}}
+    assert materialise_shapes(dict(info)) == info
+
+
+# ---------------------------------------------------------------------------
+# Refusals -- each names the field it is complaining about
+# ---------------------------------------------------------------------------
+def test_length_and_duration_are_the_same_field_under_two_names():
+    """`Length` is the .mmt column, `duration` is Myokit's Python API."""
+    a = expand_shape(normalise_shape({"events": [STIM]}, name="s"), 2000.0, name="s")
+    b_event = {k: v for k, v in STIM.items() if k != "length"}
+    b_event["duration"] = STIM["length"]
+    b = expand_shape(normalise_shape({"events": [b_event]}, name="s"), 2000.0, name="s")
+    assert a == b
+
+
+def test_giving_both_length_and_duration_is_refused():
+    event = dict(STIM)
+    event["duration"] = 2
+    with pytest.raises(ProtocolShapeError, match="only one"):
+        normalise_shape({"events": [event]}, name="s")
+
+
+def test_a_missing_length_is_refused():
+    event = {k: v for k, v in STIM.items() if k != "length"}
+    with pytest.raises(ProtocolShapeError, match="needs a 'length'"):
+        normalise_shape({"events": [event]}, name="s")
+
+
+def test_a_missing_level_is_refused():
+    event = {k: v for k, v in STIM.items() if k != "level"}
+    with pytest.raises(ProtocolShapeError, match="needs a 'level'"):
+        normalise_shape({"events": [event]}, name="s")
+
+
+def test_a_misspelled_field_is_named_rather_than_ignored():
+    event = dict(STIM)
+    event["lenght"] = 2
+    with pytest.raises(ProtocolShapeError, match="lenght"):
+        normalise_shape({"events": [event]}, name="s")
+
+
+def test_an_unknown_shape_type_is_refused():
+    with pytest.raises(ProtocolShapeError, match="expected one of"):
+        normalise_shape({"type": "sine", "events": [STIM]}, name="s")
+
+
+def test_an_empty_event_list_is_refused():
+    with pytest.raises(ProtocolShapeError, match="non-empty"):
+        normalise_shape({"events": []}, name="s")
+
+
+def test_overlapping_events_are_refused_as_myokit_refuses_them():
+    shape = {
+        "events": [
+            {"level": 1.0, "start": 100, "length": 50, "period": 0},
+            {"level": 2.0, "start": 120, "length": 10, "period": 0},
+        ]
+    }
+    with pytest.raises(ProtocolShapeError, match="overlap"):
+        materialise_shapes(_protocol(shape))
+
+
+def test_a_stimulus_that_never_fires_in_the_run_is_refused():
+    """A flat line that looks like a protocol and does nothing is the failure
+    that is hardest to notice."""
+    with pytest.raises(ProtocolShapeError, match="fires nothing"):
+        materialise_shapes(_protocol(_shape(start=5000)))
+
+
+def test_a_negative_length_is_refused():
+    with pytest.raises(ProtocolShapeError, match="must last some time"):
+        normalise_shape({"events": [dict(STIM, length=-1)]}, name="s")
+
+
+def test_a_fractional_multiplier_is_refused():
+    with pytest.raises(ProtocolShapeError, match="whole number"):
+        normalise_shape({"events": [dict(STIM, multiplier=1.5)]}, name="s")
+
+
+def test_repeats_without_a_period_are_refused():
+    with pytest.raises(ProtocolShapeError, match="no period"):
+        normalise_shape({"events": [dict(STIM, period=0, multiplier=3)]}, name="s")
+
+
+def test_a_bare_list_of_events_is_accepted_as_the_mmt_table_shorthand():
+    shape = normalise_shape([STIM], name="s")
+    assert shape["events"][0]["level"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Dangling references
+# ---------------------------------------------------------------------------
+def test_a_reference_to_nothing_is_caught_before_the_solver_reaches_it():
+    info = {
+        "pre_times": [0.0],
+        "sim_times": [[1.0]],
+        "params_to_change": {"engine/pace": [["typo"]]},
+        "protocol_traces": {"stim": {"t": [0, 1], "values": [0, 1]}},
+    }
+    with pytest.raises(ProtocolShapeError, match="typo"):
+        validate_trace_references(info)
+
+
+def test_valid_references_pass():
+    info = materialise_shapes(_protocol())
+    validate_trace_references(info)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Through the obs_data parser
+# ---------------------------------------------------------------------------
+def test_the_parser_accepts_protocol_shapes_and_returns_traces(tmp_path):
+    import json
+
+    import parsers.PrimitiveParsers as primitive_parsers
+
+    obs = {
+        "protocol_info": {
+            "pre_times": [0.0],
+            "sim_times": [[2000.0]],
+            "params_to_change": {"engine/pace": [["stim"]]},
+            "protocol_shapes": {"stim": {"events": [STIM]}},
+        },
+        "data_items": [],
+    }
+    path = tmp_path / "obs_data.json"
+    path.write_text(json.dumps(obs))
+
+    parser = primitive_parsers.ObsAndParamDataParser()
+    result = parser.parse_obs_data_json(param_id_obs_path=str(path))
+    protocol_info = result[1] if isinstance(result, tuple) else result["protocol_info"]
+    assert "stim" in protocol_info["protocol_traces"]
+    assert protocol_info["protocol_traces"]["stim"]["t"][-1] == pytest.approx(2000.0)
+
+
+# ---------------------------------------------------------------------------
+# End to end: a shape and the sub-experiments it replaces must simulate alike
+# ---------------------------------------------------------------------------
+PACED_MMT = """[[model]]
+name: paced
+membrane.V = -80
+
+[engine]
+time = 0 bind time
+pace = 0 bind pace
+
+[membrane]
+dot(V) = -0.05 * V + 50 * engine.pace
+"""
+
+
+@pytest.fixture
+def paced_cellml(tmp_path):
+    """A minimal model driven by `pace`, exported to CellML for the solver."""
+    myokit = pytest.importorskip("myokit")
+    from myokit.formats.cellml import CellML2Exporter
+
+    mmt = tmp_path / "paced.mmt"
+    mmt.write_text(PACED_MMT)
+    model, _, _ = myokit.load(str(mmt))
+    path = tmp_path / "paced.cellml"
+    CellML2Exporter().model(str(path), model)
+    return str(path)
+
+
+def _run(model_path, protocol_info):
+    from protocol_runners.protocol_runner import ProtocolRunner
+
+    inp = {"dt": 0.1, "solver_info": {"MaximumStep": 0.01}, "model_type": "cellml_only"}
+    runner = ProtocolRunner(
+        model_path=model_path, inp_data_dict=inp, solver="CVODE_myokit", model_type="cellml_only"
+    )
+    t_list, res_list, _ = runner.run_protocols(model_path, protocol_info=protocol_info)
+    idx = runner.get_var2idx_dict()
+    key = next(k for k in idx if k.endswith(".V") or k.endswith("/V"))
+    return t_list[0], res_list[0][idx[key]]
+
+
+@pytest.mark.integration
+def test_a_shape_simulates_the_same_as_the_subexperiments_it_replaces(paced_cellml):
+    """The claim the feature rests on. One sub-experiment driven by a shape and
+    five sub-experiments holding the same levels are two spellings of one
+    protocol; if they simulated differently, the shape would be a new protocol
+    wearing the old one's numbers."""
+    import numpy as np
+
+    shaped = {
+        "pre_times": [0.0],
+        "sim_times": [[500.0]],
+        "params_to_change": {"engine/pace": [["stim"]]},
+        "protocol_shapes": {
+            "stim": {
+                "events": [
+                    {"level": 1.0, "start": 100, "length": 2, "period": 200, "multiplier": 0}
+                ]
+            }
+        },
+    }
+    expanded = {
+        "pre_times": [0.0],
+        "sim_times": [[100.0, 2.0, 198.0, 2.0, 198.0]],
+        "params_to_change": {"engine/pace": [[0.0, 1.0, 0.0, 1.0, 0.0]]},
+    }
+
+    t_shape, v_shape = _run(paced_cellml, shaped)
+    t_sub, v_sub = _run(paced_cellml, expanded)
+
+    # Compared on a common grid: the two runs report at different instants
+    # because the sub-experiment version restarts the solver at every boundary.
+    grid = np.linspace(0, 500, 501)
+    on_shape = np.interp(grid, t_shape, v_shape)
+    on_sub = np.interp(grid, t_sub, v_sub)
+    assert np.max(np.abs(on_shape - on_sub)) < 1e-3 * max(1.0, np.ptp(on_sub))
+
+
+@pytest.mark.integration
+def test_the_runner_reports_the_variables_it_returns_after_a_pace_rebind(paced_cellml):
+    """Binding `pace` rebuilds the simulation and reorders the result rows. The
+    runner's name->index map is built before that, so leaving it stale made every
+    variable read as its neighbour -- a wrong answer with no error anywhere."""
+    import numpy as np
+
+    shaped = {
+        "pre_times": [0.0],
+        "sim_times": [[500.0]],
+        "params_to_change": {"engine/pace": [["stim"]]},
+        "protocol_shapes": {
+            "stim": {"events": [{"level": 1.0, "start": 100, "length": 2, "period": 200}]}
+        },
+    }
+    _t, v = _run(paced_cellml, shaped)
+    # V starts at -80 and is driven upward by the stimulus; the pace variable
+    # itself only ever sits between 0 and 1, so reading the wrong row is obvious.
+    assert np.min(v) < -1.0
+    assert np.max(v) > 1.0

--- a/tutorial/docs/parameter-identification.md
+++ b/tutorial/docs/parameter-identification.md
@@ -64,6 +64,44 @@ is mainly used to simulate for an amout of time to reach steady state or periodi
 - **params_to_change**: A dictionary where the key is a parameter name and the entry is the assigned value of that parameter in each (experiment_idx, subexperiment_idx).
 - **experiment_colors**: The line color for the plots of each experiment. 
 - **experiment_labels**: The label for each experiment, which is used for plotting and naming plots.
+- **protocol_traces** (optional): Named `{"t": [...], "values": [...]}` waveforms. A `params_to_change`
+entry may be the *name* of one instead of a number, and the parameter then follows that waveform over the
+subexperiment rather than being held constant.
+- **protocol_shapes** (optional): The same thing written as events rather than as a table of points --
+see below. A name is defined in `protocol_traces` **or** in `protocol_shapes`, whichever suits; both are
+referred to from `params_to_change` the same way.
+
+#### Time-varying inputs: protocol_shapes
+
+A stimulus is easier to write as "1 unit, 2 ms long, every 1000 ms" than as the forty numbers that
+describes. `protocol_shapes` takes the first form, using the same five fields as a Myokit `.mmt`
+`[[protocol]]` table, so a protocol imported from Myokit needs no translation:
+
+```
+# .mmt                                  # obs_data.json
+# Level  Start  Length  Period  Mult    "protocol_shapes": {
+  1.0    100    2       1000    0           "stim": {"events": [{"level": 1.0, "start": 100,
+                                                                "length": 2, "period": 1000,
+                                                                "multiplier": 0}]}
+                                        },
+                                        "params_to_change": {"membrane/stim": [["stim"]]}
+```
+
+- **level** — the value the parameter takes during the event; outside every event it takes **baseline**
+(default `0`).
+- **start**, **length** — when the event begins and how long it lasts. `duration` is accepted as a synonym
+for `length` (it is what Myokit's Python API calls it).
+- **period** — how often it repeats; `0` means it happens once.
+- **multiplier** — how many times it repeats; `0` means "for as long as the subexperiment runs", so the
+number of beats follows `sim_times` rather than having to be counted out by hand.
+
+A shape is expanded over the subexperiment that refers to it, so its length comes from `sim_times`. Give
+the shape its own `duration` if you want to override that, which is also how a shape shared between
+subexperiments of different lengths is disambiguated. Overlapping events are rejected, as they are in
+Myokit, and so is a stimulus that never fires inside the time it is run over.
+
+The expansion happens when the file is read, so everything downstream -- the solvers, the plots -- sees an
+ordinary `protocol_traces` entry and behaves exactly as it would have if you had written the points out.
 
 ### data items
 Examples of `obs_data.json`, `data_item` entries are shown in below figures for constant, constant with operation_kwargs, series, and frequency data types, respectively. 

--- a/tutorial/docs/parameter-identification.md
+++ b/tutorial/docs/parameter-identification.md
@@ -100,6 +100,16 @@ the shape its own `duration` if you want to override that, which is also how a s
 subexperiments of different lengths is disambiguated. Overlapping events are rejected, as they are in
 Myokit, and so is a stimulus that never fires inside the time it is run over.
 
+A step and a single pulse are just pacing events that do not repeat: a step is `{"level": v, "start": ts,
+"length": <rest of the subexperiment>, "period": 0}` over a `baseline`, and a pulse is the same with a
+shorter `length`. A linear sweep is not a square event, so it has its own type:
+
+```json
+"protocol_shapes": { "load": {"type": "ramp", "from": 0.0, "to": 5.0} }
+```
+
+which runs from `from` at the start of the subexperiment to `to` at its end.
+
 The expansion happens when the file is read, so everything downstream -- the solvers, the plots -- sees an
 ordinary `protocol_traces` entry and behaves exactly as it would have if you had written the points out.
 


### PR DESCRIPTION
`protocol_traces` lets a `params_to_change` entry name an arbitrary `{t, values}` waveform. That is completely general and close to unwritable by hand: a 1 Hz stimulus over ten beats is a forty-point table in which every number has to be right, and changing the period means rebuilding the table rather than editing a field.

`protocol_shapes` is the same waveform written the way Myokit's `[[protocol]]` section writes it — one line per event, in the same five columns:

```
# .mmt                                 # obs_data.json
# Level Start Length Period Mult       "protocol_shapes": {
  1.0   100   2      1000   0            "stim": {"events": [{"level": 1.0, "start": 100,
                                                              "length": 2, "period": 1000,
                                                              "multiplier": 0}]}
                                       },
                                       "params_to_change": {"engine/pace": [["stim"]]}
```

The field names are Myokit's deliberately. A model imported from a `.mmt` carries its protocol in exactly this vocabulary, and someone who has written one shouldn't have to learn a second name for `Length` (`duration` is accepted as a synonym, since that's what Myokit's Python API calls it).

**The two are alternatives, not layers.** A name is defined in `protocol_traces` **or** `protocol_shapes`, and `params_to_change` refers to it the same way either way. Shapes expand into traces at parse time, so the solvers, the plotting and anything added later keep seeing the traces they already understand — nothing downstream knows shapes exist. Expansion is idempotent, because the same `protocol_info` is passed between the parser, the runner and the solver helper, and any of them may be the first to see it.

A shape is **sized by the sub-experiment that references it**, so the number of beats follows `sim_times` rather than being counted out by hand. `multiplier: 0` means "for as long as this sub-experiment runs", as in Myokit.

Ambiguity is refused rather than guessed at: a shape used at two different lengths, a shape nobody references, overlapping events (Myokit rejects those too), and a stimulus that never fires inside the time it's run over — that last being the failure hardest to notice, since it yields a flat line that looks like a protocol.

## Three fixes it needed to work end to end

- **`ProtocolRunner` never told its helper what protocol it was running**, so a `params_to_change` entry naming a *trace* died with `params_to_change entry is a string trace key, but protocol_traces not found in protocol_info`. Traces were unusable through this path before shapes existed.
- **Binding `pace` rebuilds the simulation and reorders the result rows**, but the runner's name→index map is built in `__init__`. Left stale, every variable silently read as its neighbour — a wrong answer with no error anywhere. Found because a paced model came back flat at 0.4 mV instead of spanning −84.6 to 32.7.
- **An obs_data with no `data_items` crashed the parser** with `KeyError: 'variable'`. A protocol-only file — one saying how to drive a model but not yet what to measure — is a reasonable thing to have, and is exactly what a shapes-based protocol looks like before its targets are added.

## Tests

39, in `tests/test_protocol_shapes.py`.

The load-bearing one runs a paced model **twice** — once driven by a shape, once by the five sub-experiments it replaces — and requires the two voltage traces to agree. They are two spellings of one protocol; if they simulated differently, the shape would be a new protocol wearing the old one's numbers. On `br-1977` the two agree exactly: identical range and upstrokes at 101.9 and 1101.9 ms.

Four more check the expansion against **Myokit's own `Protocol.log_for_interval`** across periodic, counted, negative-level and single-shot events, so the shared vocabulary provably means the same thing in both. Both regressions above have tests that fail without their fix (verified by reverting each).

Existing suite: `-m "not slow and not integration and not compare_optimisers"` → 182 passed, 4 skipped. The one failure, `test_python_BDF_solver[SN_simple]`, reproduces on `master` with this branch stashed — pre-existing, not from this change.

Docs: `tutorial/docs/parameter-identification.md` (user-facing, with the `.mmt` correspondence) and `CLAUDE.md` (the expansion point, so new shape types get added there rather than taught to the solvers).