### PR TITLE
feat(aadc): stiff ODE support (bdf_tape + bdf_kernel), rebased, with the BDF methods advertised as AD-suitable

### DIFF
--- a/benchmarks/aadc_3compartment_results.md
+++ b/benchmarks/aadc_3compartment_results.md
@@ -67,9 +67,30 @@ All 4 parameters verified at nominal values with central FD (h=1e-6):
 
 AADC **16-20× faster** than both FD and CasADi on non-stiff models.
 
-### Next steps to close the gap with CasADi on stiff models
+### Tape approach: semi-implicit on AADC tape (2026-07-24, proof-of-concept)
 
-1. **Skip early warmup sensitivity**: first ~90% of warmup reaches steady state; only last few cardiac cycles matter. Could save 9× on warmup dfdp evals.
-2. **Batch VFJ**: vectorize kernel replay across sub-steps (reduce Python overhead)
-3. **C++ Newton loop**: move Newton + IFT to C++ to eliminate Python per-step overhead
-4. **AADC tape for compute_variables**: replace FD chain rule with AD for var obs
+**Key insight**: record entire BDF integration as idouble operations on one AADC tape.
+Forward+reverse replay in C++ eliminates Python loop overhead.
+
+| Metric | Python IFT | **Tape semi-implicit** | CasADi |
+|--------|-----------|----------------------|--------|
+| Per eval | 46s | **2.2s** | 2s |
+| Gradient AD/FD | 1.000 | **1.000** | 1.000 |
+| Forward error | 0% | 0.97% | 0% |
+| Recording | 0 | 10 min (one-time) | 0 |
+
+**Profiling breakdown** (Python IFT bottleneck):
+- aadc.evaluate × 22000: 19s (41%)
+- dfdp dict→numpy: 5.5s (12%)
+- Python loop overhead: 20s (43%)
+
+**Tape approach eliminates all three** — entire integration replays in compiled C++.
+
+**Sparsity**: Jacobian 10% non-zero, 6 colors → 4.5× FD speedup.
+Semi-implicit (diagonal J only) avoids GE and LU entirely.
+
+### Next steps
+
+1. **Integrate tape semi-implicit into optimizer pipeline** — record once, replay per call
+2. **Full Newton on tape** — needs pivoted GE with aadc.iif (complex but possible)
+3. **AADC tape for compute_variables**: replace FD chain rule with AD for var obs

--- a/benchmarks/aadc_3compartment_results.md
+++ b/benchmarks/aadc_3compartment_results.md
@@ -1,0 +1,50 @@
+# AADC 3compartment Benchmark Results
+
+Date: 2026-07-23
+Branch: feat/aadc-algebraic-obs
+
+## Fair Comparison (same problem, same optimizer)
+
+3compartment cardiovascular model, 27 states, 4 params, pre_time=20s, sim_time=2s.
+Optimizer: multi-start L-BFGS-B, 1 start, seed=0, 200 max calls.
+
+### Results
+
+| Method | Solver | Gradient | Cost | Time | Notes |
+|--------|--------|----------|------|------|-------|
+| **CasADi BDF** | CasADi symbolic BDF2, dt_internal=0.001 | CasADi reverse AD | **0.0228** | **3.5 min** | Reference |
+| **AADC bdf_newton** | Newton BDF1 + VFJ, dt_internal=0.001 | AADC IFT | **0.0797** | **10 min** | Our approach |
+| bdf_newton + FD | Newton BDF1 + VFJ, dt_internal=0.001 | Finite differences | 0.161 | 25 min | Same solver, FD |
+
+### Analysis
+
+- **AADC vs FD (same solver)**: AADC **2.5× faster**, **2× better cost**. Exact gradient → better convergence.
+- **CasADi vs AADC**: CasADi **2.8× faster**, **3.5× better cost**.
+  - BDF2 (2nd order) vs BDF1 (1st order) → CasADi more accurate at same dt
+  - CasADi symbolic `mapaccum` vs Python loop → no Python overhead per step
+  - CasADi rootfinder optimized, not generic Newton
+
+### Key technical achievements
+
+1. **Forward solve correct**: AADC BDF v[22]=0.000160 matches CVODE (verified)
+2. **Gradient correct**: AD/FD = 1.000 for all 4 params (verified independently)
+3. **`_aadc_passive` fix**: `math.floor(_aadc_passive(x))` → `aadc.math.floor(x)` in code generator — fixes tape replay for models with cardiac valve logic
+4. **VFJ.func optimization**: 35× faster than Python compute_rates → forward from 50s to 9.3s
+5. **IFT sensitivity only during sim_time**: skip warmup → saves 91% of dfdp evaluations
+6. **Architecture**: one small kernel (compute_rates) replayed per step — no huge tape
+
+### FHN Benchmark (non-stiff, for comparison)
+
+| Method | Cost | Time |
+|--------|------|------|
+| FD | 2.66e-03 | 50s |
+| CasADi AD | 5.33e-05 | 44s |
+| **AADC AD** | **6.06e-06** | **2.4s** |
+
+AADC **16-20× faster** than both FD and CasADi on non-stiff models.
+
+### Next steps to close the gap with CasADi on stiff models
+
+1. **BDF2**: implement 2nd order BDF (x_{n+1} = 4/3 x_n - 1/3 x_{n-1} - 2/3 dt f(x_{n+1}))
+2. **Batch VFJ**: vectorize kernel replay across sub-steps
+3. **C++ kernel**: move Newton loop to C++ to eliminate Python overhead

--- a/benchmarks/aadc_3compartment_results.md
+++ b/benchmarks/aadc_3compartment_results.md
@@ -1,36 +1,60 @@
 # AADC 3compartment Benchmark Results
 
-Date: 2026-07-23
+Date: 2026-07-24 (updated)
 Branch: feat/aadc-algebraic-obs
 
 ## Fair Comparison (same problem, same optimizer)
 
 3compartment cardiovascular model, 27 states, 4 params, pre_time=20s, sim_time=2s.
-Optimizer: multi-start L-BFGS-B, 1 start, seed=0, 200 max calls.
+Optimizer: L-BFGS-B, 1 start, seed=0, 200 max calls.
 
-### Results
+### Results (2026-07-24, with all gradient fixes)
 
 | Method | Solver | Gradient | Cost | Time | Notes |
 |--------|--------|----------|------|------|-------|
-| **CasADi BDF** | CasADi symbolic BDF2, dt_internal=0.001 | CasADi reverse AD | **0.0228** | **3.5 min** | Reference |
-| **AADC bdf_newton** | Newton BDF1 + VFJ, dt_internal=0.001 | AADC IFT | **0.0797** | **10 min** | Our approach |
-| bdf_newton + FD | Newton BDF1 + VFJ, dt_internal=0.001 | Finite differences | 0.161 | 25 min | Same solver, FD |
+| **CasADi BDF** | CasADi symbolic BDF2, dt=0.001 | CasADi reverse AD | **0.0228** | **3.5 min** | Reference |
+| **AADC bdf_newton v2** | Newton BDF2 + VFJ, dt=0.001 | AADC IFT (full) | **0.0506** | **34 min** | Correct gradient, all 6 obs |
+| AADC bdf_newton v1 | Newton BDF1 + VFJ, dt=0.001 | AADC IFT (sim only) | 0.0797 | 10 min | Wrong gradient (warmup skipped) |
+| bdf_newton + FD | Newton BDF1 + VFJ, dt=0.001 | Finite differences | 0.161 | 25 min | Same solver, FD |
+
+### Gradient verification (2026-07-24)
+
+All 4 parameters verified at nominal values with central FD (h=1e-6):
+
+| Param | Name | AD/FD ratio |
+|-------|------|-------------|
+| 0 | q_lv_init | **1.0000** |
+| 1 | C (aortic) | **1.0006** |
+| 2 | E_lv_A | **0.9995** |
+| 3 | E_lv_B | **0.9991** |
+
+### Bugs found and fixed (2026-07-24)
+
+1. **Cost=0 (indentation bug)**: operation/cost block was inside `else: continue` — dead code after `continue`. Fix: de-indent one level.
+
+2. **Warmup sensitivity skipped**: `S` was reset to zero at start of sim_time, ignoring that warmup changes the steady state in a parameter-dependent way. Fix: compute IFT sensitivity from step 0.
+
+3. **BDF2 sensitivity formula wrong**: used `S_n` instead of `(4/3)*S_n - (1/3)*S_{n-1}`. Fix: track `S_prev` and use correct BDF2 IFT formula.
+
+4. **Algebraic variable gradient missing**: var observables had `S_series = zeros`. Fix: chain rule `du/dp = (du/dx)*S + du/dp_direct` with FD of `compute_variables`.
+
+5. **Initial state param gradient = 0**: `q_lv_init` sets state `q_lv` at t=0, but `S(0) = 0`. Fix: initialize `S[state_idx, param_idx] = 1` for `*_init` parameters.
 
 ### Analysis
 
-- **AADC vs FD (same solver)**: AADC **2.5× faster**, **2× better cost**. Exact gradient → better convergence.
-- **CasADi vs AADC**: CasADi **2.8× faster**, **3.5× better cost**.
-  - BDF2 (2nd order) vs BDF1 (1st order) → CasADi more accurate at same dt
-  - CasADi symbolic `mapaccum` vs Python loop → no Python overhead per step
-  - CasADi rootfinder optimized, not generic Newton
+- **v2 vs v1**: correct gradient → better convergence (cost 0.0506 vs 0.0797), but 3.4× slower (warmup sensitivity = 20000 extra dfdp evals)
+- **CasADi vs AADC v2**: CasADi **2.2× better cost**, **10× faster**
+  - BDF2 forward accuracy identical (both use BDF2 now)
+  - Speed gap: CasADi symbolic `mapaccum` vs Python loop + AADC evaluate per step
+  - Cost gap: CasADi gradient is exact (symbolic reverse AD), AADC gradient has small FD error in var obs chain rule
 
 ### Key technical achievements
 
 1. **Forward solve correct**: AADC BDF v[22]=0.000160 matches CVODE (verified)
 2. **Gradient correct**: AD/FD = 1.000 for all 4 params (verified independently)
-3. **`_aadc_passive` fix**: `math.floor(_aadc_passive(x))` → `aadc.math.floor(x)` in code generator — fixes tape replay for models with cardiac valve logic
-4. **VFJ.func optimization**: 35× faster than Python compute_rates → forward from 50s to 9.3s
-5. **IFT sensitivity only during sim_time**: skip warmup → saves 91% of dfdp evaluations
+3. **`_aadc_passive` fix**: `math.floor(_aadc_passive(x))` → `aadc.math.floor(x)` in code generator
+4. **VFJ.func optimization**: 35× faster than Python compute_rates
+5. **Full IFT sensitivity**: warmup + BDF2 formula + algebraic vars + initial state params
 6. **Architecture**: one small kernel (compute_rates) replayed per step — no huge tape
 
 ### FHN Benchmark (non-stiff, for comparison)
@@ -45,6 +69,7 @@ AADC **16-20× faster** than both FD and CasADi on non-stiff models.
 
 ### Next steps to close the gap with CasADi on stiff models
 
-1. **BDF2**: implement 2nd order BDF (x_{n+1} = 4/3 x_n - 1/3 x_{n-1} - 2/3 dt f(x_{n+1}))
-2. **Batch VFJ**: vectorize kernel replay across sub-steps
-3. **C++ kernel**: move Newton loop to C++ to eliminate Python overhead
+1. **Skip early warmup sensitivity**: first ~90% of warmup reaches steady state; only last few cardiac cycles matter. Could save 9× on warmup dfdp evals.
+2. **Batch VFJ**: vectorize kernel replay across sub-steps (reduce Python overhead)
+3. **C++ Newton loop**: move Newton + IFT to C++ to eliminate Python per-step overhead
+4. **AADC tape for compute_variables**: replace FD chain rule with AD for var obs

--- a/src/generators/PythonGenerator.py
+++ b/src/generators/PythonGenerator.py
@@ -113,19 +113,24 @@ class _AadcCompatTransformer(ast.NodeTransformer):
                                      attr='math', ctx=ast.Load()),
                 attr=node.func.attr, ctx=ast.Load())
             return node
-        # bare floor(x) → math.floor(_aadc_passive(x))
+        # bare floor(x) → aadc.math.floor(x)
+        # aadc.math.floor works with both float and idouble, and updates
+        # correctly on tape replay (unlike math.floor(_aadc_passive(x))
+        # which baked the value at recording time).
         if isinstance(node.func, ast.Name) and node.func.id == 'floor':
-            node.func = ast.Attribute(value=ast.Name(id='math', ctx=ast.Load()),
-                                       attr='floor', ctx=ast.Load())
-            node.args = [ast.Call(func=ast.Name(id='_aadc_passive', ctx=ast.Load()),
-                                  args=node.args, keywords=[])]
+            node.func = ast.Attribute(
+                value=ast.Attribute(value=ast.Name(id='aadc', ctx=ast.Load()),
+                                    attr='math', ctx=ast.Load()),
+                attr='floor', ctx=ast.Load())
             return node
-        # math.floor(x) → math.floor(_aadc_passive(x))
+        # math.floor(x) → aadc.math.floor(x)
         if (isinstance(node.func, ast.Attribute) and
             isinstance(node.func.value, ast.Name) and
             node.func.value.id == 'math' and node.func.attr == 'floor'):
-            node.args = [ast.Call(func=ast.Name(id='_aadc_passive', ctx=ast.Load()),
-                                  args=node.args, keywords=[])]
+            node.func = ast.Attribute(
+                value=ast.Attribute(value=ast.Name(id='aadc', ctx=ast.Load()),
+                                    attr='math', ctx=ast.Load()),
+                attr='floor', ctx=ast.Load())
             return node
         # pow(x, 2.0) → x * x
         if isinstance(node.func, ast.Name) and node.func.id == 'pow' and len(node.args) == 2:

--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -103,24 +103,32 @@ def cost_and_grad(pid, param_vals):
     # being minimised, so the optimiser would descend the wrong cost. Refuse rather than
     # silently mislead. (Fully supporting algebraic observables needs the algebraic variables
     # recomputed on the tape from the state trajectory, tracked in issue #258.)
-    def _operand_is_state(op):
-        # _resolve_name is authoritative. There used to be a fallback here matching the
-        # operand's leaf name (op.split('/')[-1]) against every state name, which could
-        # declare an *algebraic* observable tapeable purely because some unrelated
-        # component happened to own a state with the same leaf -- e.g. observable
-        # 'pulmonary_artery/v' matching state 'heart/v'. That suppressed the untapeable
-        # check below, and _resolve_state_idx's matching fallback then bound the tape to
-        # the first state with that leaf: a different variable entirely. Because both the
-        # tape cost and its gradient used the wrong variable they agreed with each other,
-        # so AD-vs-FD checks passed and the optimiser converged cleanly onto a fit of a
-        # variable the user never asked for.
-        kind, _ = pid.sim_helper._resolve_name(op)
-        return kind == 'state'
+    def _operand_is_tapeable(op):
+        """Check if an operand can be represented on the AADC tape.
 
-    supported_const_ops = (None, 'max', 'min', 'mean')
+        Returns True for states (directly on tape) and algebraic variables
+        (computable from states via compute_variables on tape).
+        """
+        kind, _ = pid.sim_helper._resolve_name(op)
+        return kind in ('state', 'var')
+
+    supported_const_ops = (None, 'max', 'min', 'mean', 'max_minus_min')
     operand_names_o = pid.obs_info.get("operands", []) if pid.obs_info else []
     operations_o = pid.obs_info.get("operations", []) if pid.obs_info else []
     data_types_o = pid.obs_info.get("data_types", []) if pid.obs_info else []
+
+    # Collect which algebraic variable indices are needed on tape
+    needed_var_indices = set()
+    for jj in range(len(operand_names_o)):
+        op = operand_names_o[jj][0] if isinstance(operand_names_o[jj], (list, tuple)) \
+            else operand_names_o[jj]
+        kind, idx = pid.sim_helper._resolve_name(op)
+        if kind == 'var':
+            needed_var_indices.add(idx)
+    needed_var_indices = sorted(needed_var_indices)
+    # Store on sim_helper so the tape recording can use it
+    pid.sim_helper._needed_var_indices = needed_var_indices
+
     untaped = []
     for jj in range(len(operand_names_o)):
         op = operand_names_o[jj][0] if isinstance(operand_names_o[jj], (list, tuple)) \
@@ -128,26 +136,19 @@ def cost_and_grad(pid, param_vals):
         dtype = data_types_o[jj] if jj < len(data_types_o) else 'constant'
         oper = operations_o[jj] if jj < len(operations_o) else None
         if dtype == 'constant':
-            if not _operand_is_state(op) or oper not in supported_const_ops:
+            if not _operand_is_tapeable(op) or oper not in supported_const_ops:
                 untaped.append(f"{op} (op={oper})")
         elif dtype == 'series':
-            if not _operand_is_state(op):
+            if not _operand_is_tapeable(op):
                 untaped.append(f"{op} (series)")
         else:
             untaped.append(f"{op} (data_type={dtype})")
     if untaped:
         raise NotImplementedError(
             f"AADC is not usable with this observable set: {len(untaped)} of "
-            f"{len(operand_names_o)} observable(s) cannot be represented on the AADC tape "
-            f"(operand is an algebraic variable rather than a state, or the operation is "
-            f"unsupported such as max_minus_min): {untaped}. The current AADC wrapper can "
-            f"only tape observables whose operand is a state with a max/min/mean operation "
-            f"(or a state series). Taping these would silently minimise a reduced cost, not "
-            f"the one the optimiser evaluates. Support for algebraic-variable observables and "
-            f"max_minus_min on the tape is tracked in issue #258. For a correct gradient on "
-            f"these observables now, use model_type 'casadi_python' (solver_info method "
-            f"'bdf') or a Myokit CVODES FSA run (model_type 'cellml_only', solver "
-            f"'CVODE_myokit', do_ad true).")
+            f"{len(operand_names_o)} observable(s) cannot be represented on the AADC tape: "
+            f"{untaped}. Supported: state or algebraic-variable operands with "
+            f"max/min/mean/max_minus_min operations (or series).")
 
     weighted_obs_denominator = 0
     if pid._num_weighted_obs_by_exp_sub is not None:
@@ -155,7 +156,7 @@ def cost_and_grad(pid, param_vals):
             for sub_idx in range(num_sub_per_exp[exp_idx]):
                 weighted_obs_denominator += pid._num_weighted_obs_by_exp_sub[exp_idx][sub_idx]
 
-    def cost_on_tape(states_idouble, params_idouble, trajectory=None):
+    def cost_on_tape(states_idouble, params_idouble, trajectory=None, var_trajectory=None):
         import aadc as _aadc
         from param_id.math_backend import make_math_backend
         mb = make_math_backend("aadc")
@@ -196,11 +197,18 @@ def cost_and_grad(pid, param_vals):
         # see _operand_is_state for why the leaf-name fallback that used to live here was
         # removed (it could bind the tape to a same-leaf state in an unrelated component,
         # consistently in both cost and gradient, so nothing downstream could detect it).
-        def _resolve_state_idx(op_name):
+        def _resolve_obs_idx(op_name):
+            """Resolve operand to (source, index) where source is 'state' or 'var'.
+
+            For states: index into states array.
+            For vars: index into the var_trajectory (position in needed_var_indices).
+            """
             kind, resolved_idx = sim_helper._resolve_name(op_name)
             if kind == "state":
-                return resolved_idx
-            return None
+                return ('state', resolved_idx)
+            if kind == "var" and resolved_idx in needed_var_indices:
+                return ('var', needed_var_indices.index(resolved_idx))
+            return (None, None)
 
         gt_series = obs_info.get("ground_truth_series", [])
         std_series = obs_info.get("std_series_vec", [])
@@ -215,24 +223,38 @@ def cost_and_grad(pid, param_vals):
         for jj in range(len(operand_names)):
             op_name = operand_names[jj][0] if isinstance(operand_names[jj], (list, tuple)) else operand_names[jj]
             operation = operations[jj]
-            si = _resolve_state_idx(op_name)
+            source, si = _resolve_obs_idx(op_name)
 
             if data_types[jj] == 'constant':
-                if const_idx >= len(gt_const) or si is None:
+                if const_idx >= len(gt_const) or source is None:
                     const_idx += 1
                     continue
 
                 # Apply operation to trajectory
-                if trajectory is not None and operation in ('max', 'min', 'mean'):
-                    series_vals = [trajectory[t][si] for t in range(len(trajectory))]
+                if trajectory is not None and operation in ('max', 'min', 'mean', 'max_minus_min'):
+                    if source == 'state':
+                        series_vals = [trajectory[t][si] for t in range(len(trajectory))]
+                    elif source == 'var' and var_trajectory is not None:
+                        series_vals = [var_trajectory[t][si] for t in range(len(var_trajectory))]
+                    else:
+                        const_idx += 1
+                        continue
                     if operation == 'max':
                         obs_val = mb.max(series_vals)
                     elif operation == 'min':
                         obs_val = mb.min(series_vals)
                     elif operation == 'mean':
                         obs_val = mb.mean(series_vals)
+                    elif operation == 'max_minus_min':
+                        obs_val = mb.max(series_vals) - mb.min(series_vals)
                 else:
-                    obs_val = states_idouble[si]
+                    if source == 'state':
+                        obs_val = states_idouble[si]
+                    elif source == 'var' and var_trajectory is not None and len(var_trajectory) > 0:
+                        obs_val = var_trajectory[-1][si]  # final value
+                    else:
+                        const_idx += 1
+                        continue
 
                 gt_val = _aadc.idouble(float(gt_const[const_idx]))
                 std_val = _aadc.idouble(float(std_const[const_idx]))
@@ -243,7 +265,7 @@ def cost_and_grad(pid, param_vals):
 
             elif data_types[jj] == 'series':
                 # Series: compare trajectory at each time point
-                if trajectory is None or si is None:
+                if trajectory is None or source is None:
                     series_idx += 1
                     continue
                 if series_idx >= len(gt_series):
@@ -271,18 +293,22 @@ def cost_and_grad(pid, param_vals):
                     n_traj = len(trajectory)
                     n_pts = 0
                     terms = []
+                    traj_src = trajectory if source == 'state' else var_trajectory
+                    if traj_src is None:
+                        series_idx += 1
+                        continue
                     for k in range(len(gt_s)):
                         pos = k * obs_dt_s / sim_dt
                         lower = int(np.floor(pos))
                         if lower >= n_traj - 1:
                             if lower == n_traj - 1 and abs(pos - lower) < 1e-9:
-                                sim_val = trajectory[lower][si]
+                                sim_val = traj_src[lower][si]
                             else:
                                 break  # past the end of the simulation: no data to compare
                         else:
                             frac = pos - lower
-                            sim_val = (trajectory[lower][si] * _aadc.idouble(1.0 - frac)
-                                       + trajectory[lower + 1][si] * _aadc.idouble(frac))
+                            sim_val = (traj_src[lower][si] * _aadc.idouble(1.0 - frac)
+                                       + traj_src[lower + 1][si] * _aadc.idouble(frac))
                         terms.append((sim_val, float(gt_s[k]), float(std_raw[k])))
                         n_pts += 1
 

--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -394,6 +394,7 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
     request_dfdp = {r: a_p for r in r_r}
     need_sensitivity = False
     eye_n = np.eye(n)
+    x_prev = None  # for BDF2
 
     for step in range(total_steps):
         if step == pre_steps:
@@ -403,15 +404,20 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
         for sub in range(n_sub):
             y = x.copy()
             lu_piv = None
+            use_bdf2 = x_prev is not None
 
             for nit in range(max_newton):
-                # VFJ.func is 35× faster than Python compute_rates
                 rates_arr = vfj.func(y)
-                F = y - x - idt * rates_arr
+                if use_bdf2:
+                    F = y - (4.0/3.0) * x + (1.0/3.0) * x_prev - (2.0/3.0) * idt * rates_arr
+                    jac_coeff = 2.0 / 3.0
+                else:
+                    F = y - x - idt * rates_arr
+                    jac_coeff = 1.0
                 if np.max(np.abs(F)) < newton_tol:
                     break
                 J_rhs = vfj.jac(y)
-                J_g = eye_n - idt * J_rhs
+                J_g = eye_n - jac_coeff * idt * J_rhs
                 try:
                     lu_piv = lu_factor(J_g)
                     dy = lu_solve(lu_piv, -F)
@@ -419,7 +425,7 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
                     break
                 y += dy
 
-            # IFT sensitivity only during sim_time (skip warmup)
+            # IFT sensitivity only during sim_time
             if need_sensitivity and lu_piv is not None:
                 inputs = dict(inputs_template)
                 for i in range(n):
@@ -429,12 +435,13 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
                 for i in range(n):
                     for k in range(n_p):
                         dfdp[i, k] = float(np.asarray(res_eval[1][r_r[i]][a_p[k]]).flat[0])
-                rhs_S = S + idt * dfdp
+                rhs_S = S + jac_coeff * idt * dfdp
                 for k in range(n_p):
                     S[:, k] = lu_solve(lu_piv, rhs_S[:, k])
 
             for z in zeta_indices:
                 y[z] = max(0.0, min(1.0, y[z]))
+            x_prev = x.copy()
             x = y.copy()
 
         if step >= pre_steps:

--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -22,34 +22,21 @@ import numpy as np
 # it, so the advertised menu and the check enforced here cannot drift (issue #336). Re-exported
 # under the original name for callers that already import it from this module.
 from parsers.PrimitiveParsers import AADC_TAPE_CONSISTENT_METHODS as TAPE_CONSISTENT_METHODS
+BDF_NEWTON_METHOD = 'bdf_newton'
 
 
 def cost_and_grad(pid, param_vals):
-    """Compute J(p) and ∇J(p) via AADC tape: forward solve + cost on tape, reverse pass.
+    """Compute J(p) and ∇J(p) via AADC.
 
-    Uses sim_helper.compute_gradient_tape() which records the entire ODE
-    integration + cost function on an AADC tape and gets the gradient via
-    one reverse pass. Requires a tape-compatible solver (implicit_euler_ift
-    or semi_implicit).
+    For tape-consistent methods (rk4, semi_implicit, etc.): records the entire
+    ODE integration + cost on an AADC tape and gets the gradient via one reverse pass.
+
+    For bdf_newton: uses Newton forward solve with VFJ Jacobian + accumulated IFT
+    sensitivity. No full tape — just a small kernel for compute_rates, replayed per step.
+    This is the AADC analogue of CasADi's symbolic BDF with rootfinder + IFT.
     """
-    # The AADC tape must integrate the same discrete system as the forward solve, or the
-    # gradient is the exact gradient of a *different* function than the cost. The tape has
-    # to replay a fixed sequence of operations, so it can only record fixed-step schemes:
-    # 'rk4' (its default), 'implicit_euler_ift' and 'semi_implicit'. sim_helper.run() with
-    # 'adaptive_rk45' or 'bdf' integrates something else entirely, and the tape then quietly
-    # falls back to RK4 -- measured on Lotka-Volterra, that gave AD/FD = [1.79, 1.96, 1.32,
-    # -0.067], the last with the wrong sign. Refuse instead.
-    method = pid.sim_helper.solver_info.get('method', 'adaptive_rk45')
-    if method not in TAPE_CONSISTENT_METHODS:
-        raise ValueError(
-            f"solver method '{method}' cannot be recorded on an AADC tape, so the forward "
-            f"solve and the gradient would integrate different systems. With do_ad, use one "
-            f"of {list(TAPE_CONSISTENT_METHODS)} (fixed-step, and what the tape records) "
-            f"-- an adaptive integrator chooses its steps from the state, so its step "
-            f"sequence changes with the parameters and cannot be taped. Or turn off do_ad.")
-
+    # Common setup: resolve param names and set values
     param_names_raw = pid.param_id_info["param_names"]
-    # param_names may be lists of strings (e.g. [['alpha_Lotka_Volterra']]) — flatten
     param_names = []
     for pn in param_names_raw:
         if isinstance(pn, (list, tuple)):
@@ -57,22 +44,28 @@ def cost_and_grad(pid, param_vals):
         else:
             param_names.append(pn)
 
-    # Set up AD parameter tracking on the simulation helper
     pid.sim_helper.set_param_vals(param_names_raw, param_vals)
     pid.sim_helper._ad_param_names = list(param_names)
 
-    # Map param names to variable indices using sim_helper's name resolver
     ad_indices = []
     for pname in param_names:
         kind, idx = pid.sim_helper._resolve_name(pname)
         if kind == "var":
             ad_indices.append(idx)
         elif kind == "state":
-            raise ValueError(f"Param '{pname}' resolves to a state, not a variable. "
-                             "AADC gradient currently supports variable parameters only.")
+            raise ValueError(f"Param '{pname}' resolves to a state, not a variable.")
         else:
             raise ValueError(f"Param '{pname}' not found by name resolver.")
     pid.sim_helper._ad_param_var_indices = ad_indices
+
+    method = pid.sim_helper.solver_info.get('method', 'adaptive_rk45')
+    if method == BDF_NEWTON_METHOD:
+        return _cost_and_grad_bdf_newton(pid, param_vals)
+    if method not in TAPE_CONSISTENT_METHODS:
+        raise ValueError(
+            f"solver method '{method}' cannot be recorded on an AADC tape, so the forward "
+            f"solve and the gradient would integrate different systems. With do_ad, use one "
+            f"of {list(TAPE_CONSISTENT_METHODS)} or '{BDF_NEWTON_METHOD}' (for stiff models).")
 
     # Build cost function that works with idouble on tape.
     # Receives: final state (list of idouble), params (list of idouble),
@@ -332,3 +325,131 @@ def cost_and_grad(pid, param_vals):
     # Run forward + reverse on AADC tape. Both the cost and the gradient come out of the
     # same evaluation, so get_cost_aadc and get_jac_cost_aadc cannot drift apart.
     return pid.sim_helper.compute_cost_and_gradient_tape(cost_on_tape)
+
+
+def _cost_and_grad_bdf_newton(pid, param_vals):
+    """BDF Newton gradient via accumulated IFT sensitivity.
+
+    Forward: Newton implicit Euler with VFJ Jacobian (Python compute_rates,
+    AADC adjoint for df/dy). Gradient: forward sensitivity S = dx/dp
+    accumulated per step via IFT: S_{n+1} = (I - dt*J)^{-1} * (S_n + dt*df/dp).
+    Uses the same LU factorization as Newton → no extra ill-conditioning.
+
+    Verified: AD/FD = 1.000 on 3compartment (27 states, 4 params, 22000 steps).
+    """
+    import aadc
+    from scipy.linalg import lu_factor, lu_solve
+
+    sim_helper = pid.sim_helper
+    n = sim_helper.STATE_COUNT
+    dt = sim_helper.dt
+    total_steps = sim_helper.pre_steps + sim_helper.n_steps
+    pre_steps = sim_helper.pre_steps
+
+    # Set parameter values
+    param_names_raw = pid.param_id_info["param_names"]
+    param_names = []
+    for pn in param_names_raw:
+        param_names.append(pn[0] if isinstance(pn, (list, tuple)) else pn)
+
+    variables_all = list(sim_helper._numeric_variables_all)
+    for ci, idx in enumerate(sim_helper.constant_indices):
+        variables_all[idx] = sim_helper.variables[ci]
+
+    ad_indices = sim_helper._ad_param_var_indices
+    n_p = len(ad_indices)
+    for i, idx in enumerate(ad_indices):
+        variables_all[idx] = float(param_vals[i])
+    p_vals = [float(param_vals[i]) for i in range(n_p)]
+
+    # Build VFJ kernel if needed
+    sim_helper._integrate_bdf_newton(sim_helper.states, variables_all, 0, dt)  # init VFJ
+
+    vfj = sim_helper._bdf_vfj
+    vfj.set_params(np.array(p_vals))
+    rhs_f = sim_helper._bdf_rhs_f
+    a_p = sim_helper._bdf_a_p
+    a_x = sim_helper._bdf_a_x
+    r_r = sim_helper._bdf_r_r
+    workers = sim_helper._aad_workers
+
+    # Sub-stepping
+    max_step = float(sim_helper.solver_info.get('max_step', 0.001))
+    n_sub = max(1, int(np.ceil(dt / max_step)))
+    idt = dt / n_sub
+    max_newton = 4
+    newton_tol = 1e-10
+
+    zeta_indices = [i for i, info in enumerate(sim_helper.model.STATE_INFO)
+                    if 'zeta' in info.get('name', '').lower()]
+
+    # Forward + accumulated sensitivity
+    x = np.array(sim_helper.states[:n], dtype=float)
+    S = np.zeros((n, n_p))  # accumulated dx/dp
+    traj_sim = []
+
+    for step in range(total_steps):
+        for sub in range(n_sub):
+            t = step * dt + sub * idt
+            y = x.copy()
+            lu_piv = None
+
+            for nit in range(max_newton):
+                rates = [0.0] * n
+                sim_helper.model.compute_rates(t + idt, list(y), rates, list(variables_all))
+                F = y - x - idt * np.array(rates)
+                if np.max(np.abs(F)) < newton_tol:
+                    break
+                J_rhs = vfj.jac(y)
+                J_g = np.eye(n) - idt * J_rhs
+                try:
+                    lu_piv = lu_factor(J_g)
+                    dy = lu_solve(lu_piv, -F)
+                except np.linalg.LinAlgError:
+                    break
+                y += dy
+
+            # IFT sensitivity: S_{n+1} = (dg/dx)^{-1} * (S_n + idt * df/dp)
+            if lu_piv is not None:
+                inputs = {}
+                for i in range(n):
+                    inputs[a_x[i]] = float(y[i])
+                for k in range(n_p):
+                    inputs[a_p[k]] = p_vals[k]
+                res_eval = aadc.evaluate(rhs_f, {r: a_p for r in r_r}, inputs, workers)
+                dfdp = np.zeros((n, n_p))
+                for i in range(n):
+                    for k in range(n_p):
+                        dfdp[i, k] = float(np.asarray(res_eval[1][r_r[i]][a_p[k]]).flat[0])
+                rhs_S = S + idt * dfdp
+                for k in range(n_p):
+                    S[:, k] = lu_solve(lu_piv, rhs_S[:, k])
+
+            for z in zeta_indices:
+                y[z] = max(0.0, min(1.0, y[z]))
+            x = y.copy()
+
+        if step >= pre_steps:
+            traj_sim.append(x.copy())
+
+    # Compute cost from trajectory (same as forward solve)
+    sim_helper.state_traj = np.array(traj_sim).T
+    sim_helper._compute_var_traj(traj_sim, variables_all)
+    sim_helper._has_run = True
+
+    cost = pid.get_cost_obs_and_pred_from_params(param_vals)
+
+    # Gradient: chain rule through observables
+    # For now: numerical gradient of cost w.r.t. each observable,
+    # times sensitivity S. This is approximate but correct for linear cost.
+    # TODO: analytic dcost/dy for exact gradient.
+    grad = np.zeros(n_p)
+    eps_fd = 1e-7
+    for k in range(n_p):
+        grad[k] = 0.0
+        for state_i in range(n):
+            # How much does the observable-based cost depend on state_i at final time?
+            # Use S[state_i, k] accumulated over trajectory
+            grad[k] += S[state_i, k]  # placeholder — needs proper dcost/dstate
+
+    return cost, grad

--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -387,6 +387,7 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
     x = np.array(sim_helper.states[:n], dtype=float)
     S = np.zeros((n, n_p))  # accumulated dx/dp
     traj_sim = []
+    S_history = []  # sensitivity at each sim trajectory point
 
     for step in range(total_steps):
         for sub in range(n_sub):
@@ -431,25 +432,93 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
 
         if step >= pre_steps:
             traj_sim.append(x.copy())
+            S_history.append(S.copy())
 
-    # Compute cost from trajectory (same as forward solve)
-    sim_helper.state_traj = np.array(traj_sim).T
+    # Store trajectory and compute observables
+    sim_helper.state_traj = np.array(traj_sim).T  # (n_states, n_sim_steps)
     sim_helper._compute_var_traj(traj_sim, variables_all)
     sim_helper._has_run = True
 
-    cost = pid.get_cost_obs_and_pred_from_params(param_vals)
+    # S_history: (n_sim_steps, n_states, n_params) — sensitivity at each sim point
+    S_history = np.array(S_history)  # already collected above
+    n_sim = len(traj_sim)
 
-    # Gradient: chain rule through observables
-    # For now: numerical gradient of cost w.r.t. each observable,
-    # times sensitivity S. This is approximate but correct for linear cost.
-    # TODO: analytic dcost/dy for exact gradient.
+    # Cost computed directly from stored trajectory (avoid re-running sim)
+    # Matches the cost function in cost_on_tape / get_cost_obs_and_pred_from_params
+    cost = 0.0
+
+    # Gradient via chain rule through observables
+    # cost = sum_obs w_obs * ((obs_val - gt) / std)^2
+    # dcost/dp = sum_obs w_obs * 2*(obs_val - gt)/std^2 * d(obs_val)/dp
+    # d(obs_val)/dp depends on operation (mean/max/min/max_minus_min)
+    obs_info = pid.obs_info
+    if obs_info is None:
+        return cost, np.zeros(n_p)
+
+    gt_const = obs_info.get("ground_truth_const", [])
+    std_const = obs_info.get("std_const_vec", [])
+    operations = obs_info.get("operations", [])
+    operand_names = obs_info.get("operands", [])
+    data_types = obs_info.get("data_types", [])
+    cost_types = pid.cost_type if hasattr(pid, 'cost_type') else ['gaussian_MLE'] * len(gt_const)
+    weights = pid.protocol_info["scaled_weight_const_from_exp_sub"][0][0] \
+        if pid.protocol_info and "scaled_weight_const_from_exp_sub" in pid.protocol_info \
+        else np.ones(len(gt_const))
+    weighted_obs_denom = sum(1 for w in weights if w > 0) if len(weights) > 0 else 1
+
     grad = np.zeros(n_p)
-    eps_fd = 1e-7
-    for k in range(n_p):
-        grad[k] = 0.0
-        for state_i in range(n):
-            # How much does the observable-based cost depend on state_i at final time?
-            # Use S[state_i, k] accumulated over trajectory
-            grad[k] += S[state_i, k]  # placeholder — needs proper dcost/dstate
+    const_idx = 0
+    traj_arr = sim_helper.state_traj  # (n_states, n_sim)
+
+    for jj in range(len(operand_names)):
+        if data_types[jj] != 'constant':
+            continue
+        op_name = operand_names[jj][0] if isinstance(operand_names[jj], (list, tuple)) else operand_names[jj]
+        operation = operations[jj]
+        kind, si = sim_helper._resolve_name(op_name)
+
+        if const_idx >= len(gt_const) or kind is None:
+            const_idx += 1
+            continue
+
+        gt = float(gt_const[const_idx])
+        std = float(std_const[const_idx])
+        w = float(weights[const_idx])
+        scale = 0.5 if (const_idx < len(cost_types) and cost_types[const_idx] == 'gaussian_MLE') else 1.0
+
+        if kind == 'state' and si is not None:
+            series = traj_arr[si, :]  # (n_sim,)
+            S_series = S_history[:, si, :]  # (n_sim, n_p)
+
+            if operation == 'mean':
+                obs_val = np.mean(series)
+                dobs_dp = np.mean(S_series, axis=0)  # (n_p,)
+            elif operation == 'max':
+                k_max = np.argmax(series)
+                obs_val = series[k_max]
+                dobs_dp = S_series[k_max, :]
+            elif operation == 'min':
+                k_min = np.argmin(series)
+                obs_val = series[k_min]
+                dobs_dp = S_series[k_min, :]
+            elif operation == 'max_minus_min':
+                k_max = np.argmax(series)
+                k_min = np.argmin(series)
+                obs_val = series[k_max] - series[k_min]
+                dobs_dp = S_series[k_max, :] - S_series[k_min, :]
+            else:
+                obs_val = series[-1]
+                dobs_dp = S_series[-1, :]
+
+            # Cost contribution
+            residual = (obs_val - gt) / std
+            cost += scale * residual * residual * w / weighted_obs_denom
+
+            # dcost/dp for this observable
+            dcost_dobs = scale * 2.0 * (obs_val - gt) / (std * std) * w / weighted_obs_denom
+            grad += dcost_dobs * dobs_dp
+
+        # TODO: algebraic variable observables (kind == 'var') — need var sensitivity
+        const_idx += 1
 
     return cost, grad

--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -448,9 +448,11 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
             traj_sim.append(x.copy())
             S_history.append(S.copy())
 
-    # Store trajectory and compute observables
-    sim_helper.state_traj = np.array(traj_sim).T  # (n_states, n_sim_steps)
+    # Store trajectory and compute algebraic variables
+    sim_helper.state_traj = np.array(traj_sim).T
     sim_helper._compute_var_traj(traj_sim, variables_all)
+    # var_traj: (n_vars, n_sim_steps) — algebraic variables at each sim point
+    var_traj = sim_helper.var_traj if hasattr(sim_helper, 'var_traj') else None
     sim_helper._has_run = True
 
     # S_history: (n_sim_steps, n_states, n_params) — sensitivity at each sim point
@@ -500,9 +502,40 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
         w = float(weights[const_idx])
         scale = 0.5 if (const_idx < len(cost_types) and cost_types[const_idx] == 'gaussian_MLE') else 1.0
 
-        if kind == 'state' and si is not None:
-            series = traj_arr[si, :]  # (n_sim,)
-            S_series = S_history[:, si, :]  # (n_sim, n_p)
+        if kind == 'var' and si is not None and var_traj is not None:
+            # Algebraic variable: var = g(states)
+            series = var_traj[si, :]
+            # dvar/dp via chain rule: dvar/dp = sum_j (dvar/dstate_j) * S[j, :]
+            n_sim_pts = len(traj_sim)
+            S_series = np.zeros((n_sim_pts, n_p))
+            eps_var = 1e-7
+            for ti in range(n_sim_pts):
+                st = traj_sim[ti]
+                rates0 = [0.0] * n; vars0 = list(variables_all)
+                sim_helper.model.compute_rates(0.0, list(st), rates0, vars0)
+                try:
+                    sim_helper.model.compute_variables(0.0, list(st), rates0, vars0)
+                except AttributeError:
+                    pass
+                base_val = float(vars0[si])
+                for j in range(n):
+                    h = max(abs(st[j]) * eps_var, eps_var)
+                    st_b = list(st); st_b[j] += h
+                    rates_b = [0.0] * n; vars_b = list(variables_all)
+                    sim_helper.model.compute_rates(0.0, st_b, rates_b, vars_b)
+                    try:
+                        sim_helper.model.compute_variables(0.0, st_b, rates_b, vars_b)
+                    except AttributeError:
+                        pass
+                    dvar_dstate_j = (float(vars_b[si]) - base_val) / h
+                    S_series[ti, :] += dvar_dstate_j * S_history[ti, j, :]
+
+        elif kind == 'state' and si is not None:
+            series = traj_arr[si, :]
+            S_series = S_history[:, si, :]
+        else:
+            const_idx += 1
+            continue
 
             if operation == 'mean':
                 obs_val = np.mean(series)

--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -671,8 +671,10 @@ def _cost_and_grad_bdf_tape(pid, param_vals):
         else np.ones(len(gt_const))
     weighted_obs_denom = sum(1 for w in weights if w > 0) if len(weights) > 0 else 1
 
-    # Resolve observables: which state indices to track
-    obs_list = []  # (state_idx, operation, gt, std, w, scale)
+    # Resolve observables: which state/var indices to track
+    # kind='state': read from x[si] directly
+    # kind='var': read from id_v[var_raw_idx] after compute_variables
+    obs_list = []  # (kind, idx, op_name, operation, gt, std, w, scale)
     const_idx = 0
     for jj in range(len(operand_names)):
         if data_types[jj] != 'constant':
@@ -687,10 +689,11 @@ def _cost_and_grad_bdf_tape(pid, param_vals):
         std = float(std_const[const_idx])
         w = float(weights[const_idx])
         scale = 0.5 if (const_idx < len(cost_types) and cost_types[const_idx] == 'gaussian_MLE') else 1.0
-        if kind == 'state' and si is not None:
-            obs_list.append((si, operation, gt, std, w, scale))
-        # TODO: var observables via compute_variables on tape
+        if kind in ('state', 'var') and si is not None:
+            var_raw_idx = sim_helper.var_name_to_idx.get(op_name) if kind == 'var' else None
+            obs_list.append((kind, si, var_raw_idx, operation, gt, std, w, scale))
         const_idx += 1
+    needs_compute_variables = any(k == 'var' for k, *_ in obs_list)
 
     # Cache key: use id of pid to avoid re-recording for same model
     cache_key = id(pid)
@@ -720,8 +723,8 @@ def _cost_and_grad_bdf_tape(pid, param_vals):
 
         # Initialize sim-time accumulators for observables
         obs_accum = {}
-        for si, op, gt, std, w, scale in obs_list:
-            key = (si, op)
+        for kind, si, var_raw_idx, op, gt, std, w, scale in obs_list:
+            key = (kind, si, op)
             if key not in obs_accum:
                 if op == 'mean':
                     obs_accum[key] = {'sum': aadc.idouble(0.0), 'count': 0}
@@ -756,9 +759,24 @@ def _cost_and_grad_bdf_tape(pid, param_vals):
             # Accumulate observables during sim_time
             if step >= pre_steps:
                 sim_step_counter += 1
-                for si, op, gt, std, w, scale in obs_list:
-                    key = (si, op)
-                    xi = x[si]
+                # Compute algebraic variables if needed
+                if needs_compute_variables:
+                    rates_cv = [aadc.idouble(0.0)] * n
+                    id_v_cv = list(id_v)
+                    model.compute_rates(aadc.idouble(0.0), x, rates_cv, id_v_cv)
+                    try:
+                        model.compute_variables(aadc.idouble(0.0), x, rates_cv, id_v_cv)
+                    except AttributeError:
+                        pass
+
+                for kind, si, var_raw_idx, op, gt, std, w, scale in obs_list:
+                    key = (kind, si, op)
+                    if kind == 'state':
+                        xi = x[si]
+                    else:  # var
+                        xi = id_v_cv[var_raw_idx]
+                        if not isinstance(xi, aadc.idouble):
+                            xi = aadc.idouble(float(xi))
                     if op == 'mean':
                         obs_accum[key]['sum'] = obs_accum[key]['sum'] + xi
                         obs_accum[key]['count'] += 1
@@ -782,8 +800,8 @@ def _cost_and_grad_bdf_tape(pid, param_vals):
 
         # Compute cost on tape
         tape_cost = aadc.idouble(0.0)
-        for si, op, gt, std, w, scale in obs_list:
-            key = (si, op)
+        for kind, si, var_raw_idx, op, gt, std, w, scale in obs_list:
+            key = (kind, si, op)
             if op == 'mean':
                 obs_val = obs_accum[key]['sum'] / aadc.idouble(float(obs_accum[key]['count']))
             elif op == 'max':

--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -918,6 +918,7 @@ def _cost_and_grad_bdf_kernel(pid, param_vals):
     n_sub = max(1, int(np.ceil(dt / max_step)))
     idt = dt / n_sub
     jac_lag = int(sim_helper.solver_info.get('jac_lag', 10))
+    newton_iters = int(sim_helper.solver_info.get('newton_iters', 0))
 
     param_names_raw = pid.param_id_info["param_names"]
     param_names = [pn[0] if isinstance(pn, (list, tuple)) else pn for pn in param_names_raw]
@@ -978,7 +979,7 @@ def _cost_and_grad_bdf_kernel(pid, param_vals):
         states, variables_all,
         list(ad_indices), param_values,
         total_steps, pre_steps, n_sub, idt,
-        obs_list, None, jac_lag
+        obs_list, None, jac_lag, newton_iters
     )
 
     grad = np.array([float(g) for g in grad_list])

--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -23,6 +23,7 @@ import numpy as np
 # under the original name for callers that already import it from this module.
 from parsers.PrimitiveParsers import AADC_TAPE_CONSISTENT_METHODS as TAPE_CONSISTENT_METHODS
 BDF_NEWTON_METHOD = 'bdf_newton'
+BDF_TAPE_METHOD = 'bdf_tape'
 
 
 def cost_and_grad(pid, param_vals):
@@ -61,6 +62,8 @@ def cost_and_grad(pid, param_vals):
     method = pid.sim_helper.solver_info.get('method', 'adaptive_rk45')
     if method == BDF_NEWTON_METHOD:
         return _cost_and_grad_bdf_newton(pid, param_vals)
+    if method == BDF_TAPE_METHOD:
+        return _cost_and_grad_bdf_tape(pid, param_vals)
     if method not in TAPE_CONSISTENT_METHODS:
         raise ValueError(
             f"solver method '{method}' cannot be recorded on an AADC tape, so the forward "
@@ -609,3 +612,212 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
         const_idx += 1
 
     return cost, grad
+
+
+# ---- Tape-based semi-implicit BDF ----
+# Cache for recorded tape (shared across calls for the same pid)
+_tape_cache = {}
+
+
+def _cost_and_grad_bdf_tape(pid, param_vals):
+    """Cost and gradient via full-tape semi-implicit BDF.
+
+    Records the ENTIRE integration + cost on one AADC tape (first call only).
+    Subsequent calls replay the tape with new parameter values — no Python loop.
+
+    Semi-implicit: x_{n+1} = x_n + dt * f(x_n) / (1 - dt * diag(J))
+    Diagonal Jacobian via FD on tape. ~0.97% error vs Newton BDF at dt=0.001.
+
+    Verified: AD/FD = 1.0000 on 3compartment (27 states, 4 params).
+    Evaluate: ~2.2s for 22000 steps (vs 46s Python IFT, vs 2s CasADi).
+    """
+    import aadc
+
+    sim_helper = pid.sim_helper
+    n = sim_helper.STATE_COUNT
+    model = sim_helper.model
+    dt = sim_helper.dt
+    total_steps = sim_helper.pre_steps + sim_helper.n_steps
+    pre_steps = sim_helper.pre_steps
+    n_sim = sim_helper.n_steps
+
+    param_names_raw = pid.param_id_info["param_names"]
+    param_names = [pn[0] if isinstance(pn, (list, tuple)) else pn for pn in param_names_raw]
+
+    variables_all = list(sim_helper._numeric_variables_all)
+    for ci, idx in enumerate(sim_helper.constant_indices):
+        variables_all[idx] = sim_helper.variables[ci]
+
+    ad_indices = sim_helper._ad_param_var_indices
+    n_p = len(ad_indices)
+    max_step = float(sim_helper.solver_info.get('max_step', 0.001))
+    n_sub = max(1, int(np.ceil(dt / max_step)))
+    idt = dt / n_sub
+    total_subs = total_steps * n_sub
+
+    # Observable info
+    obs_info = pid.obs_info
+    if obs_info is None:
+        return 0.0, np.zeros(n_p)
+
+    gt_const = obs_info.get("ground_truth_const", [])
+    std_const = obs_info.get("std_const_vec", [])
+    operations = obs_info.get("operations", [])
+    operand_names = obs_info.get("operands", [])
+    data_types = obs_info.get("data_types", [])
+    cost_types = pid.cost_type if hasattr(pid, 'cost_type') else ['gaussian_MLE'] * len(gt_const)
+    weights = pid.protocol_info["scaled_weight_const_from_exp_sub"][0][0] \
+        if pid.protocol_info and "scaled_weight_const_from_exp_sub" in pid.protocol_info \
+        else np.ones(len(gt_const))
+    weighted_obs_denom = sum(1 for w in weights if w > 0) if len(weights) > 0 else 1
+
+    # Resolve observables: which state indices to track
+    obs_list = []  # (state_idx, operation, gt, std, w, scale)
+    const_idx = 0
+    for jj in range(len(operand_names)):
+        if data_types[jj] != 'constant':
+            continue
+        if const_idx >= len(gt_const):
+            const_idx += 1
+            continue
+        op_name = operand_names[jj][0] if isinstance(operand_names[jj], (list, tuple)) else operand_names[jj]
+        operation = operations[jj]
+        kind, si = sim_helper._resolve_name(op_name)
+        gt = float(gt_const[const_idx])
+        std = float(std_const[const_idx])
+        w = float(weights[const_idx])
+        scale = 0.5 if (const_idx < len(cost_types) and cost_types[const_idx] == 'gaussian_MLE') else 1.0
+        if kind == 'state' and si is not None:
+            obs_list.append((si, operation, gt, std, w, scale))
+        # TODO: var observables via compute_variables on tape
+        const_idx += 1
+
+    # Cache key: use id of pid to avoid re-recording for same model
+    cache_key = id(pid)
+    cached = _tape_cache.get(cache_key)
+
+    if cached is not None and cached['total_subs'] == total_subs:
+        # Reuse recorded tape
+        funcs = cached['funcs']
+        p_args = cached['p_args']
+        x_args = cached['x_args']
+        cost_res = cached['cost_res']
+    else:
+        # Record tape
+        funcs = aadc.Functions()
+        funcs.start_recording()
+
+        x = [aadc.idouble(float(sim_helper.states[i])) for i in range(n)]
+        x_args = [x[i].mark_as_input() for i in range(n)]
+
+        id_v = [aadc.idouble(float(v) if v == v else 0.0) for v in variables_all]
+        p_args = []
+        for k in range(n_p):
+            id_v[ad_indices[k]] = aadc.idouble(float(param_vals[k]))
+            p_args.append(id_v[ad_indices[k]].mark_as_input())
+
+        h_fd = aadc.idouble(1e-7)
+
+        # Initialize sim-time accumulators for observables
+        obs_accum = {}
+        for si, op, gt, std, w, scale in obs_list:
+            key = (si, op)
+            if key not in obs_accum:
+                if op == 'mean':
+                    obs_accum[key] = {'sum': aadc.idouble(0.0), 'count': 0}
+                elif op == 'max':
+                    obs_accum[key] = {'val': None}
+                elif op == 'min':
+                    obs_accum[key] = {'val': None}
+                elif op == 'max_minus_min':
+                    obs_accum[key] = {'max_val': None, 'min_val': None}
+
+        sim_step_counter = 0
+        for step in range(total_steps):
+            for sub in range(n_sub):
+                rates = [aadc.idouble(0.0)] * n
+                model.compute_rates(aadc.idouble(0.0), x, rates, list(id_v))
+
+                # Diagonal Jacobian via FD
+                diag_J = [aadc.idouble(0.0)] * n
+                for i in range(n):
+                    x_pert = list(x)
+                    x_pert[i] = x[i] + h_fd
+                    r_pert = [aadc.idouble(0.0)] * n
+                    model.compute_rates(aadc.idouble(0.0), x_pert, r_pert, list(id_v))
+                    ri = rates[i] if isinstance(rates[i], aadc.idouble) else aadc.idouble(float(rates[i]))
+                    rpi = r_pert[i] if isinstance(r_pert[i], aadc.idouble) else aadc.idouble(float(r_pert[i]))
+                    diag_J[i] = (rpi - ri) / h_fd
+
+                for i in range(n):
+                    ri = rates[i] if isinstance(rates[i], aadc.idouble) else aadc.idouble(float(rates[i]))
+                    x[i] = x[i] + aadc.idouble(idt) * ri / (aadc.idouble(1.0) - aadc.idouble(idt) * diag_J[i])
+
+            # Accumulate observables during sim_time
+            if step >= pre_steps:
+                sim_step_counter += 1
+                for si, op, gt, std, w, scale in obs_list:
+                    key = (si, op)
+                    xi = x[si]
+                    if op == 'mean':
+                        obs_accum[key]['sum'] = obs_accum[key]['sum'] + xi
+                        obs_accum[key]['count'] += 1
+                    elif op == 'max':
+                        if obs_accum[key]['val'] is None:
+                            obs_accum[key]['val'] = xi
+                        else:
+                            obs_accum[key]['val'] = aadc.iif(xi > obs_accum[key]['val'], xi, obs_accum[key]['val'])
+                    elif op == 'min':
+                        if obs_accum[key]['val'] is None:
+                            obs_accum[key]['val'] = xi
+                        else:
+                            obs_accum[key]['val'] = aadc.iif(xi < obs_accum[key]['val'], xi, obs_accum[key]['val'])
+                    elif op == 'max_minus_min':
+                        if obs_accum[key]['max_val'] is None:
+                            obs_accum[key]['max_val'] = xi
+                            obs_accum[key]['min_val'] = xi
+                        else:
+                            obs_accum[key]['max_val'] = aadc.iif(xi > obs_accum[key]['max_val'], xi, obs_accum[key]['max_val'])
+                            obs_accum[key]['min_val'] = aadc.iif(xi < obs_accum[key]['min_val'], xi, obs_accum[key]['min_val'])
+
+        # Compute cost on tape
+        tape_cost = aadc.idouble(0.0)
+        for si, op, gt, std, w, scale in obs_list:
+            key = (si, op)
+            if op == 'mean':
+                obs_val = obs_accum[key]['sum'] / aadc.idouble(float(obs_accum[key]['count']))
+            elif op == 'max':
+                obs_val = obs_accum[key]['val']
+            elif op == 'min':
+                obs_val = obs_accum[key]['val']
+            elif op == 'max_minus_min':
+                obs_val = obs_accum[key]['max_val'] - obs_accum[key]['min_val']
+            else:
+                continue
+            if obs_val is None:
+                continue
+            residual = (obs_val - aadc.idouble(gt)) / aadc.idouble(std)
+            tape_cost = tape_cost + aadc.idouble(scale * w / weighted_obs_denom) * residual * residual
+
+        cost_res = tape_cost.mark_as_output()
+        funcs.stop_recording()
+
+        _tape_cache[cache_key] = {
+            'funcs': funcs, 'p_args': p_args, 'x_args': x_args,
+            'cost_res': cost_res, 'total_subs': total_subs,
+        }
+
+    # Evaluate
+    workers = aadc.ThreadPool(1)
+    inputs = {x_args[i]: np.array([float(sim_helper.states[i])]) for i in range(n)}
+    for k in range(n_p):
+        inputs[p_args[k]] = np.array([float(param_vals[k])])
+    request = {cost_res: p_args}
+
+    res = aadc.evaluate(funcs, request, inputs, workers)
+    cost_val = float(np.asarray(res[0][cost_res]).flat[0])
+    grad = np.zeros(n_p)
+    for k in range(n_p):
+        grad[k] = float(np.asarray(res[1][cost_res][p_args[k]]).flat[0])
+
+    return cost_val, grad

--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -24,6 +24,7 @@ import numpy as np
 from parsers.PrimitiveParsers import AADC_TAPE_CONSISTENT_METHODS as TAPE_CONSISTENT_METHODS
 BDF_NEWTON_METHOD = 'bdf_newton'
 BDF_TAPE_METHOD = 'bdf_tape'
+BDF_KERNEL_METHOD = 'bdf_kernel'
 
 
 def cost_and_grad(pid, param_vals):
@@ -64,6 +65,8 @@ def cost_and_grad(pid, param_vals):
         return _cost_and_grad_bdf_newton(pid, param_vals)
     if method == BDF_TAPE_METHOD:
         return _cost_and_grad_bdf_tape(pid, param_vals)
+    if method == BDF_KERNEL_METHOD:
+        return _cost_and_grad_bdf_kernel(pid, param_vals)
     if method not in TAPE_CONSISTENT_METHODS:
         raise ValueError(
             f"solver method '{method}' cannot be recorded on an AADC tape, so the forward "
@@ -615,8 +618,24 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
 
 
 # ---- Tape-based semi-implicit BDF ----
-# Cache for recorded tape (shared across calls for the same pid)
+# In-memory cache for recorded tape (shared across calls for the same pid)
 _tape_cache = {}
+
+
+def _tape_cache_path(sim_helper):
+    """Path for pickle-cached tape file, based on model path + solver config."""
+    import hashlib
+    model_path = getattr(sim_helper, 'model_path', '') or ''
+    dt = sim_helper.dt
+    max_step = float(sim_helper.solver_info.get('max_step', 0.001))
+    pre_steps = sim_helper.pre_steps
+    n_steps = sim_helper.n_steps
+    key = f"{model_path}|{dt}|{max_step}|{pre_steps}|{n_steps}"
+    h = hashlib.md5(key.encode()).hexdigest()[:12]
+    import os
+    cache_dir = os.path.join(os.path.dirname(model_path) if model_path else '/tmp', '.aadc_tape_cache')
+    os.makedirs(cache_dir, exist_ok=True)
+    return os.path.join(cache_dir, f"bdf_tape_{h}.pkl")
 
 
 def _cost_and_grad_bdf_tape(pid, param_vals):
@@ -695,17 +714,33 @@ def _cost_and_grad_bdf_tape(pid, param_vals):
         const_idx += 1
     needs_compute_variables = any(k == 'var' for k, *_ in obs_list)
 
-    # Cache key: use id of pid to avoid re-recording for same model
+    # Cache: in-memory first, then disk (pickle)
+    import pickle, os
     cache_key = id(pid)
     cached = _tape_cache.get(cache_key)
+    disk_path = _tape_cache_path(sim_helper)
 
     if cached is not None and cached['total_subs'] == total_subs:
-        # Reuse recorded tape
         funcs = cached['funcs']
         p_args = cached['p_args']
         x_args = cached['x_args']
         cost_res = cached['cost_res']
+    elif os.path.exists(disk_path):
+        # Load from disk cache
+        with open(disk_path, 'rb') as f:
+            cached = pickle.load(f)
+        if cached.get('total_subs') == total_subs:
+            funcs = cached['funcs']
+            p_args = cached['p_args']
+            x_args = cached['x_args']
+            cost_res = cached['cost_res']
+            _tape_cache[cache_key] = cached
+        else:
+            cached = None
     else:
+        cached = None
+
+    if cached is None:
         # Record tape
         funcs = aadc.Functions()
         funcs.start_recording()
@@ -735,22 +770,26 @@ def _cost_and_grad_bdf_tape(pid, param_vals):
                 elif op == 'max_minus_min':
                     obs_accum[key] = {'max_val': None, 'min_val': None}
 
+        jac_lag = int(sim_helper.solver_info.get('jac_lag', 10))
+        diag_J = [aadc.idouble(0.0)] * n
+        sub_counter = 0
         sim_step_counter = 0
         for step in range(total_steps):
             for sub in range(n_sub):
                 rates = [aadc.idouble(0.0)] * n
                 model.compute_rates(aadc.idouble(0.0), x, rates, list(id_v))
 
-                # Diagonal Jacobian via FD
-                diag_J = [aadc.idouble(0.0)] * n
-                for i in range(n):
-                    x_pert = list(x)
-                    x_pert[i] = x[i] + h_fd
-                    r_pert = [aadc.idouble(0.0)] * n
-                    model.compute_rates(aadc.idouble(0.0), x_pert, r_pert, list(id_v))
-                    ri = rates[i] if isinstance(rates[i], aadc.idouble) else aadc.idouble(float(rates[i]))
-                    rpi = r_pert[i] if isinstance(r_pert[i], aadc.idouble) else aadc.idouble(float(r_pert[i]))
-                    diag_J[i] = (rpi - ri) / h_fd
+                # Diagonal Jacobian via FD (every jac_lag sub-steps)
+                if sub_counter % jac_lag == 0:
+                    for i in range(n):
+                        x_pert = list(x)
+                        x_pert[i] = x[i] + h_fd
+                        r_pert = [aadc.idouble(0.0)] * n
+                        model.compute_rates(aadc.idouble(0.0), x_pert, r_pert, list(id_v))
+                        ri = rates[i] if isinstance(rates[i], aadc.idouble) else aadc.idouble(float(rates[i]))
+                        rpi = r_pert[i] if isinstance(r_pert[i], aadc.idouble) else aadc.idouble(float(r_pert[i]))
+                        diag_J[i] = (rpi - ri) / h_fd
+                sub_counter += 1
 
                 for i in range(n):
                     ri = rates[i] if isinstance(rates[i], aadc.idouble) else aadc.idouble(float(rates[i]))
@@ -820,10 +859,17 @@ def _cost_and_grad_bdf_tape(pid, param_vals):
         cost_res = tape_cost.mark_as_output()
         funcs.stop_recording()
 
-        _tape_cache[cache_key] = {
+        tape_data = {
             'funcs': funcs, 'p_args': p_args, 'x_args': x_args,
             'cost_res': cost_res, 'total_subs': total_subs,
         }
+        _tape_cache[cache_key] = tape_data
+        # Save to disk for future process launches
+        try:
+            with open(disk_path, 'wb') as f:
+                pickle.dump(tape_data, f)
+        except Exception:
+            pass  # disk cache is best-effort
 
     # Evaluate
     workers = aadc.ThreadPool(1)
@@ -839,3 +885,101 @@ def _cost_and_grad_bdf_tape(pid, param_vals):
         grad[k] = float(np.asarray(res[1][cost_res][p_args[k]]).flat[0])
 
     return cost_val, grad
+
+
+def _cost_and_grad_bdf_kernel(pid, param_vals):
+    """Cost and gradient via C++ kernel replay (fastest method for stiff ODE).
+
+    Records compute_rates ONCE as AADC kernel, then replays it from C++
+    in a semi-implicit BDF loop with ConstStateExtFunc (forward + reverse AD).
+    First call: ~6s (kernel recording + tape creation). Subsequent: ~0.3s (cached).
+
+    Requires AADC Python module built from source with bdf_loop.cpp.
+    Falls back to bdf_tape (Python tape) if C++ function not available.
+
+    Verified: AD/FD = 1.0000 on 3compartment (27 states, 4 params, 22000 steps).
+    """
+    import aadc
+
+    if not hasattr(aadc._aadc_core, 'bdf_record_and_evaluate'):
+        import warnings
+        warnings.warn("bdf_kernel: C++ bdf_record_and_evaluate not available, "
+                      "falling back to bdf_tape (Python tape). Build AADC from "
+                      "source with bdf_loop.cpp for 10x speedup.")
+        return _cost_and_grad_bdf_tape(pid, param_vals)
+
+    sim_helper = pid.sim_helper
+    n = sim_helper.STATE_COUNT
+    dt = sim_helper.dt
+    total_steps = sim_helper.pre_steps + sim_helper.n_steps
+    pre_steps = sim_helper.pre_steps
+
+    max_step = float(sim_helper.solver_info.get('max_step', 0.001))
+    n_sub = max(1, int(np.ceil(dt / max_step)))
+    idt = dt / n_sub
+    jac_lag = int(sim_helper.solver_info.get('jac_lag', 10))
+
+    param_names_raw = pid.param_id_info["param_names"]
+    param_names = [pn[0] if isinstance(pn, (list, tuple)) else pn for pn in param_names_raw]
+
+    variables_all = list(sim_helper._numeric_variables_all)
+    for ci, idx in enumerate(sim_helper.constant_indices):
+        variables_all[idx] = sim_helper.variables[ci]
+
+    ad_indices = sim_helper._ad_param_var_indices
+    n_p = len(ad_indices)
+    for i, idx in enumerate(ad_indices):
+        variables_all[idx] = float(param_vals[i])
+
+    # Build observable list for C++ function
+    # Format: (kind, state_idx, var_raw_idx, op_code, gt, std, weight, scale)
+    # op_code: 0=mean, 1=max, 2=min, 3=max_minus_min
+    obs_info = pid.obs_info
+    if obs_info is None:
+        return 0.0, np.zeros(n_p)
+
+    gt_const = obs_info.get("ground_truth_const", [])
+    std_const = obs_info.get("std_const_vec", [])
+    operations = obs_info.get("operations", [])
+    operand_names = obs_info.get("operands", [])
+    data_types = obs_info.get("data_types", [])
+    cost_types = pid.cost_type if hasattr(pid, 'cost_type') else ['gaussian_MLE'] * len(gt_const)
+    weights = pid.protocol_info["scaled_weight_const_from_exp_sub"][0][0] \
+        if pid.protocol_info and "scaled_weight_const_from_exp_sub" in pid.protocol_info \
+        else np.ones(len(gt_const))
+    weighted_obs_denom = sum(1 for w in weights if w > 0) if len(weights) > 0 else 1
+
+    op_map = {'mean': 0, 'max': 1, 'min': 2, 'max_minus_min': 3}
+    obs_list = []
+    const_idx = 0
+    for jj in range(len(operand_names)):
+        if data_types[jj] != 'constant':
+            continue
+        if const_idx >= len(gt_const):
+            const_idx += 1
+            continue
+        op_name = operand_names[jj][0] if isinstance(operand_names[jj], (list, tuple)) else operand_names[jj]
+        operation = operations[jj]
+        kind, si = sim_helper._resolve_name(op_name)
+        gt = float(gt_const[const_idx])
+        std = float(std_const[const_idx])
+        w = float(weights[const_idx])
+        scale = 0.5 if (const_idx < len(cost_types) and cost_types[const_idx] == 'gaussian_MLE') else 1.0
+        op_code = op_map.get(operation, -1)
+        if kind == 'state' and si is not None and op_code >= 0:
+            obs_list.append((0, si, 0, op_code, gt, std, w * scale / weighted_obs_denom, 1.0))
+        const_idx += 1
+
+    states = list(sim_helper.states[:n])
+    param_values = [float(param_vals[i]) for i in range(n_p)]
+
+    cost, grad_list = aadc._aadc_core.bdf_record_and_evaluate(
+        sim_helper.model.compute_rates,
+        states, variables_all,
+        list(ad_indices), param_values,
+        total_steps, pre_steps, n_sub, idt,
+        obs_list, None, jac_lag
+    )
+
+    grad = np.array([float(g) for g in grad_list])
+    return float(cost), grad

--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -469,6 +469,13 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
     # d(obs_val)/dp depends on operation (mean/max/min/max_minus_min)
     obs_info = pid.obs_info
     if obs_info is None:
+        # obs_info not yet populated — run one forward eval to populate it
+        try:
+            pid.get_cost_obs_and_pred_from_params(param_vals)
+            obs_info = pid.obs_info
+        except Exception:
+            pass
+    if obs_info is None:
         return cost, np.zeros(n_p)
 
     gt_const = obs_info.get("ground_truth_const", [])
@@ -476,6 +483,8 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
     operations = obs_info.get("operations", [])
     operand_names = obs_info.get("operands", [])
     data_types = obs_info.get("data_types", [])
+    # DEBUG
+    import sys
     cost_types = pid.cost_type if hasattr(pid, 'cost_type') else ['gaussian_MLE'] * len(gt_const)
     weights = pid.protocol_info["scaled_weight_const_from_exp_sub"][0][0] \
         if pid.protocol_info and "scaled_weight_const_from_exp_sub" in pid.protocol_info \
@@ -503,32 +512,12 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
         scale = 0.5 if (const_idx < len(cost_types) and cost_types[const_idx] == 'gaussian_MLE') else 1.0
 
         if kind == 'var' and si is not None and var_traj is not None:
-            # Algebraic variable: var = g(states)
+            # Algebraic variable: use var_traj for cost, approximate gradient
             series = var_traj[si, :]
-            # dvar/dp via chain rule: dvar/dp = sum_j (dvar/dstate_j) * S[j, :]
-            n_sim_pts = len(traj_sim)
-            S_series = np.zeros((n_sim_pts, n_p))
-            eps_var = 1e-7
-            for ti in range(n_sim_pts):
-                st = traj_sim[ti]
-                rates0 = [0.0] * n; vars0 = list(variables_all)
-                sim_helper.model.compute_rates(0.0, list(st), rates0, vars0)
-                try:
-                    sim_helper.model.compute_variables(0.0, list(st), rates0, vars0)
-                except AttributeError:
-                    pass
-                base_val = float(vars0[si])
-                for j in range(n):
-                    h = max(abs(st[j]) * eps_var, eps_var)
-                    st_b = list(st); st_b[j] += h
-                    rates_b = [0.0] * n; vars_b = list(variables_all)
-                    sim_helper.model.compute_rates(0.0, st_b, rates_b, vars_b)
-                    try:
-                        sim_helper.model.compute_variables(0.0, st_b, rates_b, vars_b)
-                    except AttributeError:
-                        pass
-                    dvar_dstate_j = (float(vars_b[si]) - base_val) / h
-                    S_series[ti, :] += dvar_dstate_j * S_history[ti, j, :]
+            # Gradient via FD of cost w.r.t. params (approximate but correct)
+            # For now: set dobs_dp = 0 (cost correct, gradient approximate)
+            # TODO: full chain rule dvar/dstate × dstate/dp
+            S_series = np.zeros((len(traj_sim), n_p))
 
         elif kind == 'state' and si is not None:
             series = traj_arr[si, :]

--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -386,20 +386,34 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
     # Forward + accumulated sensitivity
     x = np.array(sim_helper.states[:n], dtype=float)
     S = np.zeros((n, n_p))  # accumulated dx/dp
+
+    # Initialize S for parameters that set initial state values (*_init pattern)
+    state_name_to_idx = sim_helper.state_name_to_idx
+    for k in range(n_p):
+        pname = param_names[k]
+        # Strip component prefix, e.g. 'global/q_lv_init' → 'q_lv_init'
+        short = pname.split('/')[-1] if '/' in pname else pname
+        if short.endswith('_init'):
+            state_stem = short[:-5]  # 'q_lv_init' → 'q_lv'
+            # Find matching state
+            for sname, sidx in state_name_to_idx.items():
+                s_short = sname.split('/')[-1] if '/' in sname else sname
+                if s_short == state_stem:
+                    S[sidx, k] = 1.0
+                    break
+
     traj_sim = []
     S_history = []  # sensitivity at each sim trajectory point
 
     # Pre-build inputs template
     inputs_template = {a_p[k]: p_vals[k] for k in range(n_p)}
     request_dfdp = {r: a_p for r in r_r}
-    need_sensitivity = False
+    need_sensitivity = True  # compute sensitivity from the start (warmup affects steady state)
     eye_n = np.eye(n)
     x_prev = None  # for BDF2
+    S_prev = None  # sensitivity at step n-1 (for BDF2)
 
     for step in range(total_steps):
-        if step == pre_steps:
-            need_sensitivity = True
-            S = np.zeros((n, n_p))
 
         for sub in range(n_sub):
             y = x.copy()
@@ -425,7 +439,7 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
                     break
                 y += dy
 
-            # IFT sensitivity only during sim_time
+            # IFT sensitivity: S_{n+1} = (I - c*idt*J)^{-1} * (rhs_S)
             if need_sensitivity and lu_piv is not None:
                 inputs = dict(inputs_template)
                 for i in range(n):
@@ -435,9 +449,17 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
                 for i in range(n):
                     for k in range(n_p):
                         dfdp[i, k] = float(np.asarray(res_eval[1][r_r[i]][a_p[k]]).flat[0])
-                rhs_S = S + jac_coeff * idt * dfdp
+                if use_bdf2 and S_prev is not None:
+                    # BDF2: S_{n+1} = (I - (2/3)*idt*J)^{-1} * ((4/3)*S_n - (1/3)*S_{n-1} + (2/3)*idt*df/dp)
+                    rhs_S = (4.0/3.0) * S - (1.0/3.0) * S_prev + jac_coeff * idt * dfdp
+                else:
+                    # Implicit Euler: S_{n+1} = (I - idt*J)^{-1} * (S_n + idt*df/dp)
+                    rhs_S = S + jac_coeff * idt * dfdp
+                S_new = np.zeros_like(S)
                 for k in range(n_p):
-                    S[:, k] = lu_solve(lu_piv, rhs_S[:, k])
+                    S_new[:, k] = lu_solve(lu_piv, rhs_S[:, k])
+                S_prev = S.copy()
+                S = S_new
 
             for z in zeta_indices:
                 y[z] = max(0.0, min(1.0, y[z]))
@@ -469,13 +491,6 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
     # d(obs_val)/dp depends on operation (mean/max/min/max_minus_min)
     obs_info = pid.obs_info
     if obs_info is None:
-        # obs_info not yet populated — run one forward eval to populate it
-        try:
-            pid.get_cost_obs_and_pred_from_params(param_vals)
-            obs_info = pid.obs_info
-        except Exception:
-            pass
-    if obs_info is None:
         return cost, np.zeros(n_p)
 
     gt_const = obs_info.get("ground_truth_const", [])
@@ -483,8 +498,6 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
     operations = obs_info.get("operations", [])
     operand_names = obs_info.get("operands", [])
     data_types = obs_info.get("data_types", [])
-    # DEBUG
-    import sys
     cost_types = pid.cost_type if hasattr(pid, 'cost_type') else ['gaussian_MLE'] * len(gt_const)
     weights = pid.protocol_info["scaled_weight_const_from_exp_sub"][0][0] \
         if pid.protocol_info and "scaled_weight_const_from_exp_sub" in pid.protocol_info \
@@ -512,12 +525,51 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
         scale = 0.5 if (const_idx < len(cost_types) and cost_types[const_idx] == 'gaussian_MLE') else 1.0
 
         if kind == 'var' and si is not None and var_traj is not None:
-            # Algebraic variable: use var_traj for cost, approximate gradient
+            # Algebraic variable: du/dp = (du/dx)*S + du/dp_direct
             series = var_traj[si, :]
-            # Gradient via FD of cost w.r.t. params (approximate but correct)
-            # For now: set dobs_dp = 0 (cost correct, gradient approximate)
-            # TODO: full chain rule dvar/dstate × dstate/dp
+            var_raw_idx = sim_helper.var_name_to_idx[op_name]
             S_series = np.zeros((len(traj_sim), n_p))
+            h_fd = 1e-7
+            for ti in range(len(traj_sim)):
+                st = traj_sim[ti]
+                # Reference: u at (st, p)
+                rates0 = [0.0] * n
+                v0 = list(variables_all)
+                sim_helper.model.compute_rates(0.0, st, rates0, v0)
+                try:
+                    sim_helper.model.compute_variables(0.0, st, rates0, v0)
+                except AttributeError:
+                    pass
+                u0 = v0[var_raw_idx]
+                # du/dx via FD over states
+                du_dx = np.zeros(n)
+                for j in range(n):
+                    st_p = list(st)
+                    st_p[j] += h_fd
+                    rates_p = [0.0] * n
+                    v_p = list(variables_all)
+                    sim_helper.model.compute_rates(0.0, st_p, rates_p, v_p)
+                    try:
+                        sim_helper.model.compute_variables(0.0, st_p, rates_p, v_p)
+                    except AttributeError:
+                        pass
+                    du_dx[j] = (v_p[var_raw_idx] - u0) / h_fd
+                # du/dp_direct via FD over params (relative step)
+                du_dp_direct = np.zeros(n_p)
+                for k in range(n_p):
+                    p_val = variables_all[ad_indices[k]]
+                    dp = h_fd * max(abs(p_val), 1e-15)
+                    v_pk = list(variables_all)
+                    v_pk[ad_indices[k]] = p_val + dp
+                    rates_pk = [0.0] * n
+                    sim_helper.model.compute_rates(0.0, st, rates_pk, v_pk)
+                    try:
+                        sim_helper.model.compute_variables(0.0, st, rates_pk, v_pk)
+                    except AttributeError:
+                        pass
+                    du_dp_direct[k] = (v_pk[var_raw_idx] - u0) / dp
+                # Full sensitivity: du/dp = du/dx @ S + du/dp_direct
+                S_series[ti, :] = du_dx @ S_history[ti, :, :] + du_dp_direct
 
         elif kind == 'state' and si is not None:
             series = traj_arr[si, :]
@@ -526,35 +578,34 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
             const_idx += 1
             continue
 
-            if operation == 'mean':
-                obs_val = np.mean(series)
-                dobs_dp = np.mean(S_series, axis=0)  # (n_p,)
-            elif operation == 'max':
-                k_max = np.argmax(series)
-                obs_val = series[k_max]
-                dobs_dp = S_series[k_max, :]
-            elif operation == 'min':
-                k_min = np.argmin(series)
-                obs_val = series[k_min]
-                dobs_dp = S_series[k_min, :]
-            elif operation == 'max_minus_min':
-                k_max = np.argmax(series)
-                k_min = np.argmin(series)
-                obs_val = series[k_max] - series[k_min]
-                dobs_dp = S_series[k_max, :] - S_series[k_min, :]
-            else:
-                obs_val = series[-1]
-                dobs_dp = S_series[-1, :]
+        if operation == 'mean':
+            obs_val = np.mean(series)
+            dobs_dp = np.mean(S_series, axis=0)  # (n_p,)
+        elif operation == 'max':
+            k_max = np.argmax(series)
+            obs_val = series[k_max]
+            dobs_dp = S_series[k_max, :]
+        elif operation == 'min':
+            k_min = np.argmin(series)
+            obs_val = series[k_min]
+            dobs_dp = S_series[k_min, :]
+        elif operation == 'max_minus_min':
+            k_max = np.argmax(series)
+            k_min = np.argmin(series)
+            obs_val = series[k_max] - series[k_min]
+            dobs_dp = S_series[k_max, :] - S_series[k_min, :]
+        else:
+            obs_val = series[-1]
+            dobs_dp = S_series[-1, :]
 
-            # Cost contribution
-            residual = (obs_val - gt) / std
-            cost += scale * residual * residual * w / weighted_obs_denom
+        # Cost contribution
+        residual = (obs_val - gt) / std
+        cost += scale * residual * residual * w / weighted_obs_denom
 
-            # dcost/dp for this observable
-            dcost_dobs = scale * 2.0 * (obs_val - gt) / (std * std) * w / weighted_obs_denom
-            grad += dcost_dobs * dobs_dp
+        # dcost/dp for this observable
+        dcost_dobs = scale * 2.0 * (obs_val - gt) / (std * std) * w / weighted_obs_denom
+        grad += dcost_dobs * dobs_dp
 
-        # TODO: algebraic variable observables (kind == 'var') — need var sensitivity
         const_idx += 1
 
     return cost, grad

--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -389,20 +389,29 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
     traj_sim = []
     S_history = []  # sensitivity at each sim trajectory point
 
+    # Pre-build inputs template
+    inputs_template = {a_p[k]: p_vals[k] for k in range(n_p)}
+    request_dfdp = {r: a_p for r in r_r}
+    need_sensitivity = False
+    eye_n = np.eye(n)
+
     for step in range(total_steps):
+        if step == pre_steps:
+            need_sensitivity = True
+            S = np.zeros((n, n_p))
+
         for sub in range(n_sub):
-            t = step * dt + sub * idt
             y = x.copy()
             lu_piv = None
 
             for nit in range(max_newton):
-                rates = [0.0] * n
-                sim_helper.model.compute_rates(t + idt, list(y), rates, list(variables_all))
-                F = y - x - idt * np.array(rates)
+                # VFJ.func is 35× faster than Python compute_rates
+                rates_arr = vfj.func(y)
+                F = y - x - idt * rates_arr
                 if np.max(np.abs(F)) < newton_tol:
                     break
                 J_rhs = vfj.jac(y)
-                J_g = np.eye(n) - idt * J_rhs
+                J_g = eye_n - idt * J_rhs
                 try:
                     lu_piv = lu_factor(J_g)
                     dy = lu_solve(lu_piv, -F)
@@ -410,14 +419,12 @@ def _cost_and_grad_bdf_newton(pid, param_vals):
                     break
                 y += dy
 
-            # IFT sensitivity: S_{n+1} = (dg/dx)^{-1} * (S_n + idt * df/dp)
-            if lu_piv is not None:
-                inputs = {}
+            # IFT sensitivity only during sim_time (skip warmup)
+            if need_sensitivity and lu_piv is not None:
+                inputs = dict(inputs_template)
                 for i in range(n):
                     inputs[a_x[i]] = float(y[i])
-                for k in range(n_p):
-                    inputs[a_p[k]] = p_vals[k]
-                res_eval = aadc.evaluate(rhs_f, {r: a_p for r in r_r}, inputs, workers)
+                res_eval = aadc.evaluate(rhs_f, request_dfdp, inputs, workers)
                 dfdp = np.zeros((n, n_p))
                 for i in range(n):
                     for k in range(n_p):

--- a/src/param_id/aadc_native/bdf_loop.cpp
+++ b/src/param_id/aadc_native/bdf_loop.cpp
@@ -118,6 +118,55 @@ private:
     std::vector<aadc::ExtVarIndex> rhs_idx_, out_idx_;
 };
 
+// Step kernel ExtFunc: wraps a step kernel (compute_rates + BDF step) with constant t and J_diag.
+// Gradient flows through x and p only (t and J_diag are off-tape constants).
+class StepExtFunc : public aadc::ConstStateExtFunc {
+public:
+    std::shared_ptr<Functions> kern;
+    std::vector<Argument> kx,kp; Argument kt; std::vector<Argument> kj;
+    std::vector<Result> kr;
+    std::vector<aadc::ExtVarIndex> tx,tp,to;
+    double t_val; std::vector<double> j_val;
+    mutable std::shared_ptr<WorkSpace> ws;
+    int n_, np_;
+
+    StepExtFunc(std::shared_ptr<Functions> k,
+        const std::vector<Argument>& kx_, const std::vector<Argument>& kp_,
+        Argument kt_, const std::vector<Argument>& kj_, const std::vector<Result>& kr_,
+        const std::vector<aadc::ExtVarIndex>& tx_, const std::vector<aadc::ExtVarIndex>& tp_,
+        const std::vector<aadc::ExtVarIndex>& to_,
+        double tv, const std::vector<double>& jv, std::shared_ptr<WorkSpace> w)
+        : kern(k), kx(kx_), kp(kp_), kt(kt_), kj(kj_), kr(kr_),
+          tx(tx_), tp(tp_), to(to_), t_val(tv), j_val(jv), ws(w),
+          n_(kx_.size()), np_(kp_.size()) {}
+
+    template<typename M> void forward(M* v) const {
+        for (int a=0;a<aadc::mmSize<M>();a++) {
+            for (int i=0;i<n_;i++) aadc::toDblPtr(ws->val(kx[i]))[0]=aadc::toDblPtr(v[tx[i]])[a];
+            for (int k=0;k<np_;k++) aadc::toDblPtr(ws->val(kp[k]))[0]=aadc::toDblPtr(v[tp[k]])[a];
+            aadc::toDblPtr(ws->val(kt))[0]=t_val;
+            for (int i=0;i<n_;i++) aadc::toDblPtr(ws->val(kj[i]))[0]=j_val[i];
+            kern->forward(*ws);
+            for (int i=0;i<n_;i++) aadc::toDblPtr(v[to[i]])[a]=aadc::toDblPtr(ws->val(kr[i]))[0];
+        }
+    }
+    template<class M> void reverse(const M* v, M* d) const {
+        for (int a=0;a<aadc::mmSize<M>();a++) {
+            for (int i=0;i<n_;i++) aadc::toDblPtr(ws->val(kx[i]))[0]=aadc::toDblPtr(v[tx[i]])[a];
+            for (int k=0;k<np_;k++) aadc::toDblPtr(ws->val(kp[k]))[0]=aadc::toDblPtr(v[tp[k]])[a];
+            aadc::toDblPtr(ws->val(kt))[0]=t_val;
+            for (int i=0;i<n_;i++) aadc::toDblPtr(ws->val(kj[i]))[0]=j_val[i];
+            kern->forward(*ws);
+            ws->resetDiff();
+            for (int i=0;i<n_;i++) aadc::toDblPtr(ws->diff(kr[i]))[0]=aadc::toDblPtr(d[to[i]])[a];
+            kern->reverse(*ws);
+            for (int i=0;i<n_;i++) aadc::toDblPtr(d[tx[i]])[a]+=aadc::toDblPtr(ws->diff(kx[i]))[0];
+            for (int k=0;k<np_;k++) aadc::toDblPtr(d[tp[k]])[a]+=aadc::toDblPtr(ws->diff(kp[k]))[0];
+            // t and J_diag: no gradient (constants for AD)
+        }
+    }
+};
+
 // Static cache
 static struct {
     std::shared_ptr<Functions> funcs;
@@ -177,7 +226,7 @@ py::tuple bdf_record_and_evaluate(
     int total_subs = total_steps * n_sub;
 
     if (!cache.funcs || cache.total_subs != total_subs || cache.newton_mode != newton_iters) {
-        // ---- Record kernel ----
+        // ---- Record f-kernel (compute_rates only, for Jacobian computation) ----
         auto kernel = std::make_shared<Functions>();
         kernel->startRecording();
         std::vector<idouble> kx(n); std::vector<Argument> kxa(n);
@@ -185,17 +234,46 @@ py::tuple bdf_record_and_evaluate(
         std::vector<idouble> kv(n_vars); std::vector<Argument> kpa(n_p);
         for (int i=0;i<n_vars;i++) { double v=py_variables[i].cast<double>(); kv[i]=(v==v)?v:0.0; }
         for (int k=0;k<n_p;k++) { kv[pidx[k]]=py_param_values[k].cast<double>(); kpa[k]=kv[pidx[k]].markAsInput(); }
+        idouble kt(0.0); Argument kta = kt.markAsInput();
         py::list pkx(n),pkr(n),pkv(n_vars);
         for (int i=0;i<n;i++) pkx[i]=py::cast(kx[i]);
         for (int i=0;i<n;i++) pkr[i]=py::cast(idouble(0.0));
         for (int i=0;i<n_vars;i++) pkv[i]=py::cast(kv[i]);
-        compute_rates_fn(py::cast(idouble(0.0)),pkx,pkr,pkv);
+        compute_rates_fn(py::cast(kt),pkx,pkr,pkv);
         std::vector<Result> krr(n);
         for (int i=0;i<n;i++) {
             auto o=pkr[i]; idouble rv=py::isinstance<idouble>(o)?o.cast<idouble>():idouble(o.cast<double>());
             krr[i]=rv.markAsOutput();
         }
         kernel->stopRecording();
+
+        // ---- Record step kernel (compute_rates + semi-implicit, ONE step) ----
+        // Inputs: x(n), p(n_p), t(1), J_diag(n). Outputs: x_new(n).
+        // This kernel is replayed 22000 times — NO idouble arithmetic on main tape.
+        auto step_kernel = std::make_shared<Functions>();
+        step_kernel->startRecording();
+        std::vector<idouble> sx(n); std::vector<Argument> sxa(n);
+        for (int i=0;i<n;i++) { sx[i]=py_states[i].cast<double>(); sxa[i]=sx[i].markAsInput(); }
+        std::vector<idouble> sv(n_vars); std::vector<Argument> spa(n_p);
+        for (int i=0;i<n_vars;i++) { double v=py_variables[i].cast<double>(); sv[i]=(v==v)?v:0.0; }
+        for (int k=0;k<n_p;k++) { sv[pidx[k]]=py_param_values[k].cast<double>(); spa[k]=sv[pidx[k]].markAsInput(); }
+        idouble st(0.0); Argument sta = st.markAsInput();
+        std::vector<idouble> sj(n); std::vector<Argument> sja(n);
+        for (int i=0;i<n;i++) { sj[i]=0.0; sja[i]=sj[i].markAsInput(); }
+        // Call compute_rates within step kernel recording
+        py::list spkx(n),spkr(n),spkv(n_vars);
+        for (int i=0;i<n;i++) spkx[i]=py::cast(sx[i]);
+        for (int i=0;i<n;i++) spkr[i]=py::cast(idouble(0.0));
+        for (int i=0;i<n_vars;i++) spkv[i]=py::cast(sv[i]);
+        compute_rates_fn(py::cast(st),spkx,spkr,spkv);
+        // Semi-implicit: x_new[i] = x[i] + dt*f[i] / (1 - dt*J[i])
+        std::vector<Result> sxr(n);
+        for (int i=0;i<n;i++) {
+            auto o=spkr[i]; idouble fi=py::isinstance<idouble>(o)?o.cast<idouble>():idouble(o.cast<double>());
+            idouble xnew = sx[i] + idouble(idt)*fi / (idouble(1.0) - idouble(idt)*sj[i]);
+            sxr[i] = xnew.markAsOutput();
+        }
+        step_kernel->stopRecording();
 
         // ---- Record compute_variables kernel (for var observables) ----
         bool has_var_obs = false;
@@ -268,132 +346,138 @@ py::tuple bdf_record_and_evaluate(
         std::map<Key,Acc> accs;
         for (auto&o:obs) accs[{o.kind,o.si,o.op}]=Acc{};
 
-        std::vector<idouble> dJ(n,idouble(0.0));
-        auto jac_ws = kernel->createWorkSpace();  // reused for all Jacobian computations
-        auto loop_ws = kernel->createWorkSpace();  // reused for all forward evals in loop
+        // Pre-allocate workspaces
+        auto jac_ws = kernel->createWorkSpace();
+        auto step_ws = step_kernel->createWorkSpace();
+        auto loop_ws = kernel->createWorkSpace();  // for Newton f-kernel replays
+        std::vector<double> dJ_val(n, 0.0);
         std::vector<std::vector<double>> cached_LU(n, std::vector<double>(n, 0.0));
         std::vector<int> cached_piv(n);
         for (int i=0;i<n;i++) { cached_piv[i]=i; cached_LU[i][i]=1.0; }
+
         int sc=0;
-        int cp_interval = 100; // checkpoint every 100 sub-steps
+        int cp_interval = 100;
         for (int step=0;step<total_steps;step++) {
             for (int sub=0;sub<n_sub;sub++) {
                 if (sc > 0 && sc % cp_interval == 0)
                     idouble::CheckPoint();
-                // Helper: call kernel ExtFunc, put f(y,p) on tape, return rates
-                auto call_kernel = [&](std::vector<idouble>& y) -> std::vector<idouble> {
-                    std::vector<idouble> r(n);
-                    std::vector<aadc::ExtVarIndex> txi(n),tpi(n_p),toi(n);
-                    for (int i=0;i<n;i++) txi[i]=aadc::ExtVarIndex(y[i],true,true);
-                    for (int k=0;k<n_p;k++) tpi[k]=aadc::ExtVarIndex(pid2[k],true,true);
-                    for (int i=0;i<n;i++){r[i]=idouble(0.0);toi[i]=aadc::ExtVarIndex(r[i],false,true);}
-                    aadc::addConstStateExtFunction(std::make_shared<KernelExtFunc>(kernel,kxa,kpa,krr,txi,tpi,toi,loop_ws));
-                    for (int i=0;i<n;i++) loop_ws->setVal(kxa[i],y[i].val);
-                    for (int k2=0;k2<n_p;k2++) loop_ws->setVal(kpa[k2],pid2[k2].val);
-                    kernel->forward(*loop_ws);
-                    for (int i=0;i<n;i++) r[i].val=aadc::toDblPtr(loop_ws->val(krr[i]))[0];
-                    return r;
-                };
 
-                // Helper: compute Jacobian off-tape via kernel reverse AD
-                // Row i of J: set adjoint f_i = 1, reverse, read x_j adjoints
-                // 27 reverse passes = full 27×27 Jacobian, exact (no FD approximation)
-                auto compute_jacobian = [&](const std::vector<idouble>& y, const std::vector<double>& f0) {
-                    std::vector<std::vector<double>> J(n, std::vector<double>(n, 0.0));
-                    for (int i=0;i<n;i++) jac_ws->setVal(kxa[i], y[i].val);
-                    for (int k2=0;k2<n_p;k2++) jac_ws->setVal(kpa[k2], pid2[k2].val);
-                    kernel->forward(*jac_ws);
-                    for (int i=0;i<n;i++) {
-                        jac_ws->resetDiff();
-                        jac_ws->setDiff(krr[i], 1.0);
-                        kernel->reverse(*jac_ws);
-                        for (int j=0;j<n;j++)
-                            J[i][j] = aadc::toDblPtr(jac_ws->diff(kxa[j]))[0];
-                    }
-                    return J;
-                };
+                double t_val = sc * idt;
 
-                // Helper: LU factorize (I - dt*J) off-tape, return L,U,piv
-                // Simple partial pivoting LU
-                auto lu_factorize = [&](const std::vector<std::vector<double>>& J) {
-                    std::vector<std::vector<double>> A(n, std::vector<double>(n));
-                    std::vector<int> piv(n);
-                    for (int i=0;i<n;i++) { piv[i]=i; for (int j=0;j<n;j++) A[i][j]=(i==j?1.0:0.0)-idt*J[i][j]; }
-                    for (int col=0;col<n;col++) {
-                        // partial pivot
-                        int mx=col; for (int r=col+1;r<n;r++) if (std::abs(A[r][col])>std::abs(A[mx][col])) mx=r;
-                        if (mx!=col) { std::swap(A[col],A[mx]); std::swap(piv[col],piv[mx]); }
-                        for (int r=col+1;r<n;r++) {
-                            A[r][col]/=A[col][col];
-                            for (int c=col+1;c<n;c++) A[r][c]-=A[r][col]*A[col][c];
-                        }
-                    }
-                    return std::make_pair(A, piv);
-                };
-
-                // Compute diagonal J via kernel reverse AD (off-tape, for semi-implicit predictor)
-                auto rates0_ref = call_kernel(x);
+                // Compute diagonal J off-tape via kernel reverse AD (every jac_lag steps)
                 if (sc%jac_lag==0) {
                     for (int i=0;i<n;i++) jac_ws->setVal(kxa[i], x[i].val);
                     for (int k2=0;k2<n_p;k2++) jac_ws->setVal(kpa[k2], pid2[k2].val);
+                    jac_ws->setVal(kta, t_val);
                     kernel->forward(*jac_ws);
                     for (int i=0;i<n;i++) {
                         jac_ws->resetDiff();
                         jac_ws->setDiff(krr[i], 1.0);
                         kernel->reverse(*jac_ws);
-                        dJ[i] = idouble(aadc::toDblPtr(jac_ws->diff(kxa[i]))[0]);
+                        dJ_val[i] = aadc::toDblPtr(jac_ws->diff(kxa[i]))[0];
                     }
                 }
 
                 if (newton_iters == 0) {
-                    // Semi-implicit step
-                    for (int i=0;i<n;i++)
-                        x[i]=x[i]+idouble(idt)*rates0_ref[i]/(idouble(1.0)-idouble(idt)*dJ[i]);
+                    // ---- SEMI-IMPLICIT: step kernel approach ----
+                    // ONE reference node per step, no idouble arithmetic on main tape
+                    std::vector<idouble> xnew(n);
+                    std::vector<aadc::ExtVarIndex> txi(n), tpi(n_p), toi(n);
+                    for (int i=0;i<n;i++) txi[i]=aadc::ExtVarIndex(x[i],true,true);
+                    for (int k2=0;k2<n_p;k2++) tpi[k2]=aadc::ExtVarIndex(pid2[k2],true,true);
+                    for (int i=0;i<n;i++){xnew[i]=idouble(0.0);toi[i]=aadc::ExtVarIndex(xnew[i],false,true);}
+
+                    aadc::addConstStateExtFunction(std::make_shared<StepExtFunc>(
+                        step_kernel, sxa, spa, sta, sja, sxr,
+                        txi, tpi, toi, t_val, dJ_val, step_ws));
+
+                    for (int i=0;i<n;i++) step_ws->setVal(sxa[i], x[i].val);
+                    for (int k2=0;k2<n_p;k2++) step_ws->setVal(spa[k2], pid2[k2].val);
+                    step_ws->setVal(sta, t_val);
+                    for (int i=0;i<n;i++) step_ws->setVal(sja[i], dJ_val[i]);
+                    step_kernel->forward(*step_ws);
+                    for (int i=0;i<n;i++) xnew[i].val=aadc::toDblPtr(step_ws->val(sxr[i]))[0];
+                    x = xnew;
                 } else {
-                    // Full Newton with semi-implicit predictor
+                    // ---- NEWTON: f-kernel + LUSolveExtFunc approach ----
+                    // Semi-implicit predictor via step kernel
                     std::vector<idouble> y(n);
-                    for (int i=0;i<n;i++)
-                        y[i]=x[i]+idouble(idt)*rates0_ref[i]/(idouble(1.0)-idouble(idt)*dJ[i]);
-
-                    // Compute full Jacobian at y and LU off-tape (constants)
-                    std::vector<double> f0(n);
-                    { for (int i=0;i<n;i++) loop_ws->setVal(kxa[i],y[i].val);
-                      for (int k2=0;k2<n_p;k2++) loop_ws->setVal(kpa[k2],pid2[k2].val);
-                      kernel->forward(*loop_ws);
-                      for (int i=0;i<n;i++) f0[i]=aadc::toDblPtr(loop_ws->val(krr[i]))[0];
+                    {
+                        std::vector<aadc::ExtVarIndex> txi(n), tpi(n_p), toi(n);
+                        for (int i=0;i<n;i++) txi[i]=aadc::ExtVarIndex(x[i],true,true);
+                        for (int k2=0;k2<n_p;k2++) tpi[k2]=aadc::ExtVarIndex(pid2[k2],true,true);
+                        for (int i=0;i<n;i++){y[i]=idouble(0.0);toi[i]=aadc::ExtVarIndex(y[i],false,true);}
+                        aadc::addConstStateExtFunction(std::make_shared<StepExtFunc>(
+                            step_kernel, sxa, spa, sta, sja, sxr,
+                            txi, tpi, toi, t_val, dJ_val, step_ws));
+                        for (int i=0;i<n;i++) step_ws->setVal(sxa[i], x[i].val);
+                        for (int k2=0;k2<n_p;k2++) step_ws->setVal(spa[k2], pid2[k2].val);
+                        step_ws->setVal(sta, t_val);
+                        for (int i=0;i<n;i++) step_ws->setVal(sja[i], dJ_val[i]);
+                        step_kernel->forward(*step_ws);
+                        for (int i=0;i<n;i++) y[i].val=aadc::toDblPtr(step_ws->val(sxr[i]))[0];
                     }
+
+                    // Full Jacobian + LU (off-tape, every jac_lag steps)
                     if (sc%jac_lag==0) {
-                        auto J = compute_jacobian(y, f0);
-                        auto [LU_new, piv_new] = lu_factorize(J);
-                        cached_LU = LU_new;
-                        cached_piv = piv_new;
+                        std::vector<std::vector<double>> J(n, std::vector<double>(n, 0.0));
+                        for (int i=0;i<n;i++) jac_ws->setVal(kxa[i], y[i].val);
+                        for (int k2=0;k2<n_p;k2++) jac_ws->setVal(kpa[k2], pid2[k2].val);
+                        jac_ws->setVal(kta, t_val);
+                        kernel->forward(*jac_ws);
+                        for (int i=0;i<n;i++) {
+                            jac_ws->resetDiff();
+                            jac_ws->setDiff(krr[i], 1.0);
+                            kernel->reverse(*jac_ws);
+                            for (int j=0;j<n;j++)
+                                J[i][j] = aadc::toDblPtr(jac_ws->diff(kxa[j]))[0];
+                        }
+                        // LU factorize (I - dt*J)
+                        cached_LU.assign(n, std::vector<double>(n));
+                        cached_piv.resize(n);
+                        for (int i=0;i<n;i++) { cached_piv[i]=i; for (int j=0;j<n;j++) cached_LU[i][j]=(i==j?1.0:0.0)-idt*J[i][j]; }
+                        for (int col=0;col<n;col++) {
+                            int mx=col; for (int r=col+1;r<n;r++) if (std::abs(cached_LU[r][col])>std::abs(cached_LU[mx][col])) mx=r;
+                            if (mx!=col) { std::swap(cached_LU[col],cached_LU[mx]); std::swap(cached_piv[col],cached_piv[mx]); }
+                            for (int r=col+1;r<n;r++) {
+                                cached_LU[r][col]/=cached_LU[col][col];
+                                for (int c=col+1;c<n;c++) cached_LU[r][c]-=cached_LU[r][col]*cached_LU[col][c];
+                            }
+                        }
                     }
 
-                    // Newton iterations
+                    // Newton iterations: f(y) via f-kernel + LUSolveExtFunc
                     for (int nit=0; nit<newton_iters; nit++) {
-                        auto fy = call_kernel(y);  // f(y) on tape
-                        // F = y - x - dt*f(y), on tape
+                        // f(y) on tape via KernelExtFunc
+                        std::vector<idouble> fy(n);
+                        {
+                            std::vector<aadc::ExtVarIndex> txi(n),tpi(n_p),toi(n);
+                            for (int i=0;i<n;i++) txi[i]=aadc::ExtVarIndex(y[i],true,true);
+                            for (int k2=0;k2<n_p;k2++) tpi[k2]=aadc::ExtVarIndex(pid2[k2],true,true);
+                            for (int i=0;i<n;i++){fy[i]=idouble(0.0);toi[i]=aadc::ExtVarIndex(fy[i],false,true);}
+                            aadc::addConstStateExtFunction(std::make_shared<KernelExtFunc>(kernel,kxa,kpa,krr,txi,tpi,toi,loop_ws));
+                            for (int i=0;i<n;i++) loop_ws->setVal(kxa[i],y[i].val);
+                            for (int k2=0;k2<n_p;k2++) loop_ws->setVal(kpa[k2],pid2[k2].val);
+                            loop_ws->setVal(kta, t_val);
+                            kernel->forward(*loop_ws);
+                            for (int i=0;i<n;i++) fy[i].val=aadc::toDblPtr(loop_ws->val(krr[i]))[0];
+                        }
+                        // F = y - x - dt*f(y)
                         std::vector<idouble> F(n);
                         for (int i=0;i<n;i++) F[i]=y[i]-x[i]-idouble(idt)*fy[i];
-                        // dy = LU_solve(F) via ExtFunc (off-tape LU, constant coefficients)
+                        // LU solve via ExtFunc
                         std::vector<idouble> dy(n);
                         {
                             std::vector<aadc::ExtVarIndex> rhs_ei(n), out_ei(n);
                             for (int i=0;i<n;i++) rhs_ei[i]=aadc::ExtVarIndex(F[i],true,true);
                             for (int i=0;i<n;i++){dy[i]=idouble(0.0);out_ei[i]=aadc::ExtVarIndex(dy[i],false,true);}
                             aadc::addConstStateExtFunction(std::make_shared<LUSolveExtFunc>(n,cached_LU,cached_piv,rhs_ei,out_ei));
-                            // Compute values for dy
                             std::vector<double> bv(n);
                             for (int i=0;i<n;i++) bv[i]=F[cached_piv[i]].val;
-                            for (int i=1;i<n;i++)
-                                for (int j=0;j<i;j++) bv[i]-=cached_LU[i][j]*bv[j];
-                            for (int i=n-1;i>=0;i--) {
-                                for (int j=i+1;j<n;j++) bv[i]-=cached_LU[i][j]*bv[j];
-                                bv[i]/=cached_LU[i][i];
-                            }
+                            for (int i=1;i<n;i++) for (int j=0;j<i;j++) bv[i]-=cached_LU[i][j]*bv[j];
+                            for (int i=n-1;i>=0;i--) { for (int j=i+1;j<n;j++) bv[i]-=cached_LU[i][j]*bv[j]; bv[i]/=cached_LU[i][i]; }
                             for (int i=0;i<n;i++) dy[i].val=bv[i];
                         }
-                        // y = y - dy, on tape
                         for (int i=0;i<n;i++) y[i]=y[i]-dy[i];
                     }
                     x = y;

--- a/src/param_id/aadc_native/bdf_loop.cpp
+++ b/src/param_id/aadc_native/bdf_loop.cpp
@@ -1,0 +1,540 @@
+// bdf_loop.cpp — Semi-implicit BDF loop using kernel replay with caching
+#include "pyaadc.hpp"
+#include <vector>
+#include <map>
+#include <tuple>
+#include <fstream>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/serialization/vector.hpp>
+#include <aadc/serialization.h>
+
+namespace py = pybind11;
+
+class KernelExtFunc : public aadc::ConstStateExtFunc {
+public:
+    KernelExtFunc(
+        std::shared_ptr<Functions> kernel,
+        const std::vector<Argument>& kx, const std::vector<Argument>& kp,
+        const std::vector<Result>& kr,
+        const std::vector<aadc::ExtVarIndex>& tx, const std::vector<aadc::ExtVarIndex>& tp,
+        const std::vector<aadc::ExtVarIndex>& to,
+        std::shared_ptr<WorkSpace> shared_ws = nullptr
+    ) : kernel_(kernel), kx_(kx), kp_(kp), kr_(kr), tx_(tx), tp_(tp), to_(to) {
+        ws_ = shared_ws ? shared_ws : kernel_->createWorkSpace();
+    }
+    template<typename M> void forward(M* v) const {
+        for (int a = 0; a < aadc::mmSize<M>(); a++) {
+            for (size_t i=0;i<kx_.size();i++) aadc::toDblPtr(ws_->val(kx_[i]))[0]=aadc::toDblPtr(v[tx_[i]])[a];
+            for (size_t k=0;k<kp_.size();k++) aadc::toDblPtr(ws_->val(kp_[k]))[0]=aadc::toDblPtr(v[tp_[k]])[a];
+            kernel_->forward(*ws_);
+            for (size_t i=0;i<kr_.size();i++) aadc::toDblPtr(v[to_[i]])[a]=aadc::toDblPtr(ws_->val(kr_[i]))[0];
+        }
+    }
+    template<class M> void reverse(const M* v, M* d) const {
+        for (int a = 0; a < aadc::mmSize<M>(); a++) {
+            for (size_t i=0;i<kx_.size();i++) aadc::toDblPtr(ws_->val(kx_[i]))[0]=aadc::toDblPtr(v[tx_[i]])[a];
+            for (size_t k=0;k<kp_.size();k++) aadc::toDblPtr(ws_->val(kp_[k]))[0]=aadc::toDblPtr(v[tp_[k]])[a];
+            kernel_->forward(*ws_);
+            ws_->resetDiff();
+            for (size_t i=0;i<kr_.size();i++) aadc::toDblPtr(ws_->diff(kr_[i]))[0]=aadc::toDblPtr(d[to_[i]])[a];
+            kernel_->reverse(*ws_);
+            for (size_t i=0;i<kx_.size();i++) aadc::toDblPtr(d[tx_[i]])[a]+=aadc::toDblPtr(ws_->diff(kx_[i]))[0];
+            for (size_t k=0;k<kp_.size();k++) aadc::toDblPtr(d[tp_[k]])[a]+=aadc::toDblPtr(ws_->diff(kp_[k]))[0];
+        }
+    }
+private:
+    std::shared_ptr<Functions> kernel_;
+    std::vector<Argument> kx_,kp_; std::vector<Result> kr_;
+    std::vector<aadc::ExtVarIndex> tx_,tp_,to_;
+    mutable std::shared_ptr<WorkSpace> ws_;
+};
+
+// LU solve as ConstStateExtFunc: forward = LU\rhs, reverse = LU^{-T} adjoint
+// This avoids recording ~750 idouble ops per Newton step on tape.
+class LUSolveExtFunc : public aadc::ConstStateExtFunc {
+public:
+    LUSolveExtFunc(
+        int n,
+        const std::vector<std::vector<double>>& LU,
+        const std::vector<int>& piv,
+        const std::vector<aadc::ExtVarIndex>& rhs_idx,  // inputs (F)
+        const std::vector<aadc::ExtVarIndex>& out_idx    // outputs (dy)
+    ) : n_(n), LU_(LU), piv_(piv), rhs_idx_(rhs_idx), out_idx_(out_idx) {}
+
+    template<typename M> void forward(M* v) const {
+        for (int a = 0; a < aadc::mmSize<M>(); a++) {
+            // Read rhs
+            std::vector<double> b(n_);
+            for (int i=0;i<n_;i++) b[i] = aadc::toDblPtr(v[rhs_idx_[i]])[a];
+            // Permute
+            std::vector<double> pb(n_);
+            for (int i=0;i<n_;i++) pb[i] = b[piv_[i]];
+            // Forward sub (L)
+            for (int i=1;i<n_;i++)
+                for (int j=0;j<i;j++) pb[i] -= LU_[i][j]*pb[j];
+            // Back sub (U)
+            for (int i=n_-1;i>=0;i--) {
+                for (int j=i+1;j<n_;j++) pb[i] -= LU_[i][j]*pb[j];
+                pb[i] /= LU_[i][i];
+            }
+            // Write output
+            for (int i=0;i<n_;i++) aadc::toDblPtr(v[out_idx_[i]])[a] = pb[i];
+        }
+    }
+
+    template<class M> void reverse(const M* v, M* d) const {
+        for (int a = 0; a < aadc::mmSize<M>(); a++) {
+            // Read output adjoint d_out
+            std::vector<double> dout(n_);
+            for (int i=0;i<n_;i++) dout[i] = aadc::toDblPtr(d[out_idx_[i]])[a];
+            // Reverse of LU solve = (LU)^{-T} * dout
+            // = U^{-T} L^{-T} P dout? No: reverse of Ax=b is A^T lambda = dout, drhs += P^T lambda
+            // Actually: forward is x = (LU)^{-1} P b
+            // dx/db = (LU)^{-1} P
+            // d_rhs += P^T (LU)^{-T} d_out
+            // Step 1: solve U^T z = d_out
+            std::vector<double> z(n_);
+            for (int i=0;i<n_;i++) z[i] = dout[i];
+            for (int i=0;i<n_;i++) {
+                z[i] /= LU_[i][i];
+                for (int j=i+1;j<n_;j++) z[j] -= LU_[i][j]*z[i];
+            }
+            // Step 2: solve L^T w = z
+            for (int i=n_-2;i>=0;i--)
+                for (int j=i+1;j<n_;j++) z[i] -= LU_[j][i]*z[j];
+            // Step 3: apply P^T (un-permute)
+            // piv maps row i -> original row piv[i]
+            // P^T maps: d_rhs[piv[i]] += z[i]
+            for (int i=0;i<n_;i++)
+                aadc::toDblPtr(d[rhs_idx_[piv_[i]]])[a] += z[i];
+        }
+    }
+
+private:
+    int n_;
+    std::vector<std::vector<double>> LU_;
+    std::vector<int> piv_;
+    std::vector<aadc::ExtVarIndex> rhs_idx_, out_idx_;
+};
+
+// Static cache
+static struct {
+    std::shared_ptr<Functions> funcs;
+    std::shared_ptr<WorkSpace> ws;
+    std::vector<Argument> x_args, p_args;
+    Result cost_res;
+    int total_subs = 0;
+    int newton_mode = -1;
+} cache;
+
+bool bdf_save_tape(const std::string& path) {
+    if (!cache.funcs) return false;
+    try {
+        std::ofstream ofs(path, std::ios::binary);
+        boost::archive::binary_oarchive ar(ofs);
+        serialize_AADCFunctions(ar, *cache.funcs, 0);
+        ar & cache.x_args & cache.p_args & cache.cost_res;
+        ar & cache.total_subs & cache.newton_mode;
+        return true;
+    } catch (...) { return false; }
+}
+
+bool bdf_load_tape(const std::string& path) {
+    try {
+        auto funcs = std::make_shared<Functions>();
+        std::ifstream ifs(path, std::ios::binary);
+        if (!ifs.good()) return false;
+        boost::archive::binary_iarchive ar(ifs);
+        serialize_AADCFunctions(ar, *funcs, 0);
+        std::vector<Argument> xa, pa;
+        Result cr;
+        int ts, nm;
+        ar & xa & pa & cr & ts & nm;
+        cache.funcs = funcs;
+        cache.ws = funcs->createWorkSpace();
+        cache.x_args = xa; cache.p_args = pa; cache.cost_res = cr;
+        cache.total_subs = ts; cache.newton_mode = nm;
+        return true;
+    } catch (...) { return false; }
+}
+
+py::tuple bdf_record_and_evaluate(
+    py::function compute_rates_fn, py::list py_states, py::list py_variables,
+    py::list py_param_indices, py::list py_param_values,
+    int total_steps, int pre_steps, int n_sub, double idt,
+    py::list py_obs_list, py::object compute_variables_fn, int jac_lag,
+    int newton_iters, py::list py_jac_coloring
+) {
+    int n = py::len(py_states), n_p = py::len(py_param_indices), n_vars = py::len(py_variables);
+    std::vector<int> pidx(n_p);
+    for (int k=0;k<n_p;k++) pidx[k] = py_param_indices[k].cast<int>();
+
+    // Parse coloring: list of lists of column indices
+    std::vector<std::vector<int>> jac_coloring;
+    for (auto group : py_jac_coloring)
+        jac_coloring.push_back(group.cast<std::vector<int>>());
+    int total_subs = total_steps * n_sub;
+
+    if (!cache.funcs || cache.total_subs != total_subs || cache.newton_mode != newton_iters) {
+        // ---- Record kernel ----
+        auto kernel = std::make_shared<Functions>();
+        kernel->startRecording();
+        std::vector<idouble> kx(n); std::vector<Argument> kxa(n);
+        for (int i=0;i<n;i++) { kx[i]=py_states[i].cast<double>(); kxa[i]=kx[i].markAsInput(); }
+        std::vector<idouble> kv(n_vars); std::vector<Argument> kpa(n_p);
+        for (int i=0;i<n_vars;i++) { double v=py_variables[i].cast<double>(); kv[i]=(v==v)?v:0.0; }
+        for (int k=0;k<n_p;k++) { kv[pidx[k]]=py_param_values[k].cast<double>(); kpa[k]=kv[pidx[k]].markAsInput(); }
+        py::list pkx(n),pkr(n),pkv(n_vars);
+        for (int i=0;i<n;i++) pkx[i]=py::cast(kx[i]);
+        for (int i=0;i<n;i++) pkr[i]=py::cast(idouble(0.0));
+        for (int i=0;i<n_vars;i++) pkv[i]=py::cast(kv[i]);
+        compute_rates_fn(py::cast(idouble(0.0)),pkx,pkr,pkv);
+        std::vector<Result> krr(n);
+        for (int i=0;i<n;i++) {
+            auto o=pkr[i]; idouble rv=py::isinstance<idouble>(o)?o.cast<idouble>():idouble(o.cast<double>());
+            krr[i]=rv.markAsOutput();
+        }
+        kernel->stopRecording();
+
+        // ---- Record compute_variables kernel (for var observables) ----
+        bool has_var_obs = false;
+        std::vector<int> var_obs_indices; // which variable indices are needed
+        for (auto item : py_obs_list) {
+            auto t = item.cast<py::tuple>();
+            if (t[0].cast<int>() == 1) { // kind=1 = var
+                has_var_obs = true;
+                var_obs_indices.push_back(t[2].cast<int>()); // var_raw_idx
+            }
+        }
+
+        std::shared_ptr<Functions> cv_kernel;
+        std::vector<Argument> cv_xa, cv_pa;
+        std::vector<Result> cv_res;
+        int n_cv_out = 0;
+
+        std::shared_ptr<WorkSpace> cv_loop_ws;
+        if (has_var_obs && !compute_variables_fn.is_none()) {
+            // Deduplicate var indices
+            std::sort(var_obs_indices.begin(), var_obs_indices.end());
+            var_obs_indices.erase(std::unique(var_obs_indices.begin(), var_obs_indices.end()), var_obs_indices.end());
+            n_cv_out = var_obs_indices.size();
+
+            cv_kernel = std::make_shared<Functions>();
+            cv_kernel->startRecording();
+            // Same inputs as f kernel: x and p
+            std::vector<idouble> cvx(n);
+            cv_xa.resize(n);
+            for (int i=0;i<n;i++) { cvx[i]=py_states[i].cast<double>(); cv_xa[i]=cvx[i].markAsInput(); }
+            std::vector<idouble> cvv(n_vars);
+            cv_pa.resize(n_p);
+            for (int i=0;i<n_vars;i++) { double v=py_variables[i].cast<double>(); cvv[i]=(v==v)?v:0.0; }
+            for (int k=0;k<n_p;k++) { cvv[pidx[k]]=py_param_values[k].cast<double>(); cv_pa[k]=cvv[pidx[k]].markAsInput(); }
+
+            // Call compute_rates then compute_variables
+            py::list pcvx(n), pcvr(n), pcvv(n_vars);
+            for (int i=0;i<n;i++) pcvx[i]=py::cast(cvx[i]);
+            for (int i=0;i<n;i++) pcvr[i]=py::cast(idouble(0.0));
+            for (int i=0;i<n_vars;i++) pcvv[i]=py::cast(cvv[i]);
+            compute_rates_fn(py::cast(idouble(0.0)), pcvx, pcvr, pcvv);
+            compute_variables_fn(py::cast(idouble(0.0)), pcvx, pcvr, pcvv);
+
+            // Mark needed var outputs
+            cv_res.resize(n_cv_out);
+            for (int i=0;i<n_cv_out;i++) {
+                auto obj = pcvv[var_obs_indices[i]];
+                idouble rv = py::isinstance<idouble>(obj) ? obj.cast<idouble>() : idouble(obj.cast<double>());
+                cv_res[i] = rv.markAsOutput();
+            }
+            cv_kernel->stopRecording();
+            cv_loop_ws = cv_kernel->createWorkSpace();
+        }
+
+        // ---- Record main tape ----
+        auto mf = std::make_shared<Functions>();
+        mf->startRecording();
+        std::vector<idouble> x(n); std::vector<Argument> xa(n);
+        for (int i=0;i<n;i++) { x[i]=py_states[i].cast<double>(); xa[i]=x[i].markAsInput(); }
+        std::vector<idouble> pid2(n_p); std::vector<Argument> pa(n_p);
+        for (int k=0;k<n_p;k++) { pid2[k]=py_param_values[k].cast<double>(); pa[k]=pid2[k].markAsInput(); }
+
+        struct Obs{int kind,si,vri,op;double gt,sd,w,sc;};
+        std::vector<Obs> obs;
+        for (auto item:py_obs_list) { auto t=item.cast<py::tuple>();
+            obs.push_back({t[0].cast<int>(),t[1].cast<int>(),t[2].cast<int>(),t[3].cast<int>(),
+                           t[4].cast<double>(),t[5].cast<double>(),t[6].cast<double>(),t[7].cast<double>()}); }
+        using Key=std::tuple<int,int,int>;
+        struct Acc{idouble sum{0.0};int count=0;idouble mx,mn;bool init=false;};
+        std::map<Key,Acc> accs;
+        for (auto&o:obs) accs[{o.kind,o.si,o.op}]=Acc{};
+
+        std::vector<idouble> dJ(n,idouble(0.0));
+        auto jac_ws = kernel->createWorkSpace();  // reused for all Jacobian computations
+        auto loop_ws = kernel->createWorkSpace();  // reused for all forward evals in loop
+        std::vector<std::vector<double>> cached_LU(n, std::vector<double>(n, 0.0));
+        std::vector<int> cached_piv(n);
+        for (int i=0;i<n;i++) { cached_piv[i]=i; cached_LU[i][i]=1.0; }
+        int sc=0;
+        int cp_interval = 100; // checkpoint every 100 sub-steps
+        for (int step=0;step<total_steps;step++) {
+            for (int sub=0;sub<n_sub;sub++) {
+                if (sc > 0 && sc % cp_interval == 0)
+                    idouble::CheckPoint();
+                // Helper: call kernel ExtFunc, put f(y,p) on tape, return rates
+                auto call_kernel = [&](std::vector<idouble>& y) -> std::vector<idouble> {
+                    std::vector<idouble> r(n);
+                    std::vector<aadc::ExtVarIndex> txi(n),tpi(n_p),toi(n);
+                    for (int i=0;i<n;i++) txi[i]=aadc::ExtVarIndex(y[i],true,true);
+                    for (int k=0;k<n_p;k++) tpi[k]=aadc::ExtVarIndex(pid2[k],true,true);
+                    for (int i=0;i<n;i++){r[i]=idouble(0.0);toi[i]=aadc::ExtVarIndex(r[i],false,true);}
+                    aadc::addConstStateExtFunction(std::make_shared<KernelExtFunc>(kernel,kxa,kpa,krr,txi,tpi,toi,loop_ws));
+                    for (int i=0;i<n;i++) loop_ws->setVal(kxa[i],y[i].val);
+                    for (int k2=0;k2<n_p;k2++) loop_ws->setVal(kpa[k2],pid2[k2].val);
+                    kernel->forward(*loop_ws);
+                    for (int i=0;i<n;i++) r[i].val=aadc::toDblPtr(loop_ws->val(krr[i]))[0];
+                    return r;
+                };
+
+                // Helper: compute Jacobian off-tape via kernel reverse AD
+                // Row i of J: set adjoint f_i = 1, reverse, read x_j adjoints
+                // 27 reverse passes = full 27×27 Jacobian, exact (no FD approximation)
+                auto compute_jacobian = [&](const std::vector<idouble>& y, const std::vector<double>& f0) {
+                    std::vector<std::vector<double>> J(n, std::vector<double>(n, 0.0));
+                    for (int i=0;i<n;i++) jac_ws->setVal(kxa[i], y[i].val);
+                    for (int k2=0;k2<n_p;k2++) jac_ws->setVal(kpa[k2], pid2[k2].val);
+                    kernel->forward(*jac_ws);
+                    for (int i=0;i<n;i++) {
+                        jac_ws->resetDiff();
+                        jac_ws->setDiff(krr[i], 1.0);
+                        kernel->reverse(*jac_ws);
+                        for (int j=0;j<n;j++)
+                            J[i][j] = aadc::toDblPtr(jac_ws->diff(kxa[j]))[0];
+                    }
+                    return J;
+                };
+
+                // Helper: LU factorize (I - dt*J) off-tape, return L,U,piv
+                // Simple partial pivoting LU
+                auto lu_factorize = [&](const std::vector<std::vector<double>>& J) {
+                    std::vector<std::vector<double>> A(n, std::vector<double>(n));
+                    std::vector<int> piv(n);
+                    for (int i=0;i<n;i++) { piv[i]=i; for (int j=0;j<n;j++) A[i][j]=(i==j?1.0:0.0)-idt*J[i][j]; }
+                    for (int col=0;col<n;col++) {
+                        // partial pivot
+                        int mx=col; for (int r=col+1;r<n;r++) if (std::abs(A[r][col])>std::abs(A[mx][col])) mx=r;
+                        if (mx!=col) { std::swap(A[col],A[mx]); std::swap(piv[col],piv[mx]); }
+                        for (int r=col+1;r<n;r++) {
+                            A[r][col]/=A[col][col];
+                            for (int c=col+1;c<n;c++) A[r][c]-=A[r][col]*A[col][c];
+                        }
+                    }
+                    return std::make_pair(A, piv);
+                };
+
+                // Compute diagonal J via kernel reverse AD (off-tape, for semi-implicit predictor)
+                auto rates0_ref = call_kernel(x);
+                if (sc%jac_lag==0) {
+                    for (int i=0;i<n;i++) jac_ws->setVal(kxa[i], x[i].val);
+                    for (int k2=0;k2<n_p;k2++) jac_ws->setVal(kpa[k2], pid2[k2].val);
+                    kernel->forward(*jac_ws);
+                    for (int i=0;i<n;i++) {
+                        jac_ws->resetDiff();
+                        jac_ws->setDiff(krr[i], 1.0);
+                        kernel->reverse(*jac_ws);
+                        dJ[i] = idouble(aadc::toDblPtr(jac_ws->diff(kxa[i]))[0]);
+                    }
+                }
+
+                if (newton_iters == 0) {
+                    // Semi-implicit step
+                    for (int i=0;i<n;i++)
+                        x[i]=x[i]+idouble(idt)*rates0_ref[i]/(idouble(1.0)-idouble(idt)*dJ[i]);
+                } else {
+                    // Full Newton with semi-implicit predictor
+                    std::vector<idouble> y(n);
+                    for (int i=0;i<n;i++)
+                        y[i]=x[i]+idouble(idt)*rates0_ref[i]/(idouble(1.0)-idouble(idt)*dJ[i]);
+
+                    // Compute full Jacobian at y and LU off-tape (constants)
+                    std::vector<double> f0(n);
+                    { for (int i=0;i<n;i++) loop_ws->setVal(kxa[i],y[i].val);
+                      for (int k2=0;k2<n_p;k2++) loop_ws->setVal(kpa[k2],pid2[k2].val);
+                      kernel->forward(*loop_ws);
+                      for (int i=0;i<n;i++) f0[i]=aadc::toDblPtr(loop_ws->val(krr[i]))[0];
+                    }
+                    if (sc%jac_lag==0) {
+                        auto J = compute_jacobian(y, f0);
+                        auto [LU_new, piv_new] = lu_factorize(J);
+                        cached_LU = LU_new;
+                        cached_piv = piv_new;
+                    }
+
+                    // Newton iterations
+                    for (int nit=0; nit<newton_iters; nit++) {
+                        auto fy = call_kernel(y);  // f(y) on tape
+                        // F = y - x - dt*f(y), on tape
+                        std::vector<idouble> F(n);
+                        for (int i=0;i<n;i++) F[i]=y[i]-x[i]-idouble(idt)*fy[i];
+                        // dy = LU_solve(F) via ExtFunc (off-tape LU, constant coefficients)
+                        std::vector<idouble> dy(n);
+                        {
+                            std::vector<aadc::ExtVarIndex> rhs_ei(n), out_ei(n);
+                            for (int i=0;i<n;i++) rhs_ei[i]=aadc::ExtVarIndex(F[i],true,true);
+                            for (int i=0;i<n;i++){dy[i]=idouble(0.0);out_ei[i]=aadc::ExtVarIndex(dy[i],false,true);}
+                            aadc::addConstStateExtFunction(std::make_shared<LUSolveExtFunc>(n,cached_LU,cached_piv,rhs_ei,out_ei));
+                            // Compute values for dy
+                            std::vector<double> bv(n);
+                            for (int i=0;i<n;i++) bv[i]=F[cached_piv[i]].val;
+                            for (int i=1;i<n;i++)
+                                for (int j=0;j<i;j++) bv[i]-=cached_LU[i][j]*bv[j];
+                            for (int i=n-1;i>=0;i--) {
+                                for (int j=i+1;j<n;j++) bv[i]-=cached_LU[i][j]*bv[j];
+                                bv[i]/=cached_LU[i][i];
+                            }
+                            for (int i=0;i<n;i++) dy[i].val=bv[i];
+                        }
+                        // y = y - dy, on tape
+                        for (int i=0;i<n;i++) y[i]=y[i]-dy[i];
+                    }
+                    x = y;
+                }
+                sc++;
+            }
+            if (step>=pre_steps) {
+                // Compute var observables via cv_kernel if needed
+                std::vector<idouble> var_vals;
+                if (has_var_obs && cv_kernel) {
+                    var_vals.resize(n_cv_out);
+                    std::vector<aadc::ExtVarIndex> cvtxi(n), cvtpi(n_p), cvtoi(n_cv_out);
+                    for (int i=0;i<n;i++) cvtxi[i]=aadc::ExtVarIndex(x[i],true,true);
+                    for (int k=0;k<n_p;k++) cvtpi[k]=aadc::ExtVarIndex(pid2[k],true,true);
+                    for (int i=0;i<n_cv_out;i++){var_vals[i]=idouble(0.0);cvtoi[i]=aadc::ExtVarIndex(var_vals[i],false,true);}
+                    aadc::addConstStateExtFunction(std::make_shared<KernelExtFunc>(cv_kernel,cv_xa,cv_pa,cv_res,cvtxi,cvtpi,cvtoi,cv_loop_ws));
+                    for (int i=0;i<n;i++) cv_loop_ws->setVal(cv_xa[i],x[i].val);
+                    for (int k=0;k<n_p;k++) cv_loop_ws->setVal(cv_pa[k],pid2[k].val);
+                    cv_kernel->forward(*cv_loop_ws);
+                    for (int i=0;i<n_cv_out;i++) var_vals[i].val=aadc::toDblPtr(cv_loop_ws->val(cv_res[i]))[0];
+                }
+
+                for (auto&o:obs) {
+                    auto&a=accs[{o.kind,o.si,o.op}];
+                    idouble xi;
+                    if (o.kind==0) {
+                        xi=x[o.si];
+                    } else if (has_var_obs && cv_kernel) {
+                        // Find var_obs_indices position for o.vri
+                        auto it = std::find(var_obs_indices.begin(), var_obs_indices.end(), o.vri);
+                        if (it != var_obs_indices.end()) xi = var_vals[it - var_obs_indices.begin()];
+                        else continue;
+                    } else continue;
+                    switch(o.op){
+                        case 0:a.sum=a.sum+xi;a.count++;break;
+                        case 1:if(!a.init){a.mx=xi;a.init=true;}else a.mx=iIf(xi>a.mx,xi,a.mx);break;
+                        case 2:if(!a.init){a.mn=xi;a.init=true;}else a.mn=iIf(xi<a.mn,xi,a.mn);break;
+                        case 3:if(!a.init){a.mx=xi;a.mn=xi;a.init=true;}else{
+                            a.mx=iIf(xi>a.mx,xi,a.mx);a.mn=iIf(xi<a.mn,xi,a.mn);}break;
+                    }
+                }
+            }
+        }
+        idouble cost(0.0);
+        for (auto&o:obs) {
+            auto&a=accs[{o.kind,o.si,o.op}]; idouble ov;
+            switch(o.op){case 0:ov=a.sum/idouble((double)a.count);break;case 1:ov=a.mx;break;
+                case 2:ov=a.mn;break;case 3:ov=a.mx-a.mn;break;default:continue;}
+            idouble res=(ov-idouble(o.gt))/idouble(o.sd);
+            cost=cost+idouble(o.sc*o.w)*res*res;
+        }
+        Result cr=cost.markAsOutput();
+        mf->stopRecording();
+
+        cache.funcs=mf; cache.ws=mf->createWorkSpace();
+        cache.x_args=xa; cache.p_args=pa; cache.cost_res=cr;
+        cache.total_subs=total_subs;
+        cache.newton_mode=newton_iters;
+    }
+
+    // ---- Evaluate ----
+    for (int i=0;i<n;i++) cache.ws->setVal(cache.x_args[i],py_states[i].cast<double>());
+    for (int k=0;k<n_p;k++) cache.ws->setVal(cache.p_args[k],py_param_values[k].cast<double>());
+    cache.funcs->forward(*cache.ws);
+    double cv=aadc::toDblPtr(cache.ws->val(cache.cost_res))[0];
+    cache.ws->resetDiff();
+    cache.ws->setDiff(cache.cost_res,1.0);
+    cache.funcs->reverse(*cache.ws);
+    py::list grad;
+    for (int k=0;k<n_p;k++) grad.append(aadc::toDblPtr(cache.ws->diff(cache.p_args[k]))[0]);
+    return py::make_tuple(cv,grad);
+}
+
+// Batched evaluation: 4 parameter sets in one AVX forward+reverse
+py::tuple bdf_evaluate_batch(
+    py::list py_states,
+    py::list py_param_values_batch,  // list of 4 param lists
+    int n_p
+) {
+    if (!cache.funcs) throw std::runtime_error("Call bdf_record_and_evaluate first to build tape");
+    constexpr int NLANES = sizeof(mmType) / sizeof(double);
+    int batch = py::len(py_param_values_batch);
+    if (batch > NLANES) batch = NLANES;
+    int n = py::len(py_states);
+
+    // Set inputs: states same for all lanes, params different per lane
+    for (int i = 0; i < n; i++) {
+        mmType v;
+        double sv = py_states[i].cast<double>();
+        for (int lane = 0; lane < NLANES; lane++)
+            aadc::toDblPtr(v)[lane] = sv;
+        cache.ws->setVal(cache.x_args[i], v);
+    }
+    for (int k = 0; k < n_p; k++) {
+        mmType v;
+        for (int lane = 0; lane < NLANES; lane++) {
+            if (lane < batch) {
+                py::list pv = py_param_values_batch[lane].cast<py::list>();
+                aadc::toDblPtr(v)[lane] = pv[k].cast<double>();
+            } else {
+                py::list pv = py_param_values_batch[0].cast<py::list>();
+                aadc::toDblPtr(v)[lane] = pv[k].cast<double>();
+            }
+        }
+        cache.ws->setVal(cache.p_args[k], v);
+    }
+
+    cache.funcs->forward(*cache.ws);
+
+    py::list costs;
+    for (int lane = 0; lane < batch; lane++)
+        costs.append(aadc::toDblPtr(cache.ws->val(cache.cost_res))[lane]);
+
+    // Reverse for each lane separately (adjoint is lane-specific)
+    py::list all_grads;
+    for (int lane = 0; lane < batch; lane++) {
+        cache.ws->resetDiff();
+        mmType d_cost;
+        for (int l = 0; l < NLANES; l++) aadc::toDblPtr(d_cost)[l] = (l == lane) ? 1.0 : 0.0;
+        cache.ws->setDiff(cache.cost_res, d_cost);
+        cache.funcs->reverse(*cache.ws);
+        py::list grad;
+        for (int k = 0; k < n_p; k++)
+            grad.append(aadc::toDblPtr(cache.ws->diff(cache.p_args[k]))[lane]);
+        all_grads.append(grad);
+    }
+    return py::make_tuple(costs, all_grads);
+}
+
+void init_bdf_loop(py::module& m) {
+    m.def("bdf_record_and_evaluate",&bdf_record_and_evaluate,
+        py::arg("compute_rates_fn"),py::arg("states"),py::arg("variables"),
+        py::arg("param_indices"),py::arg("param_values"),
+        py::arg("total_steps"),py::arg("pre_steps"),py::arg("n_sub"),py::arg("idt"),
+        py::arg("obs_list"),py::arg("compute_variables_fn")=py::none(),py::arg("jac_lag")=10,
+        py::arg("newton_iters")=0, py::arg("jac_coloring")=py::list());
+    m.def("bdf_evaluate_batch",&bdf_evaluate_batch,
+        py::arg("states"),py::arg("param_values_batch"),py::arg("n_p"),
+        "Evaluate 4 parameter sets simultaneously via AVX (requires prior bdf_record_and_evaluate call)");
+    m.def("bdf_save_tape", &bdf_save_tape, py::arg("path"),
+        "Save recorded tape to disk (boost serialization). Returns True on success.");
+    m.def("bdf_load_tape", &bdf_load_tape, py::arg("path"),
+        "Load tape from disk. Returns True on success. Subsequent bdf_record_and_evaluate uses cached tape.");
+}

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -91,7 +91,7 @@ SOLVER_SCHEMA = {
         # reached the tape. The AD tape has no bdf branch either, so do_ad silently recorded
         # rk4 instead -- cost and gradient were different functions. Use 'semi_implicit' for
         # stiff models, or model_type 'casadi_python' for a differentiable symbolic BDF.
-        'aadc_semi_implicit': ['adaptive_rk45', 'semi_implicit', 'implicit_euler_ift', 'implicit_newton', 'bdf_newton', 'rk4'],
+        'aadc_semi_implicit': ['adaptive_rk45', 'semi_implicit', 'implicit_euler_ift', 'implicit_newton', 'bdf_newton', 'bdf_tape', 'rk4'],
         # The user wrapper supplies the rhs; the framework integrates it with the
         # same scipy solve_ivp methods as model_type 'python'.
         'user_defined': ['RK45', 'RK23', 'DOP853', 'Radau', 'BDF', 'LSODA', 'forward_euler'],

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -91,7 +91,7 @@ SOLVER_SCHEMA = {
         # reached the tape. The AD tape has no bdf branch either, so do_ad silently recorded
         # rk4 instead -- cost and gradient were different functions. Use 'semi_implicit' for
         # stiff models, or model_type 'casadi_python' for a differentiable symbolic BDF.
-        'aadc_semi_implicit': ['adaptive_rk45', 'semi_implicit', 'implicit_euler_ift', 'implicit_newton', 'bdf_newton', 'bdf_tape', 'rk4'],
+        'aadc_semi_implicit': ['adaptive_rk45', 'semi_implicit', 'implicit_euler_ift', 'implicit_newton', 'bdf_newton', 'bdf_tape', 'bdf_kernel', 'rk4'],
         # The user wrapper supplies the rhs; the framework integrates it with the
         # same scipy solve_ivp methods as model_type 'python'.
         'user_defined': ['RK45', 'RK23', 'DOP853', 'Radau', 'BDF', 'LSODA', 'forward_euler'],

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -51,6 +51,17 @@ _CASADI_ADJOINT_METHODS = ('cvodes', 'idas')
 # dependency points one way: the backend depends on the schema, not the reverse.
 AADC_TAPE_CONSISTENT_METHODS = ('rk4', 'implicit_euler_ift', 'semi_implicit', 'implicit_newton')
 
+# The stiff BDF methods do not go through the standard replay tape at all: aadc_backend.
+# cost_and_grad dispatches each to its own gradient implementation *before* the
+# AADC_TAPE_CONSISTENT_METHODS check, so they are AD-capable without being members of it. Kept
+# as a separate tuple rather than folded into the one above, because that one means "the standard
+# tape can replay this step sequence" and these are not that -- but both are AD-capable, which is
+# what ad_suitable_methods advertises.
+AADC_BDF_AD_METHODS = ('bdf_newton', 'bdf_tape', 'bdf_kernel')
+
+# Every AADC method that can produce an analytic gradient, by either route.
+AADC_AD_METHODS = AADC_TAPE_CONSISTENT_METHODS + AADC_BDF_AD_METHODS
+
 # Single source of truth for which generated model_types exist, which solvers are
 # valid for each, and which methods/plugins are valid for each solver. Used for
 # input validation here AND surfaced to downstream tools (e.g. the CUFLynx
@@ -122,7 +133,7 @@ SOLVER_SCHEMA['ad_suitable_methods'] = {
     'casadi_integrator': [m for m in SOLVER_SCHEMA['methods_by_solver']['casadi_integrator']
                           if m not in _CASADI_ADJOINT_METHODS],
     'aadc_semi_implicit': [m for m in SOLVER_SCHEMA['methods_by_solver']['aadc_semi_implicit']
-                           if m in AADC_TAPE_CONSISTENT_METHODS],
+                           if m in AADC_AD_METHODS],
 }
 # Myokit CVODES forward-sensitivity (FSA) is the analytic gradient for stiff cellml_only models;
 # its method is 'CVODE' on the CVODE solvers. (CA's get_gradient currently produces FSA only for

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -91,7 +91,7 @@ SOLVER_SCHEMA = {
         # reached the tape. The AD tape has no bdf branch either, so do_ad silently recorded
         # rk4 instead -- cost and gradient were different functions. Use 'semi_implicit' for
         # stiff models, or model_type 'casadi_python' for a differentiable symbolic BDF.
-        'aadc_semi_implicit': ['adaptive_rk45', 'semi_implicit', 'implicit_euler_ift', 'implicit_newton', 'rk4'],
+        'aadc_semi_implicit': ['adaptive_rk45', 'semi_implicit', 'implicit_euler_ift', 'implicit_newton', 'bdf_newton', 'rk4'],
         # The user wrapper supplies the rhs; the framework integrates it with the
         # same scipy solve_ivp methods as model_type 'python'.
         'user_defined': ['RK45', 'RK23', 'DOP853', 'Radau', 'BDF', 'LSODA', 'forward_euler'],
@@ -227,6 +227,8 @@ SOLVER_INFO_FIELDS = {
          'description': 'Integration tolerance for the adaptive AADC integrator.'},
         {'name': 'threads', 'type': 'int', 'default': 4, 'required': False,
          'description': 'Number of threads for AADC evaluation.'},
+        {'name': 'max_step', 'type': 'float', 'default': 0.001, 'required': False,
+         'description': 'Internal sub-step cap for bdf_newton (default 0.001, matching CasADi BDF).'},
         # No 'gradient_method' here: nothing reads it. AD vs FD is chosen by the `do_ad` flag
         # (see SciPyMinimizeOptimiser.run, which falls back to approx_fprime when it is off),
         # and which AD backend runs follows from model_type/solver in

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -49,7 +49,7 @@ _CASADI_ADJOINT_METHODS = ('cvodes', 'idas')
 # parameters and cannot be replayed from a tape. Lives here (not in param_id/aadc_backend.py,
 # which imports it) so the schema and the check that enforces it cannot drift, and so the
 # dependency points one way: the backend depends on the schema, not the reverse.
-AADC_TAPE_CONSISTENT_METHODS = ('rk4', 'implicit_euler_ift', 'semi_implicit')
+AADC_TAPE_CONSISTENT_METHODS = ('rk4', 'implicit_euler_ift', 'semi_implicit', 'implicit_newton')
 
 # Single source of truth for which generated model_types exist, which solvers are
 # valid for each, and which methods/plugins are valid for each solver. Used for
@@ -91,7 +91,7 @@ SOLVER_SCHEMA = {
         # reached the tape. The AD tape has no bdf branch either, so do_ad silently recorded
         # rk4 instead -- cost and gradient were different functions. Use 'semi_implicit' for
         # stiff models, or model_type 'casadi_python' for a differentiable symbolic BDF.
-        'aadc_semi_implicit': ['adaptive_rk45', 'semi_implicit', 'implicit_euler_ift', 'rk4'],
+        'aadc_semi_implicit': ['adaptive_rk45', 'semi_implicit', 'implicit_euler_ift', 'implicit_newton', 'rk4'],
         # The user wrapper supplies the rhs; the framework integrates it with the
         # same scipy solve_ivp methods as model_type 'python'.
         'user_defined': ['RK45', 'RK23', 'DOP853', 'Radau', 'BDF', 'LSODA', 'forward_euler'],

--- a/src/solver_wrappers/aadc_python_solver_helper.py
+++ b/src/solver_wrappers/aadc_python_solver_helper.py
@@ -460,6 +460,93 @@ class SimulationHelper:
 
         return traj[self.pre_steps:]
 
+    def _integrate_bdf_newton(self, states, variables_all, total_steps, dt):
+        """Implicit Euler with Newton solver using AADC VFJ for exact Jacobian.
+
+        Uses VectorFunctionWithJacobian kernel for df/dy (one AADC reverse
+        pass per Newton iteration). Forward is Python compute_rates (correct
+        passive values). Sub-steps at internal_dt = solver_info['max_step']
+        (default 0.001) for stiff accuracy, matching CasADi BDF's sub-stepping.
+
+        This is the AADC analogue of CasADi's _run_symbolic_bdf: same fixed-step
+        implicit solve, same sub-stepping, but with AADC adjoint Jacobian instead
+        of CasADi symbolic Jacobian.
+        """
+        from scipy.linalg import lu_factor, lu_solve
+
+        n = self.STATE_COUNT
+        x = np.array(states[:n], dtype=float)
+        vars_all = list(variables_all)
+
+        zeta_indices = [i for i, info in enumerate(self.model.STATE_INFO)
+                        if 'zeta' in info.get('name', '').lower()]
+
+        # Sub-stepping: internal dt capped at max_step (default 0.001, same as CasADi)
+        max_step = float(self.solver_info.get('max_step', 0.001))
+        n_sub = max(1, int(np.ceil(dt / max_step)))
+        idt = dt / n_sub
+        max_newton = 4
+        newton_tol = 1e-10
+
+        # Build VFJ kernel if not already done
+        if not hasattr(self, '_bdf_vfj') or self._bdf_vfj is None:
+            rhs_f = aadc.Functions()
+            rhs_f.start_recording()
+            id_x = [aadc.idouble(float(x[i])) for i in range(n)]
+            a_x = [xi.mark_as_input() for xi in id_x]
+            id_v = [aadc.idouble(float(v) if not (isinstance(v, float) and
+                    v != v) else 0.0) for v in vars_all]
+            # Mark AD params as inputs
+            a_p_inner = []
+            if hasattr(self, '_ad_param_var_indices'):
+                for idx in self._ad_param_var_indices:
+                    id_v[idx] = aadc.idouble(float(vars_all[idx]))
+                    a_p_inner.append(id_v[idx].mark_as_input())
+            id_r = [aadc.idouble(0.0) for _ in range(n)]
+            self.model.compute_rates(aadc.idouble(0.0), id_x, id_r, list(id_v))
+            r_r = []
+            for i in range(n):
+                r_r.append((id_r[i] if hasattr(id_r[i], 'mark_as_output')
+                           else aadc.idouble(float(id_r[i]))).mark_as_output())
+            rhs_f.stop_recording()
+            self._bdf_vfj = aadc.VectorFunctionWithJacobian(
+                rhs_f, a_x, a_p_inner, r_r)
+            self._bdf_rhs_f = rhs_f
+            self._bdf_a_x = a_x
+            self._bdf_a_p = a_p_inner
+            self._bdf_r_r = r_r
+
+        if hasattr(self, '_ad_param_var_indices') and self._ad_param_var_indices:
+            param_vals = np.array([float(vars_all[idx])
+                                   for idx in self._ad_param_var_indices])
+            self._bdf_vfj.set_params(param_vals)
+
+        traj = [x.copy()]
+        for step in range(total_steps):
+            for sub in range(n_sub):
+                t = step * dt + sub * idt
+                y = x.copy()
+                for nit in range(max_newton):
+                    rates = [0.0] * n
+                    self.model.compute_rates(t + idt, list(y), rates, list(vars_all))
+                    F = y - x - idt * np.array(rates)
+                    if np.max(np.abs(F)) < newton_tol:
+                        break
+                    J_rhs = self._bdf_vfj.jac(y)
+                    J_g = np.eye(n) - idt * J_rhs
+                    try:
+                        lu_piv = lu_factor(J_g)
+                        dy = lu_solve(lu_piv, -F)
+                    except np.linalg.LinAlgError:
+                        break
+                    y += dy
+                for z in zeta_indices:
+                    y[z] = max(0.0, min(1.0, y[z]))
+                x = y.copy()
+            traj.append(x.copy())
+
+        return traj[self.pre_steps:]
+
     def _integrate_rk4(self, states, variables_all, total_steps, dt):
         """Fixed-step RK4.
 
@@ -721,6 +808,8 @@ class SimulationHelper:
             traj = self._integrate_implicit_euler_ift(self.states, variables_all, total_steps, self.dt)
         elif method == 'implicit_newton':
             traj = self._integrate_implicit_newton(self.states, variables_all, total_steps, self.dt)
+        elif method == 'bdf_newton':
+            traj = self._integrate_bdf_newton(self.states, variables_all, total_steps, self.dt)
         elif method == 'semi_implicit':
             traj = self._integrate_semi_implicit(self.states, variables_all, total_steps, self.dt)
         elif method == 'rk4':

--- a/src/solver_wrappers/aadc_python_solver_helper.py
+++ b/src/solver_wrappers/aadc_python_solver_helper.py
@@ -29,6 +29,11 @@ try:
 except ImportError:
     aadc = None
 
+# Shared FD step for Jacobian diagonal (damping). Used by both the forward
+# solve (_integrate_semi_implicit) and the tape (compute_cost_and_gradient_tape).
+# Must be identical in both paths so they integrate the same discrete system.
+_DAMPING_FD_EPS = 1e-8
+
 # Reuse the shared name resolver from circulatory_autogen
 try:
     from .name_resolver import VariableNameResolver
@@ -349,7 +354,7 @@ class SimulationHelper:
         n = self.STATE_COUNT
         x = np.array(states[:n], dtype=float)
         vars_all = list(variables_all)
-        eps_fd = 1e-8
+        eps_fd = _DAMPING_FD_EPS
 
         # Identify zeta indices (valve states to clamp to [0,1])
         zeta_indices = [i for i, info in enumerate(self.model.STATE_INFO)
@@ -1023,22 +1028,30 @@ class SimulationHelper:
                 # This puts lam on the same tape as rates → exact AD gradient.
                 # (Previous version used a separate inner kernel → passive
                 # floats → AD/FD ≈ 0.79 on stiff models.)
-                FD_EPS = 1e-6
+                # Same FD step as forward solve (_integrate_semi_implicit):
+                #   h_i = max(|x_i| * eps, eps)
+                # Using the shared _DAMPING_FD_EPS constant.
+                _eps = aadc.idouble(_DAMPING_FD_EPS)
 
-                self._tape_trajectory = [list(st)]
+                self._tape_trajectory = []
                 for step in range(total_steps):
                     t_step = step * dt
+                    # Collect trajectory BEFORE the step (matches forward solve)
+                    if step >= self.pre_steps:
+                        self._tape_trajectory.append(list(st))
+
                     # Rates at current state (on tape)
                     rates_id = [aadc.idouble(0.0) for _ in range(n)]
                     self.model.compute_rates(t_step, st, rates_id, list(vars_rec))
 
                     # Jacobian diagonal via on-tape FD: lam[i] = |df_i/dy_i|
+                    # Formula identical to forward: h = max(|x|*eps, eps)
                     lam = [aadc.idouble(0.0)] * n
                     for i in range(n):
-                        h_i = aadc.iif(st[i] >= aadc.idouble(0.0), st[i], -st[i])
-                        h_i = aadc.iif(h_i >= aadc.idouble(1e-8),
-                                       h_i * aadc.idouble(FD_EPS),
-                                       aadc.idouble(FD_EPS))
+                        abs_st = aadc.iif(st[i] >= aadc.idouble(0.0), st[i], -st[i])
+                        h_i = aadc.iif(abs_st * _eps >= _eps,
+                                       abs_st * _eps,
+                                       _eps)
                         st_bump = list(st)
                         st_bump[i] = st[i] + h_i
                         rates_bump = [aadc.idouble(0.0) for _ in range(n)]
@@ -1053,8 +1066,8 @@ class SimulationHelper:
                         st[z] = aadc.iif(st[z] >= aadc.idouble(0.0), st[z], aadc.idouble(0.0))
                         st[z] = aadc.iif(st[z] <= aadc.idouble(1.0), st[z], aadc.idouble(1.0))
 
-                    if step >= self.pre_steps:
-                        self._tape_trajectory.append(list(st))
+                # Append final state (matches forward: traj includes endpoint)
+                self._tape_trajectory.append(list(st))
             else:
                 # RK4 on tape (for non-stiff models)
                 # Collect trajectory for trajectory-based cost functions (max, min, mean)

--- a/src/solver_wrappers/aadc_python_solver_helper.py
+++ b/src/solver_wrappers/aadc_python_solver_helper.py
@@ -521,19 +521,19 @@ class SimulationHelper:
                                    for idx in self._ad_param_var_indices])
             self._bdf_vfj.set_params(param_vals)
 
+        vfj = self._bdf_vfj
+        eye_n = np.eye(n)
         traj = [x.copy()]
         for step in range(total_steps):
             for sub in range(n_sub):
-                t = step * dt + sub * idt
                 y = x.copy()
                 for nit in range(max_newton):
-                    rates = [0.0] * n
-                    self.model.compute_rates(t + idt, list(y), rates, list(vars_all))
-                    F = y - x - idt * np.array(rates)
+                    rates_arr = vfj.func(y)  # 35× faster than Python compute_rates
+                    F = y - x - idt * rates_arr
                     if np.max(np.abs(F)) < newton_tol:
                         break
-                    J_rhs = self._bdf_vfj.jac(y)
-                    J_g = np.eye(n) - idt * J_rhs
+                    J_rhs = vfj.jac(y)
+                    J_g = eye_n - idt * J_rhs
                     try:
                         lu_piv = lu_factor(J_g)
                         dy = lu_solve(lu_piv, -F)

--- a/src/solver_wrappers/aadc_python_solver_helper.py
+++ b/src/solver_wrappers/aadc_python_solver_helper.py
@@ -524,16 +524,27 @@ class SimulationHelper:
         vfj = self._bdf_vfj
         eye_n = np.eye(n)
         traj = [x.copy()]
+        x_prev = None  # for BDF2: need x_{n-1}
+
         for step in range(total_steps):
             for sub in range(n_sub):
                 y = x.copy()
+                use_bdf2 = x_prev is not None
+
                 for nit in range(max_newton):
-                    rates_arr = vfj.func(y)  # 35× faster than Python compute_rates
-                    F = y - x - idt * rates_arr
+                    rates_arr = vfj.func(y)
+                    if use_bdf2:
+                        # BDF2: x_{n+1} - 4/3 x_n + 1/3 x_{n-1} - 2/3 dt f(x_{n+1}) = 0
+                        F = y - (4.0/3.0) * x + (1.0/3.0) * x_prev - (2.0/3.0) * idt * rates_arr
+                        jac_coeff = 2.0 / 3.0
+                    else:
+                        # BDF1 (startup): x_{n+1} - x_n - dt f(x_{n+1}) = 0
+                        F = y - x - idt * rates_arr
+                        jac_coeff = 1.0
                     if np.max(np.abs(F)) < newton_tol:
                         break
                     J_rhs = vfj.jac(y)
-                    J_g = eye_n - idt * J_rhs
+                    J_g = eye_n - jac_coeff * idt * J_rhs
                     try:
                         lu_piv = lu_factor(J_g)
                         dy = lu_solve(lu_piv, -F)
@@ -542,6 +553,7 @@ class SimulationHelper:
                     y += dy
                 for z in zeta_indices:
                     y[z] = max(0.0, min(1.0, y[z]))
+                x_prev = x.copy()
                 x = y.copy()
             traj.append(x.copy())
 

--- a/src/solver_wrappers/aadc_python_solver_helper.py
+++ b/src/solver_wrappers/aadc_python_solver_helper.py
@@ -1034,11 +1034,23 @@ class SimulationHelper:
                 _eps = aadc.idouble(_DAMPING_FD_EPS)
 
                 self._tape_trajectory = []
+                self._tape_var_trajectory = []
+                _needed_vars = getattr(self, '_needed_var_indices', [])
                 for step in range(total_steps):
                     t_step = step * dt
                     # Collect trajectory BEFORE the step (matches forward solve)
                     if step >= self.pre_steps:
                         self._tape_trajectory.append(list(st))
+                        # Compute algebraic variables on tape if needed
+                        if _needed_vars:
+                            rates_cv = [aadc.idouble(0.0) for _ in range(n)]
+                            vars_cv = list(vars_rec)
+                            self.model.compute_rates(t_step, st, rates_cv, vars_cv)
+                            try:
+                                self.model.compute_variables(t_step, st, rates_cv, vars_cv)
+                            except AttributeError:
+                                pass
+                            self._tape_var_trajectory.append([vars_cv[vi] for vi in _needed_vars])
 
                     # Rates at current state (on tape)
                     rates_id = [aadc.idouble(0.0) for _ in range(n)]
@@ -1068,10 +1080,32 @@ class SimulationHelper:
 
                 # Append final state (matches forward: traj includes endpoint)
                 self._tape_trajectory.append(list(st))
+                if _needed_vars:
+                    t_final = total_steps * dt
+                    rates_cv = [aadc.idouble(0.0) for _ in range(n)]
+                    vars_cv = list(vars_rec)
+                    self.model.compute_rates(t_final, st, rates_cv, vars_cv)
+                    try:
+                        self.model.compute_variables(t_final, st, rates_cv, vars_cv)
+                    except AttributeError:
+                        pass
+                    self._tape_var_trajectory.append([vars_cv[vi] for vi in _needed_vars])
             else:
                 # RK4 on tape (for non-stiff models)
                 # Collect trajectory for trajectory-based cost functions (max, min, mean)
+                _needed_vars = getattr(self, '_needed_var_indices', [])
                 self._tape_trajectory = [list(st)]  # initial state
+                self._tape_var_trajectory = []
+                if _needed_vars:
+                    # Initial algebraic variables
+                    rates_cv = [aadc.idouble(0.0) for _ in range(n)]
+                    vars_cv = list(vars_rec)
+                    self.model.compute_rates(0.0, st, rates_cv, vars_cv)
+                    try:
+                        self.model.compute_variables(0.0, st, rates_cv, vars_cv)
+                    except AttributeError:
+                        pass
+                    self._tape_var_trajectory.append([vars_cv[vi] for vi in _needed_vars])
                 for step in range(total_steps):
                     t = aadc.idouble(step * dt)
                     k1 = [aadc.idouble(0.0) for _ in range(n)]
@@ -1090,11 +1124,27 @@ class SimulationHelper:
                     # Store post-pre_time trajectory on tape
                     if step >= self.pre_steps:
                         self._tape_trajectory.append(list(st))
+                        if _needed_vars:
+                            t_now = (step + 1) * dt
+                            rates_cv = [aadc.idouble(0.0) for _ in range(n)]
+                            vars_cv = list(vars_rec)
+                            self.model.compute_rates(t_now, st, rates_cv, vars_cv)
+                            try:
+                                self.model.compute_variables(t_now, st, rates_cv, vars_cv)
+                            except AttributeError:
+                                pass
+                            self._tape_var_trajectory.append([vars_cv[vi] for vi in _needed_vars])
 
             # Cost — pass trajectory if cost function accepts it, else final state only
             import inspect
             sig = inspect.signature(cost_func_idouble)
-            if len(sig.parameters) >= 3:
+            n_params = len(sig.parameters)
+            if n_params >= 4:
+                # cost_func(final_state, params, trajectory, var_trajectory)
+                cost = cost_func_idouble(st, id_p,
+                                         getattr(self, '_tape_trajectory', None),
+                                         getattr(self, '_tape_var_trajectory', None))
+            elif n_params >= 3:
                 # cost_func(final_state, params, trajectory)
                 cost = cost_func_idouble(st, id_p, getattr(self, '_tape_trajectory', None))
             else:

--- a/src/solver_wrappers/aadc_python_solver_helper.py
+++ b/src/solver_wrappers/aadc_python_solver_helper.py
@@ -394,6 +394,72 @@ class SimulationHelper:
         # and produce a different output length/origin than the RK45 integrator.
         return traj[self.pre_steps:]
 
+    def _integrate_implicit_newton(self, states, variables_all, total_steps, dt):
+        """Implicit Euler with full Newton iteration and FD Jacobian.
+
+        Solves F(y) = y - y_n - dt*f(y) = 0 at each step via Newton's method
+        with a full n×n Jacobian computed by finite differences.
+
+        More accurate than semi_implicit on stiff systems because:
+        - Semi_implicit uses diagonal Jacobian (1 perturbation per state)
+        - This uses full Jacobian (n perturbations per state per Newton iter)
+        - Semi_implicit does 1 implicit step; this iterates to convergence
+
+        Cost: ~n² compute_rates per step (vs ~n for semi_implicit).
+        For n=27: 27×(3-4 Newton iters) ≈ 80-110 compute_rates/step.
+        """
+        n = self.STATE_COUNT
+        x = np.array(states[:n], dtype=float)
+        vars_all = list(variables_all)
+        eps_fd = _DAMPING_FD_EPS
+
+        zeta_indices = [i for i, info in enumerate(self.model.STATE_INFO)
+                        if 'zeta' in info.get('name', '').lower()]
+
+        traj = [x.copy()]
+        max_newton = 4
+        newton_tol = 1e-10
+
+        for step in range(total_steps):
+            t = step * dt
+            y = x.copy()  # initial guess: explicit Euler or previous state
+
+            for newton_iter in range(max_newton):
+                # Compute residual F(y) = y - x - dt*f(y)
+                rates = [0.0] * n
+                self.model.compute_rates(t + dt, list(y), rates, list(vars_all))
+                F = y - x - dt * np.array(rates)
+
+                if np.max(np.abs(F)) < newton_tol:
+                    break
+
+                # Compute full Jacobian J = I - dt * df/dy via FD
+                J = np.eye(n)
+                for j in range(n):
+                    h = max(abs(y[j]) * eps_fd, eps_fd)
+                    y_bump = y.copy()
+                    y_bump[j] += h
+                    rates_bump = [0.0] * n
+                    self.model.compute_rates(t + dt, list(y_bump), rates_bump, list(vars_all))
+                    for i in range(n):
+                        J[i, j] -= dt * (rates_bump[i] - rates[i]) / h
+
+                # Newton step: dy = -J^{-1} F
+                try:
+                    dy = np.linalg.solve(J, -F)
+                except np.linalg.LinAlgError:
+                    break  # singular Jacobian — keep current y
+                y = y + dy
+
+            # Clamp zeta to [0, 1]
+            for z in zeta_indices:
+                y[z] = max(0.0, min(1.0, y[z]))
+
+            x = y.copy()
+            traj.append(x.copy())
+
+        return traj[self.pre_steps:]
+
     def _integrate_rk4(self, states, variables_all, total_steps, dt):
         """Fixed-step RK4.
 
@@ -653,6 +719,8 @@ class SimulationHelper:
         method = self.solver_info.get('method', 'adaptive_rk45')
         if method == 'implicit_euler_ift':
             traj = self._integrate_implicit_euler_ift(self.states, variables_all, total_steps, self.dt)
+        elif method == 'implicit_newton':
+            traj = self._integrate_implicit_newton(self.states, variables_all, total_steps, self.dt)
         elif method == 'semi_implicit':
             traj = self._integrate_semi_implicit(self.states, variables_all, total_steps, self.dt)
         elif method == 'rk4':
@@ -1018,6 +1086,102 @@ class SimulationHelper:
             if tape_method == 'implicit_euler_ift':
                 st = self._integrate_implicit_euler_ift_on_tape(
                     st, vars_rec, total_steps, dt, n)
+            elif tape_method == 'implicit_newton':
+                zeta_idx = [i for i, info in enumerate(self.model.STATE_INFO)
+                            if 'zeta' in info.get('name', '').lower()]
+                _eps = aadc.idouble(_DAMPING_FD_EPS)
+                _dt = aadc.idouble(dt)
+                _zero = aadc.idouble(0.0)
+                _one = aadc.idouble(1.0)
+                max_newton = 4
+
+                self._tape_trajectory = []
+                self._tape_var_trajectory = []
+                _needed_vars = getattr(self, '_needed_var_indices', [])
+
+                for step in range(total_steps):
+                    t_step = step * dt
+                    if step >= self.pre_steps:
+                        self._tape_trajectory.append(list(st))
+                        if _needed_vars:
+                            rates_cv = [aadc.idouble(0.0) for _ in range(n)]
+                            vars_cv = list(vars_rec)
+                            self.model.compute_rates(t_step, st, rates_cv, vars_cv)
+                            try:
+                                self.model.compute_variables(t_step, st, rates_cv, vars_cv)
+                            except AttributeError:
+                                pass
+                            self._tape_var_trajectory.append([vars_cv[vi] for vi in _needed_vars])
+
+                    y = list(st)  # Newton initial guess = current state
+                    for nit in range(max_newton):
+                        # Rates at y
+                        rates = [aadc.idouble(0.0) for _ in range(n)]
+                        self.model.compute_rates(t_step + dt, y, rates, list(vars_rec))
+
+                        # Residual F[i] = y[i] - st[i] - dt * rates[i]
+                        F = [y[i] - st[i] - _dt * rates[i] for i in range(n)]
+
+                        # Full Jacobian J[i][j] = delta_ij - dt * drates_i/dy_j  (via FD)
+                        J = [[aadc.idouble(0.0)] * n for _ in range(n)]
+                        for i in range(n):
+                            J[i][i] = _one
+                        for j in range(n):
+                            abs_yj = aadc.iif(y[j] >= _zero, y[j], -y[j])
+                            h_j = aadc.iif(abs_yj * _eps >= _eps, abs_yj * _eps, _eps)
+                            y_bump = list(y)
+                            y_bump[j] = y[j] + h_j
+                            rates_bump = [aadc.idouble(0.0) for _ in range(n)]
+                            self.model.compute_rates(t_step + dt, y_bump, rates_bump, list(vars_rec))
+                            for i in range(n):
+                                J[i][j] = J[i][j] - _dt * (rates_bump[i] - rates[i]) / h_j
+
+                        # Gaussian elimination with partial pivoting (idouble)
+                        # Augmented matrix [J | F]
+                        aug = [J[i] + [F[i]] for i in range(n)]
+                        for col in range(n):
+                            # Pivot: find max |aug[row][col]| for row >= col
+                            # With idouble we can't compare easily, skip pivoting
+                            # (works if diagonal dominant, which J = I - dt*df/dy usually is)
+                            pivot = aug[col][col]
+                            for row in range(col + 1, n):
+                                factor = aug[row][col] / pivot
+                                for k in range(col + 1, n + 1):
+                                    aug[row][k] = aug[row][k] - factor * aug[col][k]
+                                aug[row][col] = _zero
+
+                        # Back substitution
+                        dy = [aadc.idouble(0.0)] * n
+                        for i in range(n - 1, -1, -1):
+                            s = aug[i][n]
+                            for j in range(i + 1, n):
+                                s = s - aug[i][j] * dy[j]
+                            dy[i] = s / aug[i][i]
+
+                        # Newton update: y -= dy  (we solved J*dy = F, so y_new = y - dy)
+                        for i in range(n):
+                            y[i] = y[i] - dy[i]
+
+                    # Clamp zeta
+                    for z in zeta_idx:
+                        y[z] = aadc.iif(y[z] >= _zero, y[z], _zero)
+                        y[z] = aadc.iif(y[z] <= _one, y[z], _one)
+
+                    st = y
+
+                # Final trajectory point
+                self._tape_trajectory.append(list(st))
+                if _needed_vars:
+                    t_final = total_steps * dt
+                    rates_cv = [aadc.idouble(0.0) for _ in range(n)]
+                    vars_cv = list(vars_rec)
+                    self.model.compute_rates(t_final, st, rates_cv, vars_cv)
+                    try:
+                        self.model.compute_variables(t_final, st, rates_cv, vars_cv)
+                    except AttributeError:
+                        pass
+                    self._tape_var_trajectory.append([vars_cv[vi] for vi in _needed_vars])
+
             elif tape_method == 'semi_implicit':
                 zeta_idx = [i for i, info in enumerate(self.model.STATE_INFO)
                             if 'zeta' in info.get('name', '').lower()]

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -119,7 +119,8 @@ def test_solver_integrator_keys_derived_from_schema():
     assert _SOLVER_INTEGRATOR_KEYS['casadi_integrator'] == {
         'reltol', 'abstol', 'rtol', 'atol', 'max_num_steps', 'max_step_size', 'max_step',
         'options'}
-    assert _SOLVER_INTEGRATOR_KEYS['aadc_semi_implicit'] == {'tol', 'threads'}
+    # 'max_step' comes with the stiff BDF methods (bdf_newton / bdf_tape / bdf_kernel).
+    assert _SOLVER_INTEGRATOR_KEYS['aadc_semi_implicit'] == {'tol', 'threads', 'max_step'}
 
 
 def test_schema_settings_are_actually_read_by_the_code():
@@ -711,8 +712,13 @@ def test_aadc_ad_suitable_methods_match_what_the_tape_enforces():
     all_methods = SOLVER_SCHEMA['methods_by_solver']['aadc_semi_implicit']
     advertised = SOLVER_SCHEMA['ad_suitable_methods']['aadc_semi_implicit']
 
-    # derived from the enforced tuple, so the two cannot drift
-    assert advertised == [m for m in all_methods if m in AADC_TAPE_CONSISTENT_METHODS]
+    # Derived from AADC_AD_METHODS -- the tape-replayable methods PLUS the stiff BDF methods,
+    # which reach a gradient by their own dispatch rather than the standard tape. Asserting
+    # against AADC_TAPE_CONSISTENT_METHODS alone would exclude the BDF methods, which is exactly
+    # the gap this replaced.
+    from parsers.PrimitiveParsers import AADC_AD_METHODS
+    assert advertised == [m for m in all_methods if m in AADC_AD_METHODS]
+    assert set(AADC_TAPE_CONSISTENT_METHODS) <= set(advertised)
     assert set(advertised) <= set(all_methods), (advertised, all_methods)
     # the adaptive integrator is the one that must NOT be advertised
     assert 'adaptive_rk45' in all_methods and 'adaptive_rk45' not in advertised
@@ -747,3 +753,36 @@ def test_gradient_sources_gates_aadc_ad_on_a_tape_consistent_method():
     # unspecified or unknown method leaves AD offered, matching the casadi branch
     assert 'AD' in values(None)
     assert 'AD' in values('some_unknown_method')
+
+
+@pytest.mark.unit
+def test_aadc_bdf_methods_are_advertised_as_ad_suitable():
+    """The stiff BDF methods are AD-capable and must be advertised as such.
+
+    They do not go through the standard replay tape: aadc_backend.cost_and_grad dispatches each
+    to its own gradient implementation *before* the AADC_TAPE_CONSISTENT_METHODS check, so they
+    are AD-capable without being members of that tuple. Deriving ad_suitable_methods from the
+    tuple alone left a tool refusing AD for exactly the stiff-model methods, which is the
+    combination the BDF work exists to enable.
+    """
+    from parsers.PrimitiveParsers import (
+        AADC_AD_METHODS, AADC_BDF_AD_METHODS, AADC_TAPE_CONSISTENT_METHODS)
+    import inspect
+    from param_id import aadc_backend
+
+    advertised = SOLVER_SCHEMA['ad_suitable_methods']['aadc_semi_implicit']
+    all_methods = SOLVER_SCHEMA['methods_by_solver']['aadc_semi_implicit']
+
+    # both routes to a gradient are advertised, and nothing else is invented
+    assert AADC_AD_METHODS == AADC_TAPE_CONSISTENT_METHODS + AADC_BDF_AD_METHODS
+    assert advertised == [m for m in all_methods if m in AADC_AD_METHODS]
+    for m in AADC_BDF_AD_METHODS:
+        assert m in advertised, f"{m} has a gradient implementation but is not advertised"
+    # the adaptive integrator still must not be offered
+    assert 'adaptive_rk45' not in advertised
+
+    # each advertised BDF method really is dispatched to its own gradient path
+    src = inspect.getsource(aadc_backend.cost_and_grad)
+    for m in AADC_BDF_AD_METHODS:
+        assert m.upper() + "_METHOD" in src or repr(m) in src, (
+            f"{m} is advertised as AD-suitable but cost_and_grad does not dispatch it")


### PR DESCRIPTION
**Supersedes #317.** This is @lakshtanov's branch rebased onto current `master`, plus one commit fixing a schema gap that only appeared once #337 merged. All 18 of their commits keep their original authorship; the 19th is mine.

Open #317 cannot merge (`mergeable: false`) because `master` has moved under it — #329, #337 and #339 all landed since.

## The rebase

Two conflicts, both the same collision, resolved by one consistent rule. #337 moved `TAPE_CONSISTENT_METHODS` into `parsers/PrimitiveParsers.py` as the single source `SOLVER_SCHEMA` derives from; #317 kept editing the old in-module tuple to add methods and sibling constants. Resolution: keep the import, carry their constants (`BDF_NEWTON_METHOD`, `BDF_TAPE_METHOD`, `BDF_KERNEL_METHOD`) across, and propagate the method they added (`implicit_newton`) into the schema-side tuple. Verified the schema and the backend still agree:

```
schema  : ('rk4', 'implicit_euler_ift', 'semi_implicit', 'implicit_newton')
backend : same        agree: True
```

## The added commit

`bdf_newton`, `bdf_tape` and `bdf_kernel` each have their own gradient implementation and are dispatched in `cost_and_grad` **before** the `AADC_TAPE_CONSISTENT_METHODS` check, so they are AD-capable without being members of that tuple. After #337, `ad_suitable_methods` was derived from that tuple alone — so a tool reading the schema would have refused AD for exactly the stiff-model methods this branch exists to add. The same class of gap #336 fixed for `adaptive_rk45`, in the opposite direction.

Adds `AADC_BDF_AD_METHODS` and derives `ad_suitable_methods` from the union. Kept as a **separate** tuple rather than folded into `AADC_TAPE_CONSISTENT_METHODS`, because that one means "the standard replay tape can record this step sequence" and the BDF methods are not that — merging them would make the backend's runtime error claim they are tape-replayable, which is false.

```
ad_suitable: [semi_implicit, implicit_euler_ift, implicit_newton,
              bdf_newton, bdf_tape, bdf_kernel, rk4]

gradient_sources(bdf_tape)      -> ['FD', 'AD']
gradient_sources(adaptive_rk45) -> ['FD']      # still correctly refused
```

A test asserts every advertised BDF method really is dispatched by `cost_and_grad`, so the schema cannot advertise a gradient that does not exist.

It also fixes `test_solver_integrator_keys_derived_from_schema`, which #317 broke by adding the `max_step` solver_info field for the BDF methods without updating the expected key set — verified failing on the branch without this commit.

## Testing

`tests/test_solver_info_validation.py`: 40 passed. The AADC runtime paths need a Matlogica licence and have not been exercised here beyond import — @lakshtanov's own testing of the BDF solvers stands unchanged, since the rebase touched only the constant's location.

If you would rather keep #317 as the canonical PR, cherry-pick `8d6175b` onto it instead and close this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)