### PR TITLE
fix(cellml): one <connection> per component pair, deduplicated (#343)

### DIFF
--- a/src/generators/CVSCellMLGenerator.py
+++ b/src/generators/CVSCellMLGenerator.py
@@ -297,6 +297,7 @@ class CVS0DCellMLGenerator(object):
         return line
 
     def __generate_CellML_file(self):
+        self._reset_connections()
         print("Generating CellML file {}.cellml".format(self.file_prefix))
         output_path = os.path.join(self.output_dir, f'{self.file_prefix}.cellml')
 
@@ -390,6 +391,10 @@ class CVS0DCellMLGenerator(object):
 
                 # write the converter components
                 self.__write_unit_converter(wf)
+
+                # One <connection> per component pair, emitted after every writer has had its
+                # say -- see _add_connection for why this cannot be done as we go.
+                self.__flush_connections(wf)
 
                 # Finalise the file
                 wf.write('</model>\n')
@@ -2262,6 +2267,56 @@ class CVS0DCellMLGenerator(object):
             print(f'downstream module general ports: {[general_port["port_type"] for general_port in input_general_ports]}')
             exit()
 
+    def _reset_connections(self):
+        """Start a fresh connection accumulator for one CellML file."""
+        # key: frozenset({comp1, comp2}) -> {'components': (c1, c2), 'pairs': [(v1, v2), ...]}
+        # A dict keeps insertion order, so connections appear in the order they were first
+        # requested and the output stays diffable against previous generations.
+        self._pending_connections = {}
+
+    def _add_connection(self, comp_1, comp_2, var_pairs):
+        """Record variable mappings between two components, to be emitted as one <connection>.
+
+        CellML 2.0 allows at most one <connection> per component pair (spec 2.15.4) and at most
+        one <map_variables> per variable pair within it (2.16.3). Both are violated easily by a
+        generator that writes as it goes: a pair connected from two module rows produces two
+        blocks, and the pair is *unordered* to CellML, so writing (A, B) from one row and (B, A)
+        from the other is still a duplicate. Accumulating here -- keyed on a frozenset, with the
+        pairs deduplicated -- means every call site gets uniqueness for free, rather than each of
+        the ~27 of them having to know the rule.
+        """
+        if not hasattr(self, "_pending_connections"):
+            self._reset_connections()
+        key = frozenset((comp_1, comp_2))
+        entry = self._pending_connections.get(key)
+        if entry is None:
+            entry = {"components": (comp_1, comp_2), "pairs": []}
+            self._pending_connections[key] = entry
+        # Orientation is fixed by whichever call created the entry; a later call arriving with the
+        # components the other way round must have its variable pairs swapped to match, or the
+        # mapping would silently connect the wrong variables.
+        swapped = entry["components"] != (comp_1, comp_2)
+        for v_1, v_2 in var_pairs:
+            if not v_1 or not v_2:
+                continue
+            pair = (v_2, v_1) if swapped else (v_1, v_2)
+            if pair not in entry["pairs"]:
+                entry["pairs"].append(pair)
+
+    def __flush_connections(self, wf):
+        """Emit one <connection> per component pair, then clear the accumulator."""
+        for entry in getattr(self, "_pending_connections", {}).values():
+            if not entry["pairs"]:
+                continue
+            comp_1, comp_2 = entry["components"]
+            lines = ['<connection>\n',
+                     f'   <map_components component_1="{comp_1}" component_2="{comp_2}"/>\n']
+            for v_1, v_2 in entry["pairs"]:
+                lines.append(f'   <map_variables variable_1="{v_1}" variable_2="{v_2}"/>\n')
+            lines.append('</connection>\n')
+            wf.writelines(lines)
+        self._reset_connections()
+
     def __write_mapping(self, wf, inp_name, out_name, inp_vars_list, out_vars_list, check_unit=False):    # add kwargs for units given out_module_row
         # print(input(f"mapping {inp_name} to {out_name}"))
 
@@ -2339,40 +2394,24 @@ class CVS0DCellMLGenerator(object):
                 self.__write_unit_converter_component(wf, converter_info)  
             
             # Write direct mappings (single connection)  
-            if direct_mappings:  
-                mapping = ['<connection>\n', f'   <map_components component_1="{inp_name}" component_2="{out_name}"/>\n']  
-                for inp_var, out_var in direct_mappings:  
-                    mapping.append(f'   <map_variables variable_1="{inp_var}" variable_2="{out_var}"/>\n')  
-                mapping.append('</connection>\n')  
-                wf.writelines(mapping)  
+            if direct_mappings:
+                self._add_connection(inp_name, out_name, direct_mappings)
             
             # Write converter mappings (one connection per converter)  
             for converter_info in converter_mappings.values():  
                 converter_name = converter_info['converter_name']  
                 
                 # Input to converter connection  
-                mapping = ['<connection>\n', f'   <map_components component_1="{inp_name}" component_2="{converter_name}"/>\n']  
-                for inp_var in converter_info['inp_vars']:  
-                    mapping.append(f'   <map_variables variable_1="{inp_var}" variable_2="{inp_var}"/>\n')  
-                mapping.append('</connection>\n')  
-                wf.writelines(mapping)  
+                self._add_connection(inp_name, converter_name,
+                                     [(v, v) for v in converter_info['inp_vars']])
                 
                 # Converter to output connection  
-                mapping = ['<connection>\n', f'   <map_components component_1="{converter_name}" component_2="{out_name}"/>\n']  
-                for out_var in converter_info['out_vars']:  
-                    mapping.append(f'   <map_variables variable_1="{out_var}" variable_2="{out_var}"/>\n')  
-                mapping.append('</connection>\n')  
-                wf.writelines(mapping)  
+                self._add_connection(converter_name, out_name,
+                                     [(v, v) for v in converter_info['out_vars']])
 
         else:
-            mapping = ['<connection>\n', f'   <map_components component_1="{inp_name}" component_2="{out_name}"/>\n']
-            for inp_var, out_var in zip(inp_vars_list, out_vars_list):
-                if inp_var and out_var:
-                    mapping.append(f'   <map_variables variable_1="{inp_var}" variable_2="{out_var}"/>\n')
-
-            mapping.append('</connection>\n')
-            if len(mapping) > 3:
-                wf.writelines(mapping)
+            self._add_connection(inp_name, out_name,
+                                 list(zip(inp_vars_list, out_vars_list)))
         
 
     def __write_variable_declarations(self, wf, variables, units, in_outs):

--- a/tests/test_cellml_connection_uniqueness.py
+++ b/tests/test_cellml_connection_uniqueness.py
@@ -1,0 +1,188 @@
+"""CellML connection uniqueness in the generated model (issue #343).
+
+CellML allows at most one ``<connection>`` per component pair (spec 2.15.4, CONNECTION_UNIQUE)
+and at most one ``<map_variables>`` per variable pair inside it (2.16.3, MAP_VARIABLES_UNIQUE).
+A generator that writes connections as it goes violates both easily, and libCellML then refuses
+the model -- which is what issue #343 reported on a 37-module cardiac electrophysiology model.
+
+Three distinct ways it happened there, all covered below:
+
+1. the same pair written from two module rows in *opposite* order -- (A, B) and (B, A) are the
+   same connection to CellML, so an accumulator keyed on the ordered tuple misses it;
+2. unit-converter connections, written through call sites that bypassed the per-row accumulator
+   entirely (there are ~27 direct callers);
+3. the same variable pair appended twice inside one connection.
+
+These exercise the accumulator directly rather than through a full model: the reporter's model
+needs 37 custom module types, and none of the shipped fixtures reproduce the bug.
+"""
+import os
+import re
+import sys
+
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if os.path.join(ROOT, 'src') not in sys.path:
+    sys.path.insert(0, os.path.join(ROOT, 'src'))
+
+from generators.CVSCellMLGenerator import CVS0DCellMLGenerator
+
+
+class _Writer:
+    """Minimal stand-in for the file handle the generator writes to."""
+
+    def __init__(self):
+        self.text = ""
+
+    def writelines(self, lines):
+        self.text += "".join(lines)
+
+
+def _generator():
+    """A generator with only the connection accumulator initialised.
+
+    __init__ needs a parsed model, none of which is involved in connection bookkeeping.
+    """
+    gen = object.__new__(CVS0DCellMLGenerator)
+    gen._reset_connections()
+    return gen
+
+
+def _flush(gen):
+    wf = _Writer()
+    getattr(gen, '_CVS0DCellMLGenerator__flush_connections')(wf)   # name-mangled private
+    return wf.text
+
+
+def _connections(text):
+    out = []
+    for block in re.findall(r'<connection>(.*?)</connection>', text, re.S):
+        m = re.search(r'component_1="([^"]+)"\s+component_2="([^"]+)"', block)
+        pairs = re.findall(r'variable_1="([^"]+)"\s+variable_2="([^"]+)"', block)
+        out.append((m.groups(), pairs))
+    return out
+
+
+@pytest.mark.unit
+def test_a_component_pair_written_in_both_orders_gives_one_connection():
+    """(A, B) then (B, A) is one connection to CellML, not two.
+
+    This is the reporter's 'Cad_module' <-> 'IcaT_module' error: each module row writes its own
+    outgoing mappings, so a bidirectional pair got written once from each side.
+    """
+    gen = _generator()
+    gen._add_connection('Cad_module', 'IcaT_module', [('Ca', 'Ca')])
+    gen._add_connection('IcaT_module', 'Cad_module', [('i_CaT', 'i_CaT')])
+
+    conns = _connections(_flush(gen))
+    assert len(conns) == 1, conns
+    comps, pairs = conns[0]
+    assert set(comps) == {'Cad_module', 'IcaT_module'}
+    assert len(pairs) == 2      # both mappings survive the merge
+
+
+@pytest.mark.unit
+def test_variables_from_a_reversed_call_are_swapped_to_match_the_orientation():
+    """Merging a reversed call must swap its variables, or it connects the wrong ones.
+
+    The merged block keeps the orientation of whichever call created it, so a later call arriving
+    with the components the other way round describes its variables in the opposite order. Keeping
+    them as given would map variable_1 of one component onto a variable living in the other.
+    """
+    gen = _generator()
+    gen._add_connection('A', 'B', [('a_var', 'b_var')])
+    gen._add_connection('B', 'A', [('b_other', 'a_other')])
+
+    comps, pairs = _connections(_flush(gen))[0]
+    assert comps == ('A', 'B')
+    assert ('a_var', 'b_var') in pairs
+    assert ('a_other', 'b_other') in pairs     # re-oriented: A's variable first
+
+
+@pytest.mark.unit
+def test_a_repeated_variable_pair_is_mapped_only_once():
+    """MAP_VARIABLES_UNIQUE (2.16.3): the reporter's 'Nai' <-> 'Nai' error.
+
+    Merging connections makes this visible even where the duplicate was previously harmless, so
+    deduplicating the pairs is part of the same fix rather than a separate nicety.
+    """
+    gen = _generator()
+    gen._add_connection('Naic2_module', 'IcaL_module', [('Nai', 'Nai')])
+    gen._add_connection('Naic2_module', 'IcaL_module', [('Nai', 'Nai'), ('Ki', 'Ki')])
+
+    _comps, pairs = _connections(_flush(gen))[0]
+    assert pairs.count(('Nai', 'Nai')) == 1, pairs
+    assert ('Ki', 'Ki') in pairs
+
+
+@pytest.mark.unit
+def test_repeated_unit_converter_connections_collapse_to_one():
+    """The reporter's 'NTS_module' <-> 'unit_converter_nM_to_millimolar', which appeared 4x.
+
+    Unit-converter connections are written from call sites that bypassed the old per-row
+    accumulator, so every conversion emitted its own block.
+    """
+    gen = _generator()
+    for var in ('ACh', 'NE', 'NPY'):
+        gen._add_connection('NTS_module', 'unit_converter_nM_to_millimolar', [(var, var)])
+
+    conns = _connections(_flush(gen))
+    assert len(conns) == 1, conns
+    assert len(conns[0][1]) == 3
+
+
+@pytest.mark.unit
+def test_blank_variable_names_are_skipped():
+    """Callers pass ragged lists where a slot may be empty; an empty name is not a mapping."""
+    gen = _generator()
+    gen._add_connection('A', 'B', [('u', 'u'), ('', 'v'), ('w', None)])
+    _comps, pairs = _connections(_flush(gen))[0]
+    assert pairs == [('u', 'u')]
+
+
+@pytest.mark.unit
+def test_a_connection_with_no_usable_pairs_is_not_emitted():
+    gen = _generator()
+    gen._add_connection('A', 'B', [('', '')])
+    assert _connections(_flush(gen)) == []
+
+
+@pytest.mark.unit
+def test_flushing_clears_the_accumulator_so_the_next_file_starts_empty():
+    """The generator writes several CellML files per run; connections must not leak between them."""
+    gen = _generator()
+    gen._add_connection('A', 'B', [('u', 'u')])
+    assert len(_connections(_flush(gen))) == 1
+    assert _connections(_flush(gen)) == []
+
+
+@pytest.mark.integration
+def test_generated_model_has_no_duplicate_connections(generated_cellml_model_factory):
+    """End-to-end guard: a generated model must satisfy both uniqueness rules.
+
+    The unit tests pin the accumulator; this pins the property that actually matters, so a future
+    writer added outside the accumulator is caught.
+    """
+    import collections
+
+    cellml_path = generated_cellml_model_factory(
+        "3compartment", "3compartment_parameters.csv", solver="CVODE_myokit")
+    with open(cellml_path) as f:
+        text = f.read()
+
+    seen = collections.Counter()
+    dup_pairs = []
+    for block in re.findall(r'<connection>(.*?)</connection>', text, re.S):
+        m = re.search(r'component_1="([^"]+)"\s+component_2="([^"]+)"', block)
+        if not m:
+            continue
+        seen[frozenset(m.groups())] += 1
+        mapped = re.findall(r'variable_1="([^"]+)"\s+variable_2="([^"]+)"', block)
+        repeats = [k for k, v in collections.Counter(mapped).items() if v > 1]
+        if repeats:
+            dup_pairs.append((m.groups(), repeats))
+
+    duplicated = {tuple(sorted(k)): v for k, v in seen.items() if v > 1}
+    assert not duplicated, f"component pairs with more than one <connection>: {duplicated}"
+    assert not dup_pairs, f"connections with a repeated <map_variables>: {dup_pairs}"


### PR DESCRIPTION
Fixes #343.

libCellML refuses the generated model with `CONNECTION_UNIQUE` (spec 2.15.4) and `MAP_VARIABLES_UNIQUE` (2.16.3) errors. Reproduced on the reporter's 37-module cardiac electrophysiology model — **25 errors**, from three distinct causes.

## Why the existing fix did not cover it

`__write_module_mapping_for_row` already accumulated mappings so each component pair produced one `<connection>`. It missed all three cases:

| cause | in the reporter's model |
|---|---|
| keyed on the **ordered** `(comp1, comp2)` tuple, but a CellML connection is unordered — each module row writes its own outgoing mappings, so a bidirectional pair is written once from each side and lands in two buckets | 11 pairs, e.g. `Cad_module` ↔ `IcaT_module` written as both `(Cad, IcaT)` and `(IcaT, Cad)` |
| **local to that one function**, while `__write_mapping` has ~27 direct callers — unit-converter connections come through those and bypass it entirely | 4 blocks for `NTS_module` ↔ `unit_converter_nM_to_millimolar` |
| extends its variable lists **without deduplicating**, so one connection can map the same pair twice — a *different* CellML rule (2.16.3, not 2.15.4) | `'Nai'` ↔ `'Nai'` |

## Change

A generator-level accumulator keyed on `frozenset({comp_1, comp_2})` holding deduplicated variable pairs, flushed once before `</model>` and reset per file. All four `<connection>`-emitting sites in `__write_mapping` route through it, so every call site gets uniqueness without having to know the rule.

**The part worth reviewing** is the re-orientation. When a reversed call merges into an existing entry, its variable pairs describe the components the other way round:

```python
swapped = entry["components"] != (comp_1, comp_2)
pair = (v_2, v_1) if swapped else (v_1, v_2)
```

Keeping them as given would map `variable_1` of one component onto a variable that lives in the other — a wrong model that still validates, which is a worse failure than the error being fixed. It has a dedicated test.

## Result on the reporter's model

- 25 "not unique" errors → **0**
- 216 → 202 `<connection>` blocks (14 merged)
- zero duplicated component pairs, zero duplicated `map_variables`

That model then fails a later step — *"not a valid ODE model according to libcellml"* — which is the Analyser's strict-ODE requirement that `SN_simple` also hits, unrelated to this fix. Their OpenCOR path may now work even though CA's Python-generation validation still objects.

## Testing

`tests/test_cellml_connection_uniqueness.py` — 7 unit tests on the accumulator (reversed-order merge, variable re-orientation, repeated pair, repeated unit-converter connection, blank names, empty connection, reset between files) plus an end-to-end test asserting a generated model satisfies both rules, so a future writer added outside the accumulator is caught.

Deliberately not built from the reporter's model: it needs 37 custom module types, and none of the shipped fixtures reproduce the bug.

`tests/test_autogeneration.py`: **30/31 pass**. The one failure, `test_generate_python_model_succeeds[SN_simple]`, is the pre-existing libCellML-Analyser limitation and fails identically on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)