### PR TITLE
feat(params): declare the params_for_id prior vocabulary and validate it

### DIFF
--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -57,7 +57,8 @@ import csv
 import shutil
 from datetime import date, datetime
 # from skopt import gp_minimize, Optimizer
-from parsers.PrimitiveParsers import CSVFileParser, ObsAndParamDataParser, PARAM_ID_METHODS
+from parsers.PrimitiveParsers import (CSVFileParser, ObsAndParamDataParser, PARAM_ID_METHODS,
+                                      PARAM_PRIOR_TYPES)
 from param_id.optimisers import GeneticAlgorithmOptimiser, BayesianOptimiser, CMAESOptimiser, \
     SciPyMinimizeOptimiser, MultiStartSciPyMinimizeOptimiser
 from param_id.differentiable import (
@@ -1719,6 +1720,15 @@ class OpencorParamID():
                     mean = 0.5*(self.param_id_info["param_maxs"][idx] + self.param_id_info["param_mins"][idx])
                     lnprior += -0.5*((param_val - mean)/std)**2
 
+            else:
+                # Unreachable via params_for_id, which validates the column against
+                # PARAM_PRIOR_TYPES. Kept because falling through silently is what made a
+                # mis-spelled prior drop this parameter's range check -- the walker then
+                # left [min, max] with a finite lnprior instead of -inf, and nothing said so.
+                raise ValueError(
+                    f"unknown prior '{prior_dist}' for parameter index {idx}. "
+                    f"Valid priors are: {', '.join(sorted(PARAM_PRIOR_TYPES))}."
+                )
 
         return lnprior
 

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -368,6 +368,62 @@ _OPT_GA_NUM_CROSS_BREED = {
 }
 
 
+# Single source of truth for the prior distributions a params_for_id `prior` column may name,
+# i.e. the valid values of that column. Surfaced to downstream tools (e.g. the CUFLynx
+# params_for_id editor) the same way PARAM_ID_METHODS is, so they can populate a prior picker
+# without hardcoding the list. Keep in sync with OpencorParamID.get_lnprior_from_params().
+#
+# Declared rather than left implicit because an unrecognised value used to be *accepted*: the
+# column was read straight to a numpy array, and get_lnprior_from_params matched it against
+# 'uniform'/'exponential'/'normal' and fell through every branch when it matched none. Falling
+# through skips that parameter's own range check, so a mis-spelled prior -- 'Normal', say --
+# silently stopped bounding the parameter at all, and an MCMC walker could leave [min, max]
+# with a finite lnprior instead of -inf. A typo must not quietly unbound a parameter.
+PARAM_PRIOR_TYPES = {
+    'uniform': {
+        'label': 'Uniform',
+        'description': 'Flat across [min, max]. The default when no prior is given.',
+    },
+    'exponential': {
+        'label': 'Exponential',
+        'description': 'Decays across [min, max] at rate 1/max, favouring smaller values.',
+    },
+    'normal': {
+        'label': 'Normal',
+        'description': ('Gaussian centred on the middle of [min, max], with a standard '
+                        'deviation of one sixth of the range.'),
+    },
+}
+
+# What an absent, blank or NaN `prior` entry means -- and what the whole column defaults to
+# when params_for_id has no `prior` at all.
+DEFAULT_PARAM_PRIOR_TYPE = 'uniform'
+
+
+def normalise_prior_type(value, row_idx=None):
+    """The canonical ``PARAM_PRIOR_TYPES`` key for one ``prior`` cell.
+
+    Blank/NaN means the default. Surrounding whitespace and letter case are
+    normalised, so a hand-written 'Normal' resolves to 'normal' instead of
+    unbounding the parameter. Anything genuinely unrecognised raises, because
+    the alternative -- the historical behaviour -- was to accept it and silently
+    drop that parameter's range check.
+    """
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return DEFAULT_PARAM_PRIOR_TYPE
+    text = str(value).strip()
+    if not text or text.lower() == 'nan':
+        return DEFAULT_PARAM_PRIOR_TYPE
+    key = text.lower()
+    if key not in PARAM_PRIOR_TYPES:
+        where = '' if row_idx is None else f' (params_for_id row {row_idx})'
+        raise ValueError(
+            f"unknown prior '{text}'{where}. Valid priors are: "
+            f"{', '.join(sorted(PARAM_PRIOR_TYPES))}."
+        )
+    return key
+
+
 # Single source of truth for the parameter-identification (calibration) methods, i.e. the valid
 # values of `param_id_method`. Surfaced to downstream tools (e.g. the CUFLynx settings UI) the
 # same way SOLVER_SCHEMA is, so they can populate a calibration-method menu AND the per-method
@@ -2698,9 +2754,15 @@ class ObsAndParamDataParser(object):
                                                                   for p_names in param_id_info["param_names"]])
 
         if "prior" in filtered_params.columns:
-            param_id_info["param_prior_types"] = filtered_params["prior"].to_numpy()
+            # Validated and canonicalised here, at the one place the column is read, so an
+            # unusable prior is a parse error naming the row rather than a parameter that
+            # quietly stops being bounded once the sampler starts.
+            param_id_info["param_prior_types"] = np.array([
+                normalise_prior_type(filtered_params["prior"].iloc[II], row_idx=II)
+                for II in range(N_params)
+            ])
         else:
-            param_id_info["param_prior_types"] = np.array(["uniform"] * N_params)
+            param_id_info["param_prior_types"] = np.array([DEFAULT_PARAM_PRIOR_TYPE] * N_params)
 
         param_id_info["param_names_for_gen"] = param_names_for_gen
 

--- a/tests/test_param_priors.py
+++ b/tests/test_param_priors.py
@@ -1,0 +1,119 @@
+"""The params_for_id `prior` column is a declared vocabulary, not free text.
+
+An unrecognised prior used to be accepted: the column was read straight to a numpy
+array, and `get_lnprior_from_params` matched it against 'uniform'/'exponential'/
+'normal' and fell through every branch when it matched none. Falling through skips
+that parameter's own range check, so a mis-spelled prior stopped bounding the
+parameter at all -- an MCMC walker could leave [min, max] with a finite lnprior
+instead of -inf, silently. No model/MPI needed.
+"""
+import io
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from parsers.PrimitiveParsers import (DEFAULT_PARAM_PRIOR_TYPE, PARAM_PRIOR_TYPES,
+                                      ObsAndParamDataParser, normalise_prior_type)
+
+
+def _info(csv):
+    return ObsAndParamDataParser()._build_param_id_info_from_df(pd.read_csv(io.StringIO(csv)))
+
+
+# ---------------------------------------------------------------------------
+# The vocabulary
+# ---------------------------------------------------------------------------
+def test_every_declared_prior_is_handled_by_the_likelihood():
+    """PARAM_PRIOR_TYPES and get_lnprior_from_params must not drift apart: a prior
+    the schema advertises but the likelihood cannot evaluate would raise mid-run."""
+    from param_id.paramID import OpencorParamID
+
+    pid = OpencorParamID.__new__(OpencorParamID)
+    for prior in PARAM_PRIOR_TYPES:
+        pid.param_id_info = {
+            "param_prior_types": np.array([prior]),
+            "param_mins": np.array([1.0]),
+            "param_maxs": np.array([2.0]),
+        }
+        assert np.isfinite(pid.get_lnprior_from_params([1.5])), f"{prior} not handled"
+
+
+def test_the_default_is_one_of_the_declared_priors():
+    assert DEFAULT_PARAM_PRIOR_TYPE in PARAM_PRIOR_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Normalisation and validation
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("raw", ["Normal", " normal ", "NORMAL"])
+def test_case_and_whitespace_are_normalised(raw):
+    """'Normal' unambiguously means 'normal'. Accepting it is friendlier than
+    erroring, and far better than the old behaviour of taking it verbatim and
+    unbounding the parameter."""
+    assert normalise_prior_type(raw) == "normal"
+
+
+@pytest.mark.parametrize("blank", [None, "", "   ", float("nan")])
+def test_a_blank_prior_means_the_default(blank):
+    assert normalise_prior_type(blank) == DEFAULT_PARAM_PRIOR_TYPE
+
+
+def test_an_unknown_prior_is_rejected_with_the_valid_ones_named():
+    with pytest.raises(ValueError, match="unknown prior 'gaussian'"):
+        normalise_prior_type("gaussian")
+    with pytest.raises(ValueError, match="exponential, normal, uniform"):
+        normalise_prior_type("gaussian")
+
+
+def test_the_offending_row_is_named():
+    with pytest.raises(ValueError, match="row 3"):
+        normalise_prior_type("gaussian", row_idx=3)
+
+
+# ---------------------------------------------------------------------------
+# Through the params_for_id parser
+# ---------------------------------------------------------------------------
+def test_the_prior_column_is_canonicalised():
+    info = _info("vessel_name,param_name,min,max,prior\na,k,1,2,Normal\nb,j,1,2,\n")
+    assert list(info["param_prior_types"]) == ["normal", DEFAULT_PARAM_PRIOR_TYPE]
+
+
+def test_no_prior_column_means_the_default_throughout():
+    info = _info("vessel_name,param_name,min,max\na,k,1,2\nb,j,3,4\n")
+    assert list(info["param_prior_types"]) == [DEFAULT_PARAM_PRIOR_TYPE] * 2
+
+
+def test_an_unusable_prior_fails_the_parse_not_the_run():
+    with pytest.raises(ValueError, match="unknown prior 'lognormal'"):
+        _info("vessel_name,param_name,min,max,prior\na,k,1,2,lognormal\n")
+
+
+# ---------------------------------------------------------------------------
+# The bug itself
+# ---------------------------------------------------------------------------
+def test_a_mis_spelled_prior_no_longer_unbounds_the_parameter():
+    """The regression this all exists for. 'Normal' used to survive the parser
+    verbatim, match no branch, and leave the parameter unbounded: lnprior was 0
+    at a value far outside [min, max] where it must be -inf."""
+    from param_id.paramID import OpencorParamID
+
+    info = _info("vessel_name,param_name,min,max,prior\na,k,1,2,Normal\n")
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.param_id_info = info
+
+    assert pid.get_lnprior_from_params([999.0]) == -np.inf
+
+
+def test_a_prior_the_parser_never_saw_raises_rather_than_falling_through():
+    """Defence in depth for param_id_info built by hand rather than parsed."""
+    from param_id.paramID import OpencorParamID
+
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.param_id_info = {
+        "param_prior_types": np.array(["gaussian"]),
+        "param_mins": np.array([1.0]),
+        "param_maxs": np.array([2.0]),
+    }
+    with pytest.raises(ValueError, match="unknown prior 'gaussian'"):
+        pid.get_lnprior_from_params([1.5])


### PR DESCRIPTION
The `prior` column of params_for_id is free text today. It is read straight to a numpy array, and `get_lnprior_from_params` compares it against `uniform` / `exponential` / `normal`, falling through every branch when it matches none.

Falling through is the bug: **each branch also performs that parameter's range check**, so a value matching no branch leaves the parameter unbounded.

### The failure

A capital-N `Normal` is enough. Before this change:

```
accepted prior value: 'Normal'
lnprior at   1.5 (in bounds)    : 0
lnprior at 999.0 (OUT of bounds): 0      <- must be -inf
```

An MCMC walker could leave `[min, max]` with a finite lnprior and nothing would say so. After:

```
accepted prior value: 'normal'
lnprior at 999.0 (OUT of bounds): -inf
```

### What this adds

- **`PARAM_PRIOR_TYPES`** — the vocabulary, declared in the same introspectable shape as `PARAM_ID_METHODS` and `SOLVER_SCHEMA`. Each entry carries a label and a description of what the distribution actually *is* (that the normal is centred on the middle of the range with std = range/6, that the exponential decays at rate 1/max), which until now was only discoverable by reading the likelihood.
- **`normalise_prior_type`** — canonicalises one cell. Blank/NaN means the default; whitespace and letter case are normalised so `Normal` resolves instead of unbounding anything; anything genuinely unrecognised raises, naming the offending row and listing the valid values.
- Validation runs **where the column is read**, so an unusable prior fails the parse rather than surfacing later as a sampler quietly ignoring a bound.
- `get_lnprior_from_params` now raises on an unknown prior instead of falling through. Unreachable via the parser, but it closes the hole for `param_id_info` assembled by hand.

### Why declared rather than just fixed

CUFLynx's params_for_id editor is about to grow a prior picker (its editor currently drops the column entirely, silently reverting every prior to uniform). It should read the list from CA rather than hardcode it — the same contract `SOLVER_SCHEMA` and `PARAM_ID_METHODS` already provide.

### Compatibility

All six shipped `params_for_id` fixtures carrying a `prior` column parse unchanged (`FitzHugh_Nagumo`, `Goodwin`, `Lotka_Volterra`, `Teusink`, `TwoMinima`, `physiological` — all `uniform`). Behaviour changes only for values that were previously accepted and silently ignored.

### Tests

16 new in `tests/test_param_priors.py`, including the regression above and a drift guard that every prior the schema advertises can actually be evaluated by the likelihood. 56 passing across the parser-adjacent suites; no model or MPI needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)