### PR TITLE
feat(schema): separate AADC forward methods from gradient strategies, and advertise stiff-suitable integrators

### DIFF
--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -15,19 +15,58 @@ AADC is optional third-party proprietary software. It is imported lazily inside
 extraction -- hoisting it to module scope would change when ImportError surfaces on a
 machine without AADC.
 """
+import warnings
+
 import numpy as np
 
 # The methods whose forward integration the tape can record step-for-step. Defined in
 # parsers.PrimitiveParsers alongside SOLVER_SCHEMA['ad_suitable_methods'], which is derived from
 # it, so the advertised menu and the check enforced here cannot drift (issue #336). Re-exported
 # under the original name for callers that already import it from this module.
-from parsers.PrimitiveParsers import AADC_TAPE_CONSISTENT_METHODS as TAPE_CONSISTENT_METHODS
+from parsers.PrimitiveParsers import (AADC_TAPE_CONSISTENT_METHODS as TAPE_CONSISTENT_METHODS,
+                                      AADC_LEGACY_METHOD_ALIASES)
 BDF_NEWTON_METHOD = 'bdf_newton'
 SEMI_IMPLICIT_SIGNED_METHOD = 'semi_implicit_signed'
 # Legacy names kept so configs written before the split still run; both now select a
 # gradient_strategy of the one method rather than naming an integrator (issue #346).
 BDF_TAPE_METHOD = 'bdf_tape'
 BDF_KERNEL_METHOD = 'bdf_kernel'
+GRADIENT_STRATEGIES = ('tape', 'kernel')
+DEFAULT_GRADIENT_STRATEGY = 'tape'
+
+
+def resolve_gradient_strategy(method, solver_info):
+    """Resolve a configured method to ``(canonical_method, strategy)`` for the signed scheme.
+
+    Returns ``None`` for any method that is not ``semi_implicit_signed`` or one of its legacy
+    aliases, so the caller can fall through to the other gradient paths.
+
+    The alias table lives in PrimitiveParsers next to the schema that advertises the split, and
+    is read here rather than restated: a second copy of the mapping is exactly how 'bdf_tape'
+    and 'bdf_kernel' drifted into looking like two integrators in the first place (issue #346).
+    """
+    if method in AADC_LEGACY_METHOD_ALIASES:
+        canonical, strategy = AADC_LEGACY_METHOD_ALIASES[method]
+        configured = (solver_info or {}).get('gradient_strategy')
+        if configured is not None and configured != strategy:
+            # The legacy name is the more specific statement of intent, so it wins -- but say so,
+            # rather than dropping a setting the user deliberately wrote.
+            warnings.warn(
+                f"solver_info method {method!r} already fixes the gradient strategy to "
+                f"{strategy!r}, so gradient_strategy={configured!r} is ignored. Use method "
+                f"{canonical!r} to choose the strategy explicitly.", stacklevel=2)
+        return canonical, strategy
+
+    if method != SEMI_IMPLICIT_SIGNED_METHOD:
+        return None
+
+    strategy = (solver_info or {}).get('gradient_strategy') or DEFAULT_GRADIENT_STRATEGY
+    if strategy not in GRADIENT_STRATEGIES:
+        raise ValueError(
+            f"solver_info['gradient_strategy'] must be one of {list(GRADIENT_STRATEGIES)}, got "
+            f"{strategy!r}. It selects how '{SEMI_IMPLICIT_SIGNED_METHOD}' evaluates its "
+            f"gradient; the integration is the same either way.")
+    return SEMI_IMPLICIT_SIGNED_METHOD, strategy
 
 
 def cost_and_grad(pid, param_vals):
@@ -66,21 +105,11 @@ def cost_and_grad(pid, param_vals):
     method = pid.sim_helper.solver_info.get('method', 'adaptive_rk45')
     if method == BDF_NEWTON_METHOD:
         return _cost_and_grad_bdf_newton(pid, param_vals)
-    if method in (SEMI_IMPLICIT_SIGNED_METHOD, BDF_TAPE_METHOD, BDF_KERNEL_METHOD):
-        # One method, two execution strategies. The legacy names carried the strategy in the
-        # method itself; they still select it, so old configs keep working (issue #346).
-        strategy = pid.sim_helper.solver_info.get('gradient_strategy')
-        if method == BDF_TAPE_METHOD:
-            strategy = 'tape'
-        elif method == BDF_KERNEL_METHOD:
-            strategy = 'kernel'
-        strategy = strategy or 'tape'
-        if strategy not in ('tape', 'kernel'):
-            raise ValueError(
-                f"solver_info['gradient_strategy'] must be 'tape' or 'kernel', got "
-                f"{strategy!r}. It selects how '{SEMI_IMPLICIT_SIGNED_METHOD}' evaluates its "
-                f"gradient; the integration is the same either way.")
-        if strategy == 'kernel':
+    # One method, two execution strategies. The legacy names carried the strategy in the method
+    # itself; they still select it, so old configs keep working (issue #346).
+    signed = resolve_gradient_strategy(method, pid.sim_helper.solver_info)
+    if signed is not None:
+        if signed[1] == 'kernel':
             return _cost_and_grad_bdf_kernel(pid, param_vals)
         return _cost_and_grad_bdf_tape(pid, param_vals)
     if method not in TAPE_CONSISTENT_METHODS:

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -152,24 +152,20 @@ SOLVER_SCHEMA['ad_suitable_methods'] = {
     'aadc_semi_implicit': [m for m in SOLVER_SCHEMA['methods_by_solver']['aadc_semi_implicit']
                            if m in AADC_AD_METHODS],
 }
-# Myokit CVODES forward-sensitivity (FSA) is the analytic gradient for stiff cellml_only models;
-# its method is 'CVODE' on the CVODE solvers. (CA's get_gradient currently produces FSA only for
-# CVODE_myokit; the CVODE_opencor entry records that its FSA-capable method would likewise be
-# CVODE, so a tool gating a method menu stays correct if/when it is wired up.)
 # Which methods each solver can run as a plain forward solve. Only aadc_semi_implicit currently
 # differs from methods_by_solver -- see AADC_FORWARD_METHODS.
 SOLVER_SCHEMA['forward_methods_by_solver'] = {
     solver: (list(AADC_FORWARD_METHODS) if solver == 'aadc_semi_implicit' else list(methods))
     for solver, methods in SOLVER_SCHEMA['methods_by_solver'].items()
 }
+# Myokit CVODES forward-sensitivity (FSA) is the analytic gradient for stiff cellml_only models;
+# its method is 'CVODE' on the CVODE solvers. (CA's get_gradient currently produces FSA only for
+# CVODE_myokit; the CVODE_opencor entry records that its FSA-capable method would likewise be
+# CVODE, so a tool gating a method menu stays correct if/when it is wired up.)
 SOLVER_SCHEMA['fsa_suitable_methods'] = {
     'CVODE_myokit': ['CVODE'],
     'CVODE_opencor': ['CVODE'],
 }
-# Recommended default integrator per solver, for a front-end to pre-select an AD-friendly method:
-# casadi_python -> 'bdf' (stable and AD-suitable) rather than the adjoint 'cvodes'. This is the
-# value a tool (CUFLynx) should default its menu to; it is advisory and does not change CA's own
-# internal fallback (a plain run without a method still uses the helper's default).
 # Which integrators can be trusted on a STIFF model. A tool offering a method menu for a stiff
 # model (the cardiovascular ones are stiff) should restrict to these: the others either fail
 # outright or, worse, return a plausible-looking trace that is badly wrong.
@@ -201,9 +197,18 @@ SOLVER_SCHEMA['stiff_suitable_methods'] = {
     'user_defined': ['Radau', 'BDF', 'LSODA'],
     'casadi_integrator': ['cvodes', 'idas', 'bdf', 'semi_implicit_euler'],
     'aadc_semi_implicit': ['semi_implicit', 'implicit_newton'],
+    # Explicitly empty rather than absent: the cpp RK4 solver offers only a fixed-step explicit
+    # method, and PETSC's plugin choice is not yet assessed against a stiff model. A consumer
+    # must be able to tell "assessed, nothing qualifies" from "not in the table at all", so
+    # every solver in methods_by_solver has an entry here (enforced by the schema tests).
+    'RK4': [],
+    'PETSC': [],
 }
 
-
+# Recommended default integrator per solver, for a front-end to pre-select an AD-friendly method:
+# casadi_python -> 'bdf' (stable and AD-suitable) rather than the adjoint 'cvodes'. This is the
+# value a tool (CUFLynx) should default its menu to; it is advisory and does not change CA's own
+# internal fallback (a plain run without a method still uses the helper's default).
 SOLVER_SCHEMA['default_method_by_solver'] = {
     'casadi_integrator': 'bdf',
     # 'implicit_newton', not 'rk4'. rk4 was chosen in #336 for being tape-consistent, without

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -783,10 +783,13 @@ def test_aadc_bdf_methods_are_advertised_as_ad_suitable():
     # the adaptive integrator still must not be offered
     assert 'adaptive_rk45' not in advertised
 
-    # each advertised BDF method really is dispatched to its own gradient path
+    # each advertised BDF method really is dispatched to its own gradient path: the signed
+    # scheme through the strategy resolver, anything else by name in cost_and_grad itself
     src = inspect.getsource(aadc_backend.cost_and_grad)
     for m in AADC_BDF_AD_METHODS:
-        assert m.upper() + "_METHOD" in src or repr(m) in src, (
+        routed = aadc_backend.resolve_gradient_strategy(m, {}) is not None
+        named = m.upper() + "_METHOD" in src or repr(m) in src
+        assert routed or named, (
             f"{m} is advertised as AD-suitable but cost_and_grad does not dispatch it")
 
 
@@ -855,6 +858,50 @@ def test_semi_implicit_signed_replaces_the_two_bdf_gradient_names():
 
 
 @pytest.mark.unit
+def test_legacy_bdf_names_resolve_through_the_dispatch_not_just_the_alias_table():
+    """"Old configs keep working" has to be checked against the code that runs them.
+
+    Asserting only that 'bdf_tape' appears in AADC_LEGACY_METHOD_ALIASES tests a declaration:
+    the table could stay correct while the dispatch that consumes it was rewritten to ignore a
+    name, and the guarantee would break with every test still green. So drive the resolver.
+    """
+    from param_id.aadc_backend import resolve_gradient_strategy
+
+    assert resolve_gradient_strategy('bdf_tape', {}) == ('semi_implicit_signed', 'tape')
+    assert resolve_gradient_strategy('bdf_kernel', {}) == ('semi_implicit_signed', 'kernel')
+
+    # the canonical name honours the setting, and defaults to the tape
+    assert resolve_gradient_strategy('semi_implicit_signed', {}) == ('semi_implicit_signed', 'tape')
+    assert resolve_gradient_strategy(
+        'semi_implicit_signed', {'gradient_strategy': 'kernel'}) == ('semi_implicit_signed', 'kernel')
+
+    # anything else is not this scheme, and must fall through to the other gradient paths
+    for other in ('bdf_newton', 'rk4', 'semi_implicit', 'adaptive_rk45'):
+        assert resolve_gradient_strategy(other, {}) is None
+
+    with pytest.raises(ValueError, match='gradient_strategy'):
+        resolve_gradient_strategy('semi_implicit_signed', {'gradient_strategy': 'nonsense'})
+
+
+@pytest.mark.unit
+def test_a_legacy_name_warns_rather_than_silently_dropping_a_conflicting_strategy():
+    """'bdf_kernel' fixes the strategy, so gradient_strategy='tape' alongside it cannot be
+    honoured. The name wins (it is the more specific statement of intent), but silently
+    discarding a setting the user wrote is the failure mode this whole change is fixing."""
+    from param_id.aadc_backend import resolve_gradient_strategy
+
+    with pytest.warns(UserWarning, match='ignored'):
+        resolved = resolve_gradient_strategy('bdf_kernel', {'gradient_strategy': 'tape'})
+    assert resolved == ('semi_implicit_signed', 'kernel')
+
+    # no warning when they agree
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        assert resolve_gradient_strategy(
+            'bdf_tape', {'gradient_strategy': 'tape'}) == ('semi_implicit_signed', 'tape')
+
+
+@pytest.mark.unit
 def test_the_aadc_default_method_can_actually_integrate():
     """A default has to produce a number before it is AD-friendly.
 
@@ -890,6 +937,12 @@ def test_stiff_suitable_methods_are_real_methods_and_exclude_the_measured_failur
         assert known is not None, f"{solver} is not in methods_by_solver"
         for m in methods:
             assert m in known, f"{solver}: {m!r} is not one of its methods"
+
+    # and every solver must have an entry, so a consumer can tell "assessed, nothing qualifies"
+    # (an empty list) from "not in the table at all" -- a missing key would otherwise read as
+    # "no stiff-safe method" and silently hide the solver from a stiff-model menu
+    assert set(stiff) == set(SOLVER_SCHEMA['methods_by_solver']), (
+        "every solver needs a stiff_suitable_methods entry, empty if nothing qualifies")
 
     aadc = stiff['aadc_semi_implicit']
     assert aadc == ['semi_implicit', 'implicit_newton']


### PR DESCRIPTION
Closes #346.

`methods_by_solver` is what a GUI builds its integrator dropdown from, and four things in it did not hold for `aadc_semi_implicit`. This is the schema half of #346 — the `semi_implicit_signed` forward integrator and the accuracy investigation are separate, and deliberately not here.

## What changes

**1. `bdf_tape` and `bdf_kernel` were never two integrators.** Both step the same signed semi-implicit scheme, `x += dt*f/(1 - dt*diag J)`, differing only in where the loop runs: one AADC tape, or a C++ kernel replay that falls back to the tape when the extension is not built. They become one method, `semi_implicit_signed`, with the execution choice moved to a new `solver_info['gradient_strategy']` of `tape` | `kernel`. Both old names still select the right strategy, so existing configs keep working.

"signed" rather than "bdf" because that is the actual difference from the existing `semi_implicit`, which damps with `1 + dt*|diag J|`. The two agree exactly where the Jacobian diagonal is negative and diverge only where it is positive: `semi_implicit` damps unconditionally, this one linearises faithfully.

**2. New `forward_methods_by_solver`.** `methods_by_solver` is a superset — there is no forward-only path for `semi_implicit_signed`, so a plain solve with it raises. A tool building a "run a simulation" menu must use the new key or it offers a method that cannot solve, which is what broke interactive simulation downstream.

**3. The unknown-method error listed four methods while the dispatch accepted six.** It is now derived from `AADC_FORWARD_METHODS` so it cannot go stale again. The omission of `implicit_newton` and `bdf_newton` made the message match an older checkout exactly, and sent a user hunting an environment problem that did not exist.

**4. `default_method_by_solver` becomes `implicit_newton`.** It was set to `rk4` in #336 for tape-consistency without checking it could integrate anything. A default has to produce a number first and be AD-friendly second.

**5. New `stiff_suitable_methods`.** No existing key covered this — `ad_suitable_methods`, `fsa_suitable_methods` and `forward_methods_by_solver` each answer a different question, and a method can satisfy all three while being unusable on the models this framework generates.

The `aadc_semi_implicit` entry is measured, not assumed. On 3compartment (`sim_time=0.2`, `pre_time=0`, output `heart/u_lv`, against `CVODE_myokit` 7294 … 7.171e4):

| method | result |
|---|---|
| `rk4` | OverflowError at dt 1e-3, 1e-4, 1e-5 |
| `adaptive_rk45` | no return; killed at 180 s for a 0.01 s horizon |
| `semi_implicit` | OK, +6.7% |
| `implicit_newton` | OK, −1.9% |
| `implicit_euler_ift` | OK but −84% |
| `bdf_newton` | fails on `floor()` over an active idouble |

`implicit_euler_ift` is excluded *despite* completing. It returns a smooth, plausible trace that is wrong by a factor of six, and it remains in `ad_suitable_methods`, so a gradient-based calibration would use it without complaint. Being quietly wrong is worse than raising. Why it is wrong is not yet established, and is left open on #346.

`semi_implicit_signed` is absent from the stiff set too: it measured ~4.4x high on the same setup while its forward integrator was being written. Unexplained, so it is not advertised as stiff-safe on the strength of a docstring.

The other solvers follow from the integrators themselves — CVODE is BDF-based, solve_ivp's stiff solvers are Radau/BDF/LSODA, and CasADi's implicit methods are stable where its explicit `rk` is not.

## Review fixes in the third commit

I reviewed the first two commits before submitting and fixed three things:

- `AADC_LEGACY_METHOD_ALIASES` was declared but never read — the mapping was restated as an if-chain in `aadc_backend.cost_and_grad`, two sources of truth for the same fact, which is how those names came to look like two integrators in the first place. `cost_and_grad` now resolves through the table via a new `resolve_gradient_strategy()`. The test guarding backward compatibility asserted only that the legacy names were *in the table* — a declaration, not the code path — so it now drives the resolver instead. A legacy name alongside a contradicting `gradient_strategy` warns rather than silently discarding the setting.
- Two comment blocks ended up above the wrong dict, because the new keys were inserted between an existing comment and the assignment it described.
- `stiff_suitable_methods` had no entry for `RK4` or `PETSC`, so a consumer could not tell "assessed, nothing qualifies" from "not in the table". Both are now explicitly empty, and a test requires every solver in `methods_by_solver` to have an entry.

## Testing

`tests/test_solver_info_validation.py` grows from 46 to 48 tests, all passing, and each new schema key is locked against the code it describes rather than restated:

- every advertised forward method has a branch in `run()`, checked against the source
- the unknown-method error text is derived, not hand-written
- the default method is forward-solvable *and* AD-suitable, and is not `rk4`
- every `stiff_suitable_methods` entry is a method that solver actually offers, every solver has an entry, and every `default_method_by_solver` lands inside its solver's stiff set
- the legacy names resolve through the real dispatch

Full suite: 240 passed, 5 skipped with `-m "not slow"`. The one failure, `test_python_BDF_solver[SN_simple]`, reproduces identically on pristine master `082a65e` — it is the known libCellML-Analyser strict-ODE limitation, not a regression from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
