### PR TITLE
feat(sensitivity): finite-difference observable sensitivities for any backend (#338)

### DIFF
--- a/src/param_id/fd_backend.py
+++ b/src/param_id/fd_backend.py
@@ -1,0 +1,94 @@
+"""Finite-difference observable sensitivities -- the backend-agnostic arm of
+``OpencorParamID.get_observable_sensitivities`` (issue #338).
+
+The analytic arms are better and stay the default: CasADi differentiates the
+observable vector, and Myokit CVODES gives the exact operand sensitivity. But
+they only exist for two backends. AADC has none, and neither does the plain
+``python`` (scipy) backend, so local sensitivity analysis was simply unavailable
+there and the user was told to run a global Sobol SA instead -- a different
+analysis, costing ``num_samples*(2M+2)`` simulations rather than ``2M``.
+
+This computes the same quantity by re-simulating: central differences on the
+parameter vector, with the features re-evaluated through the ordinary observable
+path. It works wherever a forward run does.
+
+**Never a silent fallback.** ``get_observable_sensitivities`` still raises when
+no analytic backend is available and none was asked for, because a result
+quietly computed a different way is not the same result: FD costs ``2M``
+simulations, and its accuracy depends on a step size the analytic arms do not
+have. The caller opts in by name (``method='FD'``), so what produced a number is
+always something they chose.
+"""
+import numpy as np
+
+
+def _step(pj, pmin, pmax, h):
+    """The central-difference step for one parameter.
+
+    Relative to the parameter, because parameters here span many orders of
+    magnitude and one absolute step cannot suit them all. A parameter sitting at
+    exactly zero has no scale of its own, so its range supplies one; if that is
+    degenerate too, fall back to the raw h rather than a zero step, which would
+    divide by zero.
+    """
+    if pj != 0.0:
+        return abs(pj) * h
+    rng = float(pmax) - float(pmin)
+    return h * rng if rng > 0 else h
+
+
+def _features(pid, param_vals):
+    """The scalar (const) observable features at ``param_vals``.
+
+    Evaluated through the same path the cost uses, so a feature here is the
+    feature the calibration is fitting -- not a second implementation of it.
+    """
+    _, operands_list, _ = pid.get_cost_obs_and_pred_from_params(
+        np.asarray(param_vals, dtype=float), reset=True, only_one_exp=0)
+    if not operands_list or operands_list[0] is None:
+        return None
+    return np.asarray(pid.get_obs_output_dict(operands_list[0])['const'], dtype=float)
+
+
+def observable_feature_sensitivities(pid, param_vals, h=1e-3):
+    """d(observable feature)/d(param) by central finite differences.
+
+    Returns ``{observable_label: {param_name: d(feature)/d(param)}}`` -- the same
+    shape and the same quantity as the CasADi and CVODES arms, so a local
+    sensitivity analysis is comparable across backends whichever computed it.
+
+    Costs ``2M`` simulations for M parameters. A parameter whose perturbed runs
+    do not both converge is reported as None rather than as a number derived
+    from a failed solve; a caller can then see which parameter was unusable
+    instead of reading a plausible-looking zero.
+    """
+    param_vals = np.asarray(param_vals, dtype=float)
+    names = [n[0] if isinstance(n, (list, tuple)) else n
+             for n in pid.param_id_info["param_names"]]
+    mins = np.asarray(pid.param_id_info["param_mins"], dtype=float)
+    maxs = np.asarray(pid.param_id_info["param_maxs"], dtype=float)
+
+    const_to_obs = pid.obs_info["const_idx_to_obs_idx"]
+    out = {pid._observable_label(obs_idx): {} for obs_idx in const_to_obs}
+
+    if _features(pid, param_vals) is None:
+        raise RuntimeError("Local sensitivity nominal simulation failed to converge.")
+
+    for j, pname in enumerate(names):
+        step = _step(float(param_vals[j]), mins[j], maxs[j], h)
+
+        p_plus = param_vals.copy()
+        p_plus[j] += step
+        p_minus = param_vals.copy()
+        p_minus[j] -= step
+
+        f_plus = _features(pid, p_plus)
+        f_minus = _features(pid, p_minus)
+        for k, obs_idx in enumerate(const_to_obs):
+            label = pid._observable_label(obs_idx)
+            if f_plus is None or f_minus is None:
+                out[label][pname] = None
+                continue
+            d = (f_plus[k] - f_minus[k]) / (2.0 * step)
+            out[label][pname] = float(d) if np.isfinite(d) else None
+    return out

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -70,6 +70,7 @@ from param_id.plot_outputs import ParamIDPlotOutputs
 from param_id import casadi_backend
 from param_id import fsa_backend
 from param_id import aadc_backend
+from param_id import fd_backend
 import pandas as pd
 try:
     import casadi as ca
@@ -2379,24 +2380,42 @@ class OpencorParamID():
         operand = operands[0] if operands else ''
         return f"{name} ({op} {operand})" if op else f"{name} ({operand})"
 
-    def get_observable_sensitivities(self, param_vals):
+    def get_observable_sensitivities(self, param_vals, gradient_method=None):
         """d(observable feature)/d(param) for the scalar observables -- the backend-agnostic
         local-sensitivity accessor, parallel to ``get_gradient``.
 
         Returns ``{observable_label: {param_name: d(feature)/d(param)}}``, dispatching by
         model_type to the same analytic machinery the cost gradient uses: the CasADi jacobian
         of the observable vector, or the Myokit CVODES sensitivities with a directional
-        derivative of the feature. Both arms report the identical quantity so a local
-        sensitivity analysis is backend-consistent. There is no finite-difference fallback --
-        backends without an analytic sensitivity raise, pointing at global Sobol SA instead.
+        derivative of the feature. Every arm reports the identical quantity, so a local
+        sensitivity analysis is comparable across backends whichever computed it.
+
+        ``gradient_method`` selects how:
+
+        * ``None`` (default) -- the analytic arm for this backend, raising when there is
+          none. Unchanged behaviour, and deliberately still not a silent fall back to FD:
+          a result quietly computed a different way, at a different cost and accuracy, is
+          not the same result.
+        * ``'FD'`` -- central finite differences (``param_id.fd_backend``). Works on any
+          backend that runs a forward simulation, which is how AADC and the plain scipy
+          backend get a local SA at all (issue #338). Costs 2M simulations for M parameters.
         """
+        method = (gradient_method or '').strip().upper()
+        if method == 'FD':
+            return fd_backend.observable_feature_sensitivities(self, param_vals)
+        if method not in ('', 'ANALYTIC', 'AUTO'):
+            raise ValueError(
+                f"unknown gradient_method '{gradient_method}' for local sensitivity analysis. "
+                "Valid values are None/'analytic' (this backend's analytic sensitivity) or 'FD'.")
+
         if self.model_type == 'casadi_python':
             return casadi_backend.get_observable_sensitivities(self, param_vals)
         elif self.model_type == 'aadc_python':
             raise NotImplementedError(
                 "Local (derivative-based) sensitivity analysis is not yet implemented for the "
-                "AADC backend. Use model_type 'casadi_python', or 'cellml_only' with solver "
-                "'CVODE_myokit', or global Sobol SA (sa_options method 'sobol').")
+                "AADC backend. Use sa_options gradient_method 'FD', or model_type "
+                "'casadi_python', or 'cellml_only' with solver 'CVODE_myokit', or global "
+                "Sobol SA (sa_options method 'sobol').")
         elif fsa_backend.gradient_available(self):
             return fsa_backend.observable_feature_sensitivities(self, param_vals)
         else:
@@ -2404,8 +2423,9 @@ class OpencorParamID():
                 "Local (derivative-based) sensitivity analysis needs an analytic sensitivity "
                 f"backend, not available for model_type={self.model_type} / solver="
                 f"{self.solver_info.get('solver') if isinstance(self.solver_info, dict) else None}. "
-                "Use model_type 'casadi_python', or 'cellml_only' with solver 'CVODE_myokit' and "
-                "do_ad true, or global Sobol SA (sa_options method 'sobol').")
+                "Use sa_options gradient_method 'FD', or model_type 'casadi_python', or "
+                "'cellml_only' with solver 'CVODE_myokit' and do_ad true, or global Sobol SA "
+                "(sa_options method 'sobol').")
 
     def get_cost_and_gradient(self, param_vals):
         """Return ``(cost, gradient)`` in one evaluation.

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -565,8 +565,20 @@ ANALYSIS_OPTIONS = {
             {'name': 'method', 'type': 'enum', 'default': 'sobol', 'required': False,
              'choices': ['sobol', 'local'],
              'description': ('Sensitivity method: global variance-based Sobol indices, or '
-                             '"local" derivative-based sensitivities from the Myokit CVODES '
-                             'forward sensitivities (cellml_only + CVODE_myokit only).')},
+                             '"local" derivative-based sensitivities (see gradient_method '
+                             'for which backends can produce them).')},
+            # Only read by method 'local'. Declared so downstream tools offer the choice
+            # rather than hardcoding it, and so FD is something the user picks by name: it
+            # costs 2M simulations and its accuracy depends on a step size the analytic arms
+            # do not have, so it must never stand in silently for them.
+            {'name': 'gradient_method', 'type': 'enum', 'default': 'analytic', 'required': False,
+             'choices': ['analytic', 'FD'],
+             'description': ('For method "local": how to differentiate. "analytic" uses the '
+                             "backend's own sensitivity (the CasADi jacobian, or Myokit "
+                             'CVODES forward sensitivities) and fails where there is none; '
+                             '"FD" uses central finite differences and works on any backend '
+                             'that runs a forward simulation, at 2M simulations for M '
+                             'parameters.')},
             # enum, not str: sobol_SA.generate_samples dispatches on exactly these two
             # and raises ValueError on anything else, so a free string only lets a
             # typo through to run time.

--- a/src/sensitivity_analysis/sensitivityAnalysis.py
+++ b/src/sensitivity_analysis/sensitivityAnalysis.py
@@ -322,7 +322,11 @@ class SensitivityAnalysis():
             [float(v[0]) if isinstance(v, (list, tuple, np.ndarray)) else float(v)
              for v in nominal], dtype=float)
 
-        sens = engine.get_observable_sensitivities(nominal)  # {obs_label: {param: d(feat)/dp}}
+        # 'analytic' (the default) keeps the backend's own sensitivity; 'FD' opts into
+        # central finite differences, the only local SA available on a backend with no
+        # analytic arm (issue #338).
+        sens = engine.get_observable_sensitivities(  # {obs_label: {param: d(feat)/dp}}
+            nominal, gradient_method=(self.sa_options or {}).get('gradient_method'))
 
         output_names = list(sens.keys())
         n_out, n_par = len(output_names), len(param_names)
@@ -333,7 +337,15 @@ class SensitivityAnalysis():
         for i, oname in enumerate(output_names):
             fmag = feat_mag.get(oname, 0.0)
             for jj, pname in enumerate(param_names):
-                d = float(sens[oname].get(pname, 0.0))
+                raw = sens[oname].get(pname, 0.0)
+                # None means the arm could not produce this one -- an FD parameter whose
+                # perturbed runs did not converge. NaN, not 0.0: zero is a real answer
+                # ("this parameter does not matter") and would be indistinguishable from
+                # a failed evaluation in the saved CSV.
+                if raw is None:
+                    absolute[i, jj] = relative[i, jj] = np.nan
+                    continue
+                d = float(raw)
                 absolute[i, jj] = d
                 relative[i, jj] = d * abs(nominal[jj]) / fmag if fmag > 1e-30 else 0.0
 

--- a/tests/test_fd_observable_sensitivities.py
+++ b/tests/test_fd_observable_sensitivities.py
@@ -1,0 +1,185 @@
+"""Finite-difference observable sensitivities (issue #338).
+
+The analytic arms (CasADi jacobian, Myokit CVODES) only exist for two backends,
+so local sensitivity analysis was unavailable on AADC and on the plain scipy
+backend -- the user was told to run a global Sobol SA instead, which is a
+different analysis at num_samples*(2M+2) simulations rather than 2M.
+
+FD is opt-in by name, never a silent fallback: it costs 2M simulations and its
+accuracy depends on a step size the analytic arms do not have, so a caller must
+always know which produced their numbers. No model/MPI needed here -- the
+feature evaluation is stubbed, since what is under test is the differencing and
+the dispatch, not the solver.
+"""
+import numpy as np
+import pytest
+
+from param_id import fd_backend
+
+
+class _Pid:
+    """Enough of OpencorParamID for the FD arm: parameter metadata, observable
+    labels, and a feature function of the parameter vector."""
+
+    def __init__(self, feature_fn, names=("a/x", "b/y"), mins=(0.0, 0.0), maxs=(10.0, 10.0),
+                 fail_at=None):
+        self.param_id_info = {
+            "param_names": [[n] for n in names],
+            "param_mins": np.array(mins, dtype=float),
+            "param_maxs": np.array(maxs, dtype=float),
+        }
+        self.obs_info = {"const_idx_to_obs_idx": [0]}
+        self._feature_fn = feature_fn
+        self._fail_at = fail_at
+        self.calls = 0
+
+    def _observable_label(self, obs_idx):
+        return f"obs{obs_idx}"
+
+    def get_cost_obs_and_pred_from_params(self, param_vals, reset=True, only_one_exp=-1):
+        self.calls += 1
+        if self._fail_at is not None and self._fail_at(param_vals):
+            return 0.0, [None], []
+        return 0.0, [np.asarray(param_vals, dtype=float)], []
+
+    def get_obs_output_dict(self, operands):
+        return {"const": [self._feature_fn(operands)]}
+
+
+# ---------------------------------------------------------------------------
+# The differencing
+# ---------------------------------------------------------------------------
+def test_it_recovers_a_known_derivative():
+    """f(p) = 3*x + 2*y  ->  df/dx = 3, df/dy = 2."""
+    pid = _Pid(lambda p: 3.0 * p[0] + 2.0 * p[1])
+    out = fd_backend.observable_feature_sensitivities(pid, [1.0, 1.0])
+    assert out["obs0"]["a/x"] == pytest.approx(3.0, rel=1e-6)
+    assert out["obs0"]["b/y"] == pytest.approx(2.0, rel=1e-6)
+
+
+def test_it_is_central_not_forward():
+    """A central difference is exact for a quadratic; a forward one is not.
+    f = x^2 at x=2 -> 4 exactly."""
+    pid = _Pid(lambda p: p[0] ** 2)
+    out = fd_backend.observable_feature_sensitivities(pid, [2.0, 0.0])
+    assert out["obs0"]["a/x"] == pytest.approx(4.0, rel=1e-9)
+
+
+def test_it_costs_two_simulations_per_parameter_plus_one():
+    """2M for M parameters, plus the nominal convergence check."""
+    pid = _Pid(lambda p: p[0] + p[1])
+    fd_backend.observable_feature_sensitivities(pid, [1.0, 1.0])
+    assert pid.calls == 2 * 2 + 1
+
+
+# ---------------------------------------------------------------------------
+# Step size
+# ---------------------------------------------------------------------------
+def test_the_step_is_relative_to_the_parameter():
+    """Parameters span orders of magnitude, so one absolute step cannot suit
+    them all."""
+    assert fd_backend._step(1000.0, 0.0, 1.0, 1e-3) == pytest.approx(1.0)
+    assert fd_backend._step(0.001, 0.0, 1.0, 1e-3) == pytest.approx(1e-6)
+
+
+def test_a_zero_parameter_takes_its_scale_from_its_range():
+    """Zero has no scale of its own, and a zero step would divide by zero."""
+    assert fd_backend._step(0.0, -5.0, 5.0, 1e-3) == pytest.approx(1e-2)
+
+
+def test_a_zero_parameter_with_a_degenerate_range_still_steps():
+    assert fd_backend._step(0.0, 2.0, 2.0, 1e-3) == pytest.approx(1e-3)
+
+
+def test_a_derivative_is_recovered_at_a_zero_valued_parameter():
+    pid = _Pid(lambda p: 5.0 * p[0], mins=(-1.0,), maxs=(1.0,), names=("a/x",))
+    out = fd_backend.observable_feature_sensitivities(pid, [0.0])
+    assert out["obs0"]["a/x"] == pytest.approx(5.0, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Failure is reported, not disguised
+# ---------------------------------------------------------------------------
+def test_a_parameter_whose_runs_fail_is_none_not_zero():
+    """Zero is a real answer -- "this parameter does not matter" -- and must not
+    be indistinguishable from a solve that never converged."""
+    pid = _Pid(lambda p: p[0] + p[1], fail_at=lambda p: p[1] != 1.0)
+    out = fd_backend.observable_feature_sensitivities(pid, [1.0, 1.0])
+    assert out["obs0"]["a/x"] == pytest.approx(1.0, rel=1e-6)
+    assert out["obs0"]["b/y"] is None
+
+
+def test_a_failed_nominal_run_raises():
+    pid = _Pid(lambda p: p[0], fail_at=lambda p: True)
+    with pytest.raises(RuntimeError, match="nominal simulation failed"):
+        fd_backend.observable_feature_sensitivities(pid, [1.0, 1.0])
+
+
+# ---------------------------------------------------------------------------
+# Dispatch: opt-in, never silent
+# ---------------------------------------------------------------------------
+def test_fd_is_selected_by_name():
+    from param_id.paramID import OpencorParamID
+
+    pid = OpencorParamID.__new__(OpencorParamID)
+    stub = _Pid(lambda p: 3.0 * p[0])
+    for attr in ("param_id_info", "obs_info"):
+        setattr(pid, attr, getattr(stub, attr))
+    pid._observable_label = stub._observable_label
+    pid.get_cost_obs_and_pred_from_params = stub.get_cost_obs_and_pred_from_params
+    pid.get_obs_output_dict = stub.get_obs_output_dict
+    pid.model_type = "aadc_python"  # no analytic arm at all
+
+    out = pid.get_observable_sensitivities([1.0, 1.0], gradient_method="FD")
+    assert out["obs0"]["a/x"] == pytest.approx(3.0, rel=1e-6)
+
+
+def test_without_fd_an_analytic_less_backend_still_raises():
+    """The default must not quietly become FD: a result computed a different way,
+    at a different cost and accuracy, is not the same result."""
+    from param_id.paramID import OpencorParamID
+
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.model_type = "aadc_python"
+    with pytest.raises(NotImplementedError, match="AADC"):
+        pid.get_observable_sensitivities([1.0])
+
+
+def test_the_aadc_message_now_points_at_fd():
+    from param_id.paramID import OpencorParamID
+
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.model_type = "aadc_python"
+    with pytest.raises(NotImplementedError, match="gradient_method 'FD'"):
+        pid.get_observable_sensitivities([1.0])
+
+
+def test_an_unknown_gradient_method_is_rejected():
+    from param_id.paramID import OpencorParamID
+
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.model_type = "casadi_python"
+    with pytest.raises(ValueError, match="unknown gradient_method 'central'"):
+        pid.get_observable_sensitivities([1.0], gradient_method="central")
+
+
+@pytest.mark.parametrize("alias", [None, "", "analytic", "AUTO"])
+def test_the_analytic_aliases_do_not_divert_to_fd(alias):
+    from param_id.paramID import OpencorParamID
+
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.model_type = "aadc_python"
+    with pytest.raises(NotImplementedError):
+        pid.get_observable_sensitivities([1.0], gradient_method=alias)
+
+
+# ---------------------------------------------------------------------------
+# The option is declared, so downstream tools can offer it
+# ---------------------------------------------------------------------------
+def test_gradient_method_is_in_the_analysis_schema():
+    from parsers.PrimitiveParsers import ANALYSIS_OPTIONS
+
+    opts = {o["name"]: o for o in ANALYSIS_OPTIONS["sensitivity_analysis"]["options"]}
+    assert "gradient_method" in opts
+    assert opts["gradient_method"]["choices"] == ["analytic", "FD"]
+    assert opts["gradient_method"]["default"] == "analytic"


### PR DESCRIPTION
Closes #338.

Local sensitivity analysis had analytic arms only — the CasADi jacobian of the observable vector, and the Myokit CVODES forward sensitivities. Backends with neither (**AADC**, and the plain scipy `python` backend) could not run a local SA at all; the advice was to run a global Sobol SA instead, which is a *different analysis* costing `num_samples*(2M+2)` simulations against `2M`.

`param_id/fd_backend.py` computes the same quantity by re-simulating: central differences on the parameter vector, with the features re-evaluated through the ordinary observable path — so a feature here is the feature the calibration fits, not a second implementation of it. It works wherever a forward run does.

### Opt-in, never a silent fallback

The docstring on `get_observable_sensitivities` said *"there is no finite-difference fallback"*, and **that stance is kept**. With no `gradient_method` given, a backend without an analytic sensitivity still raises exactly as before.

FD costs 2M simulations and its accuracy depends on a step size the analytic arms don't have, so which one produced a number must always be something the caller chose. `gradient_method='FD'` selects it; anything unrecognised raises rather than quietly falling through to the analytic path.

`gradient_method` is declared in `ANALYSIS_OPTIONS` beside the other `sa_options`, so downstream tools (CUFLynx's sensitivity panel) offer it from the schema instead of hardcoding the choice, and `run_local_sensitivity` reads it.

### Two details worth keeping

- **The step is relative to the parameter**, because parameters span orders of magnitude and one absolute step cannot suit them all. A parameter at exactly zero has no scale of its own, so its range supplies one; a degenerate range falls back to the raw `h` rather than a zero step.
- **A parameter whose perturbed runs don't converge is `None`**, reaching the saved matrices as `NaN` rather than `0.0`. Zero is a real answer — "this parameter doesn't matter" — and must not be indistinguishable from a solve that never happened.

### Tests

18 new in `tests/test_fd_observable_sensitivities.py`; 58 passing across the parser/param_id suites. No model or MPI needed — the feature evaluation is stubbed, since what's under test is the differencing and the dispatch, not the solver. They cover the recovered derivative on a known function, that it's central rather than forward (exact on a quadratic), the 2M cost, the step-size rules including the zero-parameter case, and that the analytic aliases never divert to FD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)