### PR TITLE
feat(param_id): save the observable names beside the error vectors (#341)

### DIFF
--- a/src/param_id/plot_outputs.py
+++ b/src/param_id/plot_outputs.py
@@ -675,12 +675,33 @@ class ParamIDPlotOutputs:
         out = self.client.output_dir
         np.save(os.path.join(out, "percent_error_vec.npy"), percent_error_vec)
         np.save(os.path.join(out, "std_error_vec.npy"), std_error_vec)
+        # The error vectors are positional: entry i belongs to data_items[i]. Every
+        # consumer therefore re-derives the labels by reading obs_data.json in the
+        # same order, so reordering that file silently relabels every bar -- a wrong
+        # plot that looks entirely right. These artefacts are an interface now, not an
+        # implementation detail (#341), so the names CA itself used are saved beside
+        # them and the data identifies itself.
+        #
+        # Raw names, not the '$...$' mathtext the bar plots wrap them in: this is data
+        # for whoever reads it. A consumer wanting mathtext can add the delimiters; one
+        # wanting the plain name could not reliably strip them, since a name may
+        # legitimately contain '$'.
+        np.save(os.path.join(out, "error_vec_names.npy"), self.observable_names())
 
-    def _observable_names_for_error_plots(self) -> np.ndarray:
+    def observable_names(self) -> np.ndarray:
+        """The per-observable labels, in the order the error vectors use.
+
+        Public because it defines the meaning of ``error_vec_names.npy``: this is
+        the ordering an external consumer binds to.
+        """
         obs_info = self.client.obs_info
         return np.array(
-            [f'${obs_info["names_for_plotting"][II]}$' for II in range(obs_info["num_obs"])]
+            [str(obs_info["names_for_plotting"][II]) for II in range(obs_info["num_obs"])]
         )
+
+    def _observable_names_for_error_plots(self) -> np.ndarray:
+        """The same labels wrapped for matplotlib mathtext, for the bar plots."""
+        return np.array([f"${name}$" for name in self.observable_names()])
 
     def plot_percent_error_bar_pages(
         self, obs_names_for_plot: np.ndarray, percent_error_vec: np.ndarray

--- a/tests/test_error_vector_names.py
+++ b/tests/test_error_vector_names.py
@@ -1,0 +1,82 @@
+"""The saved error vectors identify their own observables (issue #341).
+
+``percent_error_vec.npy`` / ``std_error_vec.npy`` are positional: entry i belongs
+to ``data_items[i]``. Every consumer therefore re-derives the labels by reading
+obs_data.json in the same order, so reordering that file silently relabels every
+bar -- a wrong plot that looks entirely right. Now that these artefacts are an
+interface rather than an implementation detail, the names travel with them.
+
+No model/MPI needed: only the artefact writing is under test.
+"""
+import os
+
+import numpy as np
+import pytest
+
+from param_id.plot_outputs import ParamIDPlotOutputs
+
+
+class _Client:
+    def __init__(self, out, names):
+        self.output_dir = str(out)
+        self.obs_info = {"names_for_plotting": list(names), "num_obs": len(names)}
+
+
+def _plotter(out, names):
+    plotter = ParamIDPlotOutputs.__new__(ParamIDPlotOutputs)
+    plotter.client = _Client(out, names)
+    return plotter
+
+
+def test_the_names_are_saved_beside_the_error_vectors(tmp_path):
+    plotter = _plotter(tmp_path, ["flow", "pressure"])
+    plotter.save_error_vectors(np.array([1.0, 2.0]), np.array([0.1, 0.2]))
+
+    names = np.load(os.path.join(tmp_path, "error_vec_names.npy"), allow_pickle=True)
+    assert list(names) == ["flow", "pressure"]
+
+
+def test_the_names_are_in_the_error_vectors_order(tmp_path):
+    """The whole point: position i in the vectors is position i in the names, so a
+    consumer never has to guess the ordering from another file."""
+    plotter = _plotter(tmp_path, ["a", "b", "c"])
+    percent = np.array([10.0, 20.0, 30.0])
+    plotter.save_error_vectors(percent, np.zeros(3))
+
+    names = np.load(os.path.join(tmp_path, "error_vec_names.npy"), allow_pickle=True)
+    assert len(names) == len(percent)
+    assert dict(zip(names, percent)) == {"a": 10.0, "b": 20.0, "c": 30.0}
+
+
+def test_the_saved_names_are_raw_not_mathtext(tmp_path):
+    """Data for whoever reads it. A consumer wanting mathtext can add the '$'; one
+    wanting the plain name could not reliably strip them."""
+    plotter = _plotter(tmp_path, ["q_{lv}"])
+    plotter.save_error_vectors(np.array([1.0]), np.array([1.0]))
+
+    names = np.load(os.path.join(tmp_path, "error_vec_names.npy"), allow_pickle=True)
+    assert names[0] == "q_{lv}"
+    assert not names[0].startswith("$")
+
+
+def test_the_bar_plots_still_get_mathtext(tmp_path):
+    """The plotting path is unchanged -- it wraps the same labels."""
+    plotter = _plotter(tmp_path, ["q_{lv}", "p_{ao}"])
+    assert list(plotter._observable_names_for_error_plots()) == ["$q_{lv}$", "$p_{ao}$"]
+
+
+def test_the_existing_vectors_are_still_written(tmp_path):
+    """Additive: nothing that already read these files may break."""
+    plotter = _plotter(tmp_path, ["a"])
+    plotter.save_error_vectors(np.array([5.0]), np.array([6.0]))
+
+    assert np.load(os.path.join(tmp_path, "percent_error_vec.npy")) == pytest.approx([5.0])
+    assert np.load(os.path.join(tmp_path, "std_error_vec.npy")) == pytest.approx([6.0])
+
+
+def test_no_observables_writes_an_empty_name_vector(tmp_path):
+    plotter = _plotter(tmp_path, [])
+    plotter.save_error_vectors(np.array([]), np.array([]))
+
+    names = np.load(os.path.join(tmp_path, "error_vec_names.npy"), allow_pickle=True)
+    assert len(names) == 0


### PR DESCRIPTION
Towards #341.

`percent_error_vec.npy` and `std_error_vec.npy` are **positional** — entry *i* belongs to `data_items[i]`. Nothing records that, so every consumer re-derives the labels by reading `obs_data.json` in the same order, and reordering that file silently relabels every bar. The failure mode is a plot that looks entirely right.

#341 names this as one of three points to settle before the generated `plot_outputs` script can bind to these artefacts, and it's the cheapest of the three: CA already computes the names, one line away, and simply doesn't save them.

### What changed

`save_error_vectors` now also writes `error_vec_names.npy`, in the same order as the vectors.

**Raw names, not the `$...$` mathtext the bar plots wrap them in.** This is data for whoever reads it: a consumer wanting mathtext can add the delimiters, while one wanting the plain name could not reliably strip them, since a name may legitimately contain `$`. The wrapping moves into `_observable_names_for_error_plots`, which the plotting path already used, so the figures are unchanged.

### Additive

Both existing files are still written exactly as before, so nothing that already reads them breaks. There's a test for that.

### Tests

6 new in `tests/test_error_vector_names.py` — no model or MPI needed, only the artefact writing is under test.

### On the rest of #341

The remaining two points are the naming convention (`aortic_root/v` vs `aortic_root_module.v`) and a `plot_dir` separate from `output_dir` in `sa_options`. Happy to take those on next, and then the script generator itself — the CUFLynx implementation referenced in the issue is ~780 lines of template, which seemed worth agreeing the interface for before moving it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)