### PR TITLE
feat(params): declare and accept the values each prior takes

### DIFF
--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -1420,6 +1420,13 @@ class OpencorParamID():
             self.param_id_info["param_mins"] = np.delete(self.param_id_info["param_mins"], param_idxs_to_remove)
             self.param_id_info["param_maxs"] = np.delete(self.param_id_info["param_maxs"], param_idxs_to_remove)
             self.param_id_info["param_prior_types"] = np.delete(self.param_id_info["param_prior_types"], param_idxs_to_remove)
+            # Kept in step with the types, or every remaining parameter would read the
+            # hyper-parameters of whichever one used to sit at its index.
+            if self.param_id_info.get("param_prior_params") is not None:
+                self.param_id_info["param_prior_params"] = [
+                    p for II, p in enumerate(self.param_id_info["param_prior_params"])
+                    if II not in param_idxs_to_remove
+                ]
             self.param_norm_obj = Normalise_class(self.param_id_info["param_mins"], self.param_id_info["param_maxs"])
             self.param_init = None
 
@@ -1688,6 +1695,24 @@ class OpencorParamID():
         cost = self.get_cost_and_obs_from_params(param_vals, reset=reset)[0]
         return cost
     
+    def _prior_param(self, idx, name):
+        """One prior hyper-parameter for parameter ``idx``, or its declared default.
+
+        Tolerates a param_id_info built without ``param_prior_params`` -- assembled by
+        hand, or unpickled from before these columns existed -- by falling back to the
+        schema default, so an older config keeps the behaviour it had.
+        """
+        per_param = self.param_id_info.get("param_prior_params")
+        if per_param is not None and idx < len(per_param):
+            values = per_param[idx] or {}
+            if name in values:
+                return values[name]
+        for meta in PARAM_PRIOR_TYPES.values():
+            for spec in meta['params']:
+                if spec['name'] == name:
+                    return spec['default']
+        return None
+
     def get_lnprior_from_params(self, param_vals):
         lnprior = 0
         for idx, param_val in enumerate(param_vals):
@@ -1704,7 +1729,7 @@ class OpencorParamID():
                     pass
             
             elif prior_dist == 'exponential':
-                lamb = 1.0 # TODO make this user modifiable
+                lamb = self._prior_param(idx, 'prior_lambda')
                 if param_val < self.param_id_info["param_mins"][idx] or param_val > self.param_id_info["param_maxs"][idx]:
                     return -np.inf
                 else:
@@ -1716,9 +1741,17 @@ class OpencorParamID():
                 if param_val < self.param_id_info["param_mins"][idx] or param_val > self.param_id_info["param_maxs"][idx]:
                     return -np.inf
                 else:
-                    # temporarily make the std 1/6 of the user defined range and the mean the centre of the range
-                    std = 1/6*(self.param_id_info["param_maxs"][idx] - self.param_id_info["param_mins"][idx])
-                    mean = 0.5*(self.param_id_info["param_maxs"][idx] + self.param_id_info["param_mins"][idx])
+                    # Defaults when the user states neither: the centre of the range, and a
+                    # sixth of it, which puts [min, max] at +/- 3 sigma. Both are now
+                    # params_for_id columns (prior_mean / prior_std), because a prior whose
+                    # centre is fixed to the middle of the bounds cannot express most of
+                    # what a prior is for.
+                    std = self._prior_param(idx, 'prior_std')
+                    if std is None:
+                        std = 1/6*(self.param_id_info["param_maxs"][idx] - self.param_id_info["param_mins"][idx])
+                    mean = self._prior_param(idx, 'prior_mean')
+                    if mean is None:
+                        mean = 0.5*(self.param_id_info["param_maxs"][idx] + self.param_id_info["param_mins"][idx])
                     lnprior += -0.5*((param_val - mean)/std)**2
 
             else:

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -384,21 +384,47 @@ _OPT_GA_NUM_CROSS_BREED = {
 # through skips that parameter's own range check, so a mis-spelled prior -- 'Normal', say --
 # silently stopped bounding the parameter at all, and an MCMC walker could leave [min, max]
 # with a finite lnprior instead of -inf. A typo must not quietly unbound a parameter.
+# Each prior also declares the values it takes, in `params`. Those were previously hardcoded
+# in get_lnprior_from_params -- the exponential's rate behind a "TODO make this user
+# modifiable", the normal's mean and std behind a "temporarily" -- so a user who wanted a
+# prior centred anywhere other than the middle of the range had no way to say so, and no way
+# to discover that the number was fixed. Each entry names a params_for_id column, with the
+# previous hardcoded value as its default so existing files are unaffected.
 PARAM_PRIOR_TYPES = {
     'uniform': {
         'label': 'Uniform',
         'description': 'Flat across [min, max]. The default when no prior is given.',
+        'params': [],
     },
     'exponential': {
         'label': 'Exponential',
-        'description': 'Decays across [min, max] at rate 1/max, favouring smaller values.',
+        'description': ('Decays across [min, max] at rate prior_lambda / max, favouring '
+                        'smaller values.'),
+        'params': [
+            {'name': 'prior_lambda', 'type': 'float', 'default': 1.0, 'positive': True,
+             'description': ('Decay rate, scaled by the parameter maximum. Larger values '
+                             'concentrate the prior harder towards min.')},
+        ],
     },
     'normal': {
         'label': 'Normal',
-        'description': ('Gaussian centred on the middle of [min, max], with a standard '
-                        'deviation of one sixth of the range.'),
+        'description': 'Gaussian, truncated to [min, max].',
+        'params': [
+            {'name': 'prior_mean', 'type': 'float', 'default': None, 'positive': False,
+             'description': 'Centre of the Gaussian. Defaults to the centre of [min, max].'},
+            {'name': 'prior_std', 'type': 'float', 'default': None, 'positive': True,
+             'description': ('Standard deviation. Defaults to one sixth of the range, which '
+                             'puts [min, max] at +/- 3 sigma.')},
+        ],
     },
 }
+
+# Every `params` entry above names a params_for_id column. Collected once so the parser can
+# tell a prior hyper-parameter column from an unrelated one, and so a downstream tool can
+# render exactly the fields the chosen prior uses.
+PARAM_PRIOR_PARAM_NAMES = tuple(
+    spec['name'] for meta in PARAM_PRIOR_TYPES.values() for spec in meta['params']
+)
 
 # What an absent, blank or NaN `prior` entry means -- and what the whole column defaults to
 # when params_for_id has no `prior` at all.
@@ -427,6 +453,54 @@ def normalise_prior_type(value, row_idx=None):
             f"{', '.join(sorted(PARAM_PRIOR_TYPES))}."
         )
     return key
+
+
+def normalise_prior_params(prior_type, row, row_idx=None):
+    """The hyper-parameters for one row's prior, validated against its declaration.
+
+    ``row`` is anything supporting ``.get(name)`` -- a DataFrame row or a plain
+    dict. Returns ``{name: float or None}`` for exactly the values this prior
+    declares; None means "not stated", which the likelihood turns into the
+    documented default (the centre of the range, a sixth of the range) since
+    those depend on bounds this function does not own.
+
+    A value supplied for a prior that does not take it is an error, not something
+    to ignore: `prior_std` on a uniform row means the user believes they set a
+    width, and silently dropping it gives them a different posterior than the one
+    they asked for.
+    """
+    where = '' if row_idx is None else f' (params_for_id row {row_idx})'
+    declared = {spec['name']: spec for spec in PARAM_PRIOR_TYPES[prior_type]['params']}
+
+    for name in PARAM_PRIOR_PARAM_NAMES:
+        if name in declared:
+            continue
+        raw = row.get(name) if hasattr(row, 'get') else None
+        if raw is None or (isinstance(raw, float) and np.isnan(raw)) or str(raw).strip() == '':
+            continue
+        raise ValueError(
+            f"'{name}' was given{where}, but the prior is '{prior_type}', which does not use "
+            f"it. {prior_type} takes: {', '.join(declared) if declared else 'no parameters'}."
+        )
+
+    out = {}
+    for name, spec in declared.items():
+        raw = row.get(name) if hasattr(row, 'get') else None
+        if raw is None or (isinstance(raw, float) and np.isnan(raw)) or str(raw).strip() == '':
+            out[name] = spec['default']
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"'{name}'{where} must be a number, got {raw!r}.") from exc
+        if not np.isfinite(value):
+            raise ValueError(f"'{name}'{where} must be finite, got {raw!r}.")
+        if spec['positive'] and value <= 0:
+            raise ValueError(
+                f"'{name}'{where} must be greater than zero, got {value}.")
+        out[name] = value
+    return out
 
 
 # Single source of truth for the parameter-identification (calibration) methods, i.e. the valid
@@ -2780,6 +2854,16 @@ class ObsAndParamDataParser(object):
             ])
         else:
             param_id_info["param_prior_types"] = np.array([DEFAULT_PARAM_PRIOR_TYPE] * N_params)
+
+        # The values each prior takes (the exponential's rate, the normal's mean and std),
+        # one dict per parameter. Validated against what that row's prior actually declares,
+        # so a hyper-parameter set on a prior that ignores it is a parse error rather than a
+        # silently different posterior.
+        param_id_info["param_prior_params"] = [
+            normalise_prior_params(
+                param_id_info["param_prior_types"][II], filtered_params.iloc[II], row_idx=II)
+            for II in range(N_params)
+        ]
 
         param_id_info["param_names_for_gen"] = param_names_for_gen
 

--- a/tests/test_param_priors.py
+++ b/tests/test_param_priors.py
@@ -117,3 +117,125 @@ def test_a_prior_the_parser_never_saw_raises_rather_than_falling_through():
     }
     with pytest.raises(ValueError, match="unknown prior 'gaussian'"):
         pid.get_lnprior_from_params([1.5])
+
+
+# ---------------------------------------------------------------------------
+# The values each prior takes
+#
+# These were hardcoded in get_lnprior_from_params -- the exponential's rate behind
+# a "TODO make this user modifiable", the normal's mean and std behind a
+# "temporarily". A prior whose centre is fixed to the middle of the bounds cannot
+# express most of what a prior is for, and nothing told the user the number was
+# fixed. They are declared in the schema and settable per row now.
+# ---------------------------------------------------------------------------
+from parsers.PrimitiveParsers import PARAM_PRIOR_PARAM_NAMES, normalise_prior_params
+
+
+def _lnprior(csv, vals):
+    from param_id.paramID import OpencorParamID
+
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.param_id_info = _info(csv)
+    return pid.get_lnprior_from_params(vals)
+
+
+def test_every_declared_prior_param_is_a_known_column():
+    assert set(PARAM_PRIOR_PARAM_NAMES) == {"prior_lambda", "prior_mean", "prior_std"}
+
+
+def test_each_prior_declares_the_values_it_takes():
+    assert [s["name"] for s in PARAM_PRIOR_TYPES["exponential"]["params"]] == ["prior_lambda"]
+    assert [s["name"] for s in PARAM_PRIOR_TYPES["normal"]["params"]] == ["prior_mean", "prior_std"]
+    assert PARAM_PRIOR_TYPES["uniform"]["params"] == []
+
+
+def test_an_unstated_value_falls_back_to_the_declared_default():
+    assert normalise_prior_params("exponential", {})["prior_lambda"] == 1.0
+    # None means "derived from the bounds", which this function does not own.
+    assert normalise_prior_params("normal", {})["prior_std"] is None
+
+
+def test_a_stated_value_is_read():
+    got = normalise_prior_params("normal", {"prior_mean": 3.0, "prior_std": 0.5})
+    assert got == {"prior_mean": 3.0, "prior_std": 0.5}
+
+
+def test_a_value_for_a_prior_that_ignores_it_is_rejected():
+    """Silently dropping it would give the user a different posterior than the one
+    they believe they asked for."""
+    with pytest.raises(ValueError, match="does not use it"):
+        normalise_prior_params("uniform", {"prior_std": 2.0})
+
+
+def test_a_non_positive_scale_is_rejected():
+    with pytest.raises(ValueError, match="greater than zero"):
+        normalise_prior_params("normal", {"prior_std": 0.0})
+    with pytest.raises(ValueError, match="greater than zero"):
+        normalise_prior_params("exponential", {"prior_lambda": -1.0})
+
+
+def test_a_mean_may_be_negative_or_zero():
+    """Only the scales are constrained; a centre is free."""
+    assert normalise_prior_params("normal", {"prior_mean": -4.0})["prior_mean"] == -4.0
+
+
+def test_a_non_numeric_value_is_rejected():
+    with pytest.raises(ValueError, match="must be a number"):
+        normalise_prior_params("normal", {"prior_std": "wide"})
+
+
+def test_the_columns_are_parsed_per_row():
+    info = _info(
+        "vessel_name,param_name,min,max,prior,prior_mean,prior_std\n"
+        "a,k,0,10,normal,7.0,0.5\n"
+        "b,j,0,10,uniform,,\n"
+    )
+    assert info["param_prior_params"][0] == {"prior_mean": 7.0, "prior_std": 0.5}
+    assert info["param_prior_params"][1] == {}
+
+
+def test_the_stated_mean_moves_the_peak():
+    """The regression that motivates this: with mean fixed to the range centre the
+    prior peaked at 5; stating 9 must move it there."""
+    csv = ("vessel_name,param_name,min,max,prior,prior_mean,prior_std\n"
+           "a,k,0,10,normal,9.0,1.0\n")
+    assert _lnprior(csv, [9.0]) == pytest.approx(0.0)
+    assert _lnprior(csv, [5.0]) == pytest.approx(-8.0)
+
+
+def test_the_default_normal_is_unchanged():
+    """Existing params_for_id files must behave exactly as before: centre of the
+    range, std one sixth of it."""
+    csv = "vessel_name,param_name,min,max,prior\na,k,0,6,normal\n"
+    # centre 3, std 1 -> lnprior at 4 is -0.5
+    assert _lnprior(csv, [4.0]) == pytest.approx(-0.5)
+
+
+def test_the_default_exponential_rate_is_unchanged():
+    csv = "vessel_name,param_name,min,max,prior\na,k,0,10,exponential\n"
+    assert _lnprior(csv, [5.0]) == pytest.approx(-0.5)
+
+
+def test_a_stated_rate_steepens_the_exponential():
+    csv = ("vessel_name,param_name,min,max,prior,prior_lambda\n"
+           "a,k,0,10,exponential,4.0\n")
+    assert _lnprior(csv, [5.0]) == pytest.approx(-2.0)
+
+
+def test_bounds_still_win_over_the_stated_values():
+    csv = ("vessel_name,param_name,min,max,prior,prior_mean,prior_std\n"
+           "a,k,0,10,normal,9.0,1.0\n")
+    assert _lnprior(csv, [999.0]) == -np.inf
+
+
+def test_a_config_without_the_new_key_keeps_its_behaviour():
+    """param_id_info assembled by hand, or from before these columns existed."""
+    from param_id.paramID import OpencorParamID
+
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.param_id_info = {
+        "param_prior_types": np.array(["normal"]),
+        "param_mins": np.array([0.0]),
+        "param_maxs": np.array([6.0]),
+    }
+    assert pid.get_lnprior_from_params([4.0]) == pytest.approx(-0.5)


### PR DESCRIPTION
Follow-on to #351, which declared *which* priors exist but not what each one takes.

Those values were hardcoded:

```python
lamb = 1.0 # TODO make this user modifiable
...
# temporarily make the std 1/6 of the user defined range and the mean the centre of the range
```

A normal prior whose centre is fixed to the middle of the bounds cannot express most of what a prior is *for* — prior knowledge is usually "near this value", which is rarely the midpoint of the search range. And nothing told the user the number was fixed; it was discoverable only by reading the likelihood.

### What this adds

Each prior in `PARAM_PRIOR_TYPES` declares its `params` — name, type, default, whether it must be positive, and what it means. Each names an optional params_for_id column: `prior_lambda`, `prior_mean`, `prior_std`. Per column, because priors are per parameter and that's the only useful granularity for them.

Declared **and wired up**, in one change. Advertising a field the code ignores would be worse than not declaring it — that's the inert-setting mistake, where a form offers a knob that does nothing.

### Validation, matching the rest of the column's treatment

- A value given for a prior that doesn't use it is an **error**, not something to drop. `prior_std` on a uniform row means the user believes they set a width; ignoring it hands them a different posterior than the one they asked for.
- Scales must be positive and finite. A mean may be negative or zero — only the scales are constrained.
- An unstated value falls back to the declared default. For the normal that default is `None`, meaning "derive from the bounds" — which the parser doesn't own and the likelihood does.

### Nothing existing changes

The defaults are exactly the previously hardcoded values. All six shipped params_for_id fixtures parse identically, and a `param_id_info` built without the new key (by hand, or from before these columns existed) keeps the behaviour it had.

`param_prior_params` is also pruned alongside `param_prior_types` when parameters are removed — otherwise each remaining parameter would read the hyper-parameters of whichever one used to sit at its index.

### Tests

15 new (31 in the file, 95 across the CA suites run), including that the stated mean actually moves the peak, that the defaults reproduce the old numbers exactly, and that bounds still win over any stated value.

CUFLynx's params editor (physiomelinks/CUFLynx#189) reads `value`/`label`/`description` only, so it stays compatible; rendering the per-prior fields there is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)