### PR TITLE
feat(aadc): forward integrator for semi_implicit_signed, and the jac_lag coupling it depends on

### DIFF
--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -72,8 +72,8 @@ AADC_LEGACY_METHOD_ALIASES = {
 # The methods aadc_python_solver_helper.run() can actually integrate. A tool building a
 # "run a simulation" menu must use this rather than methods_by_solver, which is a superset
 # (issue #346).
-AADC_FORWARD_METHODS = ('adaptive_rk45', 'semi_implicit', 'implicit_euler_ift',
-                        'implicit_newton', 'bdf_newton', 'rk4')
+AADC_FORWARD_METHODS = ('adaptive_rk45', 'semi_implicit', 'semi_implicit_signed',
+                        'implicit_euler_ift', 'implicit_newton', 'bdf_newton', 'rk4')
 
 # Every AADC method that can produce an analytic gradient, by either route.
 AADC_AD_METHODS = AADC_TAPE_CONSISTENT_METHODS + AADC_BDF_AD_METHODS
@@ -179,7 +179,16 @@ SOLVER_SCHEMA['fsa_suitable_methods'] = {
 #   implicit_newton      OK, -1.9%
 #   implicit_euler_ift   OK but -84%  <- the dangerous one: it completes and looks plausible
 #   bdf_newton           fails on floor() over an active idouble
-#   semi_implicit_signed measured ~4.4x high on the same setup; unexplained, so not listed
+#   semi_implicit_signed OK, +2%  (at its defaults: max_step 0.001, jac_lag 10)
+#
+# semi_implicit_signed was previously withheld from this list after measuring ~4.4x high while
+# its forward integrator was being written. That measurement was taken from the model's own cold
+# initial conditions with pre_time=0, where the whole window is a startup transient: every
+# variant of the scheme -- and CVODE itself -- peaks near 3.1e5 there, so it showed a difference
+# between two setups rather than between two integrators. Re-measured after a 5 s spin-up, the
+# scheme's four distinguishing features (signed diagonal, lagged Jacobian, sub-stepping, no valve
+# clamp) land it within 2% of CVODE_myokit, which is better than semi_implicit's +16% at dt=0.01.
+# Its stability depends on max_step and jac_lag together, so both are documented above.
 #
 # implicit_euler_ift is deliberately excluded despite completing. It is still in
 # ad_suitable_methods, so a gradient-based calibration will use it without complaint -- being
@@ -196,7 +205,7 @@ SOLVER_SCHEMA['stiff_suitable_methods'] = {
     'solve_ivp': ['Radau', 'BDF', 'LSODA'],
     'user_defined': ['Radau', 'BDF', 'LSODA'],
     'casadi_integrator': ['cvodes', 'idas', 'bdf', 'semi_implicit_euler'],
-    'aadc_semi_implicit': ['semi_implicit', 'implicit_newton'],
+    'aadc_semi_implicit': ['semi_implicit', 'semi_implicit_signed', 'implicit_newton'],
     # Explicitly empty rather than absent: the cpp RK4 solver offers only a fixed-step explicit
     # method, and PETSC's plugin choice is not yet assessed against a stiff model. A consumer
     # must be able to tell "assessed, nothing qualifies" from "not in the table at all", so
@@ -302,7 +311,18 @@ SOLVER_INFO_FIELDS = {
         {'name': 'threads', 'type': 'int', 'default': 4, 'required': False,
          'description': 'Number of threads for AADC evaluation.'},
         {'name': 'max_step', 'type': 'float', 'default': 0.001, 'required': False,
-         'description': 'Internal sub-step cap for bdf_newton (default 0.001, matching CasADi BDF).'},
+         'description': "Internal sub-step cap for bdf_newton and semi_implicit_signed (default "
+                        "0.001, matching CasADi BDF). The number of sub-steps per output step is "
+                        "ceil(dt/max_step); raising it towards dt removes the sub-stepping that "
+                        "makes a lagged Jacobian safe -- see jac_lag."},
+        {'name': 'jac_lag', 'type': 'int', 'default': 10, 'required': False,
+         'description': "How many sub-steps the signed scheme reuses one diagonal Jacobian for "
+                        "before recomputing it (semi_implicit_signed, and the tape/kernel "
+                        "gradients of the same scheme). Higher is faster and less stable, and "
+                        "it is only safe in combination with sub-stepping: measured on "
+                        "3compartment at dt=0.01, jac_lag=10 with no sub-stepping diverges "
+                        "within 15 steps, while the same lag at max_step=0.001 (10 sub-steps) "
+                        "stays within 2% of CVODE_myokit. Set to 1 to recompute every sub-step."},
         {'name': 'gradient_strategy', 'type': 'enum', 'default': 'tape', 'required': False,
          'choices': ['tape', 'kernel'],
          'description': "How method 'semi_implicit_signed' evaluates its gradient: 'tape' "

--- a/src/solver_wrappers/aadc_python_solver_helper.py
+++ b/src/solver_wrappers/aadc_python_solver_helper.py
@@ -416,6 +416,78 @@ class SimulationHelper:
         # and produce a different output length/origin than the RK45 integrator.
         return traj[self.pre_steps:]
 
+    def _integrate_semi_implicit_signed(self, states, variables_all, total_steps, dt):
+        """Forward twin of the scheme the AADC tape records for 'semi_implicit_signed'.
+
+        ``x += idt * f / (1 - idt * diag(J))`` -- the *signed* diagonal, where
+        ``_integrate_semi_implicit`` damps unconditionally with ``1 + dt*|diag J|``. The two
+        agree exactly wherever the Jacobian diagonal is negative and diverge only where it is
+        positive: the damped form suppresses a growing mode, this one linearises it faithfully.
+
+        This exists so the forward cost and the taped gradient integrate the *identical* discrete
+        system. Every other AD-suitable method already has that property (see
+        AADC_TAPE_CONSISTENT_METHODS); until this method had a forward branch it was the one
+        exception, so a calibration using it could not simulate or plot its own best fit.
+
+        It therefore mirrors ``_cost_and_grad_bdf_tape`` deliberately, including the parts that
+        look like omissions:
+
+        * **No valve-state clamp.** ``_integrate_semi_implicit`` clamps zeta states to [0,1];
+          the tape does not, so neither does this. Measured on 3compartment, the clamp changes
+          max(heart/u_lv) by less than the printed precision either way -- it is not what keeps
+          the scheme stable.
+        * **Lagged Jacobian.** The diagonal is refreshed every ``jac_lag`` sub-steps (default 10)
+          rather than every step. This is only safe *together with* sub-stepping: measured at
+          dt=0.01 with jac_lag=10 and no sub-stepping, the integration diverges within 15 steps,
+          while the same lag at ``n_sub=10`` lands within 2% of CVODE_myokit. Do not raise
+          ``max_step`` to dt without also setting ``jac_lag`` to 1.
+
+        The one place it does *not* mirror the tape is the time argument: the tape calls
+        ``compute_rates`` at a hardcoded 0.0, this passes the real ``t``, as every other
+        integrator here does. For a CA-generated model the two are equivalent -- time enters
+        through a clock *state*, not through the variable of integration -- but they would differ
+        for a genuinely non-autonomous model, which is a latent bug on the tape side rather than
+        something to reproduce here.
+        """
+        n = self.STATE_COUNT
+        x = np.array(states[:n], dtype=float)
+        vars_all = list(variables_all)
+        eps_fd = _DAMPING_FD_EPS
+
+        jac_lag = max(1, int(self.solver_info.get('jac_lag', 10)))
+        max_step = float(self.solver_info.get('max_step', 0.001))
+        n_sub = max(1, int(np.ceil(dt / max_step)))
+        idt = dt / n_sub
+
+        diag_J = np.zeros(n)
+        sub_counter = 0
+        traj = [x.copy()]
+
+        for step in range(total_steps):
+            for sub in range(n_sub):
+                t = step * dt + sub * idt
+                rates = [0.0] * n
+                self.model.compute_rates(t, list(x), rates, list(vars_all))
+
+                if sub_counter % jac_lag == 0:
+                    for i in range(n):
+                        x_bump = list(x)
+                        h_i = max(abs(x[i]) * eps_fd, eps_fd)
+                        x_bump[i] += h_i
+                        r_bump = [0.0] * n
+                        self.model.compute_rates(t, x_bump, r_bump, list(vars_all))
+                        diag_J[i] = (r_bump[i] - rates[i]) / h_i
+                sub_counter += 1
+
+                for i in range(n):
+                    x[i] = x[i] + idt * rates[i] / (1.0 - idt * diag_J[i])
+
+            traj.append(x.copy())
+
+        # Same alignment as the other fixed-step integrators: drop the unlogged pre_time region
+        # so the result lines up with self.tSim. See _integrate_semi_implicit.
+        return traj[self.pre_steps:]
+
     def _integrate_implicit_newton(self, states, variables_all, total_steps, dt):
         """Implicit Euler with full Newton iteration and FD Jacobian.
 
@@ -846,6 +918,9 @@ class SimulationHelper:
             traj = self._integrate_bdf_newton(self.states, variables_all, total_steps, self.dt)
         elif method == 'semi_implicit':
             traj = self._integrate_semi_implicit(self.states, variables_all, total_steps, self.dt)
+        elif method == 'semi_implicit_signed':
+            # the forward twin of the taped gradient scheme -- see the method's docstring
+            traj = self._integrate_semi_implicit_signed(self.states, variables_all, total_steps, self.dt)
         elif method == 'rk4':
             # fixed-step, and identical to what the tape records -- the method to use when the
             # cost and the AD gradient have to be of the same function

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -122,7 +122,7 @@ def test_solver_integrator_keys_derived_from_schema():
     # 'max_step' comes with the stiff BDF methods (bdf_newton / bdf_tape / bdf_kernel).
     # 'gradient_strategy' selects tape vs kernel for semi_implicit_signed (issue #346).
     assert _SOLVER_INTEGRATOR_KEYS['aadc_semi_implicit'] == {
-        'tol', 'threads', 'max_step', 'gradient_strategy'}
+        'tol', 'threads', 'max_step', 'gradient_strategy', 'jac_lag'}
 
 
 def test_schema_settings_are_actually_read_by_the_code():
@@ -808,8 +808,10 @@ def test_forward_methods_are_exactly_what_the_aadc_dispatch_can_integrate():
 
     advertised = SOLVER_SCHEMA['forward_methods_by_solver']['aadc_semi_implicit']
     assert advertised == list(AADC_FORWARD_METHODS)
-    assert 'semi_implicit_signed' not in advertised
     assert set(advertised) <= set(SOLVER_SCHEMA['methods_by_solver']['aadc_semi_implicit'])
+    # semi_implicit_signed was the one method with a gradient but no forward branch, so a
+    # calibration using it could not simulate its own best fit. It has one now.
+    assert 'semi_implicit_signed' in advertised
 
     # every advertised forward method really has a branch in run()
     run_src = inspect.getsource(helper.SimulationHelper.run)
@@ -945,7 +947,7 @@ def test_stiff_suitable_methods_are_real_methods_and_exclude_the_measured_failur
         "every solver needs a stiff_suitable_methods entry, empty if nothing qualifies")
 
     aadc = stiff['aadc_semi_implicit']
-    assert aadc == ['semi_implicit', 'implicit_newton']
+    assert aadc == ['semi_implicit', 'semi_implicit_signed', 'implicit_newton']
     for excluded in ('rk4', 'adaptive_rk45', 'implicit_euler_ift'):
         assert excluded not in aadc, f"{excluded} is not usable on a stiff model; see issue #346"
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1776,3 +1776,72 @@ def test_offline_pre_time_zero_is_a_noop(generated_cellml_model_factory):
     before = list(h.simulation.default_state())
     h.run_offline_pre_and_set_default_state(0.0)
     assert list(h.simulation.default_state()) == before
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_aadc_semi_implicit_signed_forward_tracks_cvode(temp_model_dir,
+                                                       generated_cellml_model_factory):
+    """The forward twin of the taped signed scheme must track CVODE, and its lagged Jacobian
+    must be shown to depend on sub-stepping.
+
+    ``semi_implicit_signed`` was the one AD-suitable method with no forward branch, so a
+    calibration using it could not simulate or plot its own best fit. It was withheld after an
+    earlier measurement put it ~4.4x above CVODE -- but that was taken from the model's own cold
+    initial conditions with ``pre_time=0``, where the entire window is a startup transient and
+    *every* scheme, CVODE included, peaks near 3.1e5. Spin up first and the scheme lands within
+    a couple of percent, which is what this asserts.
+
+    The second half is the part worth having a test for: the default ``jac_lag`` of 10 is only
+    safe *because* of sub-stepping. Take the sub-stepping away (``max_step = dt``) and the same
+    lag diverges within a handful of steps, so the two settings cannot be tuned independently.
+    """
+    pytest.importorskip("aadc")
+
+    dt, sim_time, pre_time = 0.01, 1.0, 5.0
+    cellml_path = generated_cellml_model_factory("3compartment", "3compartment_parameters.csv")
+
+    # Only the two backends being compared are built here. _run_all_solvers_and_compare would
+    # also run solve_ivp_BDF, which cannot take a 5 s spin-up on this stiff model, so using it
+    # would fail the test for a reason that has nothing to do with the integrator under test.
+    aadc_dir = os.path.join(temp_model_dir, "aadc_signed")
+    os.makedirs(aadc_dir, exist_ok=True)
+    aadc_model_path = PythonGenerator(
+        cellml_path, output_dir=aadc_dir, module_name="3compartment", aadc_compat=True,
+    ).generate()
+
+    cvode = get_simulation_helper(
+        model_path=cellml_path, model_type="cellml_only", solver="CVODE_myokit",
+        dt=dt, sim_time=sim_time, pre_time=pre_time,
+        solver_info={"MaximumStep": 0.0001, "rtol": 1e-8, "atol": 1e-10})
+    assert cvode.run(), "CVODE_myokit reference did not run"
+
+    try:
+        helper = get_simulation_helper(
+            model_path=aadc_model_path, model_type="aadc_python", solver="aadc_semi_implicit",
+            dt=dt, sim_time=sim_time, pre_time=pre_time,
+            solver_info={"method": "semi_implicit_signed"})
+        assert helper.run(), "semi_implicit_signed forward solve failed"
+    except (ImportError, RuntimeError) as e:
+        pytest.skip(f"AADC backend unavailable: {e}")
+
+    ref = float(np.max(cvode.get_results(["heart/u_lv"])[0]))
+    got = float(np.max(helper.get_results(["heart/u_lv"])[0]))
+    rel = abs(got - ref) / abs(ref)
+    assert rel < 0.05, (
+        f"semi_implicit_signed max(heart/u_lv)={got:.4e} vs CVODE_myokit {ref:.4e} "
+        f"({100 * rel:.1f}% apart, tolerance 5%)")
+
+    # A lagged Jacobian with no sub-stepping to justify it must not be quietly accepted.
+    variables_all = list(helper._numeric_variables_all)
+    for pos, idx in enumerate(helper.constant_indices):
+        variables_all[idx] = helper.variables[pos]
+
+    helper.solver_info["jac_lag"] = 10
+    helper.solver_info["max_step"] = helper.dt  # -> n_sub = 1, i.e. no sub-stepping
+    helper.reset_states()
+    traj = helper._integrate_semi_implicit_signed(
+        helper.states, variables_all, helper.pre_steps + helper.n_steps, helper.dt)
+    assert not np.all(np.isfinite(np.array(traj, dtype=float))), (
+        "jac_lag=10 without sub-stepping is expected to diverge on this stiff model; if it no "
+        "longer does, the coupling documented on solver_info['jac_lag'] has changed")


### PR DESCRIPTION
`semi_implicit_signed` was the one AD-suitable AADC method with **no forward branch**. Its stepping existed only inside the tape recording, so a calibration using it could not simulate or plot its own best fit (`simulate_with_best_param_vals` → `protocol_executor.py:152` → `sim_helper.run()`), and `do_ad: false` raised outright.

The deeper problem: it was the only method whose forward/tape identity — the property the whole AADC backend is built on, and the reason `get_cost` takes the cost off the tape when `do_ad` is on — could not be *checked*, because no independent implementation of the scheme existed to check against.

`_integrate_semi_implicit_signed` mirrors `_cost_and_grad_bdf_tape`, including the parts that look like omissions: the signed diagonal (`1 - idt*J`, not `1 + dt*|J|`), the lagged Jacobian, the sub-stepping, and no valve-state clamp.

## Why it was parked, and why it isn't any more

It had been measured ~4.4x above CVODE and withheld on that basis, with the cause recorded as undetermined: either the forward integrator didn't reproduce the taped step, or the taped scheme was far less accurate than its docstring claimed. That mattered, because the second reading would have made every `bdf_tape`/`bdf_kernel` gradient shipped so far suspect.

It was neither. The measurement was taken from the model's own **cold initial conditions with `pre_time=0`**, where the entire window is a startup transient — the 3compartment ICs are near-zero volumes, and `reset_states()` doesn't change that. Measured now in that configuration, *every* variant of the scheme, and CVODE itself, peaks near 3.1e5. It compared two setups, not two integrators.

Re-measured after a 5 s spin-up, bisecting the four structural differences from the shipped `semi_implicit` one at a time:

| dt=0.01 | max(heart/u_lv) | vs CVODE |
|---|---|---|
| CVODE_myokit | 3.0634e+04 | 1.00x |
| `semi_implicit` (shipped) | 3.5660e+04 | 1.16x |
| &nbsp;&nbsp;− valve clamp | 3.5660e+04 | 1.16x |
| &nbsp;&nbsp;+ signed diagonal | 3.5731e+04 | 1.17x |
| &nbsp;&nbsp;+ jac_lag=10 | **diverged** (step 15) | — |
| &nbsp;&nbsp;+ sub-stepping | 3.1248e+04 | 1.02x |
| all four (= the taped scheme) | 3.1226e+04 | 1.02x |

So the taped scheme is not 4.4x wrong — it is the *most* accurate fixed-step variant of the three, because sub-stepping to `max_step` dominates. `semi_implicit_signed` therefore joins `stiff_suitable_methods`.

Two incidental findings: the **valve clamp is irrelevant** on this model (identical to printed precision with and without), and the signed diagonal does drive the denominator negative (`min denom = -8.3e5`) but is self-limiting rather than explosive — a hugely negative denominator makes the step small, not large.

## The result worth keeping

`jac_lag` and `max_step` **cannot be tuned independently**. A lagged Jacobian is only safe because sub-stepping is there to justify it: remove the sub-stepping and the same lag diverges within 15 steps. Both settings are now documented in terms of each other, and a test asserts the divergence so the coupling cannot be quietly broken.

`jac_lag` was read by `aadc_backend` (two call sites) but was **absent from `SOLVER_INFO_FIELDS`**, so CUFLynx could not offer a safety-critical setting at all. Added.

## One deliberate difference from the tape

This passes the real `t` to `compute_rates`; the tape hardcodes `0.0`. Equivalent for a CA-generated model — time enters through a clock *state* (`heart_module_s`, `rate = 1/T`), and the generated `compute_rates` never references `voi` — but a latent bug on the tape side for a genuinely non-autonomous model. Flagged rather than fixed here, since changing it would alter recorded gradients.

## Testing

New `test_aadc_semi_implicit_signed_forward_tracks_cvode` asserts max(`heart/u_lv`) within 5% of CVODE_myokit after a spin-up, then asserts that `jac_lag=10` with `max_step = dt` diverges. It builds only the two backends it compares — `_run_all_solvers_and_compare` also runs `solve_ivp_BDF`, which cannot take a 5 s spin-up on this stiff model and would fail the test for an unrelated reason.

Schema tests updated for the new forward method, the new stiff entry, and the new `jac_lag` key.

Suite: 279 passed, 5 skipped with `-m "not slow"`. Two failures, both pre-existing and verified on `upstream/master` at `c108be0`: `test_python_BDF_solver[SN_simple]` (libCellML strict-ODE), and `test_analysis_options_schema_well_formed`, which broke on master with the #353/#354 merges and is unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
