### PR TITLE
fix(params): refuse a prior_mean outside the parameter's range

### DIFF
--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -411,6 +411,7 @@ PARAM_PRIOR_TYPES = {
         'description': 'Gaussian, truncated to [min, max].',
         'params': [
             {'name': 'prior_mean', 'type': 'float', 'default': None, 'positive': False,
+             'within_bounds': True,
              'description': 'Centre of the Gaussian. Defaults to the centre of [min, max].'},
             {'name': 'prior_std', 'type': 'float', 'default': None, 'positive': True,
              'description': ('Standard deviation. Defaults to one sixth of the range, which '
@@ -468,6 +469,12 @@ def normalise_prior_params(prior_type, row, row_idx=None):
     to ignore: `prior_std` on a uniform row means the user believes they set a
     width, and silently dropping it gives them a different posterior than the one
     they asked for.
+
+    A value declared ``within_bounds`` is checked against the row's own min/max
+    when the row carries them. Every prior is truncated to [min, max], so a centre
+    outside it describes a peak the sampler can never reach: every draw sits on a
+    tail and is pulled to the nearer bound. That is legal arithmetic and almost
+    never what was meant, so it is refused here rather than run.
     """
     where = '' if row_idx is None else f' (params_for_id row {row_idx})'
     declared = {spec['name']: spec for spec in PARAM_PRIOR_TYPES[prior_type]['params']}
@@ -499,8 +506,36 @@ def normalise_prior_params(prior_type, row, row_idx=None):
         if spec['positive'] and value <= 0:
             raise ValueError(
                 f"'{name}'{where} must be greater than zero, got {value}.")
+        if spec.get('within_bounds'):
+            bounds = _row_bounds(row)
+            if bounds is not None and not (bounds[0] <= value <= bounds[1]):
+                raise ValueError(
+                    f"'{name}'{where} must lie within the parameter's range "
+                    f"[{bounds[0]}, {bounds[1]}], got {value}. Every prior is truncated to "
+                    f"that range, so a centre outside it is a peak the sampler can never "
+                    f"reach.")
         out[name] = value
     return out
+
+
+def _row_bounds(row):
+    """``(min, max)`` for a params_for_id row, or None when it does not carry them.
+
+    None rather than an error: this function is also called with a bare dict of
+    hyper-parameters (a downstream editor validating one row's fields), and a
+    caller that cannot supply bounds should still get every other check.
+    """
+    try:
+        lo = row.get('min') if hasattr(row, 'get') else None
+        hi = row.get('max') if hasattr(row, 'get') else None
+        if lo is None or hi is None:
+            return None
+        lo, hi = float(lo), float(hi)
+    except (TypeError, ValueError):
+        return None
+    if not (np.isfinite(lo) and np.isfinite(hi)):
+        return None
+    return (lo, hi)
 
 
 # Single source of truth for the parameter-identification (calibration) methods, i.e. the valid

--- a/tests/test_param_priors.py
+++ b/tests/test_param_priors.py
@@ -239,3 +239,67 @@ def test_a_config_without_the_new_key_keeps_its_behaviour():
         "param_maxs": np.array([6.0]),
     }
     assert pid.get_lnprior_from_params([4.0]) == pytest.approx(-0.5)
+
+
+# ---------------------------------------------------------------------------
+# A centre outside the range is refused
+#
+# Every prior is truncated to [min, max], so a mean outside it describes a peak
+# the sampler can never reach: every draw sits on a tail and is pulled to the
+# nearer bound. Legal arithmetic, silent, and almost never intended.
+# ---------------------------------------------------------------------------
+def test_a_mean_outside_the_range_is_rejected():
+    with pytest.raises(ValueError, match="must lie within the parameter's range"):
+        _info("vessel_name,param_name,min,max,prior,prior_mean\na,k,0,10,normal,20\n")
+
+
+def test_a_mean_below_the_range_is_rejected():
+    with pytest.raises(ValueError, match=r"\[0.0, 10.0\]"):
+        _info("vessel_name,param_name,min,max,prior,prior_mean\na,k,0,10,normal,-5\n")
+
+
+def test_the_offending_row_and_value_are_named():
+    with pytest.raises(ValueError, match="row 1"):
+        _info(
+            "vessel_name,param_name,min,max,prior,prior_mean\n"
+            "a,k,0,10,normal,5\n"
+            "b,j,0,10,normal,99\n"
+        )
+
+
+@pytest.mark.parametrize("mean", [0, 5, 10])
+def test_a_mean_on_or_inside_the_bounds_is_accepted(mean):
+    """The bounds themselves are legal centres -- a prior peaked at an endpoint is
+    a half-Gaussian, which is a reasonable thing to ask for."""
+    info = _info(
+        f"vessel_name,param_name,min,max,prior,prior_mean\na,k,0,10,normal,{mean}\n")
+    assert info["param_prior_params"][0]["prior_mean"] == float(mean)
+
+
+def test_a_negative_range_still_admits_a_negative_mean():
+    """The check is against the row's own bounds, not against zero."""
+    info = _info(
+        "vessel_name,param_name,min,max,prior,prior_mean\na,k,-10,-1,normal,-4\n")
+    assert info["param_prior_params"][0]["prior_mean"] == -4.0
+
+
+def test_the_std_is_not_bounds_checked():
+    """Only values declared within_bounds are. A std larger than the range is a
+    deliberately weak prior, not an error."""
+    info = _info(
+        "vessel_name,param_name,min,max,prior,prior_std\na,k,0,10,normal,500\n")
+    assert info["param_prior_params"][0]["prior_std"] == 500.0
+
+
+def test_bounds_are_skipped_when_the_caller_cannot_supply_them():
+    """normalise_prior_params is also called with a bare dict of fields (a
+    downstream editor validating one row); it must still run every other check."""
+    assert normalise_prior_params("normal", {"prior_mean": 999.0})["prior_mean"] == 999.0
+    with pytest.raises(ValueError, match="greater than zero"):
+        normalise_prior_params("normal", {"prior_std": -1.0})
+
+
+def test_bounds_supplied_in_a_bare_dict_are_honoured():
+    """So a downstream editor that does pass them gets the same verdict."""
+    with pytest.raises(ValueError, match="must lie within"):
+        normalise_prior_params("normal", {"prior_mean": 999.0, "min": 0, "max": 10})


### PR DESCRIPTION
Every prior is truncated to `[min, max]` — each branch of `get_lnprior_from_params` returns `-inf` outside it.

So a `prior_mean` outside that range describes a peak the sampler **can never reach**: every draw sits on a tail and is pulled towards the nearer bound. It's legal arithmetic, it runs to completion, and the posterior it produces isn't the one the user described.

`normalise_prior_params` now refuses it, next to the positivity check, so it fails at parse time naming the row and the range rather than quietly biasing a run.

### Declared, not special-cased

The rule is a `within_bounds` flag on the parameter's spec, the same way `positive` marks the scales. `prior_mean` carries it; a location parameter another prior grows would carry it too. `prior_std` deliberately does **not** — a std wider than the range is a weak prior, not a mistake.

### Where the bounds come from

The row itself, and the check is skipped when the row doesn't carry them. `normalise_prior_params` is also called with a bare dict of hyper-parameters by downstream editors validating a single row's fields (CUFLynx does exactly this), and a caller that can't supply bounds must still get every other check. One that *does* supply them gets the same verdict.

### Accepted at the edges

The bounds themselves are legal centres — a prior peaked at an endpoint is a half-Gaussian, a reasonable thing to ask for. And the check is against the row's own range rather than against zero, so a parameter on `[-10, -1]` admits a mean of `-4`.

### Tests

7 new (41 in the file, 104 across the suites run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)