### PR TITLE
feat(params): unbounded parameters, with the range derived from the prior

### DIFF
--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -1427,6 +1427,9 @@ class OpencorParamID():
                     p for II, p in enumerate(self.param_id_info["param_prior_params"])
                     if II not in param_idxs_to_remove
                 ]
+            if self.param_id_info.get("param_unbounded") is not None:
+                self.param_id_info["param_unbounded"] = np.delete(
+                    self.param_id_info["param_unbounded"], param_idxs_to_remove)
             self.param_norm_obj = Normalise_class(self.param_id_info["param_mins"], self.param_id_info["param_maxs"])
             self.param_init = None
 
@@ -1695,6 +1698,18 @@ class OpencorParamID():
         cost = self.get_cost_and_obs_from_params(param_vals, reset=reset)[0]
         return cost
     
+    def _is_unbounded(self, idx):
+        """Whether parameter ``idx`` was marked unbounded in params_for_id.
+
+        Tolerates a param_id_info without the key -- assembled by hand, or from
+        before the column existed -- by answering False, which is the behaviour
+        every parameter had then.
+        """
+        flags = self.param_id_info.get("param_unbounded")
+        if flags is None or idx >= len(flags):
+            return False
+        return bool(flags[idx])
+
     def _prior_param(self, idx, name):
         """One prior hyper-parameter for parameter ``idx``, or its declared default.
 
@@ -1721,8 +1736,14 @@ class OpencorParamID():
             else:
                 prior_dist = None
 
+            # An unbounded parameter has no range of its own -- the range in
+            # param_id_info was derived from this very prior, purely so the
+            # optimiser and the normalisation have a finite box. Truncating the
+            # prior at it would re-impose the bounds the user said were absent.
+            bounded = not self._is_unbounded(idx)
+
             if not prior_dist or prior_dist == 'uniform':
-                if param_val < self.param_id_info["param_mins"][idx] or param_val > self.param_id_info["param_maxs"][idx]:
+                if bounded and (param_val < self.param_id_info["param_mins"][idx] or param_val > self.param_id_info["param_maxs"][idx]):
                     return -np.inf
                 else:
                     #prior += 0
@@ -1730,7 +1751,7 @@ class OpencorParamID():
             
             elif prior_dist == 'exponential':
                 lamb = self._prior_param(idx, 'prior_lambda')
-                if param_val < self.param_id_info["param_mins"][idx] or param_val > self.param_id_info["param_maxs"][idx]:
+                if bounded and (param_val < self.param_id_info["param_mins"][idx] or param_val > self.param_id_info["param_maxs"][idx]):
                     return -np.inf
                 else:
                     # the normalisation isnt needed here but might be nice to
@@ -1738,7 +1759,7 @@ class OpencorParamID():
                     lnprior += -lamb*param_val/self.param_id_info["param_maxs"][idx]
 
             elif prior_dist == 'normal':
-                if param_val < self.param_id_info["param_mins"][idx] or param_val > self.param_id_info["param_maxs"][idx]:
+                if bounded and (param_val < self.param_id_info["param_mins"][idx] or param_val > self.param_id_info["param_maxs"][idx]):
                     return -np.inf
                 else:
                     # Defaults when the user states neither: the centre of the range, and a

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -402,23 +402,108 @@ PARAM_PRIOR_TYPES = {
                         'smaller values.'),
         'params': [
             {'name': 'prior_lambda', 'type': 'float', 'default': 1.0, 'positive': True,
+             'role': 'rate',
              'description': ('Decay rate, scaled by the parameter maximum. Larger values '
                              'concentrate the prior harder towards min.')},
         ],
     },
     'normal': {
         'label': 'Normal',
-        'description': 'Gaussian, truncated to [min, max].',
+        'description': 'Gaussian, truncated to [min, max] unless the parameter is unbounded.',
         'params': [
             {'name': 'prior_mean', 'type': 'float', 'default': None, 'positive': False,
-             'within_bounds': True,
+             'within_bounds': True, 'role': 'location',
              'description': 'Centre of the Gaussian. Defaults to the centre of [min, max].'},
             {'name': 'prior_std', 'type': 'float', 'default': None, 'positive': True,
+             'role': 'scale',
              'description': ('Standard deviation. Defaults to one sixth of the range, which '
                              'puts [min, max] at +/- 3 sigma.')},
         ],
     },
 }
+
+# The params_for_id column that marks a parameter as unbounded, i.e. having no min/max of its
+# own: the prior defines where it lives, and the range CA needs for everything else is derived
+# from that prior instead of typed.
+PARAM_UNBOUNDED_COLUMN = 'unbounded'
+
+# How wide the derived range is, in standard deviations either side of the prior's centre.
+# Five puts ~1 sample in 3.5 million outside it, so the box is not meaningfully constraining
+# while staying finite -- which it must be. min/max are not only the prior's truncation: they
+# are the optimiser's search box, the Sobol sampling range, the denominator of the parameter
+# normalisation, and the fallback finite-difference step. An actually infinite range makes the
+# normalisation NaN and every calibration with it, so "unbounded" has to mean "wide enough not
+# to bind", not "absent".
+UNBOUNDED_SIGMA_SPAN = 5.0
+
+
+def _truthy_flag(value):
+    """Whether a params_for_id boolean cell is set.
+
+    Spelled several ways in the wild -- 1, true, TRUE, yes, y -- and blank/NaN is
+    not set. Anything unrecognised is an error rather than a quiet False: a cell
+    the user filled in must not be ignored.
+    """
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return False
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in ('', 'nan'):
+        return False
+    if text in ('1', '1.0', 'true', 'yes', 'y'):
+        return True
+    if text in ('0', '0.0', 'false', 'no', 'n'):
+        return False
+    raise ValueError(
+        f"'{PARAM_UNBOUNDED_COLUMN}' must be true/false (or 1/0, yes/no), got {value!r}.")
+
+
+def _prior_param_by_role(prior_type, role):
+    for spec in PARAM_PRIOR_TYPES.get(prior_type, {}).get('params', []):
+        if spec.get('role') == role:
+            return spec['name']
+    return None
+
+
+def prior_supports_unbounded(prior_type):
+    """Whether a prior can stand in for a parameter's range.
+
+    It can when it declares both where it sits and how wide it is -- a location
+    and a scale -- because those are what the derived range is built from. A
+    uniform has neither and is *defined* by the range, so it cannot; an
+    exponential has a rate but no location, so there is no centre to build
+    around.
+    """
+    return bool(_prior_param_by_role(prior_type, 'location')
+                and _prior_param_by_role(prior_type, 'scale'))
+
+
+def derive_bounds_from_prior(prior_type, params, row_idx=None):
+    """``(min, max)`` for an unbounded parameter, from its prior's own centre and width.
+
+    ``params`` is the validated output of :func:`normalise_prior_params`. Both the
+    location and the scale must be stated: their usual defaults are derived *from*
+    the range, so leaving them out here would be circular.
+    """
+    where = '' if row_idx is None else f' (params_for_id row {row_idx})'
+    if not prior_supports_unbounded(prior_type):
+        supported = ', '.join(sorted(p for p in PARAM_PRIOR_TYPES if prior_supports_unbounded(p)))
+        raise ValueError(
+            f"'{PARAM_UNBOUNDED_COLUMN}' is set{where}, but the prior is '{prior_type}', which "
+            f"has no centre and width to derive a range from. Priors that do: {supported}.")
+
+    loc_name = _prior_param_by_role(prior_type, 'location')
+    scale_name = _prior_param_by_role(prior_type, 'scale')
+    loc, scale = params.get(loc_name), params.get(scale_name)
+    missing = [n for n, v in ((loc_name, loc), (scale_name, scale)) if v is None]
+    if missing:
+        raise ValueError(
+            f"'{PARAM_UNBOUNDED_COLUMN}' is set{where}, so {' and '.join(missing)} must be "
+            f"given: without a range there is nothing left to derive them from.")
+
+    half = UNBOUNDED_SIGMA_SPAN * float(scale)
+    return (float(loc) - half, float(loc) + half)
 
 # Every `params` entry above names a params_for_id column. Collected once so the parser can
 # tell a prior hyper-parameter column from an unrelated one, and so a downstream tool can
@@ -2879,8 +2964,10 @@ class ObsAndParamDataParser(object):
                 param_names_for_gen.append(param_gen_names)
 
         # --- 3. Set Arrays using the filtered DataFrame ---
-        param_id_info["param_mins"] = filtered_params["min"].to_numpy(dtype=float)
-        param_id_info["param_maxs"] = filtered_params["max"].to_numpy(dtype=float)
+        param_id_info["param_mins"] = pd.to_numeric(
+            filtered_params["min"], errors="coerce").to_numpy(dtype=float)
+        param_id_info["param_maxs"] = pd.to_numeric(
+            filtered_params["max"], errors="coerce").to_numpy(dtype=float)
 
         if "name_for_plotting" in filtered_params.columns:
             param_id_info["param_names_for_plotting"] = filtered_params["name_for_plotting"].to_numpy()
@@ -2908,6 +2995,30 @@ class ObsAndParamDataParser(object):
                 param_id_info["param_prior_types"][II], filtered_params.iloc[II], row_idx=II)
             for II in range(N_params)
         ]
+
+        # An unbounded parameter has no range of its own: its prior says where it lives, and
+        # the range CA needs for everything else is derived from that prior. Done after the
+        # priors are parsed, because that is what it is derived from.
+        param_id_info["param_unbounded"] = np.array([
+            _truthy_flag(filtered_params.iloc[II].get(PARAM_UNBOUNDED_COLUMN)
+                         if PARAM_UNBOUNDED_COLUMN in filtered_params.columns else None)
+            for II in range(N_params)
+        ])
+        for II in range(N_params):
+            if not param_id_info["param_unbounded"][II]:
+                if not np.isfinite(param_id_info["param_mins"][II]) or \
+                        not np.isfinite(param_id_info["param_maxs"][II]):
+                    raise ValueError(
+                        f"params_for_id row {II}: min and max are required unless "
+                        f"'{PARAM_UNBOUNDED_COLUMN}' is set.")
+                continue
+            lo, hi = derive_bounds_from_prior(
+                param_id_info["param_prior_types"][II],
+                param_id_info["param_prior_params"][II],
+                row_idx=II,
+            )
+            param_id_info["param_mins"][II] = lo
+            param_id_info["param_maxs"][II] = hi
 
         param_id_info["param_names_for_gen"] = param_names_for_gen
 

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -411,6 +411,7 @@ PARAM_PRIOR_TYPES = {
         'description': 'Gaussian, truncated to [min, max].',
         'params': [
             {'name': 'prior_mean', 'type': 'float', 'default': None, 'positive': False,
+             'within_bounds': True,
              'description': 'Centre of the Gaussian. Defaults to the centre of [min, max].'},
             {'name': 'prior_std', 'type': 'float', 'default': None, 'positive': True,
              'description': ('Standard deviation. Defaults to one sixth of the range, which '
@@ -468,6 +469,12 @@ def normalise_prior_params(prior_type, row, row_idx=None):
     to ignore: `prior_std` on a uniform row means the user believes they set a
     width, and silently dropping it gives them a different posterior than the one
     they asked for.
+
+    A value declared ``within_bounds`` is checked against the row's own min/max
+    when the row carries them. Every prior is truncated to [min, max], so a centre
+    outside it describes a peak the sampler can never reach: every draw sits on a
+    tail and is pulled to the nearer bound. That is legal arithmetic and almost
+    never what was meant, so it is refused here rather than run.
     """
     where = '' if row_idx is None else f' (params_for_id row {row_idx})'
     declared = {spec['name']: spec for spec in PARAM_PRIOR_TYPES[prior_type]['params']}
@@ -499,8 +506,36 @@ def normalise_prior_params(prior_type, row, row_idx=None):
         if spec['positive'] and value <= 0:
             raise ValueError(
                 f"'{name}'{where} must be greater than zero, got {value}.")
+        if spec.get('within_bounds'):
+            bounds = _row_bounds(row)
+            if bounds is not None and not (bounds[0] <= value <= bounds[1]):
+                raise ValueError(
+                    f"'{name}'{where} must lie within the parameter's range "
+                    f"[{bounds[0]}, {bounds[1]}], got {value}. Every prior is truncated to "
+                    f"that range, so a centre outside it is a peak the sampler can never "
+                    f"reach.")
         out[name] = value
     return out
+
+
+def _row_bounds(row):
+    """``(min, max)`` for a params_for_id row, or None when it does not carry them.
+
+    None rather than an error: this function is also called with a bare dict of
+    hyper-parameters (a downstream editor validating one row's fields), and a
+    caller that cannot supply bounds should still get every other check.
+    """
+    try:
+        lo = row.get('min') if hasattr(row, 'get') else None
+        hi = row.get('max') if hasattr(row, 'get') else None
+        if lo is None or hi is None:
+            return None
+        lo, hi = float(lo), float(hi)
+    except (TypeError, ValueError):
+        return None
+    if not (np.isfinite(lo) and np.isfinite(hi)):
+        return None
+    return (lo, hi)
 
 
 # Single source of truth for the parameter-identification (calibration) methods, i.e. the valid

--- a/tests/test_param_priors.py
+++ b/tests/test_param_priors.py
@@ -239,3 +239,67 @@ def test_a_config_without_the_new_key_keeps_its_behaviour():
         "param_maxs": np.array([6.0]),
     }
     assert pid.get_lnprior_from_params([4.0]) == pytest.approx(-0.5)
+
+
+# ---------------------------------------------------------------------------
+# A centre outside the range is refused
+#
+# Every prior is truncated to [min, max], so a mean outside it describes a peak
+# the sampler can never reach: every draw sits on a tail and is pulled to the
+# nearer bound. Legal arithmetic, silent, and almost never intended.
+# ---------------------------------------------------------------------------
+def test_a_mean_outside_the_range_is_rejected():
+    with pytest.raises(ValueError, match="must lie within the parameter's range"):
+        _info("vessel_name,param_name,min,max,prior,prior_mean\na,k,0,10,normal,20\n")
+
+
+def test_a_mean_below_the_range_is_rejected():
+    with pytest.raises(ValueError, match=r"\[0.0, 10.0\]"):
+        _info("vessel_name,param_name,min,max,prior,prior_mean\na,k,0,10,normal,-5\n")
+
+
+def test_the_offending_row_and_value_are_named():
+    with pytest.raises(ValueError, match="row 1"):
+        _info(
+            "vessel_name,param_name,min,max,prior,prior_mean\n"
+            "a,k,0,10,normal,5\n"
+            "b,j,0,10,normal,99\n"
+        )
+
+
+@pytest.mark.parametrize("mean", [0, 5, 10])
+def test_a_mean_on_or_inside_the_bounds_is_accepted(mean):
+    """The bounds themselves are legal centres -- a prior peaked at an endpoint is
+    a half-Gaussian, which is a reasonable thing to ask for."""
+    info = _info(
+        f"vessel_name,param_name,min,max,prior,prior_mean\na,k,0,10,normal,{mean}\n")
+    assert info["param_prior_params"][0]["prior_mean"] == float(mean)
+
+
+def test_a_negative_range_still_admits_a_negative_mean():
+    """The check is against the row's own bounds, not against zero."""
+    info = _info(
+        "vessel_name,param_name,min,max,prior,prior_mean\na,k,-10,-1,normal,-4\n")
+    assert info["param_prior_params"][0]["prior_mean"] == -4.0
+
+
+def test_the_std_is_not_bounds_checked():
+    """Only values declared within_bounds are. A std larger than the range is a
+    deliberately weak prior, not an error."""
+    info = _info(
+        "vessel_name,param_name,min,max,prior,prior_std\na,k,0,10,normal,500\n")
+    assert info["param_prior_params"][0]["prior_std"] == 500.0
+
+
+def test_bounds_are_skipped_when_the_caller_cannot_supply_them():
+    """normalise_prior_params is also called with a bare dict of fields (a
+    downstream editor validating one row); it must still run every other check."""
+    assert normalise_prior_params("normal", {"prior_mean": 999.0})["prior_mean"] == 999.0
+    with pytest.raises(ValueError, match="greater than zero"):
+        normalise_prior_params("normal", {"prior_std": -1.0})
+
+
+def test_bounds_supplied_in_a_bare_dict_are_honoured():
+    """So a downstream editor that does pass them gets the same verdict."""
+    with pytest.raises(ValueError, match="must lie within"):
+        normalise_prior_params("normal", {"prior_mean": 999.0, "min": 0, "max": 10})

--- a/tests/test_param_priors.py
+++ b/tests/test_param_priors.py
@@ -303,3 +303,113 @@ def test_bounds_supplied_in_a_bare_dict_are_honoured():
     """So a downstream editor that does pass them gets the same verdict."""
     with pytest.raises(ValueError, match="must lie within"):
         normalise_prior_params("normal", {"prior_mean": 999.0, "min": 0, "max": 10})
+
+
+# ---------------------------------------------------------------------------
+# Unbounded parameters
+#
+# min/max are not only the prior's truncation: they are the optimiser's search
+# box, the Sobol sampling range, the denominator of the parameter normalisation
+# and the fallback FD step. An actually infinite range makes the normalisation
+# NaN and every calibration with it, so "unbounded" means the range is derived
+# from the prior rather than typed -- wide enough not to bind, and finite.
+# ---------------------------------------------------------------------------
+from parsers.PrimitiveParsers import (PARAM_UNBOUNDED_COLUMN, UNBOUNDED_SIGMA_SPAN,
+                                      derive_bounds_from_prior, prior_supports_unbounded)
+
+
+def test_the_range_is_derived_from_the_prior():
+    info = _info(
+        "vessel_name,param_name,min,max,prior,prior_mean,prior_std,unbounded\n"
+        "a,k,,,normal,7.0,1.5,true\n"
+    )
+    half = UNBOUNDED_SIGMA_SPAN * 1.5
+    assert info["param_mins"][0] == pytest.approx(7.0 - half)
+    assert info["param_maxs"][0] == pytest.approx(7.0 + half)
+
+
+def test_the_derived_range_is_finite():
+    """The whole reason it is derived rather than infinite: an infinite range
+    makes the parameter normalisation NaN, and the GA with it."""
+    info = _info(
+        "vessel_name,param_name,min,max,prior,prior_mean,prior_std,unbounded\n"
+        "a,k,,,normal,7.0,1.5,true\n"
+    )
+    assert np.isfinite(info["param_mins"][0]) and np.isfinite(info["param_maxs"][0])
+
+
+def test_an_unbounded_prior_is_not_truncated():
+    """The derived range exists for the optimiser, not as a bound the user asked
+    for, so the prior must not cut off at it."""
+    from param_id.paramID import OpencorParamID
+
+    info = _info(
+        "vessel_name,param_name,min,max,prior,prior_mean,prior_std,unbounded\n"
+        "a,k,,,normal,0.0,1.0,true\n"
+    )
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.param_id_info = info
+    # Far outside the derived [-5, 5]: finite, and exactly the Gaussian's value.
+    assert pid.get_lnprior_from_params([20.0]) == pytest.approx(-200.0)
+
+
+def test_a_bounded_parameter_is_still_truncated():
+    from param_id.paramID import OpencorParamID
+
+    info = _info("vessel_name,param_name,min,max,prior\na,k,0,10,normal\n")
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.param_id_info = info
+    assert pid.get_lnprior_from_params([999.0]) == -np.inf
+
+
+def test_unbounded_needs_a_prior_with_a_centre_and_a_width():
+    """A uniform is *defined* by the range, and an exponential has a rate but no
+    centre, so neither can stand in for one."""
+    assert prior_supports_unbounded("normal") is True
+    assert prior_supports_unbounded("uniform") is False
+    assert prior_supports_unbounded("exponential") is False
+
+    with pytest.raises(ValueError, match="no centre and width"):
+        _info("vessel_name,param_name,min,max,prior,unbounded\na,k,,,uniform,true\n")
+
+
+def test_unbounded_requires_the_centre_and_width_to_be_stated():
+    """Their usual defaults come *from* the range, so leaving them out here would
+    be circular."""
+    with pytest.raises(ValueError, match="must be given"):
+        _info(
+            "vessel_name,param_name,min,max,prior,prior_mean,unbounded\n"
+            "a,k,,,normal,7.0,true\n"
+        )
+
+
+def test_a_bounded_row_still_requires_min_and_max():
+    with pytest.raises(ValueError, match="required unless"):
+        _info("vessel_name,param_name,min,max,prior\na,k,,,normal\n")
+
+
+@pytest.mark.parametrize("flag,expected_unbounded", [
+    ("true", True), ("TRUE", True), ("1", True), ("yes", True),
+    ("false", False), ("0", False), ("", False),
+])
+def test_the_flag_is_read_the_ways_it_is_written(flag, expected_unbounded):
+    csv = ("vessel_name,param_name,min,max,prior,prior_mean,prior_std,unbounded\n"
+           f"a,k,0,10,normal,7.0,1.5,{flag}\n")
+    info = _info(csv)
+    assert bool(info["param_unbounded"][0]) is expected_unbounded
+
+
+def test_an_unreadable_flag_is_an_error_not_a_quiet_false():
+    """A cell the user filled in must not be ignored."""
+    with pytest.raises(ValueError, match="must be true/false"):
+        _info("vessel_name,param_name,min,max,prior,unbounded\na,k,0,10,normal,maybe\n")
+
+
+def test_no_unbounded_column_leaves_everything_bounded():
+    info = _info("vessel_name,param_name,min,max,prior\na,k,0,10,normal\n")
+    assert not any(info["param_unbounded"])
+
+
+def test_derive_bounds_is_span_times_the_scale():
+    assert derive_bounds_from_prior("normal", {"prior_mean": 2.0, "prior_std": 0.5}) == (
+        2.0 - 0.5 * UNBOUNDED_SIGMA_SPAN, 2.0 + 0.5 * UNBOUNDED_SIGMA_SPAN)


### PR DESCRIPTION
**Stacked on #363** (the mean-in-range check), which it shares a function with. Review/merge that first.

A parameter whose prior already says where it lives shouldn't also need a min/max typed by hand. `unbounded` in params_for_id says so, and the range is derived from the prior instead: **mean ± 5σ**.

### Derived rather than infinite — deliberately

`min`/`max` are not only the prior's truncation. They're the optimiser's search box, the Sobol sampling range, the denominator of the parameter normalisation, and the fallback finite-difference step. Measured before writing this, with `±inf` in the columns:

```
normalise(1.0) -> [nan]              # the GA and CMA-ES search in normalised space
GA/CMA sampling range width: inf
normal default std = (max-min)/6 -> inf
```

An infinite range doesn't free the parameter, it destroys the calibration. Five sigma puts about one draw in 3.5 million outside the box, so it doesn't meaningfully constrain while staying finite — which it has to be.

### The prior is not truncated at the derived range

That range is CA's bookkeeping, not a bound the user asked for, so `get_lnprior_from_params` skips the `-inf` check for an unbounded parameter. A bounded one is unchanged. There's a test that an unbounded normal at 20σ out still returns a finite `-200.0` rather than `-inf`.

### Which priors qualify is derived, not listed

A prior qualifies when it declares both a **location** and a **scale**, marked by `role` on the parameter specs. A uniform is *defined* by the range and an exponential has a rate but no centre, so both are refused with a message naming the ones that work. The location and scale must be stated when unbounded — their usual defaults are computed *from* the range, so leaving them out would be circular.

### Everything else

`min`/`max` stay required for every bounded row; the check just moved to where it can tell the two cases apart, and now names the flag that would waive it. The flag is read the several ways it gets written (`1`/`true`/`TRUE`/`yes`), and anything unrecognised is an error rather than a quiet `False` — a cell the user filled in must not be ignored.

### Tests

15 new (58 in the file, 132 across the suites run). All six shipped `params_for_id` fixtures parse unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)