### PR TITLE
feat(params): declare derived prior defaults, and let the exponential be unbounded

### DIFF
--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -58,7 +58,7 @@ import shutil
 from datetime import date, datetime
 # from skopt import gp_minimize, Optimizer
 from parsers.PrimitiveParsers import (CSVFileParser, ObsAndParamDataParser, PARAM_ID_METHODS,
-                                      PARAM_PRIOR_TYPES)
+                                      PARAM_PRIOR_TYPES, prior_param_default)
 from param_id.optimisers import GeneticAlgorithmOptimiser, BayesianOptimiser, CMAESOptimiser, \
     SciPyMinimizeOptimiser, MultiStartSciPyMinimizeOptimiser
 from param_id.differentiable import (
@@ -1710,6 +1710,35 @@ class OpencorParamID():
             return False
         return bool(flags[idx])
 
+    def _resolved_prior_param(self, idx, prior_type, name):
+        """A prior hyper-parameter with its default resolved from the schema.
+
+        A stated value wins; otherwise the schema's default_expr is evaluated
+        against this parameter's bounds and its sibling values. Raises when the
+        result is unusable -- an unbounded exponential with no scale has nothing
+        to decay by, and guessing one would silently invent a prior.
+        """
+        stated = self._prior_param(idx, name)
+        if stated is not None:
+            return stated
+        bounds = {}
+        lo = self.param_id_info["param_mins"][idx]
+        hi = self.param_id_info["param_maxs"][idx]
+        if np.isfinite(lo):
+            bounds['min'] = float(lo)
+        if np.isfinite(hi):
+            bounds['max'] = float(hi)
+        siblings = dict(self.param_id_info.get("param_prior_params", [{}] * (idx + 1))[idx] or {})
+        for spec in PARAM_PRIOR_TYPES.get(prior_type, {}).get('params', []):
+            siblings.setdefault(spec['name'], spec.get('default'))
+        value = prior_param_default(prior_type, name, bounds, siblings)
+        if value is None:
+            raise ValueError(
+                f"'{name}' is needed for the {prior_type} prior on parameter index {idx} "
+                f"and could not be derived from the parameter's range. State it in "
+                f"params_for_id.")
+        return value
+
     def _prior_param(self, idx, name):
         """One prior hyper-parameter for parameter ``idx``, or its declared default.
 
@@ -1750,13 +1779,18 @@ class OpencorParamID():
                     pass
             
             elif prior_dist == 'exponential':
-                lamb = self._prior_param(idx, 'prior_lambda')
                 if bounded and (param_val < self.param_id_info["param_mins"][idx] or param_val > self.param_id_info["param_maxs"][idx]):
                     return -np.inf
                 else:
-                    # the normalisation isnt needed here but might be nice to
-                    # make sure prior for each param is between 0 and 1
-                    lnprior += -lamb*param_val/self.param_id_info["param_maxs"][idx]
+                    # -(x - origin)/scale. With both left blank this is exactly the
+                    # original -lambda*x/max: origin defaults to 0 and scale to
+                    # max/lambda. Stating a scale gives the decay a size in the
+                    # parameter's own units, which is what makes an unbounded
+                    # exponential meaningful -- the original rate is defined
+                    # *relative to max*, and an unbounded parameter has no max.
+                    origin = self._resolved_prior_param(idx, 'exponential', 'prior_origin')
+                    scale = self._resolved_prior_param(idx, 'exponential', 'prior_scale')
+                    lnprior += -(param_val - origin) / scale
 
             elif prior_dist == 'normal':
                 if bounded and (param_val < self.param_id_info["param_mins"][idx] or param_val > self.param_id_info["param_maxs"][idx]):
@@ -1767,12 +1801,11 @@ class OpencorParamID():
                     # params_for_id columns (prior_mean / prior_std), because a prior whose
                     # centre is fixed to the middle of the bounds cannot express most of
                     # what a prior is for.
-                    std = self._prior_param(idx, 'prior_std')
-                    if std is None:
-                        std = 1/6*(self.param_id_info["param_maxs"][idx] - self.param_id_info["param_mins"][idx])
-                    mean = self._prior_param(idx, 'prior_mean')
-                    if mean is None:
-                        mean = 0.5*(self.param_id_info["param_maxs"][idx] + self.param_id_info["param_mins"][idx])
+                    # Both defaults come from the schema's default_expr, so the
+                    # number used here and the one a UI shows in the blank field
+                    # are the same statement rather than two copies of it.
+                    std = self._resolved_prior_param(idx, 'normal', 'prior_std')
+                    mean = self._resolved_prior_param(idx, 'normal', 'prior_mean')
                     lnprior += -0.5*((param_val - mean)/std)**2
 
             else:

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -418,24 +418,37 @@ PARAM_PRIOR_TYPES = {
     },
     'exponential': {
         'label': 'Exponential',
-        'description': ('Decays across [min, max] at rate prior_lambda / max, favouring '
-                        'smaller values.'),
+        'description': ('Decays from prior_origin with scale prior_scale, favouring smaller '
+                        'values. Truncated to [min, max] unless the parameter is unbounded.'),
+        # One-sided: it decays away from its origin in one direction, so an unbounded
+        # exponential's derived range runs from the origin rather than straddling it.
+        'support': 'one_sided',
         'params': [
             {'name': 'prior_lambda', 'type': 'float', 'default': 1.0, 'positive': True,
              'role': 'rate',
-             'description': ('Decay rate, scaled by the parameter maximum. Larger values '
-                             'concentrate the prior harder towards min.')},
+             'description': ('Decay rate relative to max, the original parameterisation. '
+                             'Only used when prior_scale is not given.')},
+            {'name': 'prior_origin', 'type': 'float', 'default': 0.0, 'positive': False,
+             'role': 'location', 'default_expr': '0',
+             'description': 'Where the decay starts. Defaults to zero, as it always was.'},
+            {'name': 'prior_scale', 'type': 'float', 'default': None, 'positive': True,
+             'role': 'scale', 'default_expr': 'max / prior_lambda',
+             'description': ('Decay scale, in the parameter\'s own units. Defaults to '
+                             'max / prior_lambda, which reproduces the original rate. '
+                             'Required when unbounded, since there is then no max.')},
         ],
     },
     'normal': {
         'label': 'Normal',
         'description': 'Gaussian, truncated to [min, max] unless the parameter is unbounded.',
+        'support': 'symmetric',
         'params': [
             {'name': 'prior_mean', 'type': 'float', 'default': None, 'positive': False,
              'within_bounds': True, 'role': 'location',
+             'default_expr': '(min + max) / 2',
              'description': 'Centre of the Gaussian. Defaults to the centre of [min, max].'},
             {'name': 'prior_std', 'type': 'float', 'default': None, 'positive': True,
-             'role': 'scale',
+             'role': 'scale', 'default_expr': '(max - min) / 6',
              'description': ('Standard deviation. Defaults to one sixth of the range, which '
                              'puts [min, max] at +/- 3 sigma.')},
         ],
@@ -455,6 +468,75 @@ PARAM_UNBOUNDED_COLUMN = 'unbounded'
 # normalisation NaN and every calibration with it, so "unbounded" has to mean "wide enough not
 # to bind", not "absent".
 UNBOUNDED_SIGMA_SPAN = 5.0
+
+
+def eval_prior_default(expr, bounds=None, params=None):
+    """Evaluate a ``default_expr`` against a row's bounds and its other prior params.
+
+    The expressions live in PARAM_PRIOR_TYPES so there is one statement of what a
+    blank field means -- CA computes the default from it, and a downstream editor
+    shows the same number in the field's placeholder. Previously the formulas were
+    written twice: once in get_lnprior_from_params and once in whatever prose a UI
+    chose, which is how "the centre of the range" and the value actually used drift
+    apart.
+
+    Deliberately tiny: names (min/max/other params), numbers, and arithmetic. No
+    calls, no attributes, no comprehensions -- these come from CA's own schema, but
+    an evaluator that can only do arithmetic cannot become something else later.
+    Returns None when a name it needs is unavailable (an unbounded row has no max).
+    """
+    import ast as _ast
+
+    names = dict(bounds or {})
+    names.update({k: v for k, v in (params or {}).items() if v is not None})
+
+    def _ev(node):
+        if isinstance(node, _ast.Expression):
+            return _ev(node.body)
+        if isinstance(node, _ast.Constant):
+            if isinstance(node.value, (int, float)) and not isinstance(node.value, bool):
+                return float(node.value)
+            raise ValueError('non-numeric constant')
+        if isinstance(node, _ast.Name):
+            if node.id not in names or names[node.id] is None:
+                raise KeyError(node.id)
+            return float(names[node.id])
+        if isinstance(node, _ast.UnaryOp) and isinstance(node.op, (_ast.UAdd, _ast.USub)):
+            v = _ev(node.operand)
+            return v if isinstance(node.op, _ast.UAdd) else -v
+        if isinstance(node, _ast.BinOp) and isinstance(
+                node.op, (_ast.Add, _ast.Sub, _ast.Mult, _ast.Div)):
+            a, b = _ev(node.left), _ev(node.right)
+            if isinstance(node.op, _ast.Add):
+                return a + b
+            if isinstance(node.op, _ast.Sub):
+                return a - b
+            if isinstance(node.op, _ast.Mult):
+                return a * b
+            if b == 0:
+                raise ZeroDivisionError
+            return a / b
+        raise ValueError(f'unsupported expression node {type(node).__name__}')
+
+    try:
+        value = _ev(_ast.parse(str(expr), mode='eval'))
+    except (KeyError, ZeroDivisionError, ValueError, SyntaxError, TypeError):
+        return None
+    return value if np.isfinite(value) else None
+
+
+def prior_param_default(prior_type, name, bounds=None, params=None):
+    """The value a blank ``name`` takes for ``prior_type``: its literal default, or
+    the one derived from the row's bounds. None when it cannot be derived."""
+    for spec in PARAM_PRIOR_TYPES.get(prior_type, {}).get('params', []):
+        if spec['name'] != name:
+            continue
+        if spec.get('default_expr'):
+            derived = eval_prior_default(spec['default_expr'], bounds, params)
+            if derived is not None:
+                return derived
+        return spec.get('default')
+    return None
 
 
 def _truthy_flag(value):
@@ -522,8 +604,13 @@ def derive_bounds_from_prior(prior_type, params, row_idx=None):
             f"'{PARAM_UNBOUNDED_COLUMN}' is set{where}, so {' and '.join(missing)} must be "
             f"given: without a range there is nothing left to derive them from.")
 
-    half = UNBOUNDED_SIGMA_SPAN * float(scale)
-    return (float(loc) - half, float(loc) + half)
+    span = UNBOUNDED_SIGMA_SPAN * float(scale)
+    # A symmetric prior straddles its centre; a one-sided one decays away from its
+    # origin in a single direction, so a range centred on that origin would put half
+    # the box where the prior has no mass at all.
+    if PARAM_PRIOR_TYPES[prior_type].get('support') == 'one_sided':
+        return (float(loc), float(loc) + span)
+    return (float(loc) - span, float(loc) + span)
 
 # Every `params` entry above names a params_for_id column. Collected once so the parser can
 # tell a prior hyper-parameter column from an unrelated one, and so a downstream tool can

--- a/tests/test_param_priors.py
+++ b/tests/test_param_priors.py
@@ -140,11 +140,13 @@ def _lnprior(csv, vals):
 
 
 def test_every_declared_prior_param_is_a_known_column():
-    assert set(PARAM_PRIOR_PARAM_NAMES) == {"prior_lambda", "prior_mean", "prior_std"}
+    assert set(PARAM_PRIOR_PARAM_NAMES) == {
+        "prior_lambda", "prior_origin", "prior_scale", "prior_mean", "prior_std"}
 
 
 def test_each_prior_declares_the_values_it_takes():
-    assert [s["name"] for s in PARAM_PRIOR_TYPES["exponential"]["params"]] == ["prior_lambda"]
+    assert [s["name"] for s in PARAM_PRIOR_TYPES["exponential"]["params"]] == [
+        "prior_lambda", "prior_origin", "prior_scale"]
     assert [s["name"] for s in PARAM_PRIOR_TYPES["normal"]["params"]] == ["prior_mean", "prior_std"]
     assert PARAM_PRIOR_TYPES["uniform"]["params"] == []
 
@@ -365,9 +367,11 @@ def test_a_bounded_parameter_is_still_truncated():
 def test_unbounded_needs_a_prior_with_a_centre_and_a_width():
     """A uniform is *defined* by the range, and an exponential has a rate but no
     centre, so neither can stand in for one."""
+    # Both priors that carry a location and a scale qualify; a uniform is *defined*
+    # by its range and so cannot stand in for one.
     assert prior_supports_unbounded("normal") is True
+    assert prior_supports_unbounded("exponential") is True
     assert prior_supports_unbounded("uniform") is False
-    assert prior_supports_unbounded("exponential") is False
 
     with pytest.raises(ValueError, match="no centre and width"):
         _info("vessel_name,param_name,min,max,prior,unbounded\na,k,,,uniform,true\n")
@@ -413,3 +417,104 @@ def test_no_unbounded_column_leaves_everything_bounded():
 def test_derive_bounds_is_span_times_the_scale():
     assert derive_bounds_from_prior("normal", {"prior_mean": 2.0, "prior_std": 0.5}) == (
         2.0 - 0.5 * UNBOUNDED_SIGMA_SPAN, 2.0 + 0.5 * UNBOUNDED_SIGMA_SPAN)
+
+
+# ---------------------------------------------------------------------------
+# Derived defaults are declared once
+#
+# The formulas used to be written twice: in get_lnprior_from_params, and in
+# whatever prose a UI chose to describe them. `default_expr` states each once, CA
+# computes from it, and a downstream editor shows the same number in the blank
+# field's placeholder -- so the two cannot drift.
+# ---------------------------------------------------------------------------
+from parsers.PrimitiveParsers import eval_prior_default, prior_param_default
+
+
+def test_the_normal_defaults_are_the_documented_ones():
+    assert prior_param_default("normal", "prior_mean", {"min": 1.0, "max": 2.0}) == 1.5
+    assert prior_param_default("normal", "prior_std", {"min": 0.0, "max": 6.0}) == 1.0
+
+
+def test_a_derived_default_needs_the_bounds_it_names():
+    """An unbounded row has no max, so nothing is invented from one."""
+    assert prior_param_default("normal", "prior_mean", {"min": 1.0}) is None
+
+
+def test_the_evaluator_does_arithmetic_and_nothing_else():
+    """It reads CA's own schema, but an evaluator that can only add and divide
+    cannot grow into something else later."""
+    assert eval_prior_default("(min + max) / 2", {"min": 2.0, "max": 4.0}) == 3.0
+    for hostile in ("__import__('os')", "open('/etc/passwd')", "[x for x in (1,2)]", "min.__class__"):
+        assert eval_prior_default(hostile, {"min": 1.0, "max": 2.0}) is None
+
+
+def test_a_division_by_zero_yields_no_default():
+    assert eval_prior_default("max / prior_lambda", {"max": 1.0}, {"prior_lambda": 0.0}) is None
+
+
+# ---------------------------------------------------------------------------
+# The exponential's scale, and its unbounded form
+# ---------------------------------------------------------------------------
+def test_the_exponential_is_unchanged_when_nothing_is_stated():
+    """origin 0 and scale max/lambda reproduce the original -lambda*x/max exactly."""
+    from param_id.paramID import OpencorParamID
+
+    info = _info("vessel_name,param_name,min,max,prior\na,k,0,10,exponential\n")
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.param_id_info = info
+    # -1.0 * 5 / 10
+    assert pid.get_lnprior_from_params([5.0]) == pytest.approx(-0.5)
+
+
+def test_a_stated_rate_still_steepens_it():
+    from param_id.paramID import OpencorParamID
+
+    info = _info(
+        "vessel_name,param_name,min,max,prior,prior_lambda\na,k,0,10,exponential,4.0\n")
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.param_id_info = info
+    assert pid.get_lnprior_from_params([5.0]) == pytest.approx(-2.0)
+
+
+def test_a_stated_scale_is_in_the_parameters_own_units():
+    from param_id.paramID import OpencorParamID
+
+    info = _info(
+        "vessel_name,param_name,min,max,prior,prior_scale\na,k,0,10,exponential,2.0\n")
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.param_id_info = info
+    assert pid.get_lnprior_from_params([4.0]) == pytest.approx(-2.0)
+
+
+def test_an_unbounded_exponential_derives_a_one_sided_range():
+    """It decays away from its origin in one direction, so a range centred on the
+    origin would put half the box where the prior has no mass."""
+    info = _info(
+        "vessel_name,param_name,min,max,prior,prior_origin,prior_scale,unbounded\n"
+        "a,k,,,exponential,2.0,3.0,true\n"
+    )
+    assert info["param_mins"][0] == pytest.approx(2.0)
+    assert info["param_maxs"][0] == pytest.approx(2.0 + UNBOUNDED_SIGMA_SPAN * 3.0)
+
+
+def test_an_unbounded_exponential_needs_a_scale():
+    """Its original rate is defined relative to max, and an unbounded parameter
+    has no max, so the scale must be given in the parameter's own units."""
+    with pytest.raises(ValueError, match="must be given"):
+        _info(
+            "vessel_name,param_name,min,max,prior,prior_origin,unbounded\n"
+            "a,k,,,exponential,0.0,true\n"
+        )
+
+
+def test_an_unbounded_exponential_is_not_truncated():
+    from param_id.paramID import OpencorParamID
+
+    info = _info(
+        "vessel_name,param_name,min,max,prior,prior_origin,prior_scale,unbounded\n"
+        "a,k,,,exponential,0.0,1.0,true\n"
+    )
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.param_id_info = info
+    # Far past the derived [0, 5]: finite, and the exponential's own value.
+    assert pid.get_lnprior_from_params([40.0]) == pytest.approx(-40.0)


### PR DESCRIPTION
Two changes to the same declaration.

### 1. A blank hyper-parameter's default is now stated in the schema

`default_expr` — `(min + max) / 2`, `(max - min) / 6` — and CA computes from it.

The formulas were previously written twice: once in `get_lnprior_from_params`, and once in whatever prose a UI chose to describe them ("from min/max"). A downstream editor can now show the number a blank field will *actually* take, from the same statement CA uses, so the two cannot drift.

`eval_prior_default` is deliberately tiny: names, numbers and the four arithmetic operators, via `ast`. No calls, attributes or comprehensions — these expressions come from CA's own schema, but an evaluator that can only do arithmetic cannot grow into something else later. Anything it cannot evaluate (a name the row lacks, a division by zero) yields *no* default rather than a guess.

### 2. The exponential gains `prior_origin` and `prior_scale`, so it can be unbounded

Its rate was defined **relative to max** (`-lambda*x/max`), which is meaningless for a parameter with no max — so #364 had to refuse unbounded for it. With an origin and a scale in the parameter's own units, `-(x - origin)/scale`, it has a shape that doesn't depend on the bounds.

**The defaults reproduce the original exactly**: origin `0`, scale `max/lambda`, giving `-lambda*x/max`. `prior_lambda` keeps working and keeps its meaning; there's a test that a bounded exponential with nothing stated returns the identical number it always did.

The derived range for an unbounded exponential is **one-sided**, `[origin, origin + span*scale]`, declared as `support: one_sided`. A symmetric range centred on the origin would put half the optimiser's box where the prior has no mass at all.

Both priors carrying a location and a scale now support unbounded; a uniform still cannot, being defined by its range.

### Tests

10 new (68 in the file, 142 across the suites run), including that the evaluator refuses `__import__`, `open`, attribute access and comprehensions. All six shipped `params_for_id` fixtures parse unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)