### PR TITLE
test: pin the sensitivity options to include gradient_method and fd_rel_step

### DIFF
--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -188,7 +188,10 @@ def test_analysis_options_schema_well_formed():
     # option names the analysis code actually reads (sensitivityAnalysis.py / paramID.py / IA)
     def names(mode):
         return {o['name'] for o in analysis_options(mode)}
-    assert names('sensitivity_analysis') == {'method', 'sample_type', 'num_samples'}
+    # gradient_method and fd_rel_step are read by run_local_sensitivity for method
+    # 'local' (#338): which arm differentiates, and the finite-difference step.
+    assert names('sensitivity_analysis') == {
+        'method', 'sample_type', 'num_samples', 'gradient_method', 'fd_rel_step'}
     assert names('mcmc') == {'num_steps', 'num_walkers'}
     assert names('identifiability_analysis') == {'method', 'gradient_source', 'sub_method'}
     assert analysis_options('not_a_mode') == []


### PR DESCRIPTION
**This un-reds master.** `test_analysis_options_schema_well_formed` asserts the exact set of option names each analysis mode exposes:

```python
assert names('sensitivity_analysis') == {'method', 'sample_type', 'num_samples'}
```

#353 added `gradient_method` and #357 added `fd_rel_step` without updating it, so the Tests workflow has been failing on that assertion since #353 merged.

Mine, and I missed it: the test selections I ran while developing those two (`test_param_priors`, `test_fd_observable_sensitivities`, `test_operation_kwargs` and friends) never included this file. The pin is doing exactly its job — catching an option added to the schema without a matching statement of what the analysis code actually reads.

**Updated, not loosened.** The strict set is the point: an option nothing reads is the inert-setting mistake, and a pin that accepted any superset would stop catching it.

### On the rest of master's red

The run at `e30b1ba` also shows `test_generate_python_model_succeeds[SN_simple]`, `test_python_BDF_solver[SN_simple]` and `test_aadc_semi_implicit_signed_forward_tracks_cvode` failing. Those are not from my changes — at `08d3431a` the *only* failure was this assertion, and the others appear later, alongside the AADC signed-forward work. Flagging rather than touching them.

### Tests

48 passing in that file, 180 across the prior/sensitivity suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)