### PR TITLE
feat(cost): cost_kwargs contract for user cost functions, plus CSV/schema/shim test coverage

### DIFF
--- a/src/param_id/cost_kwargs.py
+++ b/src/param_id/cost_kwargs.py
@@ -1,0 +1,192 @@
+"""The ``cost_kwargs`` contract for user-defined cost functions (issue #84).
+
+Cost funcs were called with a fixed positional signature ``(output, ground_truth, std, weight)``
+at every call site, which forced two things on every cost func ever written:
+
+* it had to accept ``std`` and ``weight`` even when the cost does not use them -- and a cost that
+  genuinely has no notion of a standard deviation (an absolute bound, a barrier, a
+  distribution-fit) had to take the argument and drop it;
+* it could take nothing else, so a user cost with a tolerance, an exponent or a reference scale
+  had no way to receive it short of a module-level global.
+
+This module is the single place that decides what a given cost func is actually called with. It
+deliberately mirrors the ``operation_kwargs`` contract in ``param_id.operation_funcs`` (issue
+#304) -- same shape, same validation stance, same reserved-name handling -- so the two
+user-extension points behave the same way rather than each having their own rules.
+
+Framework-supplied arguments (``std``, ``weight``) are passed only when the func's signature has
+somewhere to put them. User arguments come from a data_item's ``cost_kwargs`` mapping.
+"""
+import inspect
+import math
+
+
+# Supplied by circulatory_autogen itself from the obs data. A data_item's `cost_kwargs` must not
+# set these -- doing so would either shadow the real std/weight (silently calibrating against the
+# wrong thing) or raise a bare "got multiple values for keyword argument".
+RESERVED_COST_KWARGS = frozenset({"std", "weight"})
+
+# The two values every call site has available to offer. Kept here rather than at the call sites
+# so adding a third framework-supplied argument is one edit, not six.
+FRAMEWORK_COST_KWARGS = ("std", "weight")
+
+
+def get_cost_kwarg_spec(func):
+    """Introspect a cost func's signature.
+
+    Returns ``(accepted, positional, accepts_any)``:
+
+    - ``accepted``: parameter names that may be supplied by keyword, framework or user.
+    - ``positional``: parameters with no default, i.e. the ones filled positionally
+      (``output`` and the ground truth), excluding anything the framework supplies by name.
+    - ``accepts_any``: True when the func declares ``**kwargs`` (e.g. ``MSE``), in which case any
+      key is accepted and every framework argument is offered.
+
+    A func whose signature cannot be introspected is treated as ``accepts_any``, so validation
+    never blocks a legitimate call -- the same fallback ``get_operation_kwarg_spec`` uses.
+    """
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return [], [], True
+
+    accepted = []
+    positional = []
+    accepts_any = False
+    for name, param in sig.parameters.items():
+        if param.kind in (param.VAR_KEYWORD, param.VAR_POSITIONAL):
+            accepts_any = True
+        elif param.kind == param.POSITIONAL_ONLY:
+            positional.append(name)
+        else:
+            accepted.append(name)
+            if param.default is param.empty and name not in RESERVED_COST_KWARGS:
+                positional.append(name)
+    return accepted, positional, accepts_any
+
+
+def framework_kwargs_for(func, std=None, weight=None):
+    """The framework-supplied kwargs this particular cost func can actually receive.
+
+    ``gaussian_MLE(output, desired_mean, std, weight)`` gets both; ``multimodal_gaussian(output,
+    prob_dist_params, weight)`` gets only ``weight``, because it has nowhere to put a std -- which
+    is the point of this function, and previously meant it could not share a call site.
+    """
+    accepted, _, accepts_any = get_cost_kwarg_spec(func)
+    available = {"std": std, "weight": weight}
+    if accepts_any:
+        return {k: v for k, v in available.items() if v is not None}
+    return {k: v for k, v in available.items() if k in accepted and v is not None}
+
+
+def _coerce_cost_kwarg(value, default):
+    """Nudge a JSON-sourced number towards the type of the func's default.
+
+    JSON has one number type, so a GUI or hand-edited obs_data.json easily writes ``2.0`` where
+    the default is the int ``2``, or ``1`` where it is a float. Only those two integral<->float
+    conversions happen; everything else passes through. Same rule as ``_coerce_operation_kwarg``.
+    """
+    if isinstance(value, bool) or isinstance(default, bool):
+        return value
+    if isinstance(default, int) and isinstance(value, float):
+        if math.isfinite(value) and float(value).is_integer():
+            return int(value)
+        return value
+    if isinstance(default, float) and isinstance(value, int):
+        return float(value)
+    return value
+
+
+def _cost_kwarg_defaults(func):
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return {}
+    return {name: p.default for name, p in sig.parameters.items() if p.default is not p.empty}
+
+
+def check_cost_kwargs(raw_kwargs, func, cost_name, data_item_name=None):
+    """Validate a data_item's ``cost_kwargs`` against the chosen cost func's signature.
+
+    An unknown key is an error rather than being ignored: a stale or misspelled key would
+    otherwise change nothing at all and quietly calibrate against the wrong cost, which is the
+    failure mode that is hardest to notice from a converged-looking fit.
+
+    Raises:
+        ValueError: for a non-string key, a key circulatory_autogen supplies itself, or a key
+            that is not a parameter of ``func``.
+    """
+    if not raw_kwargs:
+        return
+    where = f"data_item '{data_item_name}'" if data_item_name else "a data_item"
+    label = cost_name if cost_name is not None else getattr(func, "__name__", "<unknown>")
+    accepted, positional, accepts_any = get_cost_kwarg_spec(func)
+
+    for key in raw_kwargs:
+        if not isinstance(key, str):
+            raise ValueError(
+                f"Invalid 'cost_kwargs' in {where}: keys must be strings, got {key!r} "
+                f"({type(key).__name__}). 'cost_kwargs' maps keyword-argument names of the "
+                f"'cost_type' func to values.")
+        if key in RESERVED_COST_KWARGS:
+            raise ValueError(
+                f"Invalid 'cost_kwargs' key '{key}' in {where}: '{key}' is supplied by "
+                f"circulatory_autogen from the obs data and must not be set here. Set the "
+                f"data_item's own '{key}' field instead.")
+        if accepts_any:
+            continue
+        if key in positional:
+            raise ValueError(
+                f"Invalid 'cost_kwargs' key '{key}' in {where}: '{key}' is filled positionally "
+                f"by cost func '{label}' (it receives the model output and the ground truth), "
+                f"so it cannot also be given as a keyword.")
+        if key not in accepted:
+            raise ValueError(
+                f"Invalid 'cost_kwargs' key '{key}' in {where}: cost func '{label}' has no "
+                f"parameter '{key}'. Accepted: {sorted(set(accepted) - RESERVED_COST_KWARGS)}.")
+
+
+def resolve_cost_kwargs(raw_kwargs, func):
+    """Coerce a validated ``cost_kwargs`` mapping into the kwargs to splat into the call."""
+    if not raw_kwargs:
+        return {}
+    defaults = _cost_kwarg_defaults(func)
+    return {k: _coerce_cost_kwarg(v, defaults[k]) if k in defaults else v
+            for k, v in raw_kwargs.items()}
+
+
+def validate_cost_kwargs(obs_info, cost_funcs_dict, cost_types):
+    """Check every data_item's ``cost_kwargs`` up front, before any simulation runs.
+
+    Called at setup for the same reason ``validate_operation_kwargs`` is: a bad key should fail
+    immediately, not after the first expensive forward solve.
+    """
+    raw_list = obs_info.get("cost_kwargs") if obs_info else None
+    if not raw_list:
+        return
+    names = obs_info.get("names_for_plotting", []) or obs_info.get("names", [])
+    for i, raw in enumerate(raw_list):
+        if not raw:
+            continue
+        if not isinstance(raw, dict):
+            raise ValueError(
+                f"Invalid 'cost_kwargs' in obs index {i}: expected a dict of keyword arguments, "
+                f"got {type(raw).__name__}.")
+        cost_name = cost_types[i] if cost_types is not None and i < len(cost_types) else None
+        func = cost_funcs_dict.get(cost_name) if cost_name is not None else None
+        if func is None:
+            continue
+        check_cost_kwargs(raw, func, cost_name,
+                          names[i] if i < len(names) else None)
+
+
+def call_cost_func(func, *positional, std=None, weight=None, cost_kwargs=None):
+    """Invoke a cost func with only the arguments it can accept.
+
+    The single entry point the cost-assembly call sites use, so the rule about what a cost func
+    receives lives in one place rather than being restated six times.
+    """
+    kwargs = framework_kwargs_for(func, std=std, weight=weight)
+    if cost_kwargs:
+        kwargs.update(resolve_cost_kwargs(cost_kwargs, func))
+    return func(*positional, **kwargs)

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -67,6 +67,7 @@ from param_id.differentiable import (
     is_circulatory_differentiable,
 )
 from param_id.operation_funcs import resolve_operation_kwargs, validate_operation_kwargs
+from param_id.cost_kwargs import call_cost_func, validate_cost_kwargs
 from param_id.plot_outputs import ParamIDPlotOutputs
 from param_id import casadi_backend
 from param_id import fsa_backend
@@ -1276,6 +1277,7 @@ class OpencorParamID():
             )
         # Fail fast on a stale obs_data.json rather than part-way through an optimisation (#304).
         validate_operation_kwargs(self.obs_info, self.operation_funcs_dict)
+        validate_cost_kwargs(self.obs_info, self.cost_funcs_dict, self.cost_type)
         self.DEBUG = DEBUG
 
         # Per (experiment, subexperiment) count of observables with non-zero weight. The sum
@@ -1403,6 +1405,7 @@ class OpencorParamID():
         self.obs_info = obs_info
         self.cost_type = self.obs_info["cost_type"]
         validate_operation_kwargs(self.obs_info, self.operation_funcs_dict)
+        validate_cost_kwargs(self.obs_info, self.cost_funcs_dict, self.cost_type)
         self._refresh_num_weighted_obs_tables()
 
     def set_optimiser_options(self, optimiser_options):
@@ -1947,6 +1950,17 @@ class OpencorParamID():
 
         return series_entry, ground_truth[:num_in_range], std[:num_in_range]
 
+    def _cost_kwargs_for(self, obs_idx):
+        """The data_item's ``cost_kwargs`` for observable ``obs_idx`` (issue #84).
+
+        Indexed by *observable*, matching cost_type and the weight vectors, so it stays correct
+        when the const/series/amp vectors are compacted to their own index spaces.
+        """
+        raw = self.obs_info.get("cost_kwargs") if self.obs_info else None
+        if not raw or obs_idx >= len(raw):
+            return None
+        return raw[obs_idx] or None
+
     def cost_calc(self, obs_dict, exp_idx=0, sub_idx=0, is_symbolic=False):
 
         # Symbolic cost terms use the casadi-mode cost funcs; numeric ones the numpy-mode funcs
@@ -2005,8 +2019,11 @@ class OpencorParamID():
                 for const_idx in range(const.size1()):
                     obs_idx = self.obs_info['const_idx_to_obs_idx'][const_idx]
                     if updated_weight_const_vec[obs_idx] != 0:
-                        cost += cost_funcs_dict[self.cost_type[obs_idx]](const[const_idx], self.obs_info["ground_truth_const"][const_idx],
-                                                        self.obs_info["std_const_vec"][const_idx], updated_weight_const_vec[obs_idx])
+                        cost += call_cost_func(cost_funcs_dict[self.cost_type[obs_idx]],
+                                               const[const_idx], self.obs_info["ground_truth_const"][const_idx],
+                                               std=self.obs_info["std_const_vec"][const_idx],
+                                               weight=updated_weight_const_vec[obs_idx],
+                                               cost_kwargs=self._cost_kwargs_for(obs_idx))
 
             if series is not None:
                 for series_idx in range(len(series)):
@@ -2028,8 +2045,9 @@ class OpencorParamID():
                     obs_entry = ca.DM(obs_np.reshape(-1, 1))
                     std_entry = ca.DM(std_np.reshape(-1, 1))
 
-                    cost += cost_funcs_dict[self.cost_type[obs_idx]](
-                        series_entry, obs_entry, std_entry, weight_entry)
+                    cost += call_cost_func(cost_funcs_dict[self.cost_type[obs_idx]],
+                        series_entry, obs_entry, std=std_entry, weight=weight_entry,
+                        cost_kwargs=self._cost_kwargs_for(obs_idx))
 
             # Silently returning a zero cost for observables we can't differentiate would look
             # like a perfectly converged fit, so fail loudly instead.
@@ -2056,8 +2074,11 @@ class OpencorParamID():
             for const_idx in range(len(const)):
                 obs_idx = self.obs_info['const_idx_to_obs_idx'][const_idx]
                 if updated_weight_const_vec[obs_idx] != 0:
-                    cost += cost_funcs_dict[self.cost_type[obs_idx]](const[const_idx], self.obs_info["ground_truth_const"][const_idx],
-                                                    self.obs_info["std_const_vec"][const_idx], updated_weight_const_vec[obs_idx])
+                    cost += call_cost_func(cost_funcs_dict[self.cost_type[obs_idx]],
+                                           const[const_idx], self.obs_info["ground_truth_const"][const_idx],
+                                           std=self.obs_info["std_const_vec"][const_idx],
+                                           weight=updated_weight_const_vec[obs_idx],
+                                           cost_kwargs=self._cost_kwargs_for(obs_idx))
         
         # TODO debugging a strange error that occurs occasionally in GA
         # assert not np.isnan(cost), 'cost is nan'
@@ -2090,7 +2111,8 @@ class OpencorParamID():
                 obs_idx = self.obs_info['series_idx_to_obs_idx'][series_idx]
                 weight_entry = updated_weight_series_vec[obs_idx]
                 if weight_entry != 0:
-                    series_cost += cost_funcs_dict[self.cost_type[obs_idx]](series_entry, obs_entry, std_entry, weight_entry)
+                    series_cost += call_cost_func(cost_funcs_dict[self.cost_type[obs_idx]], series_entry, obs_entry,
+                                                  std=std_entry, weight=weight_entry, cost_kwargs=self._cost_kwargs_for(obs_idx))
 
 
         amp_cost = 0
@@ -2113,10 +2135,12 @@ class OpencorParamID():
                 std_entry = self.obs_info["std_amp_vec"][amp_idx]
                 if hasattr(weight_entry, '__len__'):
                     if not all(val==0 for val in weight_entry):
-                        amp_cost += cost_funcs_dict[self.cost_type[obs_idx]](amp_entry, obs_entry, std_entry, weight_entry)
+                        amp_cost += call_cost_func(cost_funcs_dict[self.cost_type[obs_idx]], amp_entry, obs_entry,
+                                                   std=std_entry, weight=weight_entry, cost_kwargs=self._cost_kwargs_for(obs_idx))
                 else:
                     if weight_entry != 0:
-                        amp_cost += cost_funcs_dict[self.cost_type[obs_idx]](amp_entry, obs_entry, std_entry, weight_entry)
+                        amp_cost += call_cost_func(cost_funcs_dict[self.cost_type[obs_idx]], amp_entry, obs_entry,
+                                                   std=std_entry, weight=weight_entry, cost_kwargs=self._cost_kwargs_for(obs_idx))
 
         phase_cost = 0
         if phase is not None:
@@ -2140,19 +2164,23 @@ class OpencorParamID():
                 weight_entry = updated_weight_phase_vec[obs_idx]
                 if hasattr(weight_entry, '__len__'):
                     if not all(val==0 for val in weight_entry):
-                        phase_cost += cost_funcs_dict[self.cost_type[obs_idx]](phase_entry, obs_entry, std_entry, weight_entry)
+                        phase_cost += call_cost_func(cost_funcs_dict[self.cost_type[obs_idx]], phase_entry, obs_entry,
+                                                     std=std_entry, weight=weight_entry, cost_kwargs=self._cost_kwargs_for(obs_idx))
                 else:
                     if weight_entry != 0:
-                        phase_cost += cost_funcs_dict[self.cost_type[obs_idx]](phase_entry, obs_entry, std_entry, weight_entry)
+                        phase_cost += call_cost_func(cost_funcs_dict[self.cost_type[obs_idx]], phase_entry, obs_entry,
+                                                     std=std_entry, weight=weight_entry, cost_kwargs=self._cost_kwargs_for(obs_idx))
 
         prob_dist_cost = 0
         if val_for_prob_dist is not None:
             for prob_dist_idx in range(len(val_for_prob_dist)):
                 obs_idx = self.obs_info['prob_dist_idx_to_obs_idx'][prob_dist_idx]
                 if updated_weight_prob_dist_vec[obs_idx] != 0:
-                    prob_dist_cost += cost_funcs_dict[self.cost_type[obs_idx]](val_for_prob_dist[prob_dist_idx], 
-                                                                    self.obs_info["ground_truth_prob_dist_params"][prob_dist_idx],
-                                                                    updated_weight_prob_dist_vec[obs_idx])
+                    prob_dist_cost += call_cost_func(cost_funcs_dict[self.cost_type[obs_idx]],
+                                                      val_for_prob_dist[prob_dist_idx],
+                                                      self.obs_info["ground_truth_prob_dist_params"][prob_dist_idx],
+                                                      weight=updated_weight_prob_dist_vec[obs_idx],
+                                                      cost_kwargs=self._cost_kwargs_for(obs_idx))
             
 
         return cost + series_cost + amp_cost + phase_cost + prob_dist_cost

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -2568,6 +2568,10 @@ class ObsAndParamDataParser(object):
                 "operands": {"types": (list, tuple, np.ndarray), "default": REQUIRED},
                 "operation": {"types": (str,), "default": None},
                 "operation_kwargs": {"types": (dict,), "default": lambda df: [{} for _ in range(len(df))]},
+                # Extra keyword arguments for the data_item's cost_type func (issue #84), the
+                # cost-side counterpart of operation_kwargs. std and weight are supplied by CA
+                # from the fields above and are rejected here -- see param_id.cost_kwargs.
+                "cost_kwargs": {"types": (dict,), "default": lambda df: [{} for _ in range(len(df))]},
                 "value": {"types": (int, float, np.integer, np.floating, list, np.ndarray), "default": REQUIRED},
                 "std": {"types": (int, float, np.integer, np.floating, list, np.ndarray), "default": REQUIRED},
                 "experiment_idx": {"types": (int, np.integer), "default": 0},
@@ -2715,6 +2719,7 @@ class ObsAndParamDataParser(object):
         obs_info["operations"] = []
         obs_info["operands"] = []
         obs_info["operation_kwargs"] = [gt_df.iloc[II].get("operation_kwargs", {}) for II in range(N)]
+        obs_info["cost_kwargs"] = [gt_df.iloc[II].get("cost_kwargs", {}) for II in range(N)]
         obs_info["freqs"] = [gt_df.iloc[II].get("frequencies") for II in range(N)]
         obs_info["names_for_plotting"] = [gt_df.iloc[II].get("name_for_plotting", obs_info["obs_names"][II]) for II in range(N)]
 

--- a/src/utilities/obs_data_helpers.py
+++ b/src/utilities/obs_data_helpers.py
@@ -149,13 +149,18 @@ class ObsDataCreator:
         required_keys = ['variable', 'name_for_plotting', 'operands',
                          'unit', 'value', 'std']
         required_series_keys = ['obs_dt']
-        optional_keys = ['name_for_plotting', 'operation', 'operation_kwargs', 'weight', 'std',
-                         'experiment_idx', 'subexperiment_idx']
+        optional_keys = ['name_for_plotting', 'operation', 'operation_kwargs', 'cost_kwargs',
+                         'weight', 'std', 'experiment_idx', 'subexperiment_idx']
 
         if 'operation_kwargs' in entry and not isinstance(entry['operation_kwargs'], dict):
             raise ValueError(
                 f"'operation_kwargs' must be a dict of keyword arguments for the 'operation' "
                 f"func, got {type(entry['operation_kwargs']).__name__}.")
+
+        if 'cost_kwargs' in entry and not isinstance(entry['cost_kwargs'], dict):
+            raise ValueError(
+                f"'cost_kwargs' must be a dict of keyword arguments for the 'cost_type' "
+                f"func, got {type(entry['cost_kwargs']).__name__}.")
 
         if 'name_for_plotting' not in entry:
             entry['name_for_plotting'] = entry['variable']

--- a/tests/test_cost_kwargs.py
+++ b/tests/test_cost_kwargs.py
@@ -1,0 +1,137 @@
+"""The ``cost_kwargs`` contract for user-defined cost functions (issue #84).
+
+Cost funcs used to be called with a fixed positional ``(output, ground_truth, std, weight)`` at
+every call site. That forced every cost func to accept a std and a weight whether or not the cost
+has any use for them, and gave a user cost no way at all to receive its own parameters. These
+tests pin the replacement: what a cost func is offered follows from its signature, and a
+data_item may add its own keyword arguments.
+"""
+import pytest
+
+from param_id.cost_kwargs import (
+    RESERVED_COST_KWARGS, call_cost_func, check_cost_kwargs, framework_kwargs_for,
+    get_cost_kwarg_spec, resolve_cost_kwargs, validate_cost_kwargs)
+
+
+def _full(output, desired_mean, std, weight):
+    return (output - desired_mean) ** 2 / (std ** 2) * weight
+
+
+def _no_std(output, prob_dist_params, weight):
+    """Mirrors multimodal_gaussian: a cost with no notion of a standard deviation."""
+    return (output - prob_dist_params) * weight
+
+
+def _with_user_kwarg(output, desired_mean, std, weight, exponent=2):
+    return abs(output - desired_mean) ** exponent / std * weight
+
+
+def _accepts_any(*args, **kwargs):
+    return (args, kwargs)
+
+
+@pytest.mark.unit
+def test_a_cost_func_is_only_offered_what_its_signature_can_hold():
+    """The point of the contract: a cost with no std must not be handed one.
+
+    Previously every call site passed four positional arguments, so a cost that does not use a
+    standard deviation still had to declare the parameter and drop it on the floor.
+    """
+    assert framework_kwargs_for(_full, std=2.0, weight=3.0) == {'std': 2.0, 'weight': 3.0}
+    assert framework_kwargs_for(_no_std, std=2.0, weight=3.0) == {'weight': 3.0}
+    # **kwargs takes everything on offer
+    assert framework_kwargs_for(_accepts_any, std=2.0, weight=3.0) == {'std': 2.0, 'weight': 3.0}
+
+
+@pytest.mark.unit
+def test_call_cost_func_dispatches_by_signature():
+    assert call_cost_func(_full, 3.0, 1.0, std=2.0, weight=1.0) == pytest.approx(1.0)
+    # no std parameter -> not passed, and no TypeError
+    assert call_cost_func(_no_std, 3.0, 1.0, std=2.0, weight=2.0) == pytest.approx(4.0)
+
+
+@pytest.mark.unit
+def test_a_user_kwarg_reaches_the_cost_func():
+    """The other half of #84: a cost's own parameters, supplied per data_item."""
+    base = call_cost_func(_with_user_kwarg, 4.0, 1.0, std=1.0, weight=1.0)
+    cubed = call_cost_func(_with_user_kwarg, 4.0, 1.0, std=1.0, weight=1.0,
+                           cost_kwargs={'exponent': 3})
+    assert base == pytest.approx(9.0)
+    assert cubed == pytest.approx(27.0)
+
+
+@pytest.mark.unit
+def test_an_unknown_cost_kwarg_is_an_error_not_a_silent_no_op():
+    """A stale or misspelled key would otherwise change nothing at all, and a calibration against
+    the wrong cost looks exactly like one against the right cost."""
+    with pytest.raises(ValueError, match="has no parameter 'expnent'"):
+        check_cost_kwargs({'expnent': 3}, _with_user_kwarg, 'custom', 'my_item')
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('reserved', sorted(RESERVED_COST_KWARGS))
+def test_cost_kwargs_may_not_shadow_what_the_framework_supplies(reserved):
+    """std and weight come from the data_item's own fields; letting cost_kwargs set them would
+    either silently calibrate against the wrong value or raise a bare duplicate-argument error."""
+    with pytest.raises(ValueError, match='supplied by circulatory_autogen'):
+        check_cost_kwargs({reserved: 1.0}, _full, 'gaussian_MLE', 'my_item')
+
+
+@pytest.mark.unit
+def test_a_positional_argument_cannot_be_given_as_a_cost_kwarg():
+    with pytest.raises(ValueError, match='filled positionally'):
+        check_cost_kwargs({'output': 1.0}, _full, 'gaussian_MLE', 'my_item')
+
+
+@pytest.mark.unit
+def test_a_non_string_key_is_rejected():
+    with pytest.raises(ValueError, match='keys must be strings'):
+        check_cost_kwargs({3: 1.0}, _full, 'gaussian_MLE', 'my_item')
+
+
+@pytest.mark.unit
+def test_a_func_accepting_kwargs_takes_any_key():
+    """MSE is *args/**kwargs, so validation must not invent a restriction it does not have."""
+    check_cost_kwargs({'anything': 1}, _accepts_any, 'MSE', 'my_item')
+
+
+@pytest.mark.unit
+def test_json_numbers_are_coerced_towards_the_default_type():
+    """JSON has one number type, so a GUI writes 3.0 where the default is the int 2."""
+    assert resolve_cost_kwargs({'exponent': 3.0}, _with_user_kwarg) == {'exponent': 3}
+    assert isinstance(resolve_cost_kwargs({'exponent': 3.0}, _with_user_kwarg)['exponent'], int)
+
+
+@pytest.mark.unit
+def test_spec_separates_positional_from_keyword():
+    accepted, positional, accepts_any = get_cost_kwarg_spec(_with_user_kwarg)
+    assert not accepts_any
+    # std/weight are framework-supplied, so they are not counted as positional fill
+    assert positional == ['output', 'desired_mean']
+    assert 'exponent' in accepted
+
+
+@pytest.mark.unit
+def test_validate_cost_kwargs_checks_every_data_item_up_front():
+    """A bad key should fail at setup, not after the first expensive forward solve."""
+    obs_info = {'cost_kwargs': [{}, {'expnent': 3}],
+                'names_for_plotting': ['ok_item', 'bad_item']}
+    with pytest.raises(ValueError, match='bad_item'):
+        validate_cost_kwargs(obs_info, {'custom': _with_user_kwarg}, ['custom', 'custom'])
+
+
+@pytest.mark.unit
+def test_validate_cost_kwargs_is_a_noop_when_nothing_declares_any():
+    validate_cost_kwargs({'cost_kwargs': [{}, {}]}, {'custom': _with_user_kwarg},
+                         ['custom', 'custom'])
+    validate_cost_kwargs({}, {}, [])
+
+
+@pytest.mark.unit
+def test_the_builtin_cost_funcs_still_receive_std_and_weight():
+    """Regression guard: the shipped funcs must keep getting what they always got."""
+    from funcs_user.cost_funcs_user import get_cost_funcs_dict_for_mode
+
+    funcs = get_cost_funcs_dict_for_mode('numpy')
+    offered = framework_kwargs_for(funcs['gaussian_MLE'], std=1.0, weight=1.0)
+    assert offered == {'std': 1.0, 'weight': 1.0}

--- a/tests/test_csv_header_parsing.py
+++ b/tests/test_csv_header_parsing.py
@@ -1,0 +1,90 @@
+"""CSV inputs must be parsed by column header, not by column position (issue #159).
+
+Position-based parsing fails silently and destructively: reorder two columns in a parameters CSV
+and every value lands in the wrong field, producing a model that builds and runs and is simply
+wrong. These tests pin the header-based behaviour by feeding the parsers column orders that
+differ from the shipped files and requiring identical results.
+"""
+import pandas as pd
+import pytest
+
+from parsers.PrimitiveParsers import CSVFileParser
+
+
+def _write(tmp_path, name, header, rows):
+    path = tmp_path / name
+    path.write_text('\n'.join([header] + rows) + '\n')
+    return str(path)
+
+
+@pytest.mark.unit
+def test_parameters_csv_is_read_by_header_not_position(tmp_path):
+    """Same rows, columns in a different order -> same parsed values."""
+    parser = CSVFileParser()
+    canonical = _write(
+        tmp_path, 'canonical.csv',
+        'variable_name,units,value,data_reference',
+        ['R_pvn,Js_per_m6,1333000,Blanco_2013_Table_8',
+         'q_C_init_pvn,m3,0.0001,user_defined'])
+    shuffled = _write(
+        tmp_path, 'shuffled.csv',
+        'data_reference,value,variable_name,units',
+        ['Blanco_2013_Table_8,1333000,R_pvn,Js_per_m6',
+         'user_defined,0.0001,q_C_init_pvn,m3'])
+
+    a = parser.get_data_as_dataframe(canonical).set_index('variable_name')
+    b = parser.get_data_as_dataframe(shuffled).set_index('variable_name')
+
+    for var in ('R_pvn', 'q_C_init_pvn'):
+        for col in ('units', 'value', 'data_reference'):
+            assert a.loc[var, col] == b.loc[var, col], (
+                f"{var}.{col} differs between column orderings -- the parser is using position")
+
+
+@pytest.mark.unit
+def test_params_for_id_csv_is_read_by_header_not_position(tmp_path):
+    """The params_for_id file is the other CSV whose column meaning matters (min vs max)."""
+    parser = CSVFileParser()
+    canonical = _write(
+        tmp_path, 'pid_canonical.csv',
+        'vessel_name,param_name,param_type,min,max,name_for_plotting',
+        ['global,q_lv_init,const,200e-6,1500e-6,q_sbv',
+         'aortic_root,C,const,1e-9,5e-8,C_ao'])
+    shuffled = _write(
+        tmp_path, 'pid_shuffled.csv',
+        'max,name_for_plotting,vessel_name,min,param_type,param_name',
+        ['1500e-6,q_sbv,global,200e-6,const,q_lv_init',
+         '5e-8,C_ao,aortic_root,1e-9,const,C'])
+
+    a = parser.get_data_as_dataframe_multistrings(canonical)
+    b = parser.get_data_as_dataframe_multistrings(shuffled)
+
+    for col in ('vessel_name', 'param_name', 'param_type', 'min', 'max', 'name_for_plotting'):
+        assert list(a[col]) == list(b[col]), (
+            f"column '{col}' differs between orderings -- min/max could be swapped silently")
+
+
+@pytest.mark.unit
+def test_a_missing_required_column_is_visible(tmp_path):
+    """Dropping a column must not quietly shift the remaining ones into its place."""
+    parser = CSVFileParser()
+    path = _write(tmp_path, 'no_units.csv',
+                  'variable_name,value,data_reference',
+                  ['R_pvn,1333000,Blanco_2013_Table_8'])
+    df = parser.get_data_as_dataframe(path)
+    assert 'units' not in df.columns
+    # the values that *are* present stayed with their own headers
+    assert df.loc[0, 'value'] == '1333000'
+    assert df.loc[0, 'data_reference'] == 'Blanco_2013_Table_8'
+
+
+@pytest.mark.unit
+def test_header_whitespace_is_stripped(tmp_path):
+    """The shipped params_for_id files are column-aligned with padding spaces, so a header
+    lookup only works because the parser strips them."""
+    parser = CSVFileParser()
+    path = _write(tmp_path, 'padded.csv',
+                  'vessel_name,                  param_name,       param_type',
+                  ['global,                        q_lv_init,        const'])
+    df = parser.get_data_as_dataframe_multistrings(path)
+    assert list(df.columns) == ['vessel_name', 'param_name', 'param_type']

--- a/tests/test_libcellml_shims.py
+++ b/tests/test_libcellml_shims.py
@@ -1,0 +1,118 @@
+"""The libCellML 0.6.x / 0.7.0 compatibility shims (issue #271).
+
+`pyproject.toml` pins `libcellml>=0.6.3,<0.7.0`, so **the 0.7.0 branches of these shims cannot
+execute in CI or in any user install**. They are dead code today, which means without these tests
+they would first run at the exact moment the pin is lifted -- the worst possible time to discover
+a mistake in them.
+
+Both sides are exercised here against fakes rather than a real libCellML, so neither branch
+depends on which version happens to be installed. This does not do the 0.7.0 migration (that is
+still #271: the generated-Python output and unit flattening changed too); it removes the risk
+that the *renames* are wrong when the pin comes off.
+"""
+import pytest
+
+from utilities.libcellml_helper_funcs import (
+    _generator_is_pre_0_7, generate_implementation_code, generate_interface_code,
+    get_analysed_model)
+
+
+class _Analyser06:
+    """0.6.x: the accessor is model()."""
+    def model(self):
+        return 'analysed-model-06'
+
+
+class _Analyser07:
+    """0.7.0: renamed to analyserModel()."""
+    def analyserModel(self):
+        return 'analysed-model-07'
+
+
+class _Generator06:
+    """0.6.x: configured via setModel()/setProfile(), then called with no arguments."""
+    def __init__(self):
+        self.model = None
+        self.profile = None
+
+    def setProfile(self, profile):
+        self.profile = profile
+
+    def setModel(self, model):
+        self.model = model
+
+    def implementationCode(self):
+        return f'impl-06({self.model},{self.profile})'
+
+    def interfaceCode(self):
+        return f'iface-06({self.model},{self.profile})'
+
+
+class _Generator07:
+    """0.7.0: the setters are gone; the model and profile are arguments."""
+    def implementationCode(self, analysed_model, profile):
+        return f'impl-07({analysed_model},{profile})'
+
+    def interfaceCode(self, analysed_model, profile):
+        return f'iface-07({analysed_model},{profile})'
+
+
+@pytest.mark.unit
+def test_analysed_model_accessor_dispatches_both_ways():
+    assert get_analysed_model(_Analyser06()) == 'analysed-model-06'
+    assert get_analysed_model(_Analyser07()) == 'analysed-model-07'
+
+
+@pytest.mark.unit
+def test_the_version_probe_keys_off_the_setter_that_only_0_6_has():
+    assert _generator_is_pre_0_7(_Generator06()) is True
+    assert _generator_is_pre_0_7(_Generator07()) is False
+
+
+@pytest.mark.unit
+def test_implementation_code_passes_model_and_profile_on_both_versions():
+    """The 0.6 branch must set *both* model and profile before calling, and the 0.7 branch must
+    forward both as arguments. Dropping either would produce code generated against a default
+    profile or an unset model, which fails late and confusingly."""
+    gen06 = _Generator06()
+    assert generate_implementation_code(gen06, 'MODEL', 'PROFILE') == 'impl-06(MODEL,PROFILE)'
+    assert gen06.model == 'MODEL' and gen06.profile == 'PROFILE'
+
+    assert generate_implementation_code(_Generator07(), 'MODEL', 'PROFILE') == \
+        'impl-07(MODEL,PROFILE)'
+
+
+@pytest.mark.unit
+def test_interface_code_passes_model_and_profile_on_both_versions():
+    gen06 = _Generator06()
+    assert generate_interface_code(gen06, 'MODEL', 'PROFILE') == 'iface-06(MODEL,PROFILE)'
+    assert gen06.model == 'MODEL' and gen06.profile == 'PROFILE'
+
+    assert generate_interface_code(_Generator07(), 'MODEL', 'PROFILE') == 'iface-07(MODEL,PROFILE)'
+
+
+@pytest.mark.unit
+def test_a_0_7_generator_is_never_handed_the_0_6_call_shape():
+    """Regression guard for the failure that would actually happen if the probe inverted: calling
+    0.7's implementationCode() with no arguments raises TypeError, and calling 0.6's with two
+    does the same. Assert the shim never produces either."""
+    with pytest.raises(TypeError):
+        _Generator07().implementationCode()
+    with pytest.raises(TypeError):
+        _Generator06().implementationCode('MODEL', 'PROFILE')
+    # ...and the shim avoids both
+    generate_implementation_code(_Generator07(), 'M', 'P')
+    generate_implementation_code(_Generator06(), 'M', 'P')
+
+
+@pytest.mark.unit
+def test_the_pin_is_still_in_place_so_these_branches_remain_untested_in_the_wild():
+    """If the pin is lifted, this test should be revisited alongside the rest of #271 -- the real
+    migration (generated-Python output, unit flattening) is not covered by these fakes."""
+    import pathlib
+    pyproject = (pathlib.Path(__file__).resolve().parent.parent / 'pyproject.toml').read_text()
+    if 'libcellml>=0.6.3,<0.7.0' not in pyproject:
+        pytest.fail(
+            "The libcellml <0.7.0 pin has changed. These shim tests cover the API renames only; "
+            "confirm the generated-Python and unit-flattening migration in #271 is done, then "
+            "update this test.")

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -140,14 +140,8 @@ def test_schema_settings_are_actually_read_by_the_code():
     always consumed by its own helper. PrimitiveParsers.py is excluded because that is where the
     schema declares the names in the first place.
 
-    KNOWN LIMITATION -- this check is per *setting*, not per *solver*, and a name that merely
-    passes through counts as "read". Both together let CVODE_myokit advertise
-    MaximumNumberOfSteps for a long time: the name appears in protocol_runner.py, but only to be
-    relayed into get_simulation_helper's solver_info, and myokit_helper drops it on the floor
-    (myokit.Simulation exposes only set_max_step_size / set_min_step_size / set_tolerance). This
-    docstring previously cited that relay as proof the setting was read, which is exactly the
-    reasoning to distrust. Tightening this to per-solver, consumption-aware checking is the real
-    fix; until then, a name appearing in the corpus is necessary but NOT sufficient.
+    This is the weak, repo-wide half of the check; the per-solver half is
+    test_each_solver_setting_is_read_by_that_solvers_consumer below (issue #330).
     """
     src_dir = pathlib.Path(__file__).resolve().parent.parent / 'src'
     corpus = '\n'.join(
@@ -176,6 +170,71 @@ def test_schema_settings_are_actually_read_by_the_code():
     assert not unread_method, (
         f'optimiser options advertised to CUFLynx but read nowhere in src/: {unread_method}. '
         'Either wire the option up or remove it from PARAM_ID_METHODS.')
+
+
+# Which module actually consumes each solver's solver_info. A setting must appear in *its own*
+# solver's consumer, not merely somewhere in src/: protocol_runner.py relays every key into
+# get_simulation_helper's solver_info whether or not the backend does anything with it, so a
+# repo-wide search counts a pass-through as a read (issue #330).
+_SOLVER_CONSUMERS = {
+    'CVODE_myokit': ['solver_wrappers/myokit_helper.py'],
+    'CVODE_opencor': ['solver_wrappers/opencor_helper.py'],
+    'solve_ivp': ['solver_wrappers/python_solver_helper.py'],
+    'user_defined': ['solver_wrappers/python_solver_helper.py'],
+    'casadi_integrator': ['solver_wrappers/casadi_python_solver_helper.py'],
+    # AADC settings are split: integrator knobs in the helper, gradient knobs (jac_lag,
+    # gradient_strategy) in the tape/kernel paths of aadc_backend.
+    'aadc_semi_implicit': ['solver_wrappers/aadc_python_solver_helper.py',
+                           'param_id/aadc_backend.py'],
+}
+
+_RELAY_FILES = ('protocol_runners/protocol_runner.py', 'parsers/PrimitiveParsers.py')
+
+
+@pytest.mark.unit
+def test_each_solver_setting_is_read_by_that_solvers_consumer():
+    """Per-solver, consumption-aware version of the check above (issue #330).
+
+    A solver_info setting is CUFLynx's contract: it renders a control for it. If the backend that
+    owns the solver never reads the key, the user gets a control that silently does nothing --
+    and the repo-wide check cannot see that, because it only asks whether the *name* appears
+    anywhere in src/, and every key appears in the relay in protocol_runner.py. That is how
+    CVODE_myokit came to advertise MaximumNumberOfSteps: myokit.Simulation exposes only
+    set_max_step_size / set_min_step_size / set_tolerance, so the value went nowhere.
+
+    The cpp solvers (CVODE/RK4/PETSC) are deliberately not mapped: their solver_info is consumed
+    by generated C++ rather than a Python backend, so there is no module to grep. They remain
+    covered by the repo-wide check only, and that gap is recorded here rather than hidden.
+    """
+    src_dir = pathlib.Path(__file__).resolve().parent.parent / 'src'
+
+    phantom = {}
+    for solver, consumers in _SOLVER_CONSUMERS.items():
+        text = ''
+        for rel in consumers:
+            path = src_dir / rel
+            assert path.exists(), 'consumer file missing for ' + solver + ': ' + rel
+            text += path.read_text(errors='ignore')
+        missing = [f['name'] for f in SOLVER_INFO_FIELDS[solver]
+                   if '"' + f['name'] + '"' not in text and "'" + f['name'] + "'" not in text]
+        if missing:
+            phantom[solver] = missing
+
+    assert not phantom, (
+        'solver_info settings advertised to CUFLynx that their own backend never reads: '
+        + str(phantom) + '. CUFLynx renders a control for each, so an unread one is a knob the '
+        'user can turn with no effect and no way to tell. Either wire it up in the consumer, or '
+        'drop it from SOLVER_INFO_FIELDS.')
+
+
+@pytest.mark.unit
+def test_the_relay_does_not_count_as_reading_a_setting():
+    """Guard on the guard: if protocol_runner ever became a mapped consumer, the per-solver check
+    above would silently degrade back into the repo-wide one it replaced."""
+    for relay in _RELAY_FILES:
+        for consumers in _SOLVER_CONSUMERS.values():
+            assert relay not in consumers, (
+                relay + ' relays solver_info wholesale and must never be treated as a consumer')
 
 
 def test_analysis_options_schema_well_formed():


### PR DESCRIPTION
Four issues from an open-issue triage, each smaller than its title suggested. Two commits: one behavioural, one tests-only.

## `cost_kwargs` for user-defined cost functions — closes #84

Cost funcs were invoked with a fixed positional `(output, ground_truth, std, weight)` at **nine** call sites, which forced two things on every cost func ever written:

- it had to accept `std` and `weight` even when the cost has no use for them — a cost with no notion of a standard deviation (an absolute bound, a barrier, a distribution fit) declared the parameter and dropped it;
- it could take nothing else, so a user cost with a tolerance, an exponent or a reference scale had no way to receive it short of a module-level global.

`src/param_id/cost_kwargs.py` is now the single place deciding what a cost func is called with. Framework-supplied arguments are offered only where the signature has somewhere to put them, and a data_item may add its own via a `cost_kwargs` mapping.

It deliberately mirrors the `operation_kwargs` contract (#304) rather than inventing a second set of rules — same introspection, same reserved-name handling, same JSON int/float coercion, same stance that an unknown key is an **error**. A stale or misspelled key would otherwise change nothing at all, and a calibration against the wrong cost looks exactly like one against the right cost.

`std` and `weight` are reserved: they come from the data_item's own fields, and letting `cost_kwargs` set them would either silently calibrate against the wrong value or raise a bare "got multiple values for keyword argument". Validation runs at setup beside `validate_operation_kwargs`, so a bad key fails before the first forward solve.

Behaviour for the shipped cost funcs is unchanged, with one improvement: `multimodal_gaussian` now receives only `weight` instead of a `std` it never declared.

## Tests for three near-done issues

**#159 — CSV headers.** Already true in the code: every caller reads with `has_header=True` and accesses by column name; the `header=None` branches are reachable only via an explicit `has_header=False` that no caller passes. What was missing was proof. The new tests feed the parsers the same rows with columns in a **different order** and require identical results — the only check that actually distinguishes header parsing from positional parsing. Positional parsing fails silently and destructively (swap two columns and every value lands in the wrong field, giving a model that builds, runs, and is wrong), so `min`/`max` on `params_for_id` gets its own case.

**#330 — per-solver, consumption-aware schema check.** The repo-wide check asks only whether a setting's *name* appears anywhere in `src/`, and `protocol_runner.py` relays every `solver_info` key into `get_simulation_helper` whether or not the backend uses it — so a pass-through counts as a read. Added a check that looks only in the module actually consuming that solver's `solver_info`, with relay files explicitly excluded and a second test asserting they stay excluded.

No phantom settings exist today — `CVODE_myokit`'s `MaximumNumberOfSteps`, the case the old docstring cited, has since been removed from `_MYOKIT_SOLVER_INFO` — so this is a guard against reintroducing one. The cpp solvers are deliberately unmapped, since their settings are consumed by generated C++ rather than a Python module; that gap is now recorded in the test rather than implied.

**#271 (partial — issue stays open).** The `libcellml<0.7.0` pin means the 0.7.0 branches of the shims cannot execute in CI or in any user install: dead code that would first run at the exact moment the pin is lifted. Both branches are now exercised against fakes, so neither depends on which libCellML is installed. This is **not** the migration — the generated-Python output and unit flattening still changed, and #271 stays open for that — it only removes the risk that the renames are wrong when the pin comes off. A guard test fails if the pin changes without this being revisited.

## Testing

`-m "not slow"`: **379 passed, 5 skipped, 1 failed**. The one failure is `test_python_BDF_solver[SN_simple]`, the libCellML strict-ODE limitation (#151), verified pre-existing on master.

24 new tests across the three new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
