### PR TITLE
fix(params): apply a grouped params_for_id row to every vessel, and honour groups in Sobol SA

### DIFF
--- a/src/sensitivity_analysis/sobolSA.py
+++ b/src/sensitivity_analysis/sobolSA.py
@@ -224,9 +224,20 @@ class sobol_SA():
         if not hasattr(self, "param_id_info") or not self.param_id_info:
             raise ValueError("param_id_info is not set. Please run __set_and_save_param_names() first.")
 
+        # A params_for_id row naming several vessels means "one calibrated value drives all of
+        # these", so it is *one* variable to the sampler and must be set on *every* member.
+        # Those are two different things and need two different lists (issue #355):
+        #   param_names   -- kept grouped, handed to set_param_vals, which broadcasts the shared
+        #                    sampled value across the group
+        #   param_labels  -- flattened to one name per variable, for the SALib problem and plots
+        # Collapsing to the first name for both is what made a grouped SA vary one vessel while
+        # calibration varied all of them, silently answering a different question.
+        grouped_names = list(self.param_id_info["param_names"])
         SA_info = {
             "sample_type": sample_type,
-            "param_names": [name[0] if isinstance(name, list) else name for name in self.param_id_info["param_names"]],
+            "param_names": grouped_names,
+            "param_labels": ['+'.join(n) if isinstance(n, (list, tuple)) else n
+                             for n in grouped_names],
             "num_samples": num_samples,
             "param_mins": list(self.param_id_info["param_mins"]),
             "param_maxs": list(self.param_id_info["param_maxs"])
@@ -236,9 +247,22 @@ class sobol_SA():
         #     print("Sensitivity Analysis Configuration:")
         #     print(json.dumps(SA_info, indent=4))
 
-        self.num_params = len(SA_info["param_names"])
+        self.num_params = len(SA_info["param_labels"])
 
         return SA_info
+
+    def _param_labels(self):
+        """One display label per sampled variable.
+
+        Derived from param_names when 'param_labels' is absent, so an SA_info built by hand or
+        loaded from an older run still works -- the key was added with grouped-parameter support
+        (issue #355) and SA_info is a semi-public structure.
+        """
+        labels = self.SA_info.get("param_labels")
+        if labels is not None:
+            return labels
+        return ['+'.join(n) if isinstance(n, (list, tuple)) else n
+                for n in self.SA_info["param_names"]]
 
     def create_SA_info(self, sample_type, num_samples):
         # Backwards compatibility alias
@@ -274,7 +298,7 @@ class sobol_SA():
 
         problem = {
             'num_vars': self.num_params,
-            'names': self.SA_info["param_names"],
+            'names': self._param_labels(),
             'bounds': list(zip(self.SA_info["param_mins"], self.SA_info["param_maxs"]))
         }
         self.problem = problem
@@ -463,12 +487,12 @@ class sobol_SA():
             # output_name = self.obs_info["names_for_plotting"][i] if hasattr(self, "obs_info") else f"Output_{i}"
 
             # Set figure width adaptively based on number of parameters (xticks)
-            fig_width = max(12, 1.0 * len(self.SA_info["param_names"]))
+            fig_width = max(12, 1.0 * len(self._param_labels()))
             plt.figure(figsize=(fig_width, 5))
             plt.bar(x - 0.2, S1, width=0.4, label='First-order', color='blue', alpha=0.7)
             plt.bar(x + 0.2, ST, width=0.4, label='Total-order', color='red', alpha=0.7)
 
-            plt.xticks(x, self.SA_info["param_names"], rotation=45, fontsize=8)
+            plt.xticks(x, self._param_labels(), rotation=45, fontsize=8)
             plt.ylabel('Sensitivity Index')
             plt.title(rf'Sobol Sensitivity - {output_name}')
             plt.legend()
@@ -496,9 +520,9 @@ class sobol_SA():
             output_name = rf"{self.obs_info['names_for_plotting'][i]} - experiment{self.obs_info['experiment_idxs'][i]}, subexperiment{self.obs_info['subexperiment_idxs'][i]}"
 
             # plt.figure(figsize=(6, 5))
-            fig_width = max(6, 1.0 * len(self.SA_info["param_names"]))
+            fig_width = max(6, 1.0 * len(self._param_labels()))
             plt.figure(figsize=(fig_width, fig_width))
-            sns.heatmap(S2, annot=True, fmt=".2f", xticklabels=self.SA_info["param_names"], yticklabels=self.SA_info["param_names"], cmap="coolwarm")
+            sns.heatmap(S2, annot=True, fmt=".2f", xticklabels=self._param_labels(), yticklabels=self._param_labels(), cmap="coolwarm")
             plt.title(rf"2nd order Sobol Indices - {output_name}")
             plt.tight_layout()
 
@@ -557,7 +581,7 @@ class sobol_SA():
         Generates 2D heatmaps for first-order (S1) and total-order (ST) Sobol indices.
         
         The heatmaps show:
-        Y-axis: Input Parameters (self.SA_info["param_names"])
+        Y-axis: Input Parameters (self._param_labels())
         X-axis: Model Outputs (concatenated names from self.obs_info)
         Color: Sobol Index Value
         
@@ -655,7 +679,7 @@ class sobol_SA():
             S2_all (np.ndarray): Second-order Sobol indices, shape (n_outputs, n_params, n_params)
         """
         n_outputs = S1_all.shape[0]
-        param_names = self.SA_info["param_names"]
+        param_names = self._param_labels()
 
         # Prepare output/feature names. Two data_items that resolve to the same
         # (name_for_plotting, experiment, subexperiment) produce identical column

--- a/src/solver_wrappers/casadi_python_solver_helper.py
+++ b/src/solver_wrappers/casadi_python_solver_helper.py
@@ -655,7 +655,25 @@ class SimulationHelper:
         return {name: val for name, val in zip(variable_names, values)}
 
     def _create_param_subset(self, param_names, param_vals=None):
-        param_names = [x[0] for x in param_names]
+        # A grouped params_for_id row ("one calibrated value drives these N vessels") cannot be
+        # honoured here yet. This builds the *symbolic* subset that the cost jacobian is taken
+        # against, so it needs one SX symbol per group substituted into every member's slot --
+        # otherwise the derivative is with respect to the first member alone.
+        #
+        # Refusing rather than dropping the extra members: silently calibrating only the first
+        # vessel is what this backend did before, and it produced a cost curve bit-identical to
+        # the ungrouped one, so nothing downstream could tell. Broadcasting on the numeric side
+        # only would be worse still -- the cost would move all members while the gradient
+        # tracked one, so the optimiser would descend a different function than it evaluates.
+        grouped = [x for x in param_names if isinstance(x, (list, tuple)) and len(x) > 1]
+        if grouped:
+            raise NotImplementedError(
+                f"Grouped parameters are not yet supported by the CasADi backend: {grouped}. "
+                f"The symbolic parameter subset takes one symbol per params_for_id row, so the "
+                f"gradient would be with respect to the first vessel only. Use model_type "
+                f"'cellml_only' with solver 'CVODE_myokit' for grouped calibration, or give "
+                f"each vessel its own row. See issue #355.")
+        param_names = [x[0] if isinstance(x, (list, tuple)) else x for x in param_names]
 
         # Resolve each param to its VARIABLE_INFO index, then find its SX symbol
         var_indices = []   # VARIABLE_INFO indices

--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -1,6 +1,8 @@
 import os
 import copy
 import numpy as np
+
+from solver_wrappers.param_grouping import pair_names_with_values
 import myokit
 from myokit.formats import cellml as cellml_format
 # src_dir = os.path.join(os.path.dirname(__file__), '..')
@@ -830,11 +832,8 @@ class SimulationHelper:
         # states they initialise are refreshed afterwards.
         changed_var_qnames = set()
         for idx, name_or_list in enumerate(param_names):
-            names = name_or_list if isinstance(name_or_list, list) else [name_or_list]
-            vals = param_vals[idx]
-            if not isinstance(vals, (list, tuple, np.ndarray)):
-                vals = [vals]
-            for name, val in zip(names, vals):
+            for name, val in pair_names_with_values(name_or_list, param_vals[idx],
+                                                   'set_param_vals'):
                 kind, qname = self._resolve_name(name)
 
                 if kind == "state":
@@ -933,11 +932,8 @@ class SimulationHelper:
         """
         found_qname = None
         for idx, name_or_list in enumerate(param_names):
-            names = name_or_list if isinstance(name_or_list, list) else [name_or_list]
-            vals = param_vals[idx]
-            if not isinstance(vals, (list, tuple, np.ndarray)):
-                vals = [vals]
-            for name, val in zip(names, vals):
+            for name, val in pair_names_with_values(name_or_list, param_vals[idx],
+                                                   'paced-variable scan'):
                 if isinstance(val, str):
                     kind, qname = self._resolve_name(name)
                     if kind != "var":

--- a/src/solver_wrappers/param_grouping.py
+++ b/src/solver_wrappers/param_grouping.py
@@ -1,0 +1,56 @@
+"""Pairing a params_for_id row's names with its value(s).
+
+A ``params_for_id`` row may name several vessels, which means "one calibrated value drives all
+of these" -- the grouped-parameter feature. Every backend's ``set_param_vals`` therefore receives
+entries that are either a single name or a list of names, against a single shared value.
+
+The obvious pairing, ``zip(names, vals)``, is wrong for exactly that case: with two names and one
+value, ``zip`` stops at the shorter sequence and silently sets only the first name. That is what
+made a grouped row calibrate its first vessel and leave the rest at their defaults, on every
+backend, with no error and a cost curve identical to the ungrouped one.
+
+``pair_names_with_values`` is the single place that decides the pairing, so the broadcast rule
+cannot drift between backends, and a genuine length mismatch raises instead of truncating.
+"""
+
+
+def as_name_list(name_or_list):
+    """Normalise a params_for_id entry to a list of names."""
+    if isinstance(name_or_list, (list, tuple)):
+        return list(name_or_list)
+    return [name_or_list]
+
+
+def as_value_list(value_or_list):
+    """Normalise a value entry to a list, without splitting strings (a protocol trace key)."""
+    if isinstance(value_or_list, str):
+        return [value_or_list]
+    if isinstance(value_or_list, (list, tuple)):
+        return list(value_or_list)
+    if hasattr(value_or_list, 'tolist') and getattr(value_or_list, 'ndim', 1) > 0:
+        return list(value_or_list.tolist())
+    return [value_or_list]
+
+
+def pair_names_with_values(name_or_list, value_or_list, context=''):
+    """Yield ``(name, value)`` for one params_for_id entry, broadcasting a shared value.
+
+    - N names, 1 value  -> the value is applied to all N. This is the grouped-parameter case
+      and the reason this helper exists.
+    - N names, N values -> paired positionally.
+    - anything else     -> ValueError, rather than the silent truncation ``zip`` would do.
+    """
+    names = as_name_list(name_or_list)
+    values = as_value_list(value_or_list)
+
+    if len(values) == 1 and len(names) > 1:
+        values = values * len(names)
+
+    if len(names) != len(values):
+        where = f' ({context})' if context else ''
+        raise ValueError(
+            f'params_for_id entry{where} has {len(names)} name(s) {names} but {len(values)} '
+            f'value(s). A grouped entry takes one shared value for all its names, or one value '
+            f'per name.')
+
+    return list(zip(names, values))

--- a/src/solver_wrappers/python_solver_helper.py
+++ b/src/solver_wrappers/python_solver_helper.py
@@ -1,5 +1,7 @@
 import importlib.util
 import numpy as np
+
+from solver_wrappers.param_grouping import pair_names_with_values
 from scipy.integrate import solve_ivp
 import copy
 import sys
@@ -331,10 +333,7 @@ class SimulationHelper:
                     pass
                 return [x]
 
-            name_or_list = _to_list(name_or_list)
-            vals = _to_list(vals)
-
-            for name, val in zip(name_or_list, vals):
+            for name, val in pair_names_with_values(name_or_list, vals, 'set_param_vals'):
                 if type(val) == str:
                     raise NotImplementedError(
                         f"'{name}' was given the protocol trace name '{val}', but the "

--- a/tests/test_grouped_params.py
+++ b/tests/test_grouped_params.py
@@ -1,0 +1,110 @@
+"""Grouped params_for_id rows: one calibrated value driving several vessels (issue #355).
+
+The feature had no tests at all, and was broken end to end: `zip(names, vals)` with N names and
+one shared value stops at the shorter sequence, so only the first vessel was ever set. A grouped
+row produced a cost curve bit-identical to the ungrouped one -- nothing downstream could tell it
+was calibrating a single vessel.
+"""
+import numpy as np
+import pytest
+
+from solver_wrappers.param_grouping import (
+    as_name_list, as_value_list, pair_names_with_values)
+
+
+@pytest.mark.unit
+def test_one_shared_value_reaches_every_member_of_a_group():
+    """The whole point of a grouped row. zip() silently dropped everything after the first."""
+    pairs = pair_names_with_values(['aortic_root/C', 'par/C'], 1.5e-8)
+    assert pairs == [('aortic_root/C', 1.5e-8), ('par/C', 1.5e-8)]
+
+
+@pytest.mark.unit
+def test_a_group_of_three_broadcasts_to_all_three():
+    pairs = pair_names_with_values(['a/R', 'b/R', 'c/R'], 2.0)
+    assert [n for n, _ in pairs] == ['a/R', 'b/R', 'c/R']
+    assert {v for _, v in pairs} == {2.0}
+
+
+@pytest.mark.unit
+def test_an_ungrouped_entry_is_unchanged():
+    assert pair_names_with_values('aortic_root/C', 1.5e-8) == [('aortic_root/C', 1.5e-8)]
+
+
+@pytest.mark.unit
+def test_per_name_values_are_paired_positionally():
+    """N names with N values keeps the existing meaning -- broadcasting must not override it."""
+    pairs = pair_names_with_values(['a/R', 'b/R'], [1.0, 2.0])
+    assert pairs == [('a/R', 1.0), ('b/R', 2.0)]
+
+
+@pytest.mark.unit
+def test_a_length_mismatch_raises_instead_of_truncating():
+    """The failure this whole issue was: zip() drops the tail without a word."""
+    with pytest.raises(ValueError, match='3 name'):
+        pair_names_with_values(['a/R', 'b/R', 'c/R'], [1.0, 2.0])
+
+
+@pytest.mark.unit
+def test_a_protocol_trace_key_is_one_value_not_a_string_of_characters():
+    """A string value is a protocol_traces key. Splitting it per character would pair 'p','a','c'
+    with the group's names and set three nonsense values."""
+    pairs = pair_names_with_values(['a/u', 'b/u'], 'pace')
+    assert pairs == [('a/u', 'pace'), ('b/u', 'pace')]
+
+
+@pytest.mark.unit
+def test_numpy_arrays_are_accepted_as_value_lists():
+    pairs = pair_names_with_values(['a/R', 'b/R'], np.array([1.0, 2.0]))
+    assert [v for _, v in pairs] == [1.0, 2.0]
+
+
+@pytest.mark.unit
+def test_a_zero_dimensional_numpy_scalar_broadcasts():
+    pairs = pair_names_with_values(['a/R', 'b/R'], np.float64(3.0))
+    assert [v for _, v in pairs] == [3.0, 3.0]
+
+
+@pytest.mark.unit
+def test_normalisers_agree_with_the_pairing():
+    assert as_name_list('x') == ['x'] and as_name_list(['x', 'y']) == ['x', 'y']
+    assert as_value_list('trace') == ['trace']
+    assert as_value_list(1.0) == [1.0]
+
+
+@pytest.mark.unit
+def test_sobol_keeps_groups_for_setting_and_flattens_only_for_labels():
+    """The SA fix: a group is one variable to the sampler but N parameters to set.
+
+    Collapsing to the first name for both is what made a grouped SA vary one vessel while
+    calibration varied all of them -- the two silently answered different questions.
+    """
+    from sensitivity_analysis.sobolSA import sobol_SA
+
+    sa = sobol_SA.__new__(sobol_SA)
+    sa.param_id_info = {
+        'param_names': [['aortic_root/C', 'par/C'], 'heart/R'],
+        'param_mins': [1e-9, 1.0],
+        'param_maxs': [5e-8, 2.0],
+    }
+    info = sa._create_SA_info('sobol', 8)
+
+    # one variable per row for the sampler...
+    assert info['param_labels'] == ['aortic_root/C+par/C', 'heart/R']
+    assert sa.num_params == 2
+    # ...but the full group survives for set_param_vals
+    assert info['param_names'] == [['aortic_root/C', 'par/C'], 'heart/R']
+
+
+@pytest.mark.unit
+def test_the_casadi_backend_refuses_a_group_rather_than_dropping_members():
+    """CasADi builds a symbolic subset with one symbol per row, so a group would be
+    differentiated with respect to its first member only. Until that is fixed properly it must
+    fail loudly: silently calibrating one vessel is what this issue is about, and broadcasting
+    on the numeric side alone would make the cost and the gradient different functions."""
+    import inspect
+    from solver_wrappers import casadi_python_solver_helper as helper
+
+    src = inspect.getsource(helper.SimulationHelper._create_param_subset)
+    assert 'NotImplementedError' in src
+    assert '#355' in src


### PR DESCRIPTION
Closes #355 (Sobol part), and fixes a larger bug the verification for it uncovered.

## Grouped rows were applied to the first vessel only, on every backend

`set_param_vals` takes entries that are either a name or a list of names sharing one value, and paired them with `zip(names, vals)`. With two names and one shared value, **`zip` stops at the shorter sequence**, so only the first vessel was ever set.

Measured on 3compartment, a group of `[aortic_root, par]` on `C` against the same parameter ungrouped:

| shared value scale | 0.8 | 1.0 | 1.25 |
|---|---|---|---|
| ungrouped `aortic_root/C` | 5189.214620504988 | 3513.567496052812 | 2414.2015502800423 |
| grouped `[aortic_root, par]/C` | 5189.214620504988 | 3513.567496052812 | 2414.2015502800423 |

Bit-identical at every value, on both Myokit and CasADi — so nothing downstream could tell that `par/C` had never moved. `set_param_vals`'s own docstring says "each entry may be a list sharing one value": the intent was right and the pairing dropped it.

`pair_names_with_values` in `solver_wrappers/param_grouping.py` is now the single place that decides the pairing — one value broadcasts across the group, N values pair positionally, and a genuine length mismatch **raises** instead of truncating. Applied at the three truncating sites (myokit ×2, python ×1). A string value stays one value rather than being split per character, since that's a `protocol_traces` key.

## Sobol SA — the original ask

A grouped row is **one** variable to the sampler and **N** parameters to set. Those are two different things and now have two lists:

- `param_names` stays grouped and goes to `set_param_vals`, which broadcasts the sampled value across the group
- `param_labels` is flattened (`'a+b'`) for the SALib problem, the plots and the heatmaps

Collapsing to the first name for both is what made a grouped SA vary one vessel while calibration varied all of them — the two silently answered different questions, which is exactly what the issue describes. `_param_labels()` derives labels when the key is absent, so an `SA_info` built by hand or loaded from an older run still works.

## CasADi refuses a group rather than dropping members

`_create_param_subset` builds the *symbolic* subset the cost jacobian is taken against, with one symbol per row. Honouring a group there means creating one SX symbol per group and substituting it into every member's slot so CasADi applies the chain rule itself — real work, not a broadcast, and out of scope here.

Fixing only its numeric side would be **worse than leaving it**: the cost would move all members while the gradient tracked only the first, so the optimiser would descend a different function than it evaluates. It now raises `NotImplementedError` pointing at #355 and at `CVODE_myokit`, which does support grouping after this change.

That is a deliberate behaviour change: a CasADi config with a grouped row that "worked" before will now fail. It was silently calibrating one vessel, so I'd rather it said so — happy to downgrade it to a warning if you prefer.

## Testing

The feature had **no tests at all**, which is presumably how this survived. 11 new ones in `tests/test_grouped_params.py` cover the broadcast, positional pairing, the mismatch error, the protocol-trace-key case, the Sobol split, and the CasADi refusal.

`-m "not slow"`: **390 passed, 5 skipped, 1 failed** — the one failure is `test_python_BDF_solver[SN_simple]` (#151), verified pre-existing on master.

## Still open on #355

The local (derivative) sensitivity arms still flatten a group to its first member — `casadi_backend.py:204` and `fsa_backend.py:137`. Those need the chain rule proper: for `p_i = θ`, `dO/dθ = Σ_i ∂O/∂p_i`, either symbolically for CasADi or as an explicit column sum for Myokit FSA. Left for a follow-up so this stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
