### PR TITLE
feat(params): params_for_id becomes JSON, with the CSV converted on read

### DIFF
--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -460,6 +460,26 @@ PARAM_PRIOR_TYPES = {
 # from that prior instead of typed.
 PARAM_UNBOUNDED_COLUMN = 'unbounded'
 
+# ---------------------------------------------------------------------------------------------
+# params_for_id as JSON.
+#
+# The CSV is still readable and always will be, but it is converted to this structure on read, so
+# there is exactly one code path behind the front door. The JSON shape exists because the CSV
+# cannot express two things the user asked for: a group of parameters with *different* names
+# (a CSV row has one param_name for all its vessels), and a parameter that modifies other
+# parameters. `targets` -- a list of full component/param qnames -- removes the first restriction;
+# the second arrives with modifier entries in a follow-up.
+PARAMS_FOR_ID_JSON_VERSION = 1
+
+# Keys an entry may carry. Anything else is a typo and is refused, on the same reasoning as
+# operation_kwargs/cost_kwargs: a key nothing reads changes nothing and gives no sign it was
+# ignored.
+PARAMS_FOR_ID_ENTRY_KEYS = frozenset({
+    'name', 'targets', 'param_type', 'min', 'max', 'name_for_plotting',
+    'prior', 'prior_params', PARAM_UNBOUNDED_COLUMN, 'comment',
+})
+
+
 # How wide the derived range is, in standard deviations either side of the prior's centre.
 # Five puts ~1 sample in 3.5 million outside it, so the box is not meaningfully constraining
 # while staying finite -- which it must be. min/max are not only the prior's truncation: they
@@ -618,6 +638,11 @@ def derive_bounds_from_prior(prior_type, params, row_idx=None):
 PARAM_PRIOR_PARAM_NAMES = tuple(
     spec['name'] for meta in PARAM_PRIOR_TYPES.values() for spec in meta['params']
 )
+
+# The CSV columns that become prior_params entries in the JSON structure rather than top-level
+# keys. Derived from the prior declarations so the converter cannot miss a newly added
+# hyper-parameter (params_for_id JSON, issue #355 follow-up).
+PARAMS_FOR_ID_CSV_PRIOR_COLUMNS = tuple(PARAM_PRIOR_PARAM_NAMES)
 
 # What an absent, blank or NaN `prior` entry means -- and what the whole column defaults to
 # when params_for_id has no `prior` at all.
@@ -2980,15 +3005,176 @@ class ObsAndParamDataParser(object):
         
         return protocol
     
+    @staticmethod
+    def _qname_to_vessel_and_param(qname):
+        """Split a 'component/param' qname. rsplit so a component containing '/' still works."""
+        if '/' not in qname:
+            raise ValueError(
+                f"params_for_id target {qname!r} is not a 'component/param' name. Targets are "
+                f"full qualified names, e.g. 'aortic_root/C' or 'global/q_lv_init'.")
+        vessel, param = qname.rsplit('/', 1)
+        return vessel.strip(), param.strip()
+
+    @classmethod
+    def params_for_id_csv_to_json(cls, csv_text_or_path):
+        """Convert a legacy params_for_id CSV into the canonical JSON structure.
+
+        Pure: text (or a path) in, dict out. No model, no solver, no simulation helper -- so a
+        front-end can show a user's existing CSV as JSON in an editor without loading anything.
+        The mapping is documented in the tutorial as well as implemented here, because a tool
+        without circulatory_autogen on sys.path has to be able to reproduce it.
+
+        Per row:
+            vessel_name='a b', param_name='C'  ->  targets: ['a/C', 'b/C']
+            min/max/param_type/name_for_plotting/comment  ->  same keys
+            prior + prior_mean/prior_std/...   ->  prior + prior_params: {...}
+            unbounded                          ->  unbounded (bool)
+            (none)                             ->  name, defaulting to the first target
+        """
+        import io
+
+        if isinstance(csv_text_or_path, str) and ('\n' in csv_text_or_path
+                                                  or ',' in csv_text_or_path.split('\n')[0]) \
+                and not os.path.exists(csv_text_or_path):
+            handle = io.StringIO(csv_text_or_path)
+        else:
+            handle = csv_text_or_path
+
+        df = pd.read_csv(handle, dtype=str)
+        df = df.rename(columns=lambda c: c.strip())
+        for column in df.columns:
+            df[column] = df[column].apply(lambda v: v.strip() if isinstance(v, str) else v)
+
+        def _present(value):
+            if value is None:
+                return False
+            if isinstance(value, float) and np.isnan(value):
+                return False
+            return str(value).strip() != ''
+
+        params = []
+        for idx in range(df.shape[0]):
+            row = df.iloc[idx]
+            vessels = [v for v in str(row.get('vessel_name', '') or '').split() if v]
+            param_name = str(row.get('param_name', '') or '').strip()
+            if not vessels or not param_name:
+                raise ValueError(
+                    f'params_for_id CSV row {idx}: both vessel_name and param_name are required '
+                    f'(got vessel_name={row.get("vessel_name")!r}, param_name={param_name!r}).')
+
+            entry = {'targets': [f'{v}/{param_name}' for v in vessels]}
+            entry['name'] = entry['targets'][0]
+
+            for key in ('param_type', 'name_for_plotting', 'comment', 'prior'):
+                if key in df.columns and _present(row.get(key)):
+                    entry[key] = str(row[key]).strip()
+            for key in ('min', 'max'):
+                if key in df.columns and _present(row.get(key)):
+                    entry[key] = str(row[key]).strip()
+            if PARAM_UNBOUNDED_COLUMN in df.columns and _present(row.get(PARAM_UNBOUNDED_COLUMN)):
+                entry[PARAM_UNBOUNDED_COLUMN] = _truthy_flag(row[PARAM_UNBOUNDED_COLUMN])
+
+            prior_params = {name: str(row[name]).strip()
+                            for name in PARAMS_FOR_ID_CSV_PRIOR_COLUMNS
+                            if name in df.columns and _present(row.get(name))}
+            if prior_params:
+                entry['prior_params'] = prior_params
+
+            params.append(entry)
+
+        return {'version': PARAMS_FOR_ID_JSON_VERSION, 'defaults': {}, 'params': params}
+
+    @classmethod
+    def resolve_params_for_id_doc(cls, doc):
+        """Validate a params_for_id document and fold `defaults` into each entry.
+
+        Resolution is a shallow per-key override -- an entry's own key wins over `defaults`, which
+        wins over whatever circulatory_autogen derives later (the prior machinery's default_expr).
+        `prior_params` merges per key too, so a defaults block setting prior_std does not wipe an
+        entry's prior_mean.
+        """
+        if not isinstance(doc, dict):
+            raise ValueError(
+                f'params_for_id JSON must be an object with a "params" list, got '
+                f'{type(doc).__name__}.')
+
+        version = doc.get('version', PARAMS_FOR_ID_JSON_VERSION)
+        if int(version) != PARAMS_FOR_ID_JSON_VERSION:
+            raise ValueError(
+                f'params_for_id JSON version {version} is not supported by this version of '
+                f'circulatory_autogen (expected {PARAMS_FOR_ID_JSON_VERSION}).')
+
+        params = doc.get('params')
+        if not isinstance(params, list) or not params:
+            raise ValueError('params_for_id JSON needs a non-empty "params" list.')
+
+        defaults = doc.get('defaults') or {}
+        if not isinstance(defaults, dict):
+            raise ValueError(
+                f'params_for_id "defaults" must be an object, got {type(defaults).__name__}.')
+        unknown_defaults = set(defaults) - PARAMS_FOR_ID_ENTRY_KEYS
+        if unknown_defaults:
+            raise ValueError(
+                f'params_for_id "defaults" has unknown key(s) {sorted(unknown_defaults)}. '
+                f'Valid keys are the entry keys: {sorted(PARAMS_FOR_ID_ENTRY_KEYS)}.')
+
+        resolved = []
+        seen_names = {}
+        for idx, raw in enumerate(params):
+            if not isinstance(raw, dict):
+                raise ValueError(
+                    f'params_for_id entry {idx} must be an object, got {type(raw).__name__}.')
+            unknown = set(raw) - PARAMS_FOR_ID_ENTRY_KEYS
+            if unknown:
+                raise ValueError(
+                    f'params_for_id entry {idx} has unknown key(s) {sorted(unknown)}. Valid '
+                    f'keys: {sorted(PARAMS_FOR_ID_ENTRY_KEYS)}.')
+
+            entry = {k: v for k, v in defaults.items() if k != 'prior_params'}
+            entry.update({k: v for k, v in raw.items() if k != 'prior_params'})
+            merged_prior = dict(defaults.get('prior_params') or {})
+            merged_prior.update(raw.get('prior_params') or {})
+            if merged_prior:
+                entry['prior_params'] = merged_prior
+
+            targets = entry.get('targets')
+            if isinstance(targets, str):
+                targets = [targets]
+            if not targets or not isinstance(targets, list):
+                raise ValueError(
+                    f'params_for_id entry {idx} needs a non-empty "targets" list of '
+                    f'component/param names.')
+            entry['targets'] = [str(t).strip() for t in targets]
+            for qname in entry['targets']:
+                cls._qname_to_vessel_and_param(qname)
+
+            entry.setdefault('name', entry['targets'][0])
+            name = str(entry['name'])
+            if name in seen_names:
+                raise ValueError(
+                    f'params_for_id entry {idx} reuses the name {name!r}, already used by entry '
+                    f'{seen_names[name]}. Entry names identify a parameter and must be unique.')
+            seen_names[name] = idx
+            entry['name'] = name
+            resolved.append(entry)
+
+        return resolved
+
     def get_param_id_info(self, params_for_id_path, idxs_to_ignore= None):
     
         if not params_for_id_path:
             print(f'params_for_id_path cannot be None, exiting')
             return None
 
-        csv_parser = CSVFileParser()
-        input_params = csv_parser.get_data_as_dataframe_multistrings(params_for_id_path)
-        return self._build_param_id_info_from_df(input_params, idxs_to_ignore=idxs_to_ignore)
+        # One code path behind the front door: a .csv is converted to the JSON structure on read,
+        # and everything downstream sees only resolved JSON entries.
+        if str(params_for_id_path).lower().endswith('.json'):
+            with open(params_for_id_path, 'r') as f:
+                doc = json.load(f)
+        else:
+            doc = self.params_for_id_csv_to_json(params_for_id_path)
+        entries = self.resolve_params_for_id_doc(doc)
+        return self._build_param_id_info_from_entries(entries, idxs_to_ignore=idxs_to_ignore)
 
     def get_param_id_info_from_entries(self, params_for_id_entries, idxs_to_ignore=None):
         """
@@ -3013,109 +3199,83 @@ class ObsAndParamDataParser(object):
         input_params = pd.DataFrame(params_for_id_entries)
         return self._build_param_id_info_from_df(input_params, idxs_to_ignore=idxs_to_ignore)
 
-    def _build_param_id_info_from_df(self, input_params, idxs_to_ignore=None):
-        if input_params is None or input_params.empty:
+    def _build_param_id_info_from_entries(self, entries, idxs_to_ignore=None):
+        """Build param_id_info from resolved params_for_id entries (the canonical JSON shape).
+
+        This is the single builder; the CSV and the programmatic dict API both convert to entries
+        first. Output shape is unchanged from the CSV-driven builder it replaces -- param_names is
+        still a list of qname lists, one per calibrated variable -- so every consumer, including
+        #376's grouped set_param_vals and the Sobol split, keeps working untouched.
+        """
+        if not entries:
             raise ValueError("No parameter entries provided")
 
-        required_cols = {"vessel_name", "param_name", "min", "max"}
-        missing = required_cols - set(input_params.columns)
-        if missing:
-            raise ValueError(f"params_for_id is missing required columns: {sorted(list(missing))}")
-
-        input_params = input_params.copy()
-
-        def _to_list(val):
-            if isinstance(val, list):
-                return val
-            if val is None:
-                return []
-            if isinstance(val, float) and np.isnan(val):
-                return []
-            val_str = str(val).strip()
-            if val_str == "":
-                return []
-            return [entry.strip() for entry in val_str.split()]
-
-        input_params["vessel_name"] = input_params["vessel_name"].apply(_to_list)
-
-        # --- 1. Filter the DataFrame first ---
-        # Create a mask for indices to KEEP (not ignore)
         if idxs_to_ignore is not None:
-            all_indices = set(range(input_params.shape[0]))
-            valid_indices = sorted(list(all_indices - set(idxs_to_ignore)))
-            filtered_params = input_params.iloc[valid_indices].reset_index(drop=True)
-        else:
-            filtered_params = input_params.reset_index(drop=True)
+            ignore = set(idxs_to_ignore)
+            entries = [e for i, e in enumerate(entries) if i not in ignore]
+            if not entries:
+                raise ValueError("No parameter entries provided")
 
-        N_params = filtered_params.shape[0]
-
+        N_params = len(entries)
         param_id_info = {}
+        param_id_info["param_names"] = [list(e["targets"]) for e in entries]
+
+        # Simplified names for the generator, per target rather than per entry. Deciding the whole
+        # row from the first vessel meant a row mixing 'global' with named vessels emitted one gen
+        # name and dropped the rest, while param_names kept all of them, so the two positional
+        # lists stopped describing the same parameters (#350).
         param_names_for_gen = []
-        param_id_info["param_names"] = []
+        for entry in entries:
+            gen = []
+            for qname in entry["targets"]:
+                vessel, param = self._qname_to_vessel_and_param(qname)
+                gen.append(param if vessel == 'global' else f'{param}_{vessel}')
+            param_names_for_gen.append(gen)
 
-        # --- 2. Iterate ONLY over the filtered data ---
-        for II in range(N_params):
-            # Current row data from the filtered DataFrame
-            row = filtered_params.iloc[II]
+        def _numeric(key):
+            out = np.empty(N_params, dtype=float)
+            for II, entry in enumerate(entries):
+                raw = entry.get(key)
+                try:
+                    out[II] = float(raw) if raw is not None and str(raw).strip() != '' else np.nan
+                except (TypeError, ValueError):
+                    out[II] = np.nan
+            return out
 
-            # A. Build the full, complex names (e.g., 'vessel_name/param_name')
-            param_full_names = [
-                row["vessel_name"][JJ] + '/' + row["param_name"]
-                for JJ in range(len(row["vessel_name"]))
-            ]
-            param_id_info["param_names"].append(param_full_names)
+        param_id_info["param_mins"] = _numeric("min")
+        param_id_info["param_maxs"] = _numeric("max")
 
-            # B. Build the simplified names for generator/code
-            # Per vessel, not per row. Deciding the whole row from vessel_name[0] meant a
-            # row mixing 'global' with named vessels emitted a single gen name and dropped
-            # every vessel after the first -- while param_names above kept all of them, so
-            # the two positional lists stopped describing the same parameters (#350).
-            param_names_for_gen.append([
-                row["param_name"] if vessel == 'global'
-                else row["param_name"] + '_' + vessel
-                for vessel in row["vessel_name"]
-            ])
+        def _plot_name(entry):
+            raw = entry.get("name_for_plotting")
+            if raw is None or (isinstance(raw, float) and np.isnan(raw)) or str(raw).strip() == '':
+                return entry["targets"][0]
+            return raw
 
-        # --- 3. Set Arrays using the filtered DataFrame ---
-        param_id_info["param_mins"] = pd.to_numeric(
-            filtered_params["min"], errors="coerce").to_numpy(dtype=float)
-        param_id_info["param_maxs"] = pd.to_numeric(
-            filtered_params["max"], errors="coerce").to_numpy(dtype=float)
+        param_id_info["param_names_for_plotting"] = np.array(
+            [_plot_name(entry) for entry in entries])
 
-        if "name_for_plotting" in filtered_params.columns:
-            param_id_info["param_names_for_plotting"] = filtered_params["name_for_plotting"].to_numpy()
-        else:
-            param_id_info["param_names_for_plotting"] = np.array([p_names[0]
-                                                                  for p_names in param_id_info["param_names"]])
+        param_id_info["param_prior_types"] = np.array([
+            normalise_prior_type(entries[II].get("prior"), row_idx=II) for II in range(N_params)
+        ])
 
-        if "prior" in filtered_params.columns:
-            # Validated and canonicalised here, at the one place the column is read, so an
-            # unusable prior is a parse error naming the row rather than a parameter that
-            # quietly stops being bounded once the sampler starts.
-            param_id_info["param_prior_types"] = np.array([
-                normalise_prior_type(filtered_params["prior"].iloc[II], row_idx=II)
-                for II in range(N_params)
-            ])
-        else:
-            param_id_info["param_prior_types"] = np.array([DEFAULT_PARAM_PRIOR_TYPE] * N_params)
-
-        # The values each prior takes (the exponential's rate, the normal's mean and std),
-        # one dict per parameter. Validated against what that row's prior actually declares,
-        # so a hyper-parameter set on a prior that ignores it is a parse error rather than a
-        # silently different posterior.
+        # normalise_prior_params takes anything with .get(), so the entry's prior_params mapping
+        # is passed straight in -- the hyper-parameters live under their own key in JSON, but the
+        # validation that owns which prior takes which is unchanged.
+        # min/max travel with the hyper-parameters: normalise_prior_params checks a centre
+        # declared `within_bounds` against the row's own range, and every prior is truncated to
+        # [min, max], so a mean outside it describes a peak the sampler can never reach. Passing
+        # prior_params alone silently disabled that check (#365).
         param_id_info["param_prior_params"] = [
             normalise_prior_params(
-                param_id_info["param_prior_types"][II], filtered_params.iloc[II], row_idx=II)
+                param_id_info["param_prior_types"][II],
+                {**dict(entries[II].get("prior_params") or {}),
+                 'min': entries[II].get('min'), 'max': entries[II].get('max')},
+                row_idx=II)
             for II in range(N_params)
         ]
 
-        # An unbounded parameter has no range of its own: its prior says where it lives, and
-        # the range CA needs for everything else is derived from that prior. Done after the
-        # priors are parsed, because that is what it is derived from.
         param_id_info["param_unbounded"] = np.array([
-            _truthy_flag(filtered_params.iloc[II].get(PARAM_UNBOUNDED_COLUMN)
-                         if PARAM_UNBOUNDED_COLUMN in filtered_params.columns else None)
-            for II in range(N_params)
+            _truthy_flag(entries[II].get(PARAM_UNBOUNDED_COLUMN)) for II in range(N_params)
         ])
         for II in range(N_params):
             if not param_id_info["param_unbounded"][II]:
@@ -3134,8 +3294,75 @@ class ObsAndParamDataParser(object):
             param_id_info["param_maxs"][II] = hi
 
         param_id_info["param_names_for_gen"] = param_names_for_gen
+        param_id_info["param_entry_names"] = [e["name"] for e in entries]
 
         return param_id_info
+
+    def _build_param_id_info_from_df(self, input_params, idxs_to_ignore=None):
+        """Adapter for the programmatic entries API (vessel_name / param_name dicts).
+
+        The documented in-code form of params_for_id is a list of
+        {vessel_name, param_name, min, max, name_for_plotting}, and vessel_name may be a list
+        sharing one calibrated value. That is converted to canonical entries here so it goes
+        through the same builder as the CSV and the JSON -- one code path, three front doors.
+        """
+        if input_params is None or getattr(input_params, 'empty', False):
+            raise ValueError("No parameter entries provided")
+
+        required_cols = {"vessel_name", "param_name", "min", "max"}
+        missing = required_cols - set(input_params.columns)
+        if missing:
+            raise ValueError(f"params_for_id is missing required columns: {sorted(list(missing))}")
+
+        def _vessels(val):
+            if isinstance(val, list):
+                return [str(v).strip() for v in val]
+            if val is None or (isinstance(val, float) and np.isnan(val)):
+                return []
+            return [v.strip() for v in str(val).strip().split() if v.strip()]
+
+        def _present(value):
+            if value is None:
+                return False
+            if isinstance(value, float) and np.isnan(value):
+                return False
+            return str(value).strip() != ''
+
+        entries = []
+        for II in range(input_params.shape[0]):
+            row = input_params.iloc[II]
+            vessels = _vessels(row["vessel_name"])
+            param_name = str(row["param_name"]).strip()
+            if not vessels or not param_name:
+                raise ValueError(
+                    f'params_for_id entry {II}: both vessel_name and param_name are required.')
+            entry = {'targets': [f'{v}/{param_name}' for v in vessels]}
+            entry['name'] = entry['targets'][0]
+            for key in ('param_type', 'name_for_plotting', 'comment', 'prior', 'min', 'max'):
+                if key in input_params.columns and _present(row.get(key)):
+                    entry[key] = row[key]
+            if PARAM_UNBOUNDED_COLUMN in input_params.columns \
+                    and _present(row.get(PARAM_UNBOUNDED_COLUMN)):
+                entry[PARAM_UNBOUNDED_COLUMN] = _truthy_flag(row[PARAM_UNBOUNDED_COLUMN])
+            prior_params = {name: row[name] for name in PARAMS_FOR_ID_CSV_PRIOR_COLUMNS
+                            if name in input_params.columns and _present(row.get(name))}
+            if prior_params:
+                entry['prior_params'] = prior_params
+            entries.append(entry)
+
+        # Names come from the first target here, so duplicates are possible in a way the JSON
+        # front door forbids; de-duplicate positionally rather than refusing a form that has
+        # always been legal.
+        seen = {}
+        for entry in entries:
+            base = entry['name']
+            if base in seen:
+                seen[base] += 1
+                entry['name'] = f'{base}#{seen[base]}'
+            else:
+                seen[base] = 0
+
+        return self._build_param_id_info_from_entries(entries, idxs_to_ignore=idxs_to_ignore)
 
     def save_param_names(self, param_id_info, output_dir):
         """

--- a/src/sensitivity_analysis/sobolSA.py
+++ b/src/sensitivity_analysis/sobolSA.py
@@ -224,9 +224,20 @@ class sobol_SA():
         if not hasattr(self, "param_id_info") or not self.param_id_info:
             raise ValueError("param_id_info is not set. Please run __set_and_save_param_names() first.")
 
+        # A params_for_id row naming several vessels means "one calibrated value drives all of
+        # these", so it is *one* variable to the sampler and must be set on *every* member.
+        # Those are two different things and need two different lists (issue #355):
+        #   param_names   -- kept grouped, handed to set_param_vals, which broadcasts the shared
+        #                    sampled value across the group
+        #   param_labels  -- flattened to one name per variable, for the SALib problem and plots
+        # Collapsing to the first name for both is what made a grouped SA vary one vessel while
+        # calibration varied all of them, silently answering a different question.
+        grouped_names = list(self.param_id_info["param_names"])
         SA_info = {
             "sample_type": sample_type,
-            "param_names": [name[0] if isinstance(name, list) else name for name in self.param_id_info["param_names"]],
+            "param_names": grouped_names,
+            "param_labels": ['+'.join(n) if isinstance(n, (list, tuple)) else n
+                             for n in grouped_names],
             "num_samples": num_samples,
             "param_mins": list(self.param_id_info["param_mins"]),
             "param_maxs": list(self.param_id_info["param_maxs"])
@@ -236,9 +247,22 @@ class sobol_SA():
         #     print("Sensitivity Analysis Configuration:")
         #     print(json.dumps(SA_info, indent=4))
 
-        self.num_params = len(SA_info["param_names"])
+        self.num_params = len(SA_info["param_labels"])
 
         return SA_info
+
+    def _param_labels(self):
+        """One display label per sampled variable.
+
+        Derived from param_names when 'param_labels' is absent, so an SA_info built by hand or
+        loaded from an older run still works -- the key was added with grouped-parameter support
+        (issue #355) and SA_info is a semi-public structure.
+        """
+        labels = self.SA_info.get("param_labels")
+        if labels is not None:
+            return labels
+        return ['+'.join(n) if isinstance(n, (list, tuple)) else n
+                for n in self.SA_info["param_names"]]
 
     def create_SA_info(self, sample_type, num_samples):
         # Backwards compatibility alias
@@ -274,7 +298,7 @@ class sobol_SA():
 
         problem = {
             'num_vars': self.num_params,
-            'names': self.SA_info["param_names"],
+            'names': self._param_labels(),
             'bounds': list(zip(self.SA_info["param_mins"], self.SA_info["param_maxs"]))
         }
         self.problem = problem
@@ -463,12 +487,12 @@ class sobol_SA():
             # output_name = self.obs_info["names_for_plotting"][i] if hasattr(self, "obs_info") else f"Output_{i}"
 
             # Set figure width adaptively based on number of parameters (xticks)
-            fig_width = max(12, 1.0 * len(self.SA_info["param_names"]))
+            fig_width = max(12, 1.0 * len(self._param_labels()))
             plt.figure(figsize=(fig_width, 5))
             plt.bar(x - 0.2, S1, width=0.4, label='First-order', color='blue', alpha=0.7)
             plt.bar(x + 0.2, ST, width=0.4, label='Total-order', color='red', alpha=0.7)
 
-            plt.xticks(x, self.SA_info["param_names"], rotation=45, fontsize=8)
+            plt.xticks(x, self._param_labels(), rotation=45, fontsize=8)
             plt.ylabel('Sensitivity Index')
             plt.title(rf'Sobol Sensitivity - {output_name}')
             plt.legend()
@@ -496,9 +520,9 @@ class sobol_SA():
             output_name = rf"{self.obs_info['names_for_plotting'][i]} - experiment{self.obs_info['experiment_idxs'][i]}, subexperiment{self.obs_info['subexperiment_idxs'][i]}"
 
             # plt.figure(figsize=(6, 5))
-            fig_width = max(6, 1.0 * len(self.SA_info["param_names"]))
+            fig_width = max(6, 1.0 * len(self._param_labels()))
             plt.figure(figsize=(fig_width, fig_width))
-            sns.heatmap(S2, annot=True, fmt=".2f", xticklabels=self.SA_info["param_names"], yticklabels=self.SA_info["param_names"], cmap="coolwarm")
+            sns.heatmap(S2, annot=True, fmt=".2f", xticklabels=self._param_labels(), yticklabels=self._param_labels(), cmap="coolwarm")
             plt.title(rf"2nd order Sobol Indices - {output_name}")
             plt.tight_layout()
 
@@ -557,7 +581,7 @@ class sobol_SA():
         Generates 2D heatmaps for first-order (S1) and total-order (ST) Sobol indices.
         
         The heatmaps show:
-        Y-axis: Input Parameters (self.SA_info["param_names"])
+        Y-axis: Input Parameters (self._param_labels())
         X-axis: Model Outputs (concatenated names from self.obs_info)
         Color: Sobol Index Value
         
@@ -655,7 +679,7 @@ class sobol_SA():
             S2_all (np.ndarray): Second-order Sobol indices, shape (n_outputs, n_params, n_params)
         """
         n_outputs = S1_all.shape[0]
-        param_names = self.SA_info["param_names"]
+        param_names = self._param_labels()
 
         # Prepare output/feature names. Two data_items that resolve to the same
         # (name_for_plotting, experiment, subexperiment) produce identical column

--- a/src/solver_wrappers/casadi_python_solver_helper.py
+++ b/src/solver_wrappers/casadi_python_solver_helper.py
@@ -655,7 +655,25 @@ class SimulationHelper:
         return {name: val for name, val in zip(variable_names, values)}
 
     def _create_param_subset(self, param_names, param_vals=None):
-        param_names = [x[0] for x in param_names]
+        # A grouped params_for_id row ("one calibrated value drives these N vessels") cannot be
+        # honoured here yet. This builds the *symbolic* subset that the cost jacobian is taken
+        # against, so it needs one SX symbol per group substituted into every member's slot --
+        # otherwise the derivative is with respect to the first member alone.
+        #
+        # Refusing rather than dropping the extra members: silently calibrating only the first
+        # vessel is what this backend did before, and it produced a cost curve bit-identical to
+        # the ungrouped one, so nothing downstream could tell. Broadcasting on the numeric side
+        # only would be worse still -- the cost would move all members while the gradient
+        # tracked one, so the optimiser would descend a different function than it evaluates.
+        grouped = [x for x in param_names if isinstance(x, (list, tuple)) and len(x) > 1]
+        if grouped:
+            raise NotImplementedError(
+                f"Grouped parameters are not yet supported by the CasADi backend: {grouped}. "
+                f"The symbolic parameter subset takes one symbol per params_for_id row, so the "
+                f"gradient would be with respect to the first vessel only. Use model_type "
+                f"'cellml_only' with solver 'CVODE_myokit' for grouped calibration, or give "
+                f"each vessel its own row. See issue #355.")
+        param_names = [x[0] if isinstance(x, (list, tuple)) else x for x in param_names]
 
         # Resolve each param to its VARIABLE_INFO index, then find its SX symbol
         var_indices = []   # VARIABLE_INFO indices

--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -1,6 +1,8 @@
 import os
 import copy
 import numpy as np
+
+from solver_wrappers.param_grouping import pair_names_with_values
 import myokit
 from myokit.formats import cellml as cellml_format
 # src_dir = os.path.join(os.path.dirname(__file__), '..')
@@ -830,11 +832,8 @@ class SimulationHelper:
         # states they initialise are refreshed afterwards.
         changed_var_qnames = set()
         for idx, name_or_list in enumerate(param_names):
-            names = name_or_list if isinstance(name_or_list, list) else [name_or_list]
-            vals = param_vals[idx]
-            if not isinstance(vals, (list, tuple, np.ndarray)):
-                vals = [vals]
-            for name, val in zip(names, vals):
+            for name, val in pair_names_with_values(name_or_list, param_vals[idx],
+                                                   'set_param_vals'):
                 kind, qname = self._resolve_name(name)
 
                 if kind == "state":
@@ -933,11 +932,8 @@ class SimulationHelper:
         """
         found_qname = None
         for idx, name_or_list in enumerate(param_names):
-            names = name_or_list if isinstance(name_or_list, list) else [name_or_list]
-            vals = param_vals[idx]
-            if not isinstance(vals, (list, tuple, np.ndarray)):
-                vals = [vals]
-            for name, val in zip(names, vals):
+            for name, val in pair_names_with_values(name_or_list, param_vals[idx],
+                                                   'paced-variable scan'):
                 if isinstance(val, str):
                     kind, qname = self._resolve_name(name)
                     if kind != "var":

--- a/src/solver_wrappers/param_grouping.py
+++ b/src/solver_wrappers/param_grouping.py
@@ -1,0 +1,56 @@
+"""Pairing a params_for_id row's names with its value(s).
+
+A ``params_for_id`` row may name several vessels, which means "one calibrated value drives all
+of these" -- the grouped-parameter feature. Every backend's ``set_param_vals`` therefore receives
+entries that are either a single name or a list of names, against a single shared value.
+
+The obvious pairing, ``zip(names, vals)``, is wrong for exactly that case: with two names and one
+value, ``zip`` stops at the shorter sequence and silently sets only the first name. That is what
+made a grouped row calibrate its first vessel and leave the rest at their defaults, on every
+backend, with no error and a cost curve identical to the ungrouped one.
+
+``pair_names_with_values`` is the single place that decides the pairing, so the broadcast rule
+cannot drift between backends, and a genuine length mismatch raises instead of truncating.
+"""
+
+
+def as_name_list(name_or_list):
+    """Normalise a params_for_id entry to a list of names."""
+    if isinstance(name_or_list, (list, tuple)):
+        return list(name_or_list)
+    return [name_or_list]
+
+
+def as_value_list(value_or_list):
+    """Normalise a value entry to a list, without splitting strings (a protocol trace key)."""
+    if isinstance(value_or_list, str):
+        return [value_or_list]
+    if isinstance(value_or_list, (list, tuple)):
+        return list(value_or_list)
+    if hasattr(value_or_list, 'tolist') and getattr(value_or_list, 'ndim', 1) > 0:
+        return list(value_or_list.tolist())
+    return [value_or_list]
+
+
+def pair_names_with_values(name_or_list, value_or_list, context=''):
+    """Yield ``(name, value)`` for one params_for_id entry, broadcasting a shared value.
+
+    - N names, 1 value  -> the value is applied to all N. This is the grouped-parameter case
+      and the reason this helper exists.
+    - N names, N values -> paired positionally.
+    - anything else     -> ValueError, rather than the silent truncation ``zip`` would do.
+    """
+    names = as_name_list(name_or_list)
+    values = as_value_list(value_or_list)
+
+    if len(values) == 1 and len(names) > 1:
+        values = values * len(names)
+
+    if len(names) != len(values):
+        where = f' ({context})' if context else ''
+        raise ValueError(
+            f'params_for_id entry{where} has {len(names)} name(s) {names} but {len(values)} '
+            f'value(s). A grouped entry takes one shared value for all its names, or one value '
+            f'per name.')
+
+    return list(zip(names, values))

--- a/src/solver_wrappers/python_solver_helper.py
+++ b/src/solver_wrappers/python_solver_helper.py
@@ -1,5 +1,7 @@
 import importlib.util
 import numpy as np
+
+from solver_wrappers.param_grouping import pair_names_with_values
 from scipy.integrate import solve_ivp
 import copy
 import sys
@@ -331,10 +333,7 @@ class SimulationHelper:
                     pass
                 return [x]
 
-            name_or_list = _to_list(name_or_list)
-            vals = _to_list(vals)
-
-            for name, val in zip(name_or_list, vals):
+            for name, val in pair_names_with_values(name_or_list, vals, 'set_param_vals'):
                 if type(val) == str:
                     raise NotImplementedError(
                         f"'{name}' was given the protocol trace name '{val}', but the "

--- a/tests/test_grouped_params.py
+++ b/tests/test_grouped_params.py
@@ -1,0 +1,110 @@
+"""Grouped params_for_id rows: one calibrated value driving several vessels (issue #355).
+
+The feature had no tests at all, and was broken end to end: `zip(names, vals)` with N names and
+one shared value stops at the shorter sequence, so only the first vessel was ever set. A grouped
+row produced a cost curve bit-identical to the ungrouped one -- nothing downstream could tell it
+was calibrating a single vessel.
+"""
+import numpy as np
+import pytest
+
+from solver_wrappers.param_grouping import (
+    as_name_list, as_value_list, pair_names_with_values)
+
+
+@pytest.mark.unit
+def test_one_shared_value_reaches_every_member_of_a_group():
+    """The whole point of a grouped row. zip() silently dropped everything after the first."""
+    pairs = pair_names_with_values(['aortic_root/C', 'par/C'], 1.5e-8)
+    assert pairs == [('aortic_root/C', 1.5e-8), ('par/C', 1.5e-8)]
+
+
+@pytest.mark.unit
+def test_a_group_of_three_broadcasts_to_all_three():
+    pairs = pair_names_with_values(['a/R', 'b/R', 'c/R'], 2.0)
+    assert [n for n, _ in pairs] == ['a/R', 'b/R', 'c/R']
+    assert {v for _, v in pairs} == {2.0}
+
+
+@pytest.mark.unit
+def test_an_ungrouped_entry_is_unchanged():
+    assert pair_names_with_values('aortic_root/C', 1.5e-8) == [('aortic_root/C', 1.5e-8)]
+
+
+@pytest.mark.unit
+def test_per_name_values_are_paired_positionally():
+    """N names with N values keeps the existing meaning -- broadcasting must not override it."""
+    pairs = pair_names_with_values(['a/R', 'b/R'], [1.0, 2.0])
+    assert pairs == [('a/R', 1.0), ('b/R', 2.0)]
+
+
+@pytest.mark.unit
+def test_a_length_mismatch_raises_instead_of_truncating():
+    """The failure this whole issue was: zip() drops the tail without a word."""
+    with pytest.raises(ValueError, match='3 name'):
+        pair_names_with_values(['a/R', 'b/R', 'c/R'], [1.0, 2.0])
+
+
+@pytest.mark.unit
+def test_a_protocol_trace_key_is_one_value_not_a_string_of_characters():
+    """A string value is a protocol_traces key. Splitting it per character would pair 'p','a','c'
+    with the group's names and set three nonsense values."""
+    pairs = pair_names_with_values(['a/u', 'b/u'], 'pace')
+    assert pairs == [('a/u', 'pace'), ('b/u', 'pace')]
+
+
+@pytest.mark.unit
+def test_numpy_arrays_are_accepted_as_value_lists():
+    pairs = pair_names_with_values(['a/R', 'b/R'], np.array([1.0, 2.0]))
+    assert [v for _, v in pairs] == [1.0, 2.0]
+
+
+@pytest.mark.unit
+def test_a_zero_dimensional_numpy_scalar_broadcasts():
+    pairs = pair_names_with_values(['a/R', 'b/R'], np.float64(3.0))
+    assert [v for _, v in pairs] == [3.0, 3.0]
+
+
+@pytest.mark.unit
+def test_normalisers_agree_with_the_pairing():
+    assert as_name_list('x') == ['x'] and as_name_list(['x', 'y']) == ['x', 'y']
+    assert as_value_list('trace') == ['trace']
+    assert as_value_list(1.0) == [1.0]
+
+
+@pytest.mark.unit
+def test_sobol_keeps_groups_for_setting_and_flattens_only_for_labels():
+    """The SA fix: a group is one variable to the sampler but N parameters to set.
+
+    Collapsing to the first name for both is what made a grouped SA vary one vessel while
+    calibration varied all of them -- the two silently answered different questions.
+    """
+    from sensitivity_analysis.sobolSA import sobol_SA
+
+    sa = sobol_SA.__new__(sobol_SA)
+    sa.param_id_info = {
+        'param_names': [['aortic_root/C', 'par/C'], 'heart/R'],
+        'param_mins': [1e-9, 1.0],
+        'param_maxs': [5e-8, 2.0],
+    }
+    info = sa._create_SA_info('sobol', 8)
+
+    # one variable per row for the sampler...
+    assert info['param_labels'] == ['aortic_root/C+par/C', 'heart/R']
+    assert sa.num_params == 2
+    # ...but the full group survives for set_param_vals
+    assert info['param_names'] == [['aortic_root/C', 'par/C'], 'heart/R']
+
+
+@pytest.mark.unit
+def test_the_casadi_backend_refuses_a_group_rather_than_dropping_members():
+    """CasADi builds a symbolic subset with one symbol per row, so a group would be
+    differentiated with respect to its first member only. Until that is fixed properly it must
+    fail loudly: silently calibrating one vessel is what this issue is about, and broadcasting
+    on the numeric side alone would make the cost and the gradient different functions."""
+    import inspect
+    from solver_wrappers import casadi_python_solver_helper as helper
+
+    src = inspect.getsource(helper.SimulationHelper._create_param_subset)
+    assert 'NotImplementedError' in src
+    assert '#355' in src

--- a/tests/test_params_for_id_json.py
+++ b/tests/test_params_for_id_json.py
@@ -1,0 +1,223 @@
+"""params_for_id as JSON, with the CSV converted on read.
+
+The CSV stays readable forever; it is converted to the JSON structure at the front door and
+everything downstream sees only resolved entries. The whole backwards-compatibility risk lives in
+that conversion: a silent error there would misparameterise a model without failing, so the
+round-trip is asserted exhaustively over every fixture in resources/ rather than by spot checks.
+"""
+import json
+import pathlib
+
+import numpy as np
+import pytest
+
+from parsers.PrimitiveParsers import (
+    ObsAndParamDataParser, PARAMS_FOR_ID_ENTRY_KEYS, PARAMS_FOR_ID_JSON_VERSION)
+
+RESOURCES = pathlib.Path(__file__).resolve().parent.parent / 'resources'
+FIXTURES = sorted(RESOURCES.glob('*params_for_id.csv'))
+
+
+def _parser():
+    return ObsAndParamDataParser()
+
+
+def _assert_info_equal(a, b, context):
+    assert set(a) == set(b), f'{context}: key sets differ'
+    for key in a:
+        left, right = a[key], b[key]
+        if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
+            left, right = np.asarray(left), np.asarray(right)
+            assert left.shape == right.shape, f'{context}: {key} shape'
+            if left.dtype.kind == 'f':
+                assert np.allclose(left, right, equal_nan=True), f'{context}: {key}'
+            else:
+                assert list(left) == list(right), f'{context}: {key}'
+        else:
+            assert left == right, f'{context}: {key}'
+
+
+@pytest.mark.unit
+def test_there_are_fixtures_to_check():
+    """A glob that silently matched nothing would make the whole suite below vacuous."""
+    assert len(FIXTURES) >= 15, [f.name for f in FIXTURES]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('csv_path', FIXTURES, ids=lambda p: p.stem)
+def test_every_fixture_converts_to_json_and_back_to_the_same_param_id_info(csv_path, tmp_path):
+    """CSV -> JSON -> param_id_info must equal CSV -> param_id_info, key by key.
+
+    This is the backwards-compatibility guarantee. Every existing user study is a CSV.
+    """
+    parser = _parser()
+    from_csv = parser.get_param_id_info(str(csv_path))
+
+    doc = parser.params_for_id_csv_to_json(str(csv_path))
+    json_path = tmp_path / f'{csv_path.stem}.json'
+    json_path.write_text(json.dumps(doc))
+    from_json = parser.get_param_id_info(str(json_path))
+
+    _assert_info_equal(from_csv, from_json, csv_path.name)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('csv_path', FIXTURES, ids=lambda p: p.stem)
+def test_the_converter_output_is_json_serialisable_and_well_formed(csv_path):
+    """CUFLynx reads this straight into an editor, so it must be plain JSON with known keys."""
+    doc = _parser().params_for_id_csv_to_json(str(csv_path))
+    json.dumps(doc)  # raises on numpy scalars or NaN-typed leftovers
+
+    assert doc['version'] == PARAMS_FOR_ID_JSON_VERSION
+    assert isinstance(doc['params'], list) and doc['params']
+    for entry in doc['params']:
+        assert set(entry) <= PARAMS_FOR_ID_ENTRY_KEYS, set(entry) - PARAMS_FOR_ID_ENTRY_KEYS
+        assert entry['targets'] and all('/' in t for t in entry['targets'])
+        assert entry['name']
+
+
+@pytest.mark.unit
+def test_a_grouped_row_becomes_one_entry_with_several_targets():
+    """vessel_name='a b' is one calibrated value over two qnames -- one entry, two targets."""
+    csv_text = ('vessel_name,param_name,min,max\n'
+                'a b,C,1e-9,5e-8\n')
+    doc = _parser().params_for_id_csv_to_json(csv_text)
+    assert len(doc['params']) == 1
+    assert doc['params'][0]['targets'] == ['a/C', 'b/C']
+
+
+@pytest.mark.unit
+def test_the_global_plus_named_vessel_gen_names_survive_conversion():
+    """#368/#350: a row mixing 'global' with named vessels must emit one gen name per vessel.
+
+    Deciding the whole row from the first vessel dropped every vessel after it, while param_names
+    kept them, so the two positional lists stopped describing the same parameters.
+    """
+    csv_text = ('vessel_name,param_name,min,max\n'
+                'global a b,C,1e-9,5e-8\n')
+    parser = _parser()
+    info = parser._build_param_id_info_from_entries(
+        parser.resolve_params_for_id_doc(parser.params_for_id_csv_to_json(csv_text)))
+
+    assert info['param_names'] == [['global/C', 'a/C', 'b/C']]
+    # 'global' contributes the bare param name; a named vessel gets the suffix
+    assert info['param_names_for_gen'] == [['C', 'C_a', 'C_b']]
+
+
+@pytest.mark.unit
+def test_targets_may_mix_different_parameter_names():
+    """The reason for JSON: a CSV row has one param_name for all its vessels, so an arbitrary
+    group could not be written at all."""
+    parser = _parser()
+    doc = {'version': 1, 'params': [
+        {'name': 'mixed', 'targets': ['aortic_root/C', 'heart/E_lv_A'], 'min': 0.5, 'max': 2.0},
+    ]}
+    info = parser._build_param_id_info_from_entries(parser.resolve_params_for_id_doc(doc))
+    assert info['param_names'] == [['aortic_root/C', 'heart/E_lv_A']]
+    assert info['param_names_for_gen'] == [['C_aortic_root', 'E_lv_A_heart']]
+
+
+@pytest.mark.unit
+def test_defaults_apply_and_an_entry_overrides_them():
+    """The 'easier to change general priors' ask: set the family once at the top."""
+    parser = _parser()
+    doc = {'version': 1,
+           'defaults': {'prior': 'uniform', 'param_type': 'const'},
+           'params': [
+               {'name': 'a', 'targets': ['x/C'], 'min': 1.0, 'max': 2.0},
+               {'name': 'b', 'targets': ['y/C'], 'min': 1.0, 'max': 2.0, 'prior': 'normal',
+                'prior_params': {'prior_mean': 1.5, 'prior_std': 0.1}},
+           ]}
+    info = parser._build_param_id_info_from_entries(parser.resolve_params_for_id_doc(doc))
+    assert list(info['param_prior_types']) == ['uniform', 'normal']
+
+
+@pytest.mark.unit
+def test_prior_params_merge_per_key_rather_than_wholesale():
+    """A defaults block setting one hyper-parameter must not wipe an entry's other one."""
+    parser = _parser()
+    doc = {'version': 1,
+           'defaults': {'prior': 'normal', 'prior_params': {'prior_std': 0.25}},
+           'params': [{'name': 'a', 'targets': ['x/C'], 'min': 1.0, 'max': 2.0,
+                       'prior_params': {'prior_mean': 1.5}}]}
+    entries = parser.resolve_params_for_id_doc(doc)
+    assert entries[0]['prior_params'] == {'prior_std': 0.25, 'prior_mean': 1.5}
+
+
+@pytest.mark.unit
+def test_an_unknown_entry_key_is_refused():
+    """Same stance as operation_kwargs/cost_kwargs: a key nothing reads changes nothing and gives
+    no sign it was ignored."""
+    parser = _parser()
+    with pytest.raises(ValueError, match='unknown key'):
+        parser.resolve_params_for_id_doc(
+            {'version': 1, 'params': [{'targets': ['x/C'], 'min': 1, 'max': 2, 'mn': 0.1}]})
+
+
+@pytest.mark.unit
+def test_an_unknown_defaults_key_is_refused():
+    parser = _parser()
+    with pytest.raises(ValueError, match='unknown key'):
+        parser.resolve_params_for_id_doc(
+            {'version': 1, 'defaults': {'priorr': 'uniform'},
+             'params': [{'targets': ['x/C'], 'min': 1, 'max': 2}]})
+
+
+@pytest.mark.unit
+def test_duplicate_entry_names_are_refused():
+    parser = _parser()
+    with pytest.raises(ValueError, match='reuses the name'):
+        parser.resolve_params_for_id_doc({'version': 1, 'params': [
+            {'name': 'dup', 'targets': ['x/C'], 'min': 1, 'max': 2},
+            {'name': 'dup', 'targets': ['y/C'], 'min': 1, 'max': 2},
+        ]})
+
+
+@pytest.mark.unit
+def test_a_target_without_a_component_is_refused():
+    """The most common typo, and it used to fail much later and less clearly."""
+    parser = _parser()
+    with pytest.raises(ValueError, match="not a 'component/param' name"):
+        parser.resolve_params_for_id_doc(
+            {'version': 1, 'params': [{'targets': ['C'], 'min': 1, 'max': 2}]})
+
+
+@pytest.mark.unit
+def test_an_unsupported_version_is_refused():
+    parser = _parser()
+    with pytest.raises(ValueError, match='version'):
+        parser.resolve_params_for_id_doc(
+            {'version': 99, 'params': [{'targets': ['x/C'], 'min': 1, 'max': 2}]})
+
+
+@pytest.mark.unit
+def test_name_defaults_to_the_first_target():
+    parser = _parser()
+    entries = parser.resolve_params_for_id_doc(
+        {'version': 1, 'params': [{'targets': ['a/C', 'b/C'], 'min': 1, 'max': 2}]})
+    assert entries[0]['name'] == 'a/C'
+
+
+@pytest.mark.unit
+def test_idxs_to_ignore_filters_entries():
+    parser = _parser()
+    doc = {'version': 1, 'params': [
+        {'name': 'a', 'targets': ['x/C'], 'min': 1, 'max': 2},
+        {'name': 'b', 'targets': ['y/C'], 'min': 3, 'max': 4},
+    ]}
+    entries = parser.resolve_params_for_id_doc(doc)
+    info = parser._build_param_id_info_from_entries(entries, idxs_to_ignore=[0])
+    assert info['param_names'] == [['y/C']]
+    assert info['param_entry_names'] == ['b']
+
+
+@pytest.mark.unit
+def test_the_programmatic_dict_api_still_works_and_agrees_with_the_csv():
+    """The in-code params_for_id form is documented in CLAUDE.md and must keep working."""
+    parser = _parser()
+    from_entries = parser.get_param_id_info_from_entries([
+        {'vessel_name': 'aortic_root', 'param_name': 'C', 'min': 1e-9, 'max': 5e-8},
+        {'vessel_name': ['a', 'b'], 'param_name': 'R', 'min': 1.0, 'max': 2.0},
+    ])
+    assert from_entries['param_names'] == [['aortic_root/C'], ['a/R', 'b/R']]
+    assert from_entries['param_names_for_gen'] == [['C_aortic_root'], ['R_a', 'R_b']]


### PR DESCRIPTION
**Stacked on #376** (`fix/grouped-params-and-sobol`), which is a prerequisite — retarget to master once that merges.

First of three, per the agreed split with the CUFLynx side: **JSON format + CSV conversion, no modifiers.** Modifier parameters and the sensitivity chain rule follow separately.

## What changes

The CSV stays readable forever. It is converted to the JSON structure **at the front door**, and everything downstream sees only resolved entries — one code path behind three doors (CSV file, JSON file, programmatic dicts).

**Why JSON at all.** A CSV row carries one `param_name` for all its vessels, so it cannot express a group of parameters with *different* names, and it has nowhere to put a parameter that modifies other parameters. `targets` — a list of full `component/param` qnames — removes the first restriction now; the second arrives with modifier entries next.

```json
{
  "version": 1,
  "defaults": {"prior": "uniform", "param_type": "const"},
  "params": [
    {"name": "C_ao", "targets": ["aortic_root/C"], "min": 1e-9, "max": 5e-8,
     "name_for_plotting": "C_{ao}"},
    {"name": "C_all", "targets": ["aortic_root/C", "par/C"], "min": 1e-9, "max": 5e-8}
  ]
}
```

`defaults` supplies any entry key to every entry that does not set it — the "easier to change general priors" ask. Resolved as a **shallow per-key override**, including inside `prior_params`, so a defaults block setting `prior_std` doesn't wipe an entry's `prior_mean`. Precedence is entry key > `defaults` > CA's derived default (`default_expr`).

**Refused rather than ignored**, matching the `operation_kwargs`/`cost_kwargs` stance: an unknown entry or `defaults` key, a duplicate entry `name`, a target that isn't a `component/param` name, an unsupported `version`. A key nothing reads changes nothing and gives no sign it was ignored.

## Public converter for downstream tools

`ObsAndParamDataParser.params_for_id_csv_to_json(csv_text_or_path) -> dict` is public and **pure** — text or path in, dict out, no model, solver or simulation helper. A front-end can show a user's legacy CSV as JSON in an editor without loading anything. The mapping is in the docstring as well as the implementation, because a tool without CA on `sys.path` has to be able to reproduce it.

`get_param_id_info(path)` dispatches on extension: `.json` reads directly, anything else converts first.

## A bug the round-trip suite caught while I was writing it

Passing only `prior_params` to `normalise_prior_params` dropped the row's `min`/`max`, which **silently disabled the check that a prior mean lies within the range** (#365 — the hard error that was specifically asked for). Three tests in `test_param_priors.py` failed until `min`/`max` travelled with the hyper-parameters. Worth noting because it's exactly the class of silent regression this PR's test strategy exists to catch.

## Testing

54 tests. The important one is a **key-by-key `param_id_info` comparison of CSV-direct against CSV → JSON → `param_id_info`, for all 20 fixtures in `resources/`**. That's the backwards-compatibility guarantee: every existing user study is a CSV, and a silent conversion error would misparameterise a model without failing loudly. There's also a guard test asserting the fixture glob actually matched something, so the suite can't go vacuous.

Also covered: the `global`+named-vessel gen names (#350/#368) surviving conversion, mixed-name targets (the new capability), `defaults` resolution and per-key `prior_params` merge, `idxs_to_ignore` filtering, the programmatic dict API, and each hard error asserted by message.

`-m "not slow"`: **444 passed, 5 skipped, 1 failed** — the one failure is `test_python_BDF_solver[SN_simple]` (#151), verified pre-existing.

## Note for the CUFLynx side

The handover's example JSON uses `"prior": "gaussian"`, which CA rejects — the vocabulary is `exponential`, `normal`, `uniform` (`PARAM_PRIOR_TYPES`). Worth correcting in the editor's defaults before it reaches a user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
