### PR TITLE
feat(params): modifier parameters -- one calibrated value that scales many (stacked on #377)

### DIFF
--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -1398,6 +1398,11 @@ class OpencorParamID():
         self.param_id_info = param_id_info
         self.num_params = len(self.param_id_info["param_names"])
         self.param_norm_obj = Normalise_class(self.param_id_info["param_mins"], self.param_id_info["param_maxs"])
+        # The constructor resolves baselines when param_id_info is already known; entry points
+        # that set it afterwards resolve here instead. Idempotent, and still before any
+        # parameter has been written, which is the property that stops theta compounding.
+        if getattr(self, 'sim_helper', None) is not None:
+            resolve_modifier_baselines(self.param_id_info, self.sim_helper)
     
     def set_protocol_info(self, protocol_info):
         self.protocol_info = protocol_info

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -68,6 +68,8 @@ from param_id.differentiable import (
 )
 from param_id.operation_funcs import resolve_operation_kwargs, validate_operation_kwargs
 from param_id.cost_kwargs import call_cost_func, validate_cost_kwargs
+from parsers.PrimitiveParsers import (expand_modifier_param_vals,
+                                      resolve_modifier_baselines)
 from param_id.plot_outputs import ParamIDPlotOutputs
 from param_id import casadi_backend
 from param_id import fsa_backend
@@ -1209,6 +1211,11 @@ class OpencorParamID():
         self.sim_helper = self.initialise_sim_helper()
         self._protocol_executor = ProtocolExecutor(self.sim_helper)
 
+        # Resolve modifier baselines here and nowhere else: the helper exists and nothing has
+        # written a parameter yet. Deriving them later would read values the optimiser had
+        # already scaled, and theta would compound every iteration.
+        resolve_modifier_baselines(self.param_id_info, self.sim_helper)
+
         if self.sim_time is not None and self.pre_time is not None:
             self.sim_helper.update_times(self.dt, 0.0, self.sim_time, self.pre_time)
             self.n_steps = int(self.sim_time/self.dt)
@@ -1623,7 +1630,10 @@ class OpencorParamID():
         sim_success, results_by_sub, extra_by_sub, _ = self._protocol_executor.run_protocol(
             self.protocol_info,
             id_param_names=self.param_id_info["param_names"],
-            id_param_vals=param_vals,
+            # A modifier occupies one slot in the optimiser's vector but names N model
+            # parameters, so its slot expands to theta * baseline_i here. Everything else passes
+            # through, and set_param_vals pairs N names with N values positionally (#376).
+            id_param_vals=expand_modifier_param_vals(self.param_id_info, param_vals),
             result_variables=self.obs_info["operands"],
             extra_result_variables=pred_names,
             exp_indices=exp_idxs_to_run,
@@ -2545,6 +2555,27 @@ class OpencorParamID():
         sub = self.obs_info["subexperiment_idxs"][obs_idx]
         return f"{base} [exp {exp}, sub {sub}]"
 
+    def _refuse_sensitivities_for_modifiers(self):
+        """A modifier's derivative is a weighted chain rule, not the plain sum a shared-value
+        group needs:
+
+            shared-value group   dO/dtheta = sum_i  dO/dp_i
+            scale modifier       dO/dtheta = sum_i (dO/dp_i) * baseline_i
+
+        Neither arm implements the weighted form yet, and both currently flatten a group to its
+        first member -- so a modifier would silently report one target's derivative as though it
+        were theta's. Refuse instead, on the same reasoning as the CasADi grouped-row refusal.
+        """
+        modifiers = (getattr(self, "param_id_info", None) or {}).get("modifiers") or []
+        if modifiers:
+            names = [m["name"] for m in modifiers]
+            raise NotImplementedError(
+                f"Local sensitivity analysis does not yet support modifier parameters {names}. "
+                f"A scale modifier's derivative is sum_i (dO/dp_i) * baseline_i, a weighted "
+                f"chain rule over its targets, which is not implemented -- reporting the first "
+                f"target's derivative instead would silently answer a different question. Use "
+                f"global Sobol SA, which handles modifiers, or remove the modifier entries.")
+
     def get_observable_sensitivities(self, param_vals, gradient_method=None, fd_rel_step=None):
         """d(observable feature)/d(param) for the scalar observables -- the backend-agnostic
         local-sensitivity accessor, parallel to ``get_gradient``.
@@ -2581,6 +2612,7 @@ class OpencorParamID():
                 f"unknown gradient_method '{gradient_method}' for local sensitivity analysis. "
                 "Valid values are None/'analytic' (this backend's analytic sensitivity) or 'FD'.")
 
+        self._refuse_sensitivities_for_modifiers()
         if self.model_type == 'casadi_python':
             return casadi_backend.get_observable_sensitivities(self, param_vals)
         elif self.model_type == 'aadc_python':

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -502,6 +502,12 @@ def resolve_modifier_baselines(param_id_info, sim_helper):
 
     Idempotent: a modifier whose baselines are already resolved is left alone.
     """
+    # param_id_info is not always set by the time a simulation helper exists -- several entry
+    # points build the helper first and call set_param_id_info afterwards -- so this has to be a
+    # no-op rather than an error when there is nothing to resolve yet. The later call from
+    # set_param_id_info does the work in that case.
+    if not param_id_info:
+        return param_id_info
     modifiers = param_id_info.get("modifiers") or []
     if not modifiers:
         return param_id_info

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -460,6 +460,26 @@ PARAM_PRIOR_TYPES = {
 # from that prior instead of typed.
 PARAM_UNBOUNDED_COLUMN = 'unbounded'
 
+# ---------------------------------------------------------------------------------------------
+# params_for_id as JSON.
+#
+# The CSV is still readable and always will be, but it is converted to this structure on read, so
+# there is exactly one code path behind the front door. The JSON shape exists because the CSV
+# cannot express two things the user asked for: a group of parameters with *different* names
+# (a CSV row has one param_name for all its vessels), and a parameter that modifies other
+# parameters. `targets` -- a list of full component/param qnames -- removes the first restriction;
+# the second arrives with modifier entries in a follow-up.
+PARAMS_FOR_ID_JSON_VERSION = 1
+
+# Keys an entry may carry. Anything else is a typo and is refused, on the same reasoning as
+# operation_kwargs/cost_kwargs: a key nothing reads changes nothing and gives no sign it was
+# ignored.
+PARAMS_FOR_ID_ENTRY_KEYS = frozenset({
+    'name', 'targets', 'param_type', 'min', 'max', 'name_for_plotting',
+    'prior', 'prior_params', PARAM_UNBOUNDED_COLUMN, 'comment',
+})
+
+
 # How wide the derived range is, in standard deviations either side of the prior's centre.
 # Five puts ~1 sample in 3.5 million outside it, so the box is not meaningfully constraining
 # while staying finite -- which it must be. min/max are not only the prior's truncation: they
@@ -618,6 +638,11 @@ def derive_bounds_from_prior(prior_type, params, row_idx=None):
 PARAM_PRIOR_PARAM_NAMES = tuple(
     spec['name'] for meta in PARAM_PRIOR_TYPES.values() for spec in meta['params']
 )
+
+# The CSV columns that become prior_params entries in the JSON structure rather than top-level
+# keys. Derived from the prior declarations so the converter cannot miss a newly added
+# hyper-parameter (params_for_id JSON, issue #355 follow-up).
+PARAMS_FOR_ID_CSV_PRIOR_COLUMNS = tuple(PARAM_PRIOR_PARAM_NAMES)
 
 # What an absent, blank or NaN `prior` entry means -- and what the whole column defaults to
 # when params_for_id has no `prior` at all.
@@ -2980,15 +3005,176 @@ class ObsAndParamDataParser(object):
         
         return protocol
     
+    @staticmethod
+    def _qname_to_vessel_and_param(qname):
+        """Split a 'component/param' qname. rsplit so a component containing '/' still works."""
+        if '/' not in qname:
+            raise ValueError(
+                f"params_for_id target {qname!r} is not a 'component/param' name. Targets are "
+                f"full qualified names, e.g. 'aortic_root/C' or 'global/q_lv_init'.")
+        vessel, param = qname.rsplit('/', 1)
+        return vessel.strip(), param.strip()
+
+    @classmethod
+    def params_for_id_csv_to_json(cls, csv_text_or_path):
+        """Convert a legacy params_for_id CSV into the canonical JSON structure.
+
+        Pure: text (or a path) in, dict out. No model, no solver, no simulation helper -- so a
+        front-end can show a user's existing CSV as JSON in an editor without loading anything.
+        The mapping is documented in the tutorial as well as implemented here, because a tool
+        without circulatory_autogen on sys.path has to be able to reproduce it.
+
+        Per row:
+            vessel_name='a b', param_name='C'  ->  targets: ['a/C', 'b/C']
+            min/max/param_type/name_for_plotting/comment  ->  same keys
+            prior + prior_mean/prior_std/...   ->  prior + prior_params: {...}
+            unbounded                          ->  unbounded (bool)
+            (none)                             ->  name, defaulting to the first target
+        """
+        import io
+
+        if isinstance(csv_text_or_path, str) and ('\n' in csv_text_or_path
+                                                  or ',' in csv_text_or_path.split('\n')[0]) \
+                and not os.path.exists(csv_text_or_path):
+            handle = io.StringIO(csv_text_or_path)
+        else:
+            handle = csv_text_or_path
+
+        df = pd.read_csv(handle, dtype=str)
+        df = df.rename(columns=lambda c: c.strip())
+        for column in df.columns:
+            df[column] = df[column].apply(lambda v: v.strip() if isinstance(v, str) else v)
+
+        def _present(value):
+            if value is None:
+                return False
+            if isinstance(value, float) and np.isnan(value):
+                return False
+            return str(value).strip() != ''
+
+        params = []
+        for idx in range(df.shape[0]):
+            row = df.iloc[idx]
+            vessels = [v for v in str(row.get('vessel_name', '') or '').split() if v]
+            param_name = str(row.get('param_name', '') or '').strip()
+            if not vessels or not param_name:
+                raise ValueError(
+                    f'params_for_id CSV row {idx}: both vessel_name and param_name are required '
+                    f'(got vessel_name={row.get("vessel_name")!r}, param_name={param_name!r}).')
+
+            entry = {'targets': [f'{v}/{param_name}' for v in vessels]}
+            entry['name'] = entry['targets'][0]
+
+            for key in ('param_type', 'name_for_plotting', 'comment', 'prior'):
+                if key in df.columns and _present(row.get(key)):
+                    entry[key] = str(row[key]).strip()
+            for key in ('min', 'max'):
+                if key in df.columns and _present(row.get(key)):
+                    entry[key] = str(row[key]).strip()
+            if PARAM_UNBOUNDED_COLUMN in df.columns and _present(row.get(PARAM_UNBOUNDED_COLUMN)):
+                entry[PARAM_UNBOUNDED_COLUMN] = _truthy_flag(row[PARAM_UNBOUNDED_COLUMN])
+
+            prior_params = {name: str(row[name]).strip()
+                            for name in PARAMS_FOR_ID_CSV_PRIOR_COLUMNS
+                            if name in df.columns and _present(row.get(name))}
+            if prior_params:
+                entry['prior_params'] = prior_params
+
+            params.append(entry)
+
+        return {'version': PARAMS_FOR_ID_JSON_VERSION, 'defaults': {}, 'params': params}
+
+    @classmethod
+    def resolve_params_for_id_doc(cls, doc):
+        """Validate a params_for_id document and fold `defaults` into each entry.
+
+        Resolution is a shallow per-key override -- an entry's own key wins over `defaults`, which
+        wins over whatever circulatory_autogen derives later (the prior machinery's default_expr).
+        `prior_params` merges per key too, so a defaults block setting prior_std does not wipe an
+        entry's prior_mean.
+        """
+        if not isinstance(doc, dict):
+            raise ValueError(
+                f'params_for_id JSON must be an object with a "params" list, got '
+                f'{type(doc).__name__}.')
+
+        version = doc.get('version', PARAMS_FOR_ID_JSON_VERSION)
+        if int(version) != PARAMS_FOR_ID_JSON_VERSION:
+            raise ValueError(
+                f'params_for_id JSON version {version} is not supported by this version of '
+                f'circulatory_autogen (expected {PARAMS_FOR_ID_JSON_VERSION}).')
+
+        params = doc.get('params')
+        if not isinstance(params, list) or not params:
+            raise ValueError('params_for_id JSON needs a non-empty "params" list.')
+
+        defaults = doc.get('defaults') or {}
+        if not isinstance(defaults, dict):
+            raise ValueError(
+                f'params_for_id "defaults" must be an object, got {type(defaults).__name__}.')
+        unknown_defaults = set(defaults) - PARAMS_FOR_ID_ENTRY_KEYS
+        if unknown_defaults:
+            raise ValueError(
+                f'params_for_id "defaults" has unknown key(s) {sorted(unknown_defaults)}. '
+                f'Valid keys are the entry keys: {sorted(PARAMS_FOR_ID_ENTRY_KEYS)}.')
+
+        resolved = []
+        seen_names = {}
+        for idx, raw in enumerate(params):
+            if not isinstance(raw, dict):
+                raise ValueError(
+                    f'params_for_id entry {idx} must be an object, got {type(raw).__name__}.')
+            unknown = set(raw) - PARAMS_FOR_ID_ENTRY_KEYS
+            if unknown:
+                raise ValueError(
+                    f'params_for_id entry {idx} has unknown key(s) {sorted(unknown)}. Valid '
+                    f'keys: {sorted(PARAMS_FOR_ID_ENTRY_KEYS)}.')
+
+            entry = {k: v for k, v in defaults.items() if k != 'prior_params'}
+            entry.update({k: v for k, v in raw.items() if k != 'prior_params'})
+            merged_prior = dict(defaults.get('prior_params') or {})
+            merged_prior.update(raw.get('prior_params') or {})
+            if merged_prior:
+                entry['prior_params'] = merged_prior
+
+            targets = entry.get('targets')
+            if isinstance(targets, str):
+                targets = [targets]
+            if not targets or not isinstance(targets, list):
+                raise ValueError(
+                    f'params_for_id entry {idx} needs a non-empty "targets" list of '
+                    f'component/param names.')
+            entry['targets'] = [str(t).strip() for t in targets]
+            for qname in entry['targets']:
+                cls._qname_to_vessel_and_param(qname)
+
+            entry.setdefault('name', entry['targets'][0])
+            name = str(entry['name'])
+            if name in seen_names:
+                raise ValueError(
+                    f'params_for_id entry {idx} reuses the name {name!r}, already used by entry '
+                    f'{seen_names[name]}. Entry names identify a parameter and must be unique.')
+            seen_names[name] = idx
+            entry['name'] = name
+            resolved.append(entry)
+
+        return resolved
+
     def get_param_id_info(self, params_for_id_path, idxs_to_ignore= None):
     
         if not params_for_id_path:
             print(f'params_for_id_path cannot be None, exiting')
             return None
 
-        csv_parser = CSVFileParser()
-        input_params = csv_parser.get_data_as_dataframe_multistrings(params_for_id_path)
-        return self._build_param_id_info_from_df(input_params, idxs_to_ignore=idxs_to_ignore)
+        # One code path behind the front door: a .csv is converted to the JSON structure on read,
+        # and everything downstream sees only resolved JSON entries.
+        if str(params_for_id_path).lower().endswith('.json'):
+            with open(params_for_id_path, 'r') as f:
+                doc = json.load(f)
+        else:
+            doc = self.params_for_id_csv_to_json(params_for_id_path)
+        entries = self.resolve_params_for_id_doc(doc)
+        return self._build_param_id_info_from_entries(entries, idxs_to_ignore=idxs_to_ignore)
 
     def get_param_id_info_from_entries(self, params_for_id_entries, idxs_to_ignore=None):
         """
@@ -3013,109 +3199,83 @@ class ObsAndParamDataParser(object):
         input_params = pd.DataFrame(params_for_id_entries)
         return self._build_param_id_info_from_df(input_params, idxs_to_ignore=idxs_to_ignore)
 
-    def _build_param_id_info_from_df(self, input_params, idxs_to_ignore=None):
-        if input_params is None or input_params.empty:
+    def _build_param_id_info_from_entries(self, entries, idxs_to_ignore=None):
+        """Build param_id_info from resolved params_for_id entries (the canonical JSON shape).
+
+        This is the single builder; the CSV and the programmatic dict API both convert to entries
+        first. Output shape is unchanged from the CSV-driven builder it replaces -- param_names is
+        still a list of qname lists, one per calibrated variable -- so every consumer, including
+        #376's grouped set_param_vals and the Sobol split, keeps working untouched.
+        """
+        if not entries:
             raise ValueError("No parameter entries provided")
 
-        required_cols = {"vessel_name", "param_name", "min", "max"}
-        missing = required_cols - set(input_params.columns)
-        if missing:
-            raise ValueError(f"params_for_id is missing required columns: {sorted(list(missing))}")
-
-        input_params = input_params.copy()
-
-        def _to_list(val):
-            if isinstance(val, list):
-                return val
-            if val is None:
-                return []
-            if isinstance(val, float) and np.isnan(val):
-                return []
-            val_str = str(val).strip()
-            if val_str == "":
-                return []
-            return [entry.strip() for entry in val_str.split()]
-
-        input_params["vessel_name"] = input_params["vessel_name"].apply(_to_list)
-
-        # --- 1. Filter the DataFrame first ---
-        # Create a mask for indices to KEEP (not ignore)
         if idxs_to_ignore is not None:
-            all_indices = set(range(input_params.shape[0]))
-            valid_indices = sorted(list(all_indices - set(idxs_to_ignore)))
-            filtered_params = input_params.iloc[valid_indices].reset_index(drop=True)
-        else:
-            filtered_params = input_params.reset_index(drop=True)
+            ignore = set(idxs_to_ignore)
+            entries = [e for i, e in enumerate(entries) if i not in ignore]
+            if not entries:
+                raise ValueError("No parameter entries provided")
 
-        N_params = filtered_params.shape[0]
-
+        N_params = len(entries)
         param_id_info = {}
+        param_id_info["param_names"] = [list(e["targets"]) for e in entries]
+
+        # Simplified names for the generator, per target rather than per entry. Deciding the whole
+        # row from the first vessel meant a row mixing 'global' with named vessels emitted one gen
+        # name and dropped the rest, while param_names kept all of them, so the two positional
+        # lists stopped describing the same parameters (#350).
         param_names_for_gen = []
-        param_id_info["param_names"] = []
+        for entry in entries:
+            gen = []
+            for qname in entry["targets"]:
+                vessel, param = self._qname_to_vessel_and_param(qname)
+                gen.append(param if vessel == 'global' else f'{param}_{vessel}')
+            param_names_for_gen.append(gen)
 
-        # --- 2. Iterate ONLY over the filtered data ---
-        for II in range(N_params):
-            # Current row data from the filtered DataFrame
-            row = filtered_params.iloc[II]
+        def _numeric(key):
+            out = np.empty(N_params, dtype=float)
+            for II, entry in enumerate(entries):
+                raw = entry.get(key)
+                try:
+                    out[II] = float(raw) if raw is not None and str(raw).strip() != '' else np.nan
+                except (TypeError, ValueError):
+                    out[II] = np.nan
+            return out
 
-            # A. Build the full, complex names (e.g., 'vessel_name/param_name')
-            param_full_names = [
-                row["vessel_name"][JJ] + '/' + row["param_name"]
-                for JJ in range(len(row["vessel_name"]))
-            ]
-            param_id_info["param_names"].append(param_full_names)
+        param_id_info["param_mins"] = _numeric("min")
+        param_id_info["param_maxs"] = _numeric("max")
 
-            # B. Build the simplified names for generator/code
-            # Per vessel, not per row. Deciding the whole row from vessel_name[0] meant a
-            # row mixing 'global' with named vessels emitted a single gen name and dropped
-            # every vessel after the first -- while param_names above kept all of them, so
-            # the two positional lists stopped describing the same parameters (#350).
-            param_names_for_gen.append([
-                row["param_name"] if vessel == 'global'
-                else row["param_name"] + '_' + vessel
-                for vessel in row["vessel_name"]
-            ])
+        def _plot_name(entry):
+            raw = entry.get("name_for_plotting")
+            if raw is None or (isinstance(raw, float) and np.isnan(raw)) or str(raw).strip() == '':
+                return entry["targets"][0]
+            return raw
 
-        # --- 3. Set Arrays using the filtered DataFrame ---
-        param_id_info["param_mins"] = pd.to_numeric(
-            filtered_params["min"], errors="coerce").to_numpy(dtype=float)
-        param_id_info["param_maxs"] = pd.to_numeric(
-            filtered_params["max"], errors="coerce").to_numpy(dtype=float)
+        param_id_info["param_names_for_plotting"] = np.array(
+            [_plot_name(entry) for entry in entries])
 
-        if "name_for_plotting" in filtered_params.columns:
-            param_id_info["param_names_for_plotting"] = filtered_params["name_for_plotting"].to_numpy()
-        else:
-            param_id_info["param_names_for_plotting"] = np.array([p_names[0]
-                                                                  for p_names in param_id_info["param_names"]])
+        param_id_info["param_prior_types"] = np.array([
+            normalise_prior_type(entries[II].get("prior"), row_idx=II) for II in range(N_params)
+        ])
 
-        if "prior" in filtered_params.columns:
-            # Validated and canonicalised here, at the one place the column is read, so an
-            # unusable prior is a parse error naming the row rather than a parameter that
-            # quietly stops being bounded once the sampler starts.
-            param_id_info["param_prior_types"] = np.array([
-                normalise_prior_type(filtered_params["prior"].iloc[II], row_idx=II)
-                for II in range(N_params)
-            ])
-        else:
-            param_id_info["param_prior_types"] = np.array([DEFAULT_PARAM_PRIOR_TYPE] * N_params)
-
-        # The values each prior takes (the exponential's rate, the normal's mean and std),
-        # one dict per parameter. Validated against what that row's prior actually declares,
-        # so a hyper-parameter set on a prior that ignores it is a parse error rather than a
-        # silently different posterior.
+        # normalise_prior_params takes anything with .get(), so the entry's prior_params mapping
+        # is passed straight in -- the hyper-parameters live under their own key in JSON, but the
+        # validation that owns which prior takes which is unchanged.
+        # min/max travel with the hyper-parameters: normalise_prior_params checks a centre
+        # declared `within_bounds` against the row's own range, and every prior is truncated to
+        # [min, max], so a mean outside it describes a peak the sampler can never reach. Passing
+        # prior_params alone silently disabled that check (#365).
         param_id_info["param_prior_params"] = [
             normalise_prior_params(
-                param_id_info["param_prior_types"][II], filtered_params.iloc[II], row_idx=II)
+                param_id_info["param_prior_types"][II],
+                {**dict(entries[II].get("prior_params") or {}),
+                 'min': entries[II].get('min'), 'max': entries[II].get('max')},
+                row_idx=II)
             for II in range(N_params)
         ]
 
-        # An unbounded parameter has no range of its own: its prior says where it lives, and
-        # the range CA needs for everything else is derived from that prior. Done after the
-        # priors are parsed, because that is what it is derived from.
         param_id_info["param_unbounded"] = np.array([
-            _truthy_flag(filtered_params.iloc[II].get(PARAM_UNBOUNDED_COLUMN)
-                         if PARAM_UNBOUNDED_COLUMN in filtered_params.columns else None)
-            for II in range(N_params)
+            _truthy_flag(entries[II].get(PARAM_UNBOUNDED_COLUMN)) for II in range(N_params)
         ])
         for II in range(N_params):
             if not param_id_info["param_unbounded"][II]:
@@ -3134,8 +3294,75 @@ class ObsAndParamDataParser(object):
             param_id_info["param_maxs"][II] = hi
 
         param_id_info["param_names_for_gen"] = param_names_for_gen
+        param_id_info["param_entry_names"] = [e["name"] for e in entries]
 
         return param_id_info
+
+    def _build_param_id_info_from_df(self, input_params, idxs_to_ignore=None):
+        """Adapter for the programmatic entries API (vessel_name / param_name dicts).
+
+        The documented in-code form of params_for_id is a list of
+        {vessel_name, param_name, min, max, name_for_plotting}, and vessel_name may be a list
+        sharing one calibrated value. That is converted to canonical entries here so it goes
+        through the same builder as the CSV and the JSON -- one code path, three front doors.
+        """
+        if input_params is None or getattr(input_params, 'empty', False):
+            raise ValueError("No parameter entries provided")
+
+        required_cols = {"vessel_name", "param_name", "min", "max"}
+        missing = required_cols - set(input_params.columns)
+        if missing:
+            raise ValueError(f"params_for_id is missing required columns: {sorted(list(missing))}")
+
+        def _vessels(val):
+            if isinstance(val, list):
+                return [str(v).strip() for v in val]
+            if val is None or (isinstance(val, float) and np.isnan(val)):
+                return []
+            return [v.strip() for v in str(val).strip().split() if v.strip()]
+
+        def _present(value):
+            if value is None:
+                return False
+            if isinstance(value, float) and np.isnan(value):
+                return False
+            return str(value).strip() != ''
+
+        entries = []
+        for II in range(input_params.shape[0]):
+            row = input_params.iloc[II]
+            vessels = _vessels(row["vessel_name"])
+            param_name = str(row["param_name"]).strip()
+            if not vessels or not param_name:
+                raise ValueError(
+                    f'params_for_id entry {II}: both vessel_name and param_name are required.')
+            entry = {'targets': [f'{v}/{param_name}' for v in vessels]}
+            entry['name'] = entry['targets'][0]
+            for key in ('param_type', 'name_for_plotting', 'comment', 'prior', 'min', 'max'):
+                if key in input_params.columns and _present(row.get(key)):
+                    entry[key] = row[key]
+            if PARAM_UNBOUNDED_COLUMN in input_params.columns \
+                    and _present(row.get(PARAM_UNBOUNDED_COLUMN)):
+                entry[PARAM_UNBOUNDED_COLUMN] = _truthy_flag(row[PARAM_UNBOUNDED_COLUMN])
+            prior_params = {name: row[name] for name in PARAMS_FOR_ID_CSV_PRIOR_COLUMNS
+                            if name in input_params.columns and _present(row.get(name))}
+            if prior_params:
+                entry['prior_params'] = prior_params
+            entries.append(entry)
+
+        # Names come from the first target here, so duplicates are possible in a way the JSON
+        # front door forbids; de-duplicate positionally rather than refusing a form that has
+        # always been legal.
+        seen = {}
+        for entry in entries:
+            base = entry['name']
+            if base in seen:
+                seen[base] += 1
+                entry['name'] = f'{base}#{seen[base]}'
+            else:
+                seen[base] = 0
+
+        return self._build_param_id_info_from_entries(entries, idxs_to_ignore=idxs_to_ignore)
 
     def save_param_names(self, param_id_info, output_dir):
         """

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -471,12 +471,112 @@ PARAM_UNBOUNDED_COLUMN = 'unbounded'
 # the second arrives with modifier entries in a follow-up.
 PARAMS_FOR_ID_JSON_VERSION = 1
 
+# What a modifier parameter can do to the parameters it names. Exported as data, not hardcoded
+# downstream: a front-end builds its menu by reading this, the same way it reads PARAM_PRIOR_TYPES
+# and the cost-func registry, so adding an operation here is the only edit needed.
+#
+# `default_min`/`default_max` are advisory bounds for the UI. A scale multiplier is
+# dimensionless, so unlike every other parameter its bounds are not physical values -- which is
+# the most likely user error, and the reason the UI should be able to offer sane ones.
+PARAM_MODIFIER_OPERATIONS = {
+    'scale': {
+        'description': 'one calibrated multiplier applied to every target\'s default value',
+        'applies_to': 'value',
+        'dimensionless': True,
+        'default_min': 0.5,
+        'default_max': 2.0,
+    },
+}
+DEFAULT_PARAM_MODIFIER_OPERATION = 'scale'
+
+
+def resolve_modifier_baselines(param_id_info, sim_helper):
+    """Fill in each modifier's `baselines` from the model, once.
+
+    Resolved once at setup and never re-derived, because on some backends
+    ``get_init_param_vals`` reads the live parameter array: after ``set_param_vals`` has written,
+    it returns the value just written, not the model default. Re-deriving a scale baseline from
+    it mid-calibration would apply theta to an already-scaled value and compound the factor every
+    iteration -- theta=1.2 twice giving 1.44x. ``get_default_param_vals`` reads the frozen
+    snapshot instead, and this runs before any parameter has been set.
+
+    Idempotent: a modifier whose baselines are already resolved is left alone.
+    """
+    modifiers = param_id_info.get("modifiers") or []
+    if not modifiers:
+        return param_id_info
+
+    if not hasattr(sim_helper, 'get_default_param_vals'):
+        raise NotImplementedError(
+            f"{type(sim_helper).__name__} does not implement get_default_param_vals, which a "
+            f"modifier parameter needs to resolve its baselines. A modifier applies "
+            f"theta * baseline_i, and reading the baseline from the live parameter array would "
+            f"compound the factor across calibration iterations.")
+
+    for mod in modifiers:
+        if mod.get("baselines") is not None:
+            continue
+        raw = sim_helper.get_default_param_vals([[q] for q in mod["targets"]])
+        baselines = []
+        for value in raw:
+            if isinstance(value, (list, tuple)):
+                value = value[0]
+            baselines.append(float(value))
+        mod["baselines"] = baselines
+    return param_id_info
+
+
+def expand_modifier_param_vals(param_id_info, param_vals):
+    """Turn the optimiser's parameter vector into the values set_param_vals receives.
+
+    A modifier occupies one slot in the vector (its theta) but names N model parameters, so its
+    slot expands to N values, one per target. Everything else passes through untouched.
+
+    The expansion is the whole of the modifier's arithmetic:
+        scale ->  p_i = theta * baseline_i
+
+    N names against N values is paired positionally by pair_names_with_values (#376), which is
+    why no backend needs to know modifiers exist.
+    """
+    modifiers = param_id_info.get("modifiers") or []
+    if not modifiers:
+        return list(param_vals)
+
+    by_index = {mod["index"]: mod for mod in modifiers}
+    out = []
+    for idx, value in enumerate(param_vals):
+        mod = by_index.get(idx)
+        if mod is None:
+            out.append(value)
+            continue
+        baselines = mod.get("baselines")
+        if baselines is None:
+            raise ValueError(
+                f"modifier '{mod['name']}' has no resolved baselines. Call "
+                f"resolve_modifier_baselines(param_id_info, sim_helper) once at setup, before "
+                f"any parameter has been written.")
+        if mod["operation"] != 'scale':
+            raise NotImplementedError(
+                f"modifier operation {mod['operation']!r} is declared but not implemented.")
+        out.append([float(value) * b for b in baselines])
+    return out
+
+
+def param_modifier_operations():
+    """The modifier operations this version of circulatory_autogen implements."""
+    return {name: dict(meta) for name, meta in PARAM_MODIFIER_OPERATIONS.items()}
+
+
 # Keys an entry may carry. Anything else is a typo and is refused, on the same reasoning as
 # operation_kwargs/cost_kwargs: a key nothing reads changes nothing and gives no sign it was
 # ignored.
 PARAMS_FOR_ID_ENTRY_KEYS = frozenset({
     'name', 'targets', 'param_type', 'min', 'max', 'name_for_plotting',
     'prior', 'prior_params', PARAM_UNBOUNDED_COLUMN, 'comment',
+    # A modifier entry names the parameters it acts on with `modifies` instead of `targets`, and
+    # says what it does to them with `operation`. min/max/prior belong to the modifier's own
+    # calibrated value, not to the parameters it modifies.
+    'modifies', 'operation',
 })
 
 
@@ -3137,18 +3237,56 @@ class ObsAndParamDataParser(object):
             if merged_prior:
                 entry['prior_params'] = merged_prior
 
-            targets = entry.get('targets')
-            if isinstance(targets, str):
-                targets = [targets]
-            if not targets or not isinstance(targets, list):
+            has_targets = entry.get('targets') is not None
+            has_modifies = entry.get('modifies') is not None
+            if has_targets and has_modifies:
+                raise ValueError(
+                    f'params_for_id entry {idx} sets both "targets" and "modifies". An entry is '
+                    f'either a parameter (targets) or a modifier of parameters (modifies), not '
+                    f'both.')
+            if not has_targets and not has_modifies:
                 raise ValueError(
                     f'params_for_id entry {idx} needs a non-empty "targets" list of '
-                    f'component/param names.')
-            entry['targets'] = [str(t).strip() for t in targets]
-            for qname in entry['targets']:
-                cls._qname_to_vessel_and_param(qname)
+                    f'component/param names (or "modifies" for a modifier entry).')
 
-            entry.setdefault('name', entry['targets'][0])
+            key = 'modifies' if has_modifies else 'targets'
+            names = entry.get(key)
+            if isinstance(names, str):
+                names = [names]
+            if not names or not isinstance(names, list):
+                raise ValueError(
+                    f'params_for_id entry {idx} needs a non-empty "{key}" list of '
+                    f'component/param names.')
+            names = [str(t).strip() for t in names]
+            for qname in names:
+                cls._qname_to_vessel_and_param(qname)
+            entry[key] = names
+
+            if has_modifies:
+                operation = entry.get('operation') or DEFAULT_PARAM_MODIFIER_OPERATION
+                if operation not in PARAM_MODIFIER_OPERATIONS:
+                    raise ValueError(
+                        f'params_for_id entry {idx} has unknown operation {operation!r}. '
+                        f'Implemented operations: {sorted(PARAM_MODIFIER_OPERATIONS)}.')
+                entry['operation'] = operation
+                # A multiplier range that straddles zero flips the sign of every target
+                # somewhere inside it. That is legal arithmetic and almost never intended.
+                try:
+                    lo, hi = float(entry.get('min')), float(entry.get('max'))
+                except (TypeError, ValueError):
+                    lo = hi = None
+                if lo is not None and operation == 'scale' and lo <= 0 < hi:
+                    warnings.warn(
+                        f'params_for_id entry {idx} ({entry.get("name", "?")}) is a scale '
+                        f'modifier with min={lo} and max={hi}, a range crossing zero. Every '
+                        f'target changes sign inside it; scale bounds are multipliers, not '
+                        f'physical values.')
+            elif entry.get('operation') is not None:
+                raise ValueError(
+                    f'params_for_id entry {idx} sets "operation" but has no "modifies". '
+                    f'operation only applies to a modifier entry.')
+
+            entry.setdefault('name', entry[key][0])
             name = str(entry['name'])
             if name in seen_names:
                 raise ValueError(
@@ -3158,7 +3296,58 @@ class ObsAndParamDataParser(object):
             entry['name'] = name
             resolved.append(entry)
 
+        cls._validate_modifier_relationships(resolved)
         return resolved
+
+    @staticmethod
+    def _validate_modifier_relationships(entries):
+        """Cross-entry rules that only make sense once every entry is known.
+
+        Both are refusals rather than warnings because both produce a calibration that runs,
+        converges and means nothing.
+        """
+        free_owner = {}
+        for entry in entries:
+            for qname in entry.get('targets', []):
+                free_owner.setdefault(qname, entry['name'])
+
+        modifier_names = {e['name'] for e in entries if e.get('modifies')}
+
+        # 3. Two modifiers on the same parameter multiply: p = theta_1 * theta_2 * baseline, so
+        #    only the product is identifiable and each factor alone is meaningless -- the same
+        #    flat ridge as rule 1, reached a different way.
+        modified_by = {}
+        for entry in entries:
+            for qname in entry.get('modifies', []):
+                if qname in modified_by:
+                    raise ValueError(
+                        f"params_for_id: '{qname}' is modified by both "
+                        f"'{modified_by[qname]}' and '{entry['name']}'. Two modifiers on one "
+                        f"parameter multiply, so only their product is identifiable and neither "
+                        f"factor means anything on its own. Combine them into one modifier.")
+                modified_by[qname] = entry['name']
+
+        for entry in entries:
+            modifies = entry.get('modifies')
+            if not modifies:
+                continue
+            for qname in modifies:
+                # 1. A modified parameter must not also be calibrated freely. (theta, p) and
+                #    (theta*k, p/k) give an identical cost, so the optimiser wanders a flat
+                #    ridge and both reported values are meaningless.
+                if qname in free_owner:
+                    raise ValueError(
+                        f"params_for_id: '{qname}' is modified by '{entry['name']}' and is also "
+                        f"a free parameter in entry '{free_owner[qname]}'. That is structurally "
+                        f"unidentifiable -- scaling the modifier and dividing the free parameter "
+                        f"by the same factor gives an identical cost, so neither value means "
+                        f"anything. Remove one of the two entries.")
+                # 2. One level, no chains: a modifier of a modifier has no defined baseline.
+                if qname in modifier_names:
+                    raise ValueError(
+                        f"params_for_id: '{entry['name']}' modifies '{qname}', which is itself a "
+                        f"modifier. Modifiers apply to model parameters only -- chains are not "
+                        f"supported.")
 
     def get_param_id_info(self, params_for_id_path, idxs_to_ignore= None):
     
@@ -3218,16 +3407,21 @@ class ObsAndParamDataParser(object):
 
         N_params = len(entries)
         param_id_info = {}
-        param_id_info["param_names"] = [list(e["targets"]) for e in entries]
+        # A modifier looks exactly like a grouped row to every consumer: one variable to the
+        # sampler and to the optimiser, N parameters to set. The only difference is what value
+        # each of the N receives, which is resolved when the values are expanded (see
+        # expand_modifier_param_vals) rather than here.
+        param_id_info["param_names"] = [
+            list(e["modifies"]) if e.get("modifies") else list(e["targets"]) for e in entries]
 
         # Simplified names for the generator, per target rather than per entry. Deciding the whole
         # row from the first vessel meant a row mixing 'global' with named vessels emitted one gen
         # name and dropped the rest, while param_names kept all of them, so the two positional
         # lists stopped describing the same parameters (#350).
         param_names_for_gen = []
-        for entry in entries:
+        for entry, qnames in zip(entries, param_id_info["param_names"]):
             gen = []
-            for qname in entry["targets"]:
+            for qname in qnames:
                 vessel, param = self._qname_to_vessel_and_param(qname)
                 gen.append(param if vessel == 'global' else f'{param}_{vessel}')
             param_names_for_gen.append(gen)
@@ -3248,7 +3442,10 @@ class ObsAndParamDataParser(object):
         def _plot_name(entry):
             raw = entry.get("name_for_plotting")
             if raw is None or (isinstance(raw, float) and np.isnan(raw)) or str(raw).strip() == '':
-                return entry["targets"][0]
+                # A modifier falls back to its own name, not to one of the parameters it
+                # modifies -- theta is its own quantity (dimensionless for scale) and labelling
+                # it with a target's name would misreport what was calibrated.
+                return entry["name"] if entry.get("modifies") else entry["targets"][0]
             return raw
 
         param_id_info["param_names_for_plotting"] = np.array(
@@ -3295,6 +3492,32 @@ class ObsAndParamDataParser(object):
 
         param_id_info["param_names_for_gen"] = param_names_for_gen
         param_id_info["param_entry_names"] = [e["name"] for e in entries]
+
+        # One display label per calibrated variable. A grouped row joins its qnames; a modifier
+        # uses its own name. Downstream (the SALib problem, plots) reads this rather than
+        # rebuilding it, so the two cannot drift.
+        param_id_info["param_labels"] = [
+            str(param_id_info["param_names_for_plotting"][II]) if entries[II].get("modifies")
+            else '+'.join(param_id_info["param_names"][II])
+            for II in range(N_params)
+        ]
+
+        # The modifier record downstream tools code against. `index` is a position in
+        # param_names/param_labels and is computed *after* idxs_to_ignore filtering, so it is
+        # always valid for the param_id_info it ships with -- but match on `name` if you carry a
+        # modifier between two different builds. `baselines` is filled in once a simulation
+        # helper is available (resolve_modifier_baselines); it is None until then rather than
+        # absent, so a consumer can tell "not resolved yet" from "no baseline".
+        param_id_info["modifiers"] = [
+            {
+                "index": II,
+                "name": entries[II]["name"],
+                "operation": entries[II].get("operation", DEFAULT_PARAM_MODIFIER_OPERATION),
+                "targets": list(entries[II]["modifies"]),
+                "baselines": None,
+            }
+            for II in range(N_params) if entries[II].get("modifies")
+        ]
 
         return param_id_info
 
@@ -3381,6 +3604,16 @@ class ObsAndParamDataParser(object):
             with open(param_gen_path, 'w', newline='') as f:
                 wr = csv.writer(f)
                 wr.writerows(param_id_info["param_names_for_gen"])
+
+            # 3. Save the modifier records, baselines included. A scale result is
+            #    uninterpretable without them -- best_param_vals holds theta, and theta alone
+            #    does not say what any model parameter ended up at. Recording them here means
+            #    reproducing a result does not depend on the model file being unchanged.
+            modifiers = param_id_info.get("modifiers") or []
+            if modifiers:
+                modifiers_path = os.path.join(output_dir, 'param_modifiers.json')
+                with open(modifiers_path, 'w') as f:
+                    json.dump(modifiers, f, indent=2)
         return
 
 

--- a/src/sensitivity_analysis/sobolSA.py
+++ b/src/sensitivity_analysis/sobolSA.py
@@ -40,6 +40,7 @@ from SALib.analyze import sobol
 import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
+from parsers.PrimitiveParsers import expand_modifier_param_vals
 from parsers.PrimitiveParsers import scriptFunctionParser
 from param_id.operation_funcs import resolve_operation_kwargs, validate_operation_kwargs
 from mpi4py import MPI
@@ -236,8 +237,11 @@ class sobol_SA():
         SA_info = {
             "sample_type": sample_type,
             "param_names": grouped_names,
-            "param_labels": ['+'.join(n) if isinstance(n, (list, tuple)) else n
-                             for n in grouped_names],
+            # param_id_info already computes one label per variable, and knows that a modifier
+            # is labelled by its own name rather than a join of the parameters it modifies.
+            "param_labels": list(self.param_id_info.get("param_labels") or
+                                 ['+'.join(n) if isinstance(n, (list, tuple)) else n
+                                  for n in grouped_names]),
             "num_samples": num_samples,
             "param_mins": list(self.param_id_info["param_mins"]),
             "param_maxs": list(self.param_id_info["param_maxs"])
@@ -315,7 +319,9 @@ class sobol_SA():
         return samples
     
     def run_model_and_get_results(self, param_vals):
-        self.sim_helper.set_param_vals(self.SA_info["param_names"], param_vals)
+        self.sim_helper.set_param_vals(
+            self.SA_info["param_names"],
+            expand_modifier_param_vals(self.param_id_info, param_vals))
         self.sim_helper.reset_states()
         success = self.sim_helper.run()
         if not success:
@@ -362,7 +368,7 @@ class sobol_SA():
                 _success, operands_outputs_dict, _, _ = self._protocol_executor.run_protocol(
                     self.protocol_info,
                     id_param_names=self.param_id_info["param_names"],
-                    id_param_vals=param_vals,
+                    id_param_vals=expand_modifier_param_vals(self.param_id_info, param_vals),
                     result_variables=self.obs_info["operands"],
                     continue_on_failure=True,
                 )

--- a/src/sensitivity_analysis/sobolSA.py
+++ b/src/sensitivity_analysis/sobolSA.py
@@ -224,9 +224,20 @@ class sobol_SA():
         if not hasattr(self, "param_id_info") or not self.param_id_info:
             raise ValueError("param_id_info is not set. Please run __set_and_save_param_names() first.")
 
+        # A params_for_id row naming several vessels means "one calibrated value drives all of
+        # these", so it is *one* variable to the sampler and must be set on *every* member.
+        # Those are two different things and need two different lists (issue #355):
+        #   param_names   -- kept grouped, handed to set_param_vals, which broadcasts the shared
+        #                    sampled value across the group
+        #   param_labels  -- flattened to one name per variable, for the SALib problem and plots
+        # Collapsing to the first name for both is what made a grouped SA vary one vessel while
+        # calibration varied all of them, silently answering a different question.
+        grouped_names = list(self.param_id_info["param_names"])
         SA_info = {
             "sample_type": sample_type,
-            "param_names": [name[0] if isinstance(name, list) else name for name in self.param_id_info["param_names"]],
+            "param_names": grouped_names,
+            "param_labels": ['+'.join(n) if isinstance(n, (list, tuple)) else n
+                             for n in grouped_names],
             "num_samples": num_samples,
             "param_mins": list(self.param_id_info["param_mins"]),
             "param_maxs": list(self.param_id_info["param_maxs"])
@@ -236,9 +247,22 @@ class sobol_SA():
         #     print("Sensitivity Analysis Configuration:")
         #     print(json.dumps(SA_info, indent=4))
 
-        self.num_params = len(SA_info["param_names"])
+        self.num_params = len(SA_info["param_labels"])
 
         return SA_info
+
+    def _param_labels(self):
+        """One display label per sampled variable.
+
+        Derived from param_names when 'param_labels' is absent, so an SA_info built by hand or
+        loaded from an older run still works -- the key was added with grouped-parameter support
+        (issue #355) and SA_info is a semi-public structure.
+        """
+        labels = self.SA_info.get("param_labels")
+        if labels is not None:
+            return labels
+        return ['+'.join(n) if isinstance(n, (list, tuple)) else n
+                for n in self.SA_info["param_names"]]
 
     def create_SA_info(self, sample_type, num_samples):
         # Backwards compatibility alias
@@ -274,7 +298,7 @@ class sobol_SA():
 
         problem = {
             'num_vars': self.num_params,
-            'names': self.SA_info["param_names"],
+            'names': self._param_labels(),
             'bounds': list(zip(self.SA_info["param_mins"], self.SA_info["param_maxs"]))
         }
         self.problem = problem
@@ -463,12 +487,12 @@ class sobol_SA():
             # output_name = self.obs_info["names_for_plotting"][i] if hasattr(self, "obs_info") else f"Output_{i}"
 
             # Set figure width adaptively based on number of parameters (xticks)
-            fig_width = max(12, 1.0 * len(self.SA_info["param_names"]))
+            fig_width = max(12, 1.0 * len(self._param_labels()))
             plt.figure(figsize=(fig_width, 5))
             plt.bar(x - 0.2, S1, width=0.4, label='First-order', color='blue', alpha=0.7)
             plt.bar(x + 0.2, ST, width=0.4, label='Total-order', color='red', alpha=0.7)
 
-            plt.xticks(x, self.SA_info["param_names"], rotation=45, fontsize=8)
+            plt.xticks(x, self._param_labels(), rotation=45, fontsize=8)
             plt.ylabel('Sensitivity Index')
             plt.title(rf'Sobol Sensitivity - {output_name}')
             plt.legend()
@@ -496,9 +520,9 @@ class sobol_SA():
             output_name = rf"{self.obs_info['names_for_plotting'][i]} - experiment{self.obs_info['experiment_idxs'][i]}, subexperiment{self.obs_info['subexperiment_idxs'][i]}"
 
             # plt.figure(figsize=(6, 5))
-            fig_width = max(6, 1.0 * len(self.SA_info["param_names"]))
+            fig_width = max(6, 1.0 * len(self._param_labels()))
             plt.figure(figsize=(fig_width, fig_width))
-            sns.heatmap(S2, annot=True, fmt=".2f", xticklabels=self.SA_info["param_names"], yticklabels=self.SA_info["param_names"], cmap="coolwarm")
+            sns.heatmap(S2, annot=True, fmt=".2f", xticklabels=self._param_labels(), yticklabels=self._param_labels(), cmap="coolwarm")
             plt.title(rf"2nd order Sobol Indices - {output_name}")
             plt.tight_layout()
 
@@ -557,7 +581,7 @@ class sobol_SA():
         Generates 2D heatmaps for first-order (S1) and total-order (ST) Sobol indices.
         
         The heatmaps show:
-        Y-axis: Input Parameters (self.SA_info["param_names"])
+        Y-axis: Input Parameters (self._param_labels())
         X-axis: Model Outputs (concatenated names from self.obs_info)
         Color: Sobol Index Value
         
@@ -655,7 +679,7 @@ class sobol_SA():
             S2_all (np.ndarray): Second-order Sobol indices, shape (n_outputs, n_params, n_params)
         """
         n_outputs = S1_all.shape[0]
-        param_names = self.SA_info["param_names"]
+        param_names = self._param_labels()
 
         # Prepare output/feature names. Two data_items that resolve to the same
         # (name_for_plotting, experiment, subexperiment) produce identical column

--- a/src/solver_wrappers/casadi_python_solver_helper.py
+++ b/src/solver_wrappers/casadi_python_solver_helper.py
@@ -140,6 +140,15 @@ class SimulationHelper:
         )
         # Full-length array for model function calls (compute_computed_constants, etc.)
         self.variables_model = list(self._numeric_variables_all)
+        # A frozen copy of the constants array as the model was loaded, taken here rather than in
+        # _store_constants_defaults because self.variables only becomes the constants-only array
+        # (the one _var_idx_to_const_pos indexes) on the line above.
+        #
+        # get_init_param_vals reads the *live* array, so once set_param_vals has written it
+        # reports the current value, not the model default -- unlike the Myokit backend, which
+        # keeps default_values. Anything needing a stable baseline (a scale modifier's
+        # theta * baseline_i) must read this, or the factor compounds across iterations.
+        self.default_variables = list(self.variables)
 
     def _compute_states_symb(self):
         states = self.states.copy()
@@ -276,6 +285,28 @@ class SimulationHelper:
             self.states = list(self._sub_carry_state)
 
     # ---- parameter helpers ----
+    def get_default_param_vals(self, param_names):
+        """The model's values as loaded, regardless of what has been written since.
+
+        Same shape as get_init_param_vals, but read from the frozen snapshot rather than the live
+        arrays. See the note in _store_constants_defaults.
+        """
+        vals = []
+        for name_or_list in param_names:
+            if not isinstance(name_or_list, list):
+                name_or_list = [name_or_list]
+            sub = []
+            for name in name_or_list:
+                kind, idx = self._resolver.resolve(name)
+                if kind == "state":
+                    sub.append(self.default_state_inits[idx])
+                elif kind == "var":
+                    sub.append(self.default_variables[self._var_idx_to_const_pos(idx)])
+                else:
+                    raise ValueError(f"Parameter {name!r} not found (resolved kind={kind!r})")
+            vals.append(sub[0] if len(sub) == 1 else sub)
+        return vals
+
     def get_init_param_vals(self, param_names):
         vals = []
         for name_or_list in param_names:

--- a/src/solver_wrappers/casadi_python_solver_helper.py
+++ b/src/solver_wrappers/casadi_python_solver_helper.py
@@ -655,7 +655,25 @@ class SimulationHelper:
         return {name: val for name, val in zip(variable_names, values)}
 
     def _create_param_subset(self, param_names, param_vals=None):
-        param_names = [x[0] for x in param_names]
+        # A grouped params_for_id row ("one calibrated value drives these N vessels") cannot be
+        # honoured here yet. This builds the *symbolic* subset that the cost jacobian is taken
+        # against, so it needs one SX symbol per group substituted into every member's slot --
+        # otherwise the derivative is with respect to the first member alone.
+        #
+        # Refusing rather than dropping the extra members: silently calibrating only the first
+        # vessel is what this backend did before, and it produced a cost curve bit-identical to
+        # the ungrouped one, so nothing downstream could tell. Broadcasting on the numeric side
+        # only would be worse still -- the cost would move all members while the gradient
+        # tracked one, so the optimiser would descend a different function than it evaluates.
+        grouped = [x for x in param_names if isinstance(x, (list, tuple)) and len(x) > 1]
+        if grouped:
+            raise NotImplementedError(
+                f"Grouped parameters are not yet supported by the CasADi backend: {grouped}. "
+                f"The symbolic parameter subset takes one symbol per params_for_id row, so the "
+                f"gradient would be with respect to the first vessel only. Use model_type "
+                f"'cellml_only' with solver 'CVODE_myokit' for grouped calibration, or give "
+                f"each vessel its own row. See issue #355.")
+        param_names = [x[0] if isinstance(x, (list, tuple)) else x for x in param_names]
 
         # Resolve each param to its VARIABLE_INFO index, then find its SX symbol
         var_indices = []   # VARIABLE_INFO indices

--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -687,6 +687,12 @@ class SimulationHelper:
 
         raise RuntimeError("Unable to determine time series key from Myokit log.")
 
+    def get_default_param_vals(self, param_names):
+        """The model's values as loaded. On this backend get_init_param_vals already reads the
+        default_values snapshot rather than the live simulation, so the two agree -- but the name
+        says which is meant, and other backends do not have that property."""
+        return self.get_init_param_vals(param_names)
+
     def get_init_param_vals(self, param_names):
         param_init = []
         for name_or_list in param_names:

--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -1,6 +1,8 @@
 import os
 import copy
 import numpy as np
+
+from solver_wrappers.param_grouping import pair_names_with_values
 import myokit
 from myokit.formats import cellml as cellml_format
 # src_dir = os.path.join(os.path.dirname(__file__), '..')
@@ -830,11 +832,8 @@ class SimulationHelper:
         # states they initialise are refreshed afterwards.
         changed_var_qnames = set()
         for idx, name_or_list in enumerate(param_names):
-            names = name_or_list if isinstance(name_or_list, list) else [name_or_list]
-            vals = param_vals[idx]
-            if not isinstance(vals, (list, tuple, np.ndarray)):
-                vals = [vals]
-            for name, val in zip(names, vals):
+            for name, val in pair_names_with_values(name_or_list, param_vals[idx],
+                                                   'set_param_vals'):
                 kind, qname = self._resolve_name(name)
 
                 if kind == "state":
@@ -933,11 +932,8 @@ class SimulationHelper:
         """
         found_qname = None
         for idx, name_or_list in enumerate(param_names):
-            names = name_or_list if isinstance(name_or_list, list) else [name_or_list]
-            vals = param_vals[idx]
-            if not isinstance(vals, (list, tuple, np.ndarray)):
-                vals = [vals]
-            for name, val in zip(names, vals):
+            for name, val in pair_names_with_values(name_or_list, param_vals[idx],
+                                                   'paced-variable scan'):
                 if isinstance(val, str):
                     kind, qname = self._resolve_name(name)
                     if kind != "var":

--- a/src/solver_wrappers/param_grouping.py
+++ b/src/solver_wrappers/param_grouping.py
@@ -1,0 +1,56 @@
+"""Pairing a params_for_id row's names with its value(s).
+
+A ``params_for_id`` row may name several vessels, which means "one calibrated value drives all
+of these" -- the grouped-parameter feature. Every backend's ``set_param_vals`` therefore receives
+entries that are either a single name or a list of names, against a single shared value.
+
+The obvious pairing, ``zip(names, vals)``, is wrong for exactly that case: with two names and one
+value, ``zip`` stops at the shorter sequence and silently sets only the first name. That is what
+made a grouped row calibrate its first vessel and leave the rest at their defaults, on every
+backend, with no error and a cost curve identical to the ungrouped one.
+
+``pair_names_with_values`` is the single place that decides the pairing, so the broadcast rule
+cannot drift between backends, and a genuine length mismatch raises instead of truncating.
+"""
+
+
+def as_name_list(name_or_list):
+    """Normalise a params_for_id entry to a list of names."""
+    if isinstance(name_or_list, (list, tuple)):
+        return list(name_or_list)
+    return [name_or_list]
+
+
+def as_value_list(value_or_list):
+    """Normalise a value entry to a list, without splitting strings (a protocol trace key)."""
+    if isinstance(value_or_list, str):
+        return [value_or_list]
+    if isinstance(value_or_list, (list, tuple)):
+        return list(value_or_list)
+    if hasattr(value_or_list, 'tolist') and getattr(value_or_list, 'ndim', 1) > 0:
+        return list(value_or_list.tolist())
+    return [value_or_list]
+
+
+def pair_names_with_values(name_or_list, value_or_list, context=''):
+    """Yield ``(name, value)`` for one params_for_id entry, broadcasting a shared value.
+
+    - N names, 1 value  -> the value is applied to all N. This is the grouped-parameter case
+      and the reason this helper exists.
+    - N names, N values -> paired positionally.
+    - anything else     -> ValueError, rather than the silent truncation ``zip`` would do.
+    """
+    names = as_name_list(name_or_list)
+    values = as_value_list(value_or_list)
+
+    if len(values) == 1 and len(names) > 1:
+        values = values * len(names)
+
+    if len(names) != len(values):
+        where = f' ({context})' if context else ''
+        raise ValueError(
+            f'params_for_id entry{where} has {len(names)} name(s) {names} but {len(values)} '
+            f'value(s). A grouped entry takes one shared value for all its names, or one value '
+            f'per name.')
+
+    return list(zip(names, values))

--- a/src/solver_wrappers/python_solver_helper.py
+++ b/src/solver_wrappers/python_solver_helper.py
@@ -1,5 +1,7 @@
 import importlib.util
 import numpy as np
+
+from solver_wrappers.param_grouping import pair_names_with_values
 from scipy.integrate import solve_ivp
 import copy
 import sys
@@ -331,10 +333,7 @@ class SimulationHelper:
                     pass
                 return [x]
 
-            name_or_list = _to_list(name_or_list)
-            vals = _to_list(vals)
-
-            for name, val in zip(name_or_list, vals):
+            for name, val in pair_names_with_values(name_or_list, vals, 'set_param_vals'):
                 if type(val) == str:
                     raise NotImplementedError(
                         f"'{name}' was given the protocol trace name '{val}', but the "

--- a/tests/test_grouped_params.py
+++ b/tests/test_grouped_params.py
@@ -1,0 +1,110 @@
+"""Grouped params_for_id rows: one calibrated value driving several vessels (issue #355).
+
+The feature had no tests at all, and was broken end to end: `zip(names, vals)` with N names and
+one shared value stops at the shorter sequence, so only the first vessel was ever set. A grouped
+row produced a cost curve bit-identical to the ungrouped one -- nothing downstream could tell it
+was calibrating a single vessel.
+"""
+import numpy as np
+import pytest
+
+from solver_wrappers.param_grouping import (
+    as_name_list, as_value_list, pair_names_with_values)
+
+
+@pytest.mark.unit
+def test_one_shared_value_reaches_every_member_of_a_group():
+    """The whole point of a grouped row. zip() silently dropped everything after the first."""
+    pairs = pair_names_with_values(['aortic_root/C', 'par/C'], 1.5e-8)
+    assert pairs == [('aortic_root/C', 1.5e-8), ('par/C', 1.5e-8)]
+
+
+@pytest.mark.unit
+def test_a_group_of_three_broadcasts_to_all_three():
+    pairs = pair_names_with_values(['a/R', 'b/R', 'c/R'], 2.0)
+    assert [n for n, _ in pairs] == ['a/R', 'b/R', 'c/R']
+    assert {v for _, v in pairs} == {2.0}
+
+
+@pytest.mark.unit
+def test_an_ungrouped_entry_is_unchanged():
+    assert pair_names_with_values('aortic_root/C', 1.5e-8) == [('aortic_root/C', 1.5e-8)]
+
+
+@pytest.mark.unit
+def test_per_name_values_are_paired_positionally():
+    """N names with N values keeps the existing meaning -- broadcasting must not override it."""
+    pairs = pair_names_with_values(['a/R', 'b/R'], [1.0, 2.0])
+    assert pairs == [('a/R', 1.0), ('b/R', 2.0)]
+
+
+@pytest.mark.unit
+def test_a_length_mismatch_raises_instead_of_truncating():
+    """The failure this whole issue was: zip() drops the tail without a word."""
+    with pytest.raises(ValueError, match='3 name'):
+        pair_names_with_values(['a/R', 'b/R', 'c/R'], [1.0, 2.0])
+
+
+@pytest.mark.unit
+def test_a_protocol_trace_key_is_one_value_not_a_string_of_characters():
+    """A string value is a protocol_traces key. Splitting it per character would pair 'p','a','c'
+    with the group's names and set three nonsense values."""
+    pairs = pair_names_with_values(['a/u', 'b/u'], 'pace')
+    assert pairs == [('a/u', 'pace'), ('b/u', 'pace')]
+
+
+@pytest.mark.unit
+def test_numpy_arrays_are_accepted_as_value_lists():
+    pairs = pair_names_with_values(['a/R', 'b/R'], np.array([1.0, 2.0]))
+    assert [v for _, v in pairs] == [1.0, 2.0]
+
+
+@pytest.mark.unit
+def test_a_zero_dimensional_numpy_scalar_broadcasts():
+    pairs = pair_names_with_values(['a/R', 'b/R'], np.float64(3.0))
+    assert [v for _, v in pairs] == [3.0, 3.0]
+
+
+@pytest.mark.unit
+def test_normalisers_agree_with_the_pairing():
+    assert as_name_list('x') == ['x'] and as_name_list(['x', 'y']) == ['x', 'y']
+    assert as_value_list('trace') == ['trace']
+    assert as_value_list(1.0) == [1.0]
+
+
+@pytest.mark.unit
+def test_sobol_keeps_groups_for_setting_and_flattens_only_for_labels():
+    """The SA fix: a group is one variable to the sampler but N parameters to set.
+
+    Collapsing to the first name for both is what made a grouped SA vary one vessel while
+    calibration varied all of them -- the two silently answered different questions.
+    """
+    from sensitivity_analysis.sobolSA import sobol_SA
+
+    sa = sobol_SA.__new__(sobol_SA)
+    sa.param_id_info = {
+        'param_names': [['aortic_root/C', 'par/C'], 'heart/R'],
+        'param_mins': [1e-9, 1.0],
+        'param_maxs': [5e-8, 2.0],
+    }
+    info = sa._create_SA_info('sobol', 8)
+
+    # one variable per row for the sampler...
+    assert info['param_labels'] == ['aortic_root/C+par/C', 'heart/R']
+    assert sa.num_params == 2
+    # ...but the full group survives for set_param_vals
+    assert info['param_names'] == [['aortic_root/C', 'par/C'], 'heart/R']
+
+
+@pytest.mark.unit
+def test_the_casadi_backend_refuses_a_group_rather_than_dropping_members():
+    """CasADi builds a symbolic subset with one symbol per row, so a group would be
+    differentiated with respect to its first member only. Until that is fixed properly it must
+    fail loudly: silently calibrating one vessel is what this issue is about, and broadcasting
+    on the numeric side alone would make the cost and the gradient different functions."""
+    import inspect
+    from solver_wrappers import casadi_python_solver_helper as helper
+
+    src = inspect.getsource(helper.SimulationHelper._create_param_subset)
+    assert 'NotImplementedError' in src
+    assert '#355' in src

--- a/tests/test_param_modifiers.py
+++ b/tests/test_param_modifiers.py
@@ -1,0 +1,299 @@
+"""Modifier parameters: one calibrated value that scales several model parameters.
+
+A modifier occupies one slot in the optimiser's vector but names N model parameters, applying
+`theta * baseline_i` to each. To every consumer it looks exactly like a grouped row -- one
+variable to the sampler, N parameters to set -- which is the distinction #376 already drew.
+"""
+import numpy as np
+import pytest
+
+from parsers.PrimitiveParsers import (
+    DEFAULT_PARAM_MODIFIER_OPERATION, ObsAndParamDataParser, PARAM_MODIFIER_OPERATIONS,
+    expand_modifier_param_vals, param_modifier_operations, resolve_modifier_baselines)
+
+
+def _parser():
+    return ObsAndParamDataParser()
+
+
+def _doc(**overrides):
+    entry = {'name': 'compliance_scale', 'modifies': ['aortic_root/C', 'par/C'],
+             'operation': 'scale', 'min': 0.5, 'max': 2.0}
+    entry.update(overrides)
+    return {'version': 1, 'params': [entry]}
+
+
+def _info(doc):
+    parser = _parser()
+    return parser._build_param_id_info_from_entries(parser.resolve_params_for_id_doc(doc))
+
+
+class _FakeHelper:
+    """Returns model defaults regardless of what has been 'written' -- the property a baseline
+    needs, and the one CasADi's get_init_param_vals does not have."""
+
+    def __init__(self, defaults):
+        self.defaults = defaults
+
+    def get_default_param_vals(self, param_names):
+        return [[self.defaults[q] for q in group] if isinstance(group, list)
+                else self.defaults[group] for group in param_names]
+
+
+# ------------------------------------------------------------------ vocabulary
+
+
+@pytest.mark.unit
+def test_the_operation_vocabulary_is_exported_as_data():
+    """A front-end builds its menu by reading this rather than hardcoding CA's vocabulary."""
+    ops = param_modifier_operations()
+    assert 'scale' in ops
+    assert DEFAULT_PARAM_MODIFIER_OPERATION in ops
+    meta = ops['scale']
+    for key in ('description', 'applies_to', 'dimensionless', 'default_min', 'default_max'):
+        assert key in meta, key
+    assert meta['dimensionless'] is True
+    assert meta['default_min'] < meta['default_max']
+
+
+@pytest.mark.unit
+def test_the_exported_vocabulary_is_a_copy():
+    """A consumer mutating what it introspected must not change CA's own table."""
+    param_modifier_operations()['scale']['default_min'] = 999
+    assert PARAM_MODIFIER_OPERATIONS['scale']['default_min'] != 999
+
+
+# ------------------------------------------------------------------ parsing
+
+
+@pytest.mark.unit
+def test_a_modifier_looks_like_a_grouped_row_to_param_names():
+    info = _info(_doc())
+    assert info['param_names'] == [['aortic_root/C', 'par/C']]
+
+
+@pytest.mark.unit
+def test_a_modifier_is_labelled_by_its_own_name_not_by_its_targets():
+    """theta is its own quantity -- dimensionless for scale -- so labelling it with a target's
+    name would misreport what was calibrated."""
+    info = _info(_doc())
+    assert info['param_labels'] == ['compliance_scale']
+    assert '+' not in info['param_labels'][0]
+
+
+@pytest.mark.unit
+def test_a_modifier_uses_name_for_plotting_when_given():
+    info = _info(_doc(name_for_plotting=r'\theta_{C}'))
+    assert info['param_labels'] == [r'\theta_{C}']
+
+
+@pytest.mark.unit
+def test_the_modifiers_record_carries_what_a_downstream_tool_needs():
+    info = _info(_doc())
+    assert len(info['modifiers']) == 1
+    mod = info['modifiers'][0]
+    assert mod['index'] == 0
+    assert mod['name'] == 'compliance_scale'
+    assert mod['operation'] == 'scale'
+    assert mod['targets'] == ['aortic_root/C', 'par/C']
+    # unresolved is None rather than absent, so a consumer can tell it apart from "no baseline"
+    assert mod['baselines'] is None
+
+
+@pytest.mark.unit
+def test_operation_defaults_to_scale():
+    doc = _doc()
+    del doc['params'][0]['operation']
+    assert _info(doc)['modifiers'][0]['operation'] == DEFAULT_PARAM_MODIFIER_OPERATION
+
+
+@pytest.mark.unit
+def test_the_index_is_computed_after_filtering():
+    """idxs_to_ignore shifts positions, and a stale index would point a slider at the wrong
+    parameter."""
+    parser = _parser()
+    doc = {'version': 1, 'params': [
+        {'name': 'free', 'targets': ['x/C'], 'min': 1, 'max': 2},
+        {'name': 'scale_it', 'modifies': ['y/C'], 'min': 0.5, 'max': 2.0},
+    ]}
+    entries = parser.resolve_params_for_id_doc(doc)
+    info = parser._build_param_id_info_from_entries(entries, idxs_to_ignore=[0])
+    assert info['param_labels'] == ['scale_it']
+    assert info['modifiers'][0]['index'] == 0
+
+
+# ------------------------------------------------------------------ hard errors
+
+
+@pytest.mark.unit
+def test_a_modified_parameter_may_not_also_be_free():
+    """(theta, p) and (theta*k, p/k) give an identical cost, so the optimiser wanders a flat
+    ridge and both reported values are meaningless."""
+    parser = _parser()
+    with pytest.raises(ValueError, match='structurally unidentifiable'):
+        parser.resolve_params_for_id_doc({'version': 1, 'params': [
+            {'name': 'free_C', 'targets': ['aortic_root/C'], 'min': 1e-9, 'max': 5e-8},
+            {'name': 'scale_C', 'modifies': ['aortic_root/C'], 'min': 0.5, 'max': 2.0},
+        ]})
+
+
+@pytest.mark.unit
+def test_the_error_names_both_entries():
+    parser = _parser()
+    with pytest.raises(ValueError, match='free_C'):
+        parser.resolve_params_for_id_doc({'version': 1, 'params': [
+            {'name': 'free_C', 'targets': ['aortic_root/C'], 'min': 1e-9, 'max': 5e-8},
+            {'name': 'scale_C', 'modifies': ['aortic_root/C'], 'min': 0.5, 'max': 2.0},
+        ]})
+
+
+@pytest.mark.unit
+def test_a_modifier_may_not_modify_another_modifier():
+    parser = _parser()
+    # `modifies` holds qnames, and a modifier's name defaults to its first modified qname, so a
+    # chain is reachable whenever a modifier's name is qname-shaped.
+    with pytest.raises(ValueError, match='itself a modifier'):
+        parser.resolve_params_for_id_doc({'version': 1, 'params': [
+            {'name': 'x/C', 'modifies': ['a/C'], 'min': 0.5, 'max': 2.0},
+            {'name': 'outer', 'modifies': ['x/C'], 'min': 0.5, 'max': 2.0},
+        ]})
+
+
+@pytest.mark.unit
+def test_two_modifiers_may_not_act_on_the_same_parameter():
+    """p = theta_1 * theta_2 * baseline: only the product is identifiable, so each factor alone
+    is meaningless -- the same flat ridge as a modified parameter that is also free."""
+    parser = _parser()
+    with pytest.raises(ValueError, match='modified by both'):
+        parser.resolve_params_for_id_doc({'version': 1, 'params': [
+            {'name': 'first', 'modifies': ['a/C'], 'min': 0.5, 'max': 2.0},
+            {'name': 'second', 'modifies': ['a/C'], 'min': 0.5, 'max': 2.0},
+        ]})
+
+
+@pytest.mark.unit
+def test_an_entry_may_not_set_both_targets_and_modifies():
+    parser = _parser()
+    with pytest.raises(ValueError, match='both "targets" and "modifies"'):
+        parser.resolve_params_for_id_doc({'version': 1, 'params': [
+            {'name': 'both', 'targets': ['a/C'], 'modifies': ['b/C'], 'min': 1, 'max': 2}]})
+
+
+@pytest.mark.unit
+def test_operation_without_modifies_is_refused():
+    parser = _parser()
+    with pytest.raises(ValueError, match='no "modifies"'):
+        parser.resolve_params_for_id_doc({'version': 1, 'params': [
+            {'name': 'x', 'targets': ['a/C'], 'operation': 'scale', 'min': 1, 'max': 2}]})
+
+
+@pytest.mark.unit
+def test_an_unknown_operation_is_refused():
+    parser = _parser()
+    with pytest.raises(ValueError, match='unknown operation'):
+        parser.resolve_params_for_id_doc({'version': 1, 'params': [
+            {'name': 'x', 'modifies': ['a/C'], 'operation': 'offset', 'min': 1, 'max': 2}]})
+
+
+@pytest.mark.unit
+def test_a_scale_range_crossing_zero_warns():
+    """A multiplier range straddling zero flips the sign of every target somewhere inside it."""
+    parser = _parser()
+    with pytest.warns(UserWarning, match='crossing zero'):
+        parser.resolve_params_for_id_doc({'version': 1, 'params': [
+            {'name': 'x', 'modifies': ['a/C'], 'min': -1.0, 'max': 2.0}]})
+
+
+# ------------------------------------------------------------------ baselines and expansion
+
+
+@pytest.mark.unit
+def test_baselines_are_resolved_from_the_model_defaults():
+    info = _info(_doc())
+    helper = _FakeHelper({'aortic_root/C': 1.2028e-08, 'par/C': 3.09077e-10})
+    resolve_modifier_baselines(info, helper)
+    assert info['modifiers'][0]['baselines'] == [1.2028e-08, 3.09077e-10]
+
+
+@pytest.mark.unit
+def test_theta_expands_to_one_value_per_target():
+    info = _info(_doc())
+    resolve_modifier_baselines(info, _FakeHelper({'aortic_root/C': 2.0, 'par/C': 5.0}))
+    assert expand_modifier_param_vals(info, [1.5]) == [[3.0, 7.5]]
+
+
+@pytest.mark.unit
+def test_free_parameters_pass_through_the_expansion_untouched():
+    parser = _parser()
+    doc = {'version': 1, 'params': [
+        {'name': 'free', 'targets': ['x/C'], 'min': 1, 'max': 2},
+        {'name': 'scale_it', 'modifies': ['y/C', 'z/C'], 'min': 0.5, 'max': 2.0},
+    ]}
+    info = parser._build_param_id_info_from_entries(parser.resolve_params_for_id_doc(doc))
+    resolve_modifier_baselines(info, _FakeHelper({'y/C': 10.0, 'z/C': 100.0}))
+    assert expand_modifier_param_vals(info, [7.0, 2.0]) == [7.0, [20.0, 200.0]]
+
+
+@pytest.mark.unit
+def test_scaling_does_not_compound_across_iterations():
+    """The highest-value test here: theta must always multiply the *model default*, never the
+    value the previous iteration wrote.
+
+    Re-deriving baselines from the live parameter array would give theta=1.2 twice as 1.44x,
+    silently corrupting a long optimisation. This is not hypothetical -- CasADi's
+    get_init_param_vals reads the live array, which is why baselines are resolved once from the
+    frozen snapshot and never again.
+    """
+    info = _info(_doc())
+    helper = _FakeHelper({'aortic_root/C': 1.0, 'par/C': 2.0})
+    resolve_modifier_baselines(info, helper)
+
+    first = expand_modifier_param_vals(info, [1.2])
+    # a second calibration step at the same theta must give the same absolute values
+    second = expand_modifier_param_vals(info, [1.2])
+    assert first == second == [[1.2, 2.4]]
+    # and re-resolving must not move the baselines either
+    resolve_modifier_baselines(info, helper)
+    assert info['modifiers'][0]['baselines'] == [1.0, 2.0]
+    assert expand_modifier_param_vals(info, [1.2]) == [[1.2, 2.4]]
+
+
+@pytest.mark.unit
+def test_expanding_before_baselines_are_resolved_raises():
+    """Silently expanding with a default of 1.0 would calibrate the wrong quantity."""
+    info = _info(_doc())
+    with pytest.raises(ValueError, match='no resolved baselines'):
+        expand_modifier_param_vals(info, [1.5])
+
+
+@pytest.mark.unit
+def test_a_backend_without_default_param_vals_raises_clearly():
+    info = _info(_doc())
+
+    class _NoDefaults:
+        pass
+
+    with pytest.raises(NotImplementedError, match='get_default_param_vals'):
+        resolve_modifier_baselines(info, _NoDefaults())
+
+
+@pytest.mark.unit
+def test_expansion_is_a_noop_without_modifiers():
+    parser = _parser()
+    info = parser._build_param_id_info_from_entries(parser.resolve_params_for_id_doc(
+        {'version': 1, 'params': [{'name': 'a', 'targets': ['x/C'], 'min': 1, 'max': 2}]}))
+    assert info['modifiers'] == []
+    assert expand_modifier_param_vals(info, [3.0]) == [3.0]
+
+
+@pytest.mark.unit
+def test_the_expanded_values_pair_positionally_with_the_target_names():
+    """The seam with #376: N names against N values is paired positionally, which is why no
+    backend needs to know modifiers exist."""
+    from solver_wrappers.param_grouping import pair_names_with_values
+
+    info = _info(_doc())
+    resolve_modifier_baselines(info, _FakeHelper({'aortic_root/C': 2.0, 'par/C': 5.0}))
+    names = info['param_names'][0]
+    values = expand_modifier_param_vals(info, [3.0])[0]
+    assert pair_names_with_values(names, values) == [('aortic_root/C', 6.0), ('par/C', 15.0)]

--- a/tests/test_params_for_id_json.py
+++ b/tests/test_params_for_id_json.py
@@ -1,0 +1,223 @@
+"""params_for_id as JSON, with the CSV converted on read.
+
+The CSV stays readable forever; it is converted to the JSON structure at the front door and
+everything downstream sees only resolved entries. The whole backwards-compatibility risk lives in
+that conversion: a silent error there would misparameterise a model without failing, so the
+round-trip is asserted exhaustively over every fixture in resources/ rather than by spot checks.
+"""
+import json
+import pathlib
+
+import numpy as np
+import pytest
+
+from parsers.PrimitiveParsers import (
+    ObsAndParamDataParser, PARAMS_FOR_ID_ENTRY_KEYS, PARAMS_FOR_ID_JSON_VERSION)
+
+RESOURCES = pathlib.Path(__file__).resolve().parent.parent / 'resources'
+FIXTURES = sorted(RESOURCES.glob('*params_for_id.csv'))
+
+
+def _parser():
+    return ObsAndParamDataParser()
+
+
+def _assert_info_equal(a, b, context):
+    assert set(a) == set(b), f'{context}: key sets differ'
+    for key in a:
+        left, right = a[key], b[key]
+        if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
+            left, right = np.asarray(left), np.asarray(right)
+            assert left.shape == right.shape, f'{context}: {key} shape'
+            if left.dtype.kind == 'f':
+                assert np.allclose(left, right, equal_nan=True), f'{context}: {key}'
+            else:
+                assert list(left) == list(right), f'{context}: {key}'
+        else:
+            assert left == right, f'{context}: {key}'
+
+
+@pytest.mark.unit
+def test_there_are_fixtures_to_check():
+    """A glob that silently matched nothing would make the whole suite below vacuous."""
+    assert len(FIXTURES) >= 15, [f.name for f in FIXTURES]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('csv_path', FIXTURES, ids=lambda p: p.stem)
+def test_every_fixture_converts_to_json_and_back_to_the_same_param_id_info(csv_path, tmp_path):
+    """CSV -> JSON -> param_id_info must equal CSV -> param_id_info, key by key.
+
+    This is the backwards-compatibility guarantee. Every existing user study is a CSV.
+    """
+    parser = _parser()
+    from_csv = parser.get_param_id_info(str(csv_path))
+
+    doc = parser.params_for_id_csv_to_json(str(csv_path))
+    json_path = tmp_path / f'{csv_path.stem}.json'
+    json_path.write_text(json.dumps(doc))
+    from_json = parser.get_param_id_info(str(json_path))
+
+    _assert_info_equal(from_csv, from_json, csv_path.name)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('csv_path', FIXTURES, ids=lambda p: p.stem)
+def test_the_converter_output_is_json_serialisable_and_well_formed(csv_path):
+    """CUFLynx reads this straight into an editor, so it must be plain JSON with known keys."""
+    doc = _parser().params_for_id_csv_to_json(str(csv_path))
+    json.dumps(doc)  # raises on numpy scalars or NaN-typed leftovers
+
+    assert doc['version'] == PARAMS_FOR_ID_JSON_VERSION
+    assert isinstance(doc['params'], list) and doc['params']
+    for entry in doc['params']:
+        assert set(entry) <= PARAMS_FOR_ID_ENTRY_KEYS, set(entry) - PARAMS_FOR_ID_ENTRY_KEYS
+        assert entry['targets'] and all('/' in t for t in entry['targets'])
+        assert entry['name']
+
+
+@pytest.mark.unit
+def test_a_grouped_row_becomes_one_entry_with_several_targets():
+    """vessel_name='a b' is one calibrated value over two qnames -- one entry, two targets."""
+    csv_text = ('vessel_name,param_name,min,max\n'
+                'a b,C,1e-9,5e-8\n')
+    doc = _parser().params_for_id_csv_to_json(csv_text)
+    assert len(doc['params']) == 1
+    assert doc['params'][0]['targets'] == ['a/C', 'b/C']
+
+
+@pytest.mark.unit
+def test_the_global_plus_named_vessel_gen_names_survive_conversion():
+    """#368/#350: a row mixing 'global' with named vessels must emit one gen name per vessel.
+
+    Deciding the whole row from the first vessel dropped every vessel after it, while param_names
+    kept them, so the two positional lists stopped describing the same parameters.
+    """
+    csv_text = ('vessel_name,param_name,min,max\n'
+                'global a b,C,1e-9,5e-8\n')
+    parser = _parser()
+    info = parser._build_param_id_info_from_entries(
+        parser.resolve_params_for_id_doc(parser.params_for_id_csv_to_json(csv_text)))
+
+    assert info['param_names'] == [['global/C', 'a/C', 'b/C']]
+    # 'global' contributes the bare param name; a named vessel gets the suffix
+    assert info['param_names_for_gen'] == [['C', 'C_a', 'C_b']]
+
+
+@pytest.mark.unit
+def test_targets_may_mix_different_parameter_names():
+    """The reason for JSON: a CSV row has one param_name for all its vessels, so an arbitrary
+    group could not be written at all."""
+    parser = _parser()
+    doc = {'version': 1, 'params': [
+        {'name': 'mixed', 'targets': ['aortic_root/C', 'heart/E_lv_A'], 'min': 0.5, 'max': 2.0},
+    ]}
+    info = parser._build_param_id_info_from_entries(parser.resolve_params_for_id_doc(doc))
+    assert info['param_names'] == [['aortic_root/C', 'heart/E_lv_A']]
+    assert info['param_names_for_gen'] == [['C_aortic_root', 'E_lv_A_heart']]
+
+
+@pytest.mark.unit
+def test_defaults_apply_and_an_entry_overrides_them():
+    """The 'easier to change general priors' ask: set the family once at the top."""
+    parser = _parser()
+    doc = {'version': 1,
+           'defaults': {'prior': 'uniform', 'param_type': 'const'},
+           'params': [
+               {'name': 'a', 'targets': ['x/C'], 'min': 1.0, 'max': 2.0},
+               {'name': 'b', 'targets': ['y/C'], 'min': 1.0, 'max': 2.0, 'prior': 'normal',
+                'prior_params': {'prior_mean': 1.5, 'prior_std': 0.1}},
+           ]}
+    info = parser._build_param_id_info_from_entries(parser.resolve_params_for_id_doc(doc))
+    assert list(info['param_prior_types']) == ['uniform', 'normal']
+
+
+@pytest.mark.unit
+def test_prior_params_merge_per_key_rather_than_wholesale():
+    """A defaults block setting one hyper-parameter must not wipe an entry's other one."""
+    parser = _parser()
+    doc = {'version': 1,
+           'defaults': {'prior': 'normal', 'prior_params': {'prior_std': 0.25}},
+           'params': [{'name': 'a', 'targets': ['x/C'], 'min': 1.0, 'max': 2.0,
+                       'prior_params': {'prior_mean': 1.5}}]}
+    entries = parser.resolve_params_for_id_doc(doc)
+    assert entries[0]['prior_params'] == {'prior_std': 0.25, 'prior_mean': 1.5}
+
+
+@pytest.mark.unit
+def test_an_unknown_entry_key_is_refused():
+    """Same stance as operation_kwargs/cost_kwargs: a key nothing reads changes nothing and gives
+    no sign it was ignored."""
+    parser = _parser()
+    with pytest.raises(ValueError, match='unknown key'):
+        parser.resolve_params_for_id_doc(
+            {'version': 1, 'params': [{'targets': ['x/C'], 'min': 1, 'max': 2, 'mn': 0.1}]})
+
+
+@pytest.mark.unit
+def test_an_unknown_defaults_key_is_refused():
+    parser = _parser()
+    with pytest.raises(ValueError, match='unknown key'):
+        parser.resolve_params_for_id_doc(
+            {'version': 1, 'defaults': {'priorr': 'uniform'},
+             'params': [{'targets': ['x/C'], 'min': 1, 'max': 2}]})
+
+
+@pytest.mark.unit
+def test_duplicate_entry_names_are_refused():
+    parser = _parser()
+    with pytest.raises(ValueError, match='reuses the name'):
+        parser.resolve_params_for_id_doc({'version': 1, 'params': [
+            {'name': 'dup', 'targets': ['x/C'], 'min': 1, 'max': 2},
+            {'name': 'dup', 'targets': ['y/C'], 'min': 1, 'max': 2},
+        ]})
+
+
+@pytest.mark.unit
+def test_a_target_without_a_component_is_refused():
+    """The most common typo, and it used to fail much later and less clearly."""
+    parser = _parser()
+    with pytest.raises(ValueError, match="not a 'component/param' name"):
+        parser.resolve_params_for_id_doc(
+            {'version': 1, 'params': [{'targets': ['C'], 'min': 1, 'max': 2}]})
+
+
+@pytest.mark.unit
+def test_an_unsupported_version_is_refused():
+    parser = _parser()
+    with pytest.raises(ValueError, match='version'):
+        parser.resolve_params_for_id_doc(
+            {'version': 99, 'params': [{'targets': ['x/C'], 'min': 1, 'max': 2}]})
+
+
+@pytest.mark.unit
+def test_name_defaults_to_the_first_target():
+    parser = _parser()
+    entries = parser.resolve_params_for_id_doc(
+        {'version': 1, 'params': [{'targets': ['a/C', 'b/C'], 'min': 1, 'max': 2}]})
+    assert entries[0]['name'] == 'a/C'
+
+
+@pytest.mark.unit
+def test_idxs_to_ignore_filters_entries():
+    parser = _parser()
+    doc = {'version': 1, 'params': [
+        {'name': 'a', 'targets': ['x/C'], 'min': 1, 'max': 2},
+        {'name': 'b', 'targets': ['y/C'], 'min': 3, 'max': 4},
+    ]}
+    entries = parser.resolve_params_for_id_doc(doc)
+    info = parser._build_param_id_info_from_entries(entries, idxs_to_ignore=[0])
+    assert info['param_names'] == [['y/C']]
+    assert info['param_entry_names'] == ['b']
+
+
+@pytest.mark.unit
+def test_the_programmatic_dict_api_still_works_and_agrees_with_the_csv():
+    """The in-code params_for_id form is documented in CLAUDE.md and must keep working."""
+    parser = _parser()
+    from_entries = parser.get_param_id_info_from_entries([
+        {'vessel_name': 'aortic_root', 'param_name': 'C', 'min': 1e-9, 'max': 5e-8},
+        {'vessel_name': ['a', 'b'], 'param_name': 'R', 'min': 1.0, 'max': 2.0},
+    ])
+    assert from_entries['param_names'] == [['aortic_root/C'], ['a/R', 'b/R']]
+    assert from_entries['param_names_for_gen'] == [['C_aortic_root'], ['R_a', 'R_b']]


### PR DESCRIPTION
**Stacked on #377** (`feat/params-for-id-json`). GitHub will not base a cross-fork PR on a fork branch, so this is opened against `master` and currently shows **both** commits — #377's JSON commit and this one. Merge #377 first and this diff reduces to the modifier commit alone. Second of three; the sensitivity chain rule is PR 3.

## Modifier entries

A modifier names the parameters it acts on with `modifies` and what it does with `operation`. Its `min`/`max`/`prior` belong to **its own calibrated value**, not to the parameters it modifies — for `scale`, θ is dimensionless and the bounds are multipliers.

```json
{"name": "compliance_scale",
 "modifies": ["aortic_root/C", "par/C", "heart/E_lv_A"],
 "operation": "scale", "min": 0.5, "max": 2.0,
 "name_for_plotting": "\\theta_{C}"}
```

To every consumer a modifier looks exactly like a grouped row — one variable to the sampler and the optimiser, N parameters to set, the distinction #376 already drew. The only difference is *what value* each of the N receives, resolved in one place: `expand_modifier_param_vals` turns θ into `θ · baseline_i`, then `pair_names_with_values` pairs N names with N values positionally. **No backend needs to know modifiers exist.**

## Baselines: the correction from the handover reply

The CUFLynx handover assumed `get_init_param_vals` returns pristine model values after `set_param_vals` has written. That's **true on Myokit** (it reads `default_values`) and **false on CasADi**, which reads the live array `set_param_vals` writes into — measured directly: after writing `2.4056e-08`, CasADi returned `2.4056e-08` while Myokit still returned `1.2028e-08`.

Re-deriving a baseline mid-calibration would therefore apply θ to an already-scaled value and compound it every iteration — **θ=1.2 twice giving 1.44×**, exactly the failure the handover flagged as its highest-value test.

So baselines are resolved **once**, right after the simulation helper is built and before anything has written, via a new backend-agnostic `get_default_param_vals`. On CasADi that snapshot has to be taken after `_store_variable_defaults`, since `self.variables` only becomes the constants-only array there — I got that wrong first and caught it reading the init order.

## Hard errors

Each produces a calibration that runs, converges, and means nothing:

- **A parameter that is both modified and free** — (θ, p) and (θ·k, p/k) give an identical cost, so the optimiser wanders a flat ridge and neither value means anything. Names both entries.
- **Two modifiers on one parameter** — only the product θ₁·θ₂ is identifiable. *Not in the original spec; found while writing the tests, same flat ridge reached a different way.*
- **A modifier of a modifier**; an entry setting both `targets` and `modifies`; `operation` without `modifies`; an unknown operation.

A `scale` range crossing zero **warns** rather than raises — legal arithmetic, just almost never meant.

## Interface for downstream tools

`PARAM_MODIFIER_OPERATIONS` is exported as data beside `PARAM_PRIOR_TYPES`, with `param_modifier_operations()` returning a copy so a consumer mutating what it introspected can't corrupt CA's table.

`param_id_info` gains:

- **`modifiers`** — `index`, `name`, `operation`, `targets`, `baselines`. `index` is computed **after** `idxs_to_ignore` filtering so it's valid for the dict it ships with; match on `name` if carrying a modifier between builds. `baselines` is `None` until resolved rather than absent, so "not resolved yet" is distinguishable from "no baseline".
- **`param_labels`** — a modifier is labelled by its own name, never by a `'+'`-join of its targets. θ is its own quantity and labelling it with a target's name would misreport what was calibrated.

Resolved records are written to `param_modifiers.json` in the output dir: `best_param_vals` holds θ, and θ alone doesn't say what any model parameter ended up at.

## Sensitivity arms refuse a modifier, for now

Per §7 of the handover. A modifier's derivative is a **weighted** chain rule, `dO/dθ = Σᵢ (∂O/∂pᵢ)·baselineᵢ`, not the plain sum a shared-value group needs — and both arms still flatten a group to its first member, so a modifier would silently report one target's derivative as θ's. Global Sobol SA handles modifiers correctly and the error says so.

## Testing

24 new tests in `tests/test_param_modifiers.py`, including the compounding test the handover called the highest-value one: θ applied twice must give the same absolute values, and re-resolving must not move the baselines.

`-m "not slow"`: **468 passed, 5 skipped, 1 failed** — `test_python_BDF_solver[SN_simple]` (#151), verified pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
