### PR TITLE
fix(solvers): Myokit set_tolerance args were swapped; CVODE_myokit defaults become rel 1e-6 / abs 1e-8

### DIFF
--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -259,7 +259,16 @@ _CVODE_FAMILY_SOLVER_INFO = [
 _MYOKIT_SOLVER_INFO = [
     {'name': 'MaximumStep', 'type': 'float', 'default': 0.001, 'required': False,
      'description': 'Maximum integrator step size (myokit Simulation.set_max_step_size).'},
-    _SI_RTOL, _SI_ATOL,
+    # Myokit's own set_tolerance defaults (rel 1e-4, abs 1e-6), not the 1e-8/1e-8 the rest of
+    # the CVODE family declares. Front-ends seed interactive solves from these declared
+    # defaults, and 1e-8/1e-8 costs ~2.3x per solve on 3compartment (209 ms vs 92 ms) with no
+    # accuracy need on the plain forward path -- tighter is a deliberate user choice. FSA is
+    # unaffected: it still forces 1e-8/1e-8 when the user set none, because a sloppy forward
+    # solve makes a poor gradient (see myokit_helper.apply_cvodes_tolerances).
+    {**_SI_RTOL, 'default': 1e-4,
+     'description': "Relative integration tolerance (default: Myokit's own, 1e-4)."},
+    {**_SI_ATOL, 'default': 1e-6,
+     'description': "Absolute integration tolerance (default: Myokit's own, 1e-6)."},
 ]
 
 # Shared by 'solve_ivp' and 'user_defined': the user wrapper supplies only the RHS and is

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -259,16 +259,17 @@ _CVODE_FAMILY_SOLVER_INFO = [
 _MYOKIT_SOLVER_INFO = [
     {'name': 'MaximumStep', 'type': 'float', 'default': 0.001, 'required': False,
      'description': 'Maximum integrator step size (myokit Simulation.set_max_step_size).'},
-    # Myokit's own set_tolerance defaults (rel 1e-4, abs 1e-6), not the 1e-8/1e-8 the rest of
-    # the CVODE family declares. Front-ends seed interactive solves from these declared
-    # defaults, and 1e-8/1e-8 costs ~2.3x per solve on 3compartment (209 ms vs 92 ms) with no
-    # accuracy need on the plain forward path -- tighter is a deliberate user choice. FSA is
-    # unaffected: it still forces 1e-8/1e-8 when the user set none, because a sloppy forward
-    # solve makes a poor gradient (see myokit_helper.apply_cvodes_tolerances).
-    {**_SI_RTOL, 'default': 1e-4,
-     'description': "Relative integration tolerance (default: Myokit's own, 1e-4)."},
-    {**_SI_ATOL, 'default': 1e-6,
-     'description': "Absolute integration tolerance (default: Myokit's own, 1e-6)."},
+    # rel 1e-6 / abs 1e-8, not the 1e-8/1e-8 the rest of the CVODE family declares. abs stays
+    # at the 1e-8 floor previous users ran at, so existing models do not start failing; rel is
+    # relaxed to 1e-6 because the relative knob is where most of the 1e-8/1e-8 interactive
+    # solve cost was (1e-8/1e-8 measured ~2.3x slower than Myokit's own defaults on
+    # 3compartment). Front-ends seed interactive solves from these declared defaults, and the
+    # helper applies the same values when the user sets neither, so declared and effective
+    # cannot drift (mirrored by myokit_helper.CA_DEFAULT_*; a test pins them equal). FSA still
+    # forces 1e-8/1e-8 when the user set none -- a sloppy forward solve makes a poor gradient
+    # (see myokit_helper.apply_cvodes_tolerances).
+    {**_SI_RTOL, 'default': 1e-6},
+    {**_SI_ATOL, 'default': 1e-8},
 ]
 
 # Shared by 'solve_ivp' and 'user_defined': the user wrapper supplies only the RHS and is

--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -18,11 +18,14 @@ import re
 import os
 
 
-# Myokit's own Simulation.set_tolerance defaults. Used to fill in whichever of rtol/atol the
-# user left unset (set_tolerance takes both, so a partial setting needs a partner value), and
-# mirrored by the CVODE_myokit schema defaults in PrimitiveParsers.SOLVER_INFO_FIELDS.
-MYOKIT_DEFAULT_ABS_TOL = 1e-6
-MYOKIT_DEFAULT_REL_TOL = 1e-4
+# CA's default CVODES tolerances for the Myokit backend, mirrored by the CVODE_myokit schema
+# defaults in PrimitiveParsers.SOLVER_INFO_FIELDS (a test pins the two equal). abs 1e-8 keeps
+# the absolute floor previous users ran at (the long-standing declared default was 1e-8/1e-8),
+# so existing models do not start failing; rel 1e-6 relaxes only the relative knob, which is
+# where most of the 1e-8/1e-8 solve cost was. Applied whenever the user sets neither value, and
+# used to fill in the partner when only one is set (set_tolerance takes both).
+CA_DEFAULT_ABS_TOL = 1e-8
+CA_DEFAULT_REL_TOL = 1e-6
 
 
 def apply_cvodes_tolerances(simulation, solver_info, fsa_enabled):
@@ -34,31 +37,30 @@ def apply_cvodes_tolerances(simulation, solver_info, fsa_enabled):
     symmetric 1e-8/1e-8, and measurable the moment they differ. Keyword arguments make the
     mapping explicit so it cannot silently swap again.
 
-    With neither tolerance set the simulation keeps Myokit's own defaults -- except under FSA:
-    CVODES forward sensitivities are only as accurate as the state integration, and the default
-    tolerance leaves a noise floor that swamps small sensitivities, so tighten to 1e-8/1e-8
-    (unless the user set explicit tolerances) when FSA is active.
+    With neither tolerance set, CA's own defaults apply (CA_DEFAULT_ABS_TOL /
+    CA_DEFAULT_REL_TOL) -- the declared schema default and the applied value are the same
+    thing, whichever front door the run came through. Under FSA the unset case tightens
+    further to 1e-8/1e-8: CVODES forward sensitivities are only as accurate as the state
+    integration, and a looser tolerance leaves a noise floor that swamps small sensitivities.
+    Explicit user values always win.
 
     Returns the effective ``(abs_tol, rel_tol)`` -- what the simulation will actually integrate
-    with, Myokit's own defaults included -- so failure diagnostics can report real values
-    rather than re-deriving them.
+    with -- so failure diagnostics can report real values rather than re-deriving them.
     """
     rtol = solver_info.get("rtol", None)
     atol = solver_info.get("atol", None)
     if (rtol is None and atol is None) and fsa_enabled:
         rtol, atol = 1e-8, 1e-8
-    if rtol is None and atol is None:
-        return MYOKIT_DEFAULT_ABS_TOL, MYOKIT_DEFAULT_REL_TOL
-    abs_tol = atol if atol is not None else MYOKIT_DEFAULT_ABS_TOL
-    rel_tol = rtol if rtol is not None else MYOKIT_DEFAULT_REL_TOL
+    abs_tol = atol if atol is not None else CA_DEFAULT_ABS_TOL
+    rel_tol = rtol if rtol is not None else CA_DEFAULT_REL_TOL
     simulation.set_tolerance(abs_tol=abs_tol, rel_tol=rel_tol)
     return abs_tol, rel_tol
 
 
 def stability_hint(solver_info, effective_tolerances):
     """The one-line hint a failed solve carries: the three solver_info knobs that govern CVODES
-    stability, with their *effective* values (Myokit defaults included, so 'unset' still reads
-    as a number a user can decrease)."""
+    stability, with their *effective* values (CA defaults included, so 'unset' still reads as
+    a number a user can decrease)."""
     max_step = solver_info.get("MaximumStep")
     abs_tol, rel_tol = effective_tolerances
     max_step_str = "unset (unbounded)" if max_step is None else f"{max_step}"
@@ -595,7 +597,7 @@ class SimulationHelper:
                 + stability_hint(
                     self.solver_info,
                     getattr(self, '_effective_tolerances',
-                            (MYOKIT_DEFAULT_ABS_TOL, MYOKIT_DEFAULT_REL_TOL))))
+                            (CA_DEFAULT_ABS_TOL, CA_DEFAULT_REL_TOL))))
             return False
         return True
 

--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -16,6 +16,38 @@ import re
 import os
 
 
+# Myokit's own Simulation.set_tolerance defaults. Used to fill in whichever of rtol/atol the
+# user left unset (set_tolerance takes both, so a partial setting needs a partner value), and
+# mirrored by the CVODE_myokit schema defaults in PrimitiveParsers.SOLVER_INFO_FIELDS.
+MYOKIT_DEFAULT_ABS_TOL = 1e-6
+MYOKIT_DEFAULT_REL_TOL = 1e-4
+
+
+def apply_cvodes_tolerances(simulation, solver_info, fsa_enabled):
+    """Apply solver_info's ``rtol``/``atol`` to a myokit Simulation.
+
+    Myokit's signature is ``set_tolerance(abs_tol, rel_tol)`` -- absolute *first*, the reverse
+    of the rtol-then-atol order CA's schema lists. They were passed positionally in that schema
+    order, so each reached the other argument: invisible while CA's declared default was a
+    symmetric 1e-8/1e-8, and measurable the moment they differ. Keyword arguments make the
+    mapping explicit so it cannot silently swap again.
+
+    With neither tolerance set the simulation keeps Myokit's own defaults -- except under FSA:
+    CVODES forward sensitivities are only as accurate as the state integration, and the default
+    tolerance leaves a noise floor that swamps small sensitivities, so tighten to 1e-8/1e-8
+    (unless the user set explicit tolerances) when FSA is active.
+    """
+    rtol = solver_info.get("rtol", None)
+    atol = solver_info.get("atol", None)
+    if (rtol is None and atol is None) and fsa_enabled:
+        rtol, atol = 1e-8, 1e-8
+    if rtol is not None or atol is not None:
+        simulation.set_tolerance(
+            abs_tol=atol if atol is not None else MYOKIT_DEFAULT_ABS_TOL,
+            rel_tol=rtol if rtol is not None else MYOKIT_DEFAULT_REL_TOL,
+        )
+
+
 class SimulationHelper:
     """
     Myokit-based solver wrapper matching the OpenCOR SimulationHelper interface.
@@ -277,18 +309,7 @@ class SimulationHelper:
                 self.simulation.set_max_step_size(self.solver_info["MaximumStep"])
             except Exception:
                 pass
-        rtol = self.solver_info.get("rtol", None)
-        atol = self.solver_info.get("atol", None)
-        if (rtol is None and atol is None) and self._fsa_enabled:
-            # CVODES forward sensitivities are only as accurate as the state integration;
-            # the default tolerance leaves a noise floor that swamps small sensitivities,
-            # so tighten it (unless the user set explicit tolerances) when FSA is active.
-            rtol, atol = 1e-8, 1e-8
-        if rtol is not None or atol is not None:
-            self.simulation.set_tolerance(
-                rtol if rtol is not None else 1e-8,
-                atol if atol is not None else 1e-8,
-            )
+        apply_cvodes_tolerances(self.simulation, self.solver_info, self._fsa_enabled)
         self.last_log = None
         if hasattr(self, "all_vars"):
             self._init_defaults()

--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -1,5 +1,7 @@
 import os
 import copy
+import warnings
+
 import numpy as np
 
 from solver_wrappers.param_grouping import pair_names_with_values
@@ -36,16 +38,32 @@ def apply_cvodes_tolerances(simulation, solver_info, fsa_enabled):
     CVODES forward sensitivities are only as accurate as the state integration, and the default
     tolerance leaves a noise floor that swamps small sensitivities, so tighten to 1e-8/1e-8
     (unless the user set explicit tolerances) when FSA is active.
+
+    Returns the effective ``(abs_tol, rel_tol)`` -- what the simulation will actually integrate
+    with, Myokit's own defaults included -- so failure diagnostics can report real values
+    rather than re-deriving them.
     """
     rtol = solver_info.get("rtol", None)
     atol = solver_info.get("atol", None)
     if (rtol is None and atol is None) and fsa_enabled:
         rtol, atol = 1e-8, 1e-8
-    if rtol is not None or atol is not None:
-        simulation.set_tolerance(
-            abs_tol=atol if atol is not None else MYOKIT_DEFAULT_ABS_TOL,
-            rel_tol=rtol if rtol is not None else MYOKIT_DEFAULT_REL_TOL,
-        )
+    if rtol is None and atol is None:
+        return MYOKIT_DEFAULT_ABS_TOL, MYOKIT_DEFAULT_REL_TOL
+    abs_tol = atol if atol is not None else MYOKIT_DEFAULT_ABS_TOL
+    rel_tol = rtol if rtol is not None else MYOKIT_DEFAULT_REL_TOL
+    simulation.set_tolerance(abs_tol=abs_tol, rel_tol=rel_tol)
+    return abs_tol, rel_tol
+
+
+def stability_hint(solver_info, effective_tolerances):
+    """The one-line hint a failed solve carries: the three solver_info knobs that govern CVODES
+    stability, with their *effective* values (Myokit defaults included, so 'unset' still reads
+    as a number a user can decrease)."""
+    max_step = solver_info.get("MaximumStep")
+    abs_tol, rel_tol = effective_tolerances
+    max_step_str = "unset (unbounded)" if max_step is None else f"{max_step}"
+    return (f"MaximumStep is {max_step_str}, atol is {abs_tol}, rtol is {rel_tol}; "
+            f"decreasing these (solver_info MaximumStep / atol / rtol) may help stability.")
 
 
 class SimulationHelper:
@@ -309,7 +327,8 @@ class SimulationHelper:
                 self.simulation.set_max_step_size(self.solver_info["MaximumStep"])
             except Exception:
                 pass
-        apply_cvodes_tolerances(self.simulation, self.solver_info, self._fsa_enabled)
+        self._effective_tolerances = apply_cvodes_tolerances(
+            self.simulation, self.solver_info, self._fsa_enabled)
         self.last_log = None
         if hasattr(self, "all_vars"):
             self._init_defaults()
@@ -568,6 +587,15 @@ class SimulationHelper:
                 )
             else:
                 print(f"Myokit simulation failed: {e}")
+            # The three solver_info knobs that govern CVODES stability, with their effective
+            # values -- so a failed solve tells the user which numbers to turn, not just that
+            # it failed.
+            warnings.warn(
+                "Myokit simulation failed: "
+                + stability_hint(
+                    self.solver_info,
+                    getattr(self, '_effective_tolerances',
+                            (MYOKIT_DEFAULT_ABS_TOL, MYOKIT_DEFAULT_REL_TOL))))
             return False
         return True
 

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -1067,13 +1067,14 @@ def test_asymmetric_tolerances_reach_the_right_myokit_arguments():
 
 
 @pytest.mark.unit
-def test_no_tolerances_means_myokits_own_defaults():
-    """With neither set (and no FSA), set_tolerance is not called at all -- the simulation
-    keeps whatever Myokit chose, and CA does not restate it. The effective values are still
-    reported, so failure diagnostics have real numbers."""
+def test_no_tolerances_means_cas_own_defaults_are_applied():
+    """With neither set (and no FSA), CA's declared defaults are applied -- abs stays at the
+    1e-8 floor previous users ran at (so existing models do not start failing), rel relaxes
+    to 1e-6. Declared and effective are the same thing, whichever front door the run came
+    through."""
     calls, effective = _apply({})
-    assert calls == []
-    assert effective == (1e-6, 1e-4)
+    assert calls == [{'abs_tol': 1e-8, 'rel_tol': 1e-6}]
+    assert effective == (1e-8, 1e-6)
 
 
 @pytest.mark.unit
@@ -1092,12 +1093,11 @@ def test_explicit_tolerances_win_over_the_fsa_tightening():
 
 
 @pytest.mark.unit
-def test_a_partial_setting_fills_the_partner_with_myokits_default():
-    """set_tolerance takes both values, so setting only one needs a partner: Myokit's own
-    default for the other, not 1e-8 (which would silently tighten a knob the user never
-    touched)."""
-    assert _apply({'rtol': 1e-5})[0] == [{'abs_tol': 1e-6, 'rel_tol': 1e-5}]
-    assert _apply({'atol': 1e-9})[0] == [{'abs_tol': 1e-9, 'rel_tol': 1e-4}]
+def test_a_partial_setting_fills_the_partner_with_cas_default():
+    """set_tolerance takes both values, so setting only one needs a partner: CA's declared
+    default for the other, the same value the schema advertises."""
+    assert _apply({'rtol': 1e-5})[0] == [{'abs_tol': 1e-8, 'rel_tol': 1e-5}]
+    assert _apply({'atol': 1e-9})[0] == [{'abs_tol': 1e-9, 'rel_tol': 1e-6}]
 
 
 @pytest.mark.unit
@@ -1105,10 +1105,10 @@ def test_a_failed_solve_names_the_stability_knobs_and_their_values():
     """A failed solve must tell the user which numbers to turn: the effective MaximumStep,
     atol and rtol, and that decreasing them may help stability."""
     from solver_wrappers.myokit_helper import stability_hint
-    hint = stability_hint({'MaximumStep': 0.001}, (1e-6, 1e-4))
+    hint = stability_hint({'MaximumStep': 0.001}, (1e-8, 1e-6))
     assert 'MaximumStep is 0.001' in hint
-    assert 'atol is 1e-06' in hint
-    assert 'rtol is 0.0001' in hint
+    assert 'atol is 1e-08' in hint
+    assert 'rtol is 1e-06' in hint
     assert 'decreasing these' in hint and 'stability' in hint
 
 
@@ -1117,7 +1117,7 @@ def test_the_stability_hint_reports_an_unset_maximum_step_honestly():
     """No MaximumStep in solver_info means the integrator step is unbounded -- say so, rather
     than inventing a number the user never set."""
     from solver_wrappers.myokit_helper import stability_hint
-    hint = stability_hint({}, (1e-6, 1e-4))
+    hint = stability_hint({}, (1e-8, 1e-6))
     assert 'MaximumStep is unset (unbounded)' in hint
 
 
@@ -1132,13 +1132,12 @@ def test_myokit_set_tolerance_still_takes_abs_and_rel_keywords():
 
 
 @pytest.mark.unit
-def test_cvode_myokit_schema_declares_myokits_own_defaults():
+def test_cvode_myokit_schema_declares_cas_defaults():
     """Front-ends seed interactive solves from these declared defaults (they deliberately do
-    not restate them), so the declaration is the one place the default is decided. 1e-8/1e-8
-    measured ~2.3x slower per solve on 3compartment with no accuracy need on the plain
-    forward path."""
-    from solver_wrappers.myokit_helper import (
-        MYOKIT_DEFAULT_ABS_TOL, MYOKIT_DEFAULT_REL_TOL)
+    not restate them), so the declaration is the one place the default is decided -- and it
+    must equal what the helper applies when the user sets neither, or declared and effective
+    drift apart. abs keeps the 1e-8 floor previous users ran at; rel relaxes to 1e-6."""
+    from solver_wrappers.myokit_helper import CA_DEFAULT_ABS_TOL, CA_DEFAULT_REL_TOL
     fields = {f['name']: f for f in solver_info_fields('CVODE_myokit')}
-    assert fields['rtol']['default'] == MYOKIT_DEFAULT_REL_TOL == 1e-4
-    assert fields['atol']['default'] == MYOKIT_DEFAULT_ABS_TOL == 1e-6
+    assert fields['rtol']['default'] == CA_DEFAULT_REL_TOL == 1e-6
+    assert fields['atol']['default'] == CA_DEFAULT_ABS_TOL == 1e-8

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -1052,8 +1052,8 @@ class _RecordingSimulation:
 def _apply(solver_info, fsa_enabled=False):
     from solver_wrappers.myokit_helper import apply_cvodes_tolerances
     sim = _RecordingSimulation()
-    apply_cvodes_tolerances(sim, solver_info, fsa_enabled)
-    return sim.tolerance_calls
+    effective = apply_cvodes_tolerances(sim, solver_info, fsa_enabled)
+    return sim.tolerance_calls, effective
 
 
 @pytest.mark.unit
@@ -1061,27 +1061,33 @@ def test_asymmetric_tolerances_reach_the_right_myokit_arguments():
     """rtol must arrive as rel_tol and atol as abs_tol. Swapped, this call would apply
     abs 1e-4 / rel 1e-6 -- measured bit-identical to Myokit's own defaults on 3compartment,
     which is how the swap stayed invisible."""
-    calls = _apply({'rtol': 1e-4, 'atol': 1e-6})
+    calls, effective = _apply({'rtol': 1e-4, 'atol': 1e-6})
     assert calls == [{'abs_tol': 1e-6, 'rel_tol': 1e-4}]
+    assert effective == (1e-6, 1e-4)
 
 
 @pytest.mark.unit
 def test_no_tolerances_means_myokits_own_defaults():
     """With neither set (and no FSA), set_tolerance is not called at all -- the simulation
-    keeps whatever Myokit chose, and CA does not restate it."""
-    assert _apply({}) == []
+    keeps whatever Myokit chose, and CA does not restate it. The effective values are still
+    reported, so failure diagnostics have real numbers."""
+    calls, effective = _apply({})
+    assert calls == []
+    assert effective == (1e-6, 1e-4)
 
 
 @pytest.mark.unit
 def test_fsa_tightens_to_1e8_when_the_user_set_none():
     """CVODES sensitivities are only as accurate as the state solve; the default tolerance's
     noise floor swamps small sensitivities."""
-    assert _apply({}, fsa_enabled=True) == [{'abs_tol': 1e-8, 'rel_tol': 1e-8}]
+    calls, effective = _apply({}, fsa_enabled=True)
+    assert calls == [{'abs_tol': 1e-8, 'rel_tol': 1e-8}]
+    assert effective == (1e-8, 1e-8)
 
 
 @pytest.mark.unit
 def test_explicit_tolerances_win_over_the_fsa_tightening():
-    calls = _apply({'rtol': 1e-5, 'atol': 1e-7}, fsa_enabled=True)
+    calls, _ = _apply({'rtol': 1e-5, 'atol': 1e-7}, fsa_enabled=True)
     assert calls == [{'abs_tol': 1e-7, 'rel_tol': 1e-5}]
 
 
@@ -1090,8 +1096,29 @@ def test_a_partial_setting_fills_the_partner_with_myokits_default():
     """set_tolerance takes both values, so setting only one needs a partner: Myokit's own
     default for the other, not 1e-8 (which would silently tighten a knob the user never
     touched)."""
-    assert _apply({'rtol': 1e-5}) == [{'abs_tol': 1e-6, 'rel_tol': 1e-5}]
-    assert _apply({'atol': 1e-9}) == [{'abs_tol': 1e-9, 'rel_tol': 1e-4}]
+    assert _apply({'rtol': 1e-5})[0] == [{'abs_tol': 1e-6, 'rel_tol': 1e-5}]
+    assert _apply({'atol': 1e-9})[0] == [{'abs_tol': 1e-9, 'rel_tol': 1e-4}]
+
+
+@pytest.mark.unit
+def test_a_failed_solve_names_the_stability_knobs_and_their_values():
+    """A failed solve must tell the user which numbers to turn: the effective MaximumStep,
+    atol and rtol, and that decreasing them may help stability."""
+    from solver_wrappers.myokit_helper import stability_hint
+    hint = stability_hint({'MaximumStep': 0.001}, (1e-6, 1e-4))
+    assert 'MaximumStep is 0.001' in hint
+    assert 'atol is 1e-06' in hint
+    assert 'rtol is 0.0001' in hint
+    assert 'decreasing these' in hint and 'stability' in hint
+
+
+@pytest.mark.unit
+def test_the_stability_hint_reports_an_unset_maximum_step_honestly():
+    """No MaximumStep in solver_info means the integrator step is unbounded -- say so, rather
+    than inventing a number the user never set."""
+    from solver_wrappers.myokit_helper import stability_hint
+    hint = stability_hint({}, (1e-6, 1e-4))
+    assert 'MaximumStep is unset (unbounded)' in hint
 
 
 @pytest.mark.unit

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -1029,3 +1029,89 @@ def test_every_default_method_is_stiff_suitable_where_the_solver_has_a_stiff_set
         if solver in stiff:
             assert default in stiff[solver], (
                 f"default for {solver} is {default!r}, which is not stiff-suitable")
+
+
+# --------------------------------------------------------- Myokit CVODES tolerance mapping
+#
+# Myokit's signature is set_tolerance(abs_tol, rel_tol) -- absolute FIRST, the reverse of the
+# rtol-then-atol order CA's schema lists. The helper passed them positionally in schema order,
+# so each reached the other argument. A symmetric pair cannot catch that, so every test here
+# uses asymmetric values and asserts which value reached which keyword.
+
+
+class _RecordingSimulation:
+    """Stands in for myokit.Simulation; records what reached set_tolerance."""
+
+    def __init__(self):
+        self.tolerance_calls = []
+
+    def set_tolerance(self, abs_tol=1e-6, rel_tol=1e-4):
+        self.tolerance_calls.append({'abs_tol': abs_tol, 'rel_tol': rel_tol})
+
+
+def _apply(solver_info, fsa_enabled=False):
+    from solver_wrappers.myokit_helper import apply_cvodes_tolerances
+    sim = _RecordingSimulation()
+    apply_cvodes_tolerances(sim, solver_info, fsa_enabled)
+    return sim.tolerance_calls
+
+
+@pytest.mark.unit
+def test_asymmetric_tolerances_reach_the_right_myokit_arguments():
+    """rtol must arrive as rel_tol and atol as abs_tol. Swapped, this call would apply
+    abs 1e-4 / rel 1e-6 -- measured bit-identical to Myokit's own defaults on 3compartment,
+    which is how the swap stayed invisible."""
+    calls = _apply({'rtol': 1e-4, 'atol': 1e-6})
+    assert calls == [{'abs_tol': 1e-6, 'rel_tol': 1e-4}]
+
+
+@pytest.mark.unit
+def test_no_tolerances_means_myokits_own_defaults():
+    """With neither set (and no FSA), set_tolerance is not called at all -- the simulation
+    keeps whatever Myokit chose, and CA does not restate it."""
+    assert _apply({}) == []
+
+
+@pytest.mark.unit
+def test_fsa_tightens_to_1e8_when_the_user_set_none():
+    """CVODES sensitivities are only as accurate as the state solve; the default tolerance's
+    noise floor swamps small sensitivities."""
+    assert _apply({}, fsa_enabled=True) == [{'abs_tol': 1e-8, 'rel_tol': 1e-8}]
+
+
+@pytest.mark.unit
+def test_explicit_tolerances_win_over_the_fsa_tightening():
+    calls = _apply({'rtol': 1e-5, 'atol': 1e-7}, fsa_enabled=True)
+    assert calls == [{'abs_tol': 1e-7, 'rel_tol': 1e-5}]
+
+
+@pytest.mark.unit
+def test_a_partial_setting_fills_the_partner_with_myokits_default():
+    """set_tolerance takes both values, so setting only one needs a partner: Myokit's own
+    default for the other, not 1e-8 (which would silently tighten a knob the user never
+    touched)."""
+    assert _apply({'rtol': 1e-5}) == [{'abs_tol': 1e-6, 'rel_tol': 1e-5}]
+    assert _apply({'atol': 1e-9}) == [{'abs_tol': 1e-9, 'rel_tol': 1e-4}]
+
+
+@pytest.mark.unit
+def test_myokit_set_tolerance_still_takes_abs_and_rel_keywords():
+    """The keyword call is the whole fix; a Myokit rename must break loudly here, not revert
+    the helper to positional guessing."""
+    myokit = pytest.importorskip('myokit')
+    import inspect
+    params = inspect.signature(myokit.Simulation.set_tolerance).parameters
+    assert 'abs_tol' in params and 'rel_tol' in params
+
+
+@pytest.mark.unit
+def test_cvode_myokit_schema_declares_myokits_own_defaults():
+    """Front-ends seed interactive solves from these declared defaults (they deliberately do
+    not restate them), so the declaration is the one place the default is decided. 1e-8/1e-8
+    measured ~2.3x slower per solve on 3compartment with no accuracy need on the plain
+    forward path."""
+    from solver_wrappers.myokit_helper import (
+        MYOKIT_DEFAULT_ABS_TOL, MYOKIT_DEFAULT_REL_TOL)
+    fields = {f['name']: f for f in solver_info_fields('CVODE_myokit')}
+    assert fields['rtol']['default'] == MYOKIT_DEFAULT_REL_TOL == 1e-4
+    assert fields['atol']['default'] == MYOKIT_DEFAULT_ABS_TOL == 1e-6


### PR DESCRIPTION
## 1. `set_tolerance` arguments were swapped (accuracy bug)

Myokit's signature is **`set_tolerance(abs_tol, rel_tol)`** — absolute *first*, the reverse of the rtol-then-atol order CA's schema lists. `myokit_helper` passed them positionally in schema order, so each reached the other argument. Invisible while CA's declared default was a symmetric `1e-8/1e-8`; measured on 3compartment (by the CUFLynx agent), `rtol=1e-6, atol=1e-4` — the names reversed — produced a cost **bit-identical** to Myokit's own `abs 1e-6 / rel 1e-4` defaults, which is only possible if the arguments were exchanged.

The application now lives in `apply_cvodes_tolerances`, called **by keyword** so the mapping cannot silently swap again. A partially-set pair fills the missing partner with CA's declared default. The FSA behaviour is unchanged: still forces `1e-8/1e-8` when sensitivities are enabled and the user set none.

## 2. `CVODE_myokit` defaults become rel 1e-6 / abs 1e-8

Front-ends seed interactive solves from the declared schema defaults rather than restating them (CUFLynx #200), so the declaration is the one place the default is decided. The absolute tolerance **keeps the 1e-8 floor previous users ran at**, so existing models do not start failing; only the relative knob relaxes to 1e-6 — the relative tolerance is where most of the `1e-8/1e-8` interactive solve cost was (`1e-8/1e-8` measured ~2.3× slower than Myokit's own defaults on 3compartment). The helper now **applies** these defaults whenever the user sets neither value, so declared and effective cannot drift whichever front door the run came through; explicit values and the FSA `1e-8/1e-8` tightening still win. Only `CVODE_myokit` changes; the rest of the CVODE family keeps `1e-8/1e-8`.

## Tests

All new tests use **asymmetric** pairs (a symmetric pair cannot catch the swap) and assert which value reached which keyword argument:

- rtol→`rel_tol` / atol→`abs_tol` mapping (fails against the positional call)
- no tolerances → CA's declared defaults applied (abs 1e-8, rel 1e-6), pinned equal to the schema declaration
- FSA tightening to 1e-8/1e-8, and explicit tolerances winning over it
- partial setting fills the partner with CA's default
- a failed solve warns with the effective MaximumStep / atol / rtol and that decreasing them may help stability
- `inspect.signature` check that Myokit still takes `abs_tol`/`rel_tol` keywords — a rename breaks loudly
- schema defaults pinned to the helper's constants

Reported by the CUFLynx agent (`handover_CA_tolerances.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
