### PR TITLE
feat(params): FSA sensitivities follow the grouped/modifier chain rule; gradient_method speaks AD/FSA

### DIFF
--- a/src/identifiabilty_analysis/identifiabilityAnalysis.py
+++ b/src/identifiabilty_analysis/identifiabilityAnalysis.py
@@ -172,8 +172,10 @@ class IdentifiabilityAnalysis():
                 "'FD' for finite differences.)")
 
         sens = pid.get_observable_sensitivities(np.asarray(self.best_param_vals, dtype=float))
-        param_names = [n[0] if isinstance(n, (list, tuple)) else n
-                       for n in pid.param_id_info['param_names']]
+        # The arms key their result dicts by entry label (one per calibrated theta, matching
+        # best_param_vals); first-member qnames would miss every grouped column and read 0.0.
+        from parsers.PrimitiveParsers import param_entry_labels
+        param_names = param_entry_labels(pid.param_id_info)
         obs_info = pid.obs_info
         const_to_obs = obs_info['const_idx_to_obs_idx']
         stds = np.asarray(obs_info['std_const_vec'], dtype=float)

--- a/src/param_id/casadi_backend.py
+++ b/src/param_id/casadi_backend.py
@@ -200,8 +200,12 @@ def get_observable_sensitivities(pid, param_vals):
     output instead of the aggregated cost.
     """
     import casadi as ca
+    from parsers.PrimitiveParsers import param_entry_labels
     param_names = pid.param_id_info["param_names"]
-    flat_names = [n[0] if isinstance(n, list) else n for n in param_names]
+    # Grouped rows never reach here (_create_param_subset refuses them), so each label is its
+    # entry's single qname today -- but keying by param_entry_labels keeps the report shape
+    # identical to the Myokit FSA arm, which does handle groups and modifiers.
+    flat_names = param_entry_labels(pid.param_id_info)
     build_functions(pid, param_names, param_vals)
 
     # jacobian of the flattened observable vector w.r.t. the differentiated parameter subset.

--- a/src/param_id/fd_backend.py
+++ b/src/param_id/fd_backend.py
@@ -21,6 +21,8 @@ always something they chose.
 """
 import numpy as np
 
+from parsers.PrimitiveParsers import param_entry_labels
+
 
 def _step(pj, pmin, pmax, h):
     """The central-difference step for one parameter.
@@ -85,9 +87,12 @@ def _features(pid, param_vals):
 def observable_feature_sensitivities(pid, param_vals, h=1e-3):
     """d(observable feature)/d(param) by central finite differences.
 
-    Returns ``{observable_label: {param_name: d(feature)/d(param)}}`` -- the same
-    shape and the same quantity as the CasADi and CVODES arms, so a local
-    sensitivity analysis is comparable across backends whichever computed it.
+    Returns ``{observable_label: {param_label: d(feature)/d(param)}}`` -- the same
+    shape and the same quantity as the CasADi and CVODES arms, keyed by
+    ``param_entry_labels``, so a local sensitivity analysis is comparable across
+    backends whichever computed it. The perturbation is in theta, which
+    ``get_cost_obs_and_pred_from_params`` expands to every member of a grouped or
+    modifier entry, so those derivatives are d(feature)/d(theta) already.
 
     Costs ``2M`` simulations for M parameters. A parameter whose perturbed runs
     do not both converge is reported as None rather than as a number derived
@@ -95,8 +100,7 @@ def observable_feature_sensitivities(pid, param_vals, h=1e-3):
     instead of reading a plausible-looking zero.
     """
     param_vals = np.asarray(param_vals, dtype=float)
-    names = [n[0] if isinstance(n, (list, tuple)) else n
-             for n in pid.param_id_info["param_names"]]
+    names = param_entry_labels(pid.param_id_info)
     mins = np.asarray(pid.param_id_info["param_mins"], dtype=float)
     maxs = np.asarray(pid.param_id_info["param_maxs"], dtype=float)
 

--- a/src/param_id/fsa_backend.py
+++ b/src/param_id/fsa_backend.py
@@ -22,6 +22,13 @@ import warnings
 
 import numpy as np
 
+from parsers.PrimitiveParsers import modifier_weights_by_index, param_entry_labels
+
+# Dict key under which a combined (per-entry) sensitivity is handed to
+# perturb_operands_along_sensitivity -- the perturbation machinery is unchanged and looks the
+# trace up by name, so the combined trace travels under a name no model variable can have.
+_THETA_KEY = '<theta>'
+
 
 def operand_sensitivities(sim_helper, dependent_names, param_names, sensitivities=None):
     """d(operand_trace)/d(param) for every param that carries a sensitivity.
@@ -68,13 +75,16 @@ def observable_feature_sensitivities(pid, param_vals):
     operation/observable code with no re-simulation, exactly as get_jac_cost does for the cost.
     Single sub-experiment only (the SA local path); the multi-sub carry stays in get_jac_cost.
 
-    This is the Myokit arm of ``OpencorParamID.get_observable_sensitivities``. Only parameters
-    that carry a CVODES sensitivity (FSA-eligible plus initial-value chain-rule, #270) are
-    included; there is no finite-difference fallback here.
+    This is the Myokit arm of ``OpencorParamID.get_observable_sensitivities``. Sensitivities
+    are per calibrated variable, keyed by ``param_entry_labels``: a grouped or modifier entry
+    reports d(feature)/d(theta) = sum_i w_i * d(feature)/d(p_i) over its members (see
+    ``combined_entry_sensitivities``). Only entries whose members all carry a CVODES
+    sensitivity (FSA-eligible plus initial-value chain-rule, #270) are included; there is no
+    finite-difference fallback here.
     """
     ensure_setup(pid)
     param_vals = np.asarray(param_vals, dtype=float)
-    flat_names = pid._fsa_param_names_flat
+    labels = param_entry_labels(pid.param_id_info)
 
     num_sub_total = sum(len(st) for st in pid.protocol_info["sim_times"])
     if num_sub_total != 1:
@@ -88,24 +98,26 @@ def observable_feature_sensitivities(pid, param_vals):
         raise RuntimeError("Local sensitivity nominal simulation failed to converge.")
     operands = operands_list[0]
 
-    sens = operand_sensitivities(pid.sim_helper, pid._fsa_dependent_names, flat_names)
+    sens = operand_sensitivities(
+        pid.sim_helper, pid._fsa_dependent_names, pid._fsa_param_names_flat)
     has_sensitivity = (set(pid.sim_helper._fsa_eligible_param_names or [])
                        | set(getattr(pid.sim_helper, '_fsa_chain_rule_map', None) or {}))
 
     const_to_obs = pid.obs_info["const_idx_to_obs_idx"]
     out = {pid._observable_label(obs_idx): {} for obs_idx in const_to_obs}
-    for j, pname in enumerate(flat_names):
-        if pname not in has_sensitivity:
+    for j, label in enumerate(labels):
+        if not entry_has_sensitivity(pid, j, has_sensitivity):
             continue
+        entry_sens = combined_entry_sensitivities(pid, sens, j)
         pj = float(param_vals[j])
         h = 1e-3 * abs(pj) if pj != 0.0 else 1e-4
-        pert_p = perturb_operands_along_sensitivity(pid, operands, sens, pname, h)
-        pert_m = perturb_operands_along_sensitivity(pid, operands, sens, pname, -h)
+        pert_p = perturb_operands_along_sensitivity(pid, operands, entry_sens, _THETA_KEY, h)
+        pert_m = perturb_operands_along_sensitivity(pid, operands, entry_sens, _THETA_KEY, -h)
         const_p = np.asarray(pid.get_obs_output_dict(pert_p)['const'], dtype=float)
         const_m = np.asarray(pid.get_obs_output_dict(pert_m)['const'], dtype=float)
         d_feature = (const_p - const_m) / (2.0 * h)
         for k, obs_idx in enumerate(const_to_obs):
-            out[pid._observable_label(obs_idx)][pname] = float(d_feature[k])
+            out[pid._observable_label(obs_idx)][label] = float(d_feature[k])
     return out
 
 
@@ -133,9 +145,27 @@ def ensure_setup(pid):
     """
     if getattr(pid, '_fsa_setup_done', False):
         return
-    # Flatten param names (a param may be shared across several vessels via a list).
-    pid._fsa_param_names_flat = [
-        n[0] if isinstance(n, list) else n for n in pid.param_id_info["param_names"]]
+    # One calibrated variable (theta) may govern several model parameters: a grouped row
+    # shares one value across all members, a scale modifier applies theta * baseline_i to
+    # each. Since #376 set_param_vals moves every member, so the cost is a function of all of
+    # them and the gradient must be too: d/dtheta = sum_i w_i * d/dp_i, with w_i = 1 for a
+    # shared-value group and w_i = baseline_i for a scale modifier. CVODES therefore needs a
+    # sensitivity column per *member*, and each entry keeps its (member, weight) list for the
+    # combination in combined_entry_sensitivities.
+    weights = modifier_weights_by_index(pid.param_id_info)
+    entry_members = []
+    for j, names in enumerate(pid.param_id_info["param_names"]):
+        members = list(names) if isinstance(names, (list, tuple)) else [names]
+        w = weights.get(j)
+        entry_members.append(list(zip(members, w)) if w is not None
+                             else [(m, 1.0) for m in members])
+    pid._fsa_entry_members = entry_members
+    flat = []
+    for members in entry_members:
+        for m, _ in members:
+            if m not in flat:
+                flat.append(m)
+    pid._fsa_param_names_flat = flat
     # Unique operand variables across all observables, order-preserving.
     dep_names = []
     for operands in pid.obs_info["operands"]:
@@ -158,9 +188,43 @@ def ensure_setup(pid):
             f"FSA: {len(pid._fsa_ineligible_names)} of {n_total} parameters are "
             f"unsuitable for CVODES forward sensitivity (they enter the dynamics *and* a "
             f"state's initial-value expression, so the initial-value chain rule is "
-            f"incomplete): {pid._fsa_ineligible_names}; these will use finite-difference "
-            f"gradients (2 extra simulations each per gradient).")
+            f"incomplete): {pid._fsa_ineligible_names}; each calibrated variable containing "
+            f"one falls back to finite-difference gradients (2 extra simulations per "
+            f"gradient).")
     pid._fsa_setup_done = True
+
+
+def entry_has_sensitivity(pid, entry_idx, has_sensitivity):
+    """True when every member of entry ``entry_idx`` carries an analytic sensitivity.
+
+    The combined derivative sum_i w_i * S_i needs every S_i; with one member missing the sum
+    would silently drop that member's contribution, so a partially-covered entry falls back to
+    finite differences as a whole.
+    """
+    return all(m in has_sensitivity for m, _ in pid._fsa_entry_members[entry_idx])
+
+
+def combined_entry_sensitivities(pid, sens, entry_idx):
+    """d(operand)/d(theta) for one params_for_id entry: sum_i w_i * S_i over its members.
+
+    ``sens`` is ``{dependent_name: {member_name: trace}}`` from operand_sensitivities. Returns
+    the same two-level shape keyed by ``_THETA_KEY``, so
+    perturb_operands_along_sensitivity works on it unchanged -- all three cases (ungrouped,
+    shared-value group, scale modifier) differ only in the weights fixed at ensure_setup.
+    """
+    members = pid._fsa_entry_members[entry_idx]
+    out = {}
+    for var, per_param in sens.items():
+        acc = None
+        for pname, w in members:
+            s_trace = per_param.get(pname)
+            if s_trace is None:
+                continue
+            term = np.asarray(s_trace, dtype=float) * float(w)
+            acc = term if acc is None else acc + term
+        if acc is not None:
+            out[var] = {_THETA_KEY: acc}
+    return out
 
 
 def get_jac_cost(pid, param_vals, return_cost=False):
@@ -177,8 +241,12 @@ def get_jac_cost(pid, param_vals, return_cost=False):
     operand traces along S (operand + h*S ≈ operand(p+h)) and re-evaluate the *existing*
     cost path get_cost_from_operands; the finite difference over h is dJ/dp exactly (S is
     the true trace derivative), reusing every operation / weight / std / cost function
-    with no duplication. FSA-ineligible parameters get a central finite difference over
-    the full cost.
+    with no duplication. An entry containing any FSA-ineligible member gets a central
+    finite difference over the full cost instead.
+
+    Grouped and modifier entries are exact: theta's perturbation runs along the combined
+    sensitivity sum_i w_i * S_i of all members (w_i = 1 shared-value, w_i = baseline_i
+    scale modifier), matching how set_param_vals moves every member since #376.
 
     Multi-sub-experiment protocols are supported: the Myokit helper carries dy/dp across
     sub-experiment boundaries (myokit_helper.update_times), so each sub's operand
@@ -199,7 +267,6 @@ def get_jac_cost(pid, param_vals, return_cost=False):
     # these and the eligible params, so both are "has_sensitivity" here.
     chain_rule_map = getattr(pid.sim_helper, '_fsa_chain_rule_map', None) or {}
     has_sensitivity = eligible_names | set(chain_rule_map)
-    # Map each flattened param name to its column index in param_vals.
     flat_names = pid._fsa_param_names_flat
     grad = np.zeros(n_params)
     denom = float(pid._total_weighted_obs_denominator())
@@ -238,9 +305,13 @@ def get_jac_cost(pid, param_vals, return_cost=False):
                 pid.sim_helper, pid._fsa_dependent_names, flat_names, sensitivities=sens_arr)
 
             for j in range(n_params):
-                pname = flat_names[j]
-                if pname not in has_sensitivity:
+                if not entry_has_sensitivity(pid, j, has_sensitivity):
                     continue
+                # Perturbing theta by h moves member i by w_i * h, so the perturbation is
+                # along the combined sensitivity sum_i w_i * S_i (identical to S itself for
+                # an ungrouped parameter). The directional-difference machinery below is
+                # unchanged; the three cases fall out of the weights fixed at ensure_setup.
+                entry_sens = combined_entry_sensitivities(pid, sens, j)
                 pj = float(param_vals[j])
                 # Central directional difference along the exact sensitivity S. The step acts
                 # on fixed operand traces (not the solver), so it is immune to integration
@@ -248,16 +319,21 @@ def get_jac_cost(pid, param_vals, return_cost=False):
                 # while staying small enough that argmax/argmin of max/min observables is
                 # stable and linear operations (mean) are reproduced exactly.
                 h = 1e-3 * abs(pj) if pj != 0.0 else 1e-4
-                pert_p = perturb_operands_along_sensitivity(pid, operands, sens, pname, h)
-                pert_m = perturb_operands_along_sensitivity(pid, operands, sens, pname, -h)
+                pert_p = perturb_operands_along_sensitivity(
+                    pid, operands, entry_sens, _THETA_KEY, h)
+                pert_m = perturb_operands_along_sensitivity(
+                    pid, operands, entry_sens, _THETA_KEY, -h)
                 raw_p = float(pid.get_cost_from_operands(pert_p, exp_idx=exp_idx, sub_idx=sub_idx))
                 raw_m = float(pid.get_cost_from_operands(pert_m, exp_idx=exp_idx, sub_idx=sub_idx))
                 grad[j] += (raw_p - raw_m) / (2.0 * h)
 
     grad /= denom
 
-    # ---- Ineligible params: central finite difference over the full mean cost ----
-    ineligible_idx = [j for j in range(n_params) if flat_names[j] not in has_sensitivity]
+    # ---- Entries without full analytic coverage: central FD over the full mean cost.
+    # The step is in theta, and get_cost_from_params expands theta to every member (and
+    # through a modifier's baselines), so this is correct for grouped entries too. ----
+    ineligible_idx = [j for j in range(n_params)
+                      if not entry_has_sensitivity(pid, j, has_sensitivity)]
     if ineligible_idx:
         base_cost = float(pid.get_cost_from_params(param_vals))
         if not np.isfinite(base_cost):

--- a/src/param_id/fsa_backend.py
+++ b/src/param_id/fsa_backend.py
@@ -68,7 +68,7 @@ def observable_feature_sensitivities(pid, param_vals):
     """d(observable feature)/d(param) for the scalar (const) observables, via the Myokit CVODES
     sensitivities and a directional derivative.
 
-    Returns ``{observable_label: {param_name: d(feature)/d(param)}}`` -- the same shape as the
+    Returns ``{observable_label: {param_label: d(feature)/d(param)}}`` -- the same shape as the
     CasADi arm -- so the two backends report the identical quantity. FSA gives the exact operand
     sensitivity S = d(operand)/d(param); the feature (max/min/mean/...) is re-evaluated on
     ``operands +/- h*S`` and central-differenced, so d(feature)/d(param) reuses the existing

--- a/src/param_id/optimisers.py
+++ b/src/param_id/optimisers.py
@@ -625,7 +625,10 @@ class CMAESOptimiser(Optimiser):
                 for i in out_of_bounds:
                     param_name = param_names[i] if i < len(param_names) else f'Parameter {i}'
                     print(f'  Parameter: {param_name}')
-                    print(f'    Value from CSV: {self.param_id_obj.param_init[i] if self.param_id_obj.param_init else "N/A"}')
+                    # param_init is an ndarray (one flat theta slot per calibrated variable),
+                    # so guard with `is not None` -- bare truthiness on an array raises.
+                    print(f'    Value from CSV: '
+                          f'{self.param_id_obj.param_init[i] if self.param_id_obj.param_init is not None else "N/A"}')
                     print(f'    Bounds: [{self.param_mins[i]:.6e}, {self.param_maxs[i]:.6e}]')
                     print(f'    Setting to mean: {x0[i]:.6e}')
                 print('='*80 + '\n')

--- a/src/param_id/optimisers.py
+++ b/src/param_id/optimisers.py
@@ -1309,10 +1309,12 @@ class MultiStartSciPyMinimizeOptimiser(Optimiser):
             pass
 
     def _param_labels(self):
-        """Column labels for the parameters (a param shared across vessels uses its first name),
-        with '/' replaced by ' ' -- matching multi_start_summary.csv so both files line up."""
-        return [(names[0] if isinstance(names, (list, tuple)) else str(names)).replace('/', ' ')
-                for names in self.param_id_info["param_names"]]
+        """Column labels for the parameters (one per calibrated variable: a grouped row joins
+        its qnames, a modifier uses its own name), with '/' replaced by ' ' -- matching
+        multi_start_summary.csv so both files line up."""
+        from parsers.PrimitiveParsers import param_entry_labels
+        return [label.replace('/', ' ')
+                for label in param_entry_labels(self.param_id_info)]
 
     def _append_start_params(self, start_idx, iteration, x_norm):
         """Append one ``start_idx, iteration, <param values>`` row to the live per-start parameter
@@ -1733,8 +1735,8 @@ class MultiStartSciPyMinimizeOptimiser(Optimiser):
 
     def _write_start_summary(self, all_results):
         """One row per start, so the basins the starts fell into can be inspected."""
-        param_labels = [names[0] if isinstance(names, (list, tuple)) else str(names)
-                        for names in self.param_id_info["param_names"]]
+        from parsers.PrimitiveParsers import param_entry_labels
+        param_labels = param_entry_labels(self.param_id_info)
 
         summary_path = os.path.join(self.output_dir, 'multi_start_summary.csv')
         with open(summary_path, 'w') as file:
@@ -1787,8 +1789,8 @@ class MultiStartSciPyMinimizeOptimiser(Optimiser):
         clusters.sort(key=lambda c: c['count'], reverse=True)
         self.convergence_clusters = clusters
 
-        param_labels = [names[0] if isinstance(names, (list, tuple)) else str(names)
-                        for names in self.param_id_info["param_names"]]
+        from parsers.PrimitiveParsers import param_entry_labels
+        param_labels = param_entry_labels(self.param_id_info)
         path = os.path.join(self.output_dir, 'multi_start_convergence_clusters.csv')
         with open(path, 'w') as file:
             writer = csv.writer(file)

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -2612,12 +2612,20 @@ class OpencorParamID():
         derivative of the feature. Every arm reports the identical quantity, so a local
         sensitivity analysis is comparable across backends whichever computed it.
 
-        ``gradient_method`` selects how:
+        ``gradient_method`` selects how, in the same FD/AD/FSA vocabulary as
+        ``gradient_sources()`` and the Laplace ``gradient_source`` -- the arm's own name, so a
+        front-end can offer it, disable it, and report back which one ran:
 
-        * ``None`` (default) -- the analytic arm for this backend, raising when there is
-          none. Unchanged behaviour, and deliberately still not a silent fall back to FD:
-          a result quietly computed a different way, at a different cost and accuracy, is
-          not the same result.
+        * ``None`` / ``'auto'`` / ``'analytic'`` (default) -- the analytic arm for this
+          backend, raising when there is none. Deliberately still not a silent fall back to
+          FD: a result quietly computed a different way, at a different cost and accuracy,
+          is not the same result.
+        * ``'AD'`` -- the exact CasADi jacobian; requires ``model_type='casadi_python'``
+          (``aadc_python`` names its arm AD too, but its local SA is not implemented yet and
+          says so). Any other backend raises naming the mismatch rather than silently
+          reinterpreting.
+        * ``'FSA'`` -- Myokit CVODES forward sensitivities; requires ``cellml_only`` +
+          ``CVODE_myokit`` + ``do_ad``. Raises naming exactly what is missing otherwise.
         * ``'FD'`` -- central finite differences (``param_id.fd_backend``). Works on any
           backend that runs a forward simulation, which is how AADC and the plain scipy
           backend get a local SA at all (issue #338). Costs 2M simulations for M parameters.
@@ -2633,10 +2641,36 @@ class OpencorParamID():
         if method == 'FD':
             kwargs = {} if fd_rel_step is None else {'h': float(fd_rel_step)}
             return fd_backend.observable_feature_sensitivities(self, param_vals, **kwargs)
-        if method not in ('', 'ANALYTIC', 'AUTO'):
+        if method not in ('', 'ANALYTIC', 'AUTO', 'AD', 'FSA'):
             raise ValueError(
                 f"unknown gradient_method '{gradient_method}' for local sensitivity analysis. "
-                "Valid values are None/'analytic' (this backend's analytic sensitivity) or 'FD'.")
+                "Valid values are 'AD' (exact CasADi jacobian, casadi_python), 'FSA' (Myokit "
+                "CVODES forward sensitivities, cellml_only + CVODE_myokit + do_ad), 'FD' "
+                "(central finite differences, any backend), or None/'auto'/'analytic' (this "
+                "backend's analytic arm).")
+
+        solver_info = getattr(self, 'solver_info', None)
+        solver = solver_info.get('solver') if isinstance(solver_info, dict) else None
+        # An explicit arm name validates against the backend instead of being silently
+        # reinterpreted -- a caller that asked for FSA must get FSA or an error, never a
+        # different arm with plausible numbers (the same reason FD never stands in above).
+        if method == 'AD' and self.model_type not in ('casadi_python', 'aadc_python'):
+            raise ValueError(
+                f"gradient_method 'AD' needs model_type 'casadi_python' (the exact CasADi "
+                f"jacobian); this run is model_type='{self.model_type}', solver='{solver}'. "
+                "Use 'FSA' for cellml_only + CVODE_myokit + do_ad, or 'FD'.")
+        if method == 'FSA' and not fsa_backend.gradient_available(self):
+            missing = []
+            if self.model_type != 'cellml_only':
+                missing.append(f"model_type is '{self.model_type}', needs 'cellml_only'")
+            if not hasattr(getattr(self, 'sim_helper', None), 'enable_fsa'):
+                missing.append(f"solver is '{solver}', needs 'CVODE_myokit' (its helper "
+                               "provides CVODES forward sensitivities)")
+            if not getattr(self, 'do_ad', False):
+                missing.append("do_ad must be true")
+            raise ValueError(
+                "gradient_method 'FSA' is not available for this run: "
+                + "; ".join(missing) + ". Use 'AD' for casadi_python, or 'FD'.")
 
         if self.model_type == 'casadi_python':
             self._refuse_sensitivities_for_modifiers()

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -2561,25 +2561,28 @@ class OpencorParamID():
         return f"{base} [exp {exp}, sub {sub}]"
 
     def _refuse_sensitivities_for_modifiers(self):
-        """A modifier's derivative is a weighted chain rule, not the plain sum a shared-value
-        group needs:
+        """A modifier's derivative is a weighted chain rule over its targets:
 
             shared-value group   dO/dtheta = sum_i  dO/dp_i
             scale modifier       dO/dtheta = sum_i (dO/dp_i) * baseline_i
 
-        Neither arm implements the weighted form yet, and both currently flatten a group to its
-        first member -- so a modifier would silently report one target's derivative as though it
-        were theta's. Refuse instead, on the same reasoning as the CasADi grouped-row refusal.
+        The Myokit FSA arm implements exactly that (fsa_backend.combined_entry_sensitivities),
+        but the CasADi arm cannot reach it: _create_param_subset refuses any grouped row, of
+        which a modifier is one. Refuse with the modifier-specific message rather than let the
+        grouped-row error report a different problem. Removing this means implementing symbolic
+        substitution of theta (or theta * baseline_i) into every member's slot -- see the
+        grouped-calibration refusal in casadi_python_solver_helper.
         """
         modifiers = (getattr(self, "param_id_info", None) or {}).get("modifiers") or []
         if modifiers:
             names = [m["name"] for m in modifiers]
             raise NotImplementedError(
-                f"Local sensitivity analysis does not yet support modifier parameters {names}. "
-                f"A scale modifier's derivative is sum_i (dO/dp_i) * baseline_i, a weighted "
-                f"chain rule over its targets, which is not implemented -- reporting the first "
-                f"target's derivative instead would silently answer a different question. Use "
-                f"global Sobol SA, which handles modifiers, or remove the modifier entries.")
+                f"The CasADi local sensitivity arm does not yet support modifier parameters "
+                f"{names}. A scale modifier's derivative is sum_i (dO/dp_i) * baseline_i, a "
+                f"weighted chain rule over its targets, which the CasADi backend cannot express "
+                f"until grouped rows are substituted symbolically. Use model_type 'cellml_only' "
+                f"with solver 'CVODE_myokit' (the FSA arm implements the chain rule), global "
+                f"Sobol SA, or remove the modifier entries.")
 
     def get_observable_sensitivities(self, param_vals, gradient_method=None, fd_rel_step=None):
         """d(observable feature)/d(param) for the scalar observables -- the backend-agnostic
@@ -2617,8 +2620,8 @@ class OpencorParamID():
                 f"unknown gradient_method '{gradient_method}' for local sensitivity analysis. "
                 "Valid values are None/'analytic' (this backend's analytic sensitivity) or 'FD'.")
 
-        self._refuse_sensitivities_for_modifiers()
         if self.model_type == 'casadi_python':
+            self._refuse_sensitivities_for_modifiers()
             return casadi_backend.get_observable_sensitivities(self, param_vals)
         elif self.model_type == 'aadc_python':
             raise NotImplementedError(

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -68,8 +68,10 @@ from param_id.differentiable import (
 )
 from param_id.operation_funcs import resolve_operation_kwargs, validate_operation_kwargs
 from param_id.cost_kwargs import call_cost_func, validate_cost_kwargs
-from parsers.PrimitiveParsers import (expand_modifier_param_vals,
-                                      resolve_modifier_baselines)
+from parsers.PrimitiveParsers import (apply_modifier_identity_nominals,
+                                      expand_modifier_param_vals,
+                                      resolve_modifier_baselines,
+                                      save_param_modifiers)
 from param_id.plot_outputs import ParamIDPlotOutputs
 from param_id import casadi_backend
 from param_id import fsa_backend
@@ -1518,7 +1520,23 @@ class OpencorParamID():
         # ________ Do parameter identification ________
 
         # Don't remove the get_init_param_vals, this also checks the parameters names are correct.
-        self.param_init = self.sim_helper.get_init_param_vals(self.param_id_info["param_names"])
+        raw_init = self.sim_helper.get_init_param_vals(self.param_id_info["param_names"])
+        # One x0 slot per calibrated variable (theta), flat. get_init_param_vals returns a
+        # *list* of member values for a multi-name entry, and np.asarray over that ragged
+        # structure is a crash in every optimiser's x0 handling -- a grouped row starts at its
+        # first member's default (the shared value). A modifier's slot is theta, not a model
+        # value, so it starts at the operation's identity (scale -> 1.0), where every target
+        # sits at its baseline; a member's raw default there (~1e-8 for a compliance) would be
+        # taken as a scale factor.
+        self.param_init = apply_modifier_identity_nominals(
+            self.param_id_info,
+            np.array([v[0] if isinstance(v, (list, tuple)) else v for v in raw_init],
+                     dtype=float))
+
+        # The param_modifiers.json written at parse time has baselines: None -- no simulation
+        # helper existed yet. Re-save now they are resolved; without baselines the recorded
+        # theta is uninterpretable, which is the file's whole purpose.
+        save_param_modifiers(self.param_id_info, self.output_dir)
 
         # C_T min and max was 1e-9 and 1e-5 before
 

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -632,6 +632,22 @@ def modifier_weights_by_index(param_id_info):
     return out
 
 
+def save_param_modifiers(param_id_info, output_dir):
+    """Write ``param_modifiers.json`` to ``output_dir`` (rank 0 only; no-op without modifiers).
+
+    A scale result is uninterpretable without this record -- best_param_vals holds theta, and
+    theta alone does not say what any model parameter ended up at. Recording the baselines
+    means reproducing a result does not depend on the model file being unchanged. Callable at
+    any point (idempotent overwrite): the parse-time save happens before baselines can be
+    resolved, so the calibration run saves again once they are.
+    """
+    modifiers = param_id_info.get("modifiers") or []
+    if modifiers and rank == 0:
+        modifiers_path = os.path.join(output_dir, 'param_modifiers.json')
+        with open(modifiers_path, 'w') as f:
+            json.dump(modifiers, f, indent=2)
+
+
 def param_modifier_operations():
     """The modifier operations this version of circulatory_autogen implements."""
     return {name: dict(meta) for name, meta in PARAM_MODIFIER_OPERATIONS.items()}
@@ -3675,15 +3691,10 @@ class ObsAndParamDataParser(object):
                 wr = csv.writer(f)
                 wr.writerows(param_id_info["param_names_for_gen"])
 
-            # 3. Save the modifier records, baselines included. A scale result is
-            #    uninterpretable without them -- best_param_vals holds theta, and theta alone
-            #    does not say what any model parameter ended up at. Recording them here means
-            #    reproducing a result does not depend on the model file being unchanged.
-            modifiers = param_id_info.get("modifiers") or []
-            if modifiers:
-                modifiers_path = os.path.join(output_dir, 'param_modifiers.json')
-                with open(modifiers_path, 'w') as f:
-                    json.dump(modifiers, f, indent=2)
+            # 3. Save the modifier records (see save_param_modifiers). At this point the
+            #    baselines may still be None -- parsing happens before a simulation helper
+            #    exists -- so the calibration run re-saves once they are resolved.
+            save_param_modifiers(param_id_info, output_dir)
         return
 
 

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -485,6 +485,10 @@ PARAM_MODIFIER_OPERATIONS = {
         'dimensionless': True,
         'default_min': 0.5,
         'default_max': 2.0,
+        # The theta at which the operation leaves every target at its baseline. Local
+        # sensitivity analysis evaluates there: theta's model-default is not a model value
+        # (reading a target's default as theta would scale every target by it).
+        'identity': 1.0,
     },
 }
 DEFAULT_PARAM_MODIFIER_OPERATION = 'scale'
@@ -565,6 +569,66 @@ def expand_modifier_param_vals(param_id_info, param_vals):
             raise NotImplementedError(
                 f"modifier operation {mod['operation']!r} is declared but not implemented.")
         out.append([float(value) * b for b in baselines])
+    return out
+
+
+def param_entry_labels(param_id_info):
+    """One reporting label per calibrated variable (theta), for anything keyed by parameter.
+
+    Reads ``param_labels`` (a grouped row joins its qnames, a modifier uses its own name), with
+    the same fallback as ``sobolSA._param_labels`` for a param_id_info built by hand or loaded
+    from before the key existed (#355). Sensitivities and their consumers key on this rather
+    than on a row's first member: a grouped derivative is d/dtheta over all members, and
+    labelling it with one member's qname would report it as a different quantity.
+    """
+    labels = param_id_info.get("param_labels")
+    if labels is not None:
+        return list(labels)
+    return ['+'.join(n) if isinstance(n, (list, tuple)) else str(n)
+            for n in param_id_info["param_names"]]
+
+
+def apply_modifier_identity_nominals(param_id_info, nominal_vals):
+    """Overwrite each modifier's slot in ``nominal_vals`` with its operation's identity theta.
+
+    A nominal parameter vector read from the model (``get_init_param_vals`` over first members)
+    is right for ordinary and grouped rows, but a modifier's slot is theta, not a model value --
+    the first target's default there would scale every target by it. The identity (scale -> 1.0)
+    is the theta at which every target sits at its baseline, which is what "nominal" means.
+    Returns ``nominal_vals``, modified in place.
+    """
+    for mod in param_id_info.get("modifiers") or []:
+        operation = mod.get("operation", DEFAULT_PARAM_MODIFIER_OPERATION)
+        meta = PARAM_MODIFIER_OPERATIONS.get(operation)
+        if meta is None or 'identity' not in meta:
+            raise NotImplementedError(
+                f"modifier operation {operation!r} has no identity value; cannot choose a "
+                f"nominal theta for '{mod['name']}'.")
+        nominal_vals[mod["index"]] = meta['identity']
+    return nominal_vals
+
+
+def modifier_weights_by_index(param_id_info):
+    """Per-entry chain-rule weights: ``{entry_index: [w_i per member]}`` for modifier entries.
+
+    A calibrated theta that governs several model parameters has
+    ``d(anything)/d(theta) = sum_i w_i * d(anything)/d(p_i)`` with ``w_i = dp_i/dtheta``. For a
+    scale modifier ``p_i = theta * baseline_i`` so ``w_i = baseline_i``. Shared-value groups
+    (``w_i = 1``) are not in the map -- absence means unit weights. Raises if a modifier's
+    baselines have not been resolved, because a weight guessed at is a gradient silently wrong.
+    """
+    out = {}
+    for mod in param_id_info.get("modifiers") or []:
+        baselines = mod.get("baselines")
+        if baselines is None:
+            raise ValueError(
+                f"modifier '{mod['name']}' has no resolved baselines. Call "
+                f"resolve_modifier_baselines(param_id_info, sim_helper) once at setup, before "
+                f"any parameter has been written.")
+        if mod.get("operation", DEFAULT_PARAM_MODIFIER_OPERATION) != 'scale':
+            raise NotImplementedError(
+                f"modifier operation {mod['operation']!r} is declared but not implemented.")
+        out[mod["index"]] = [float(b) for b in baselines]
     return out
 
 

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -1143,15 +1143,21 @@ ANALYSIS_OPTIONS = {
             # Only read by method 'local'. Declared so downstream tools offer the choice
             # rather than hardcoding it, and so FD is something the user picks by name: it
             # costs 2M simulations and its accuracy depends on a step size the analytic arms
-            # do not have, so it must never stand in silently for them.
-            {'name': 'gradient_method', 'type': 'enum', 'default': 'analytic', 'required': False,
-             'choices': ['analytic', 'FD'],
-             'description': ('For method "local": how to differentiate. "analytic" uses the '
-                             "backend's own sensitivity (the CasADi jacobian, or Myokit "
-                             'CVODES forward sensitivities) and fails where there is none; '
-                             '"FD" uses central finite differences and works on any backend '
-                             'that runs a forward simulation, at 2M simulations for M '
-                             'parameters.')},
+            # do not have, so it must never stand in silently for them. The arms carry their
+            # own names -- AD / FSA, the same vocabulary as gradient_sources() and the Laplace
+            # gradient_source -- because only an explicit name can be offered, disabled, or
+            # reported back by a UI; each validates against the backend rather than being
+            # silently reinterpreted. 'analytic' remains accepted in code as a legacy spelling
+            # of 'auto' but is no longer advertised.
+            {'name': 'gradient_method', 'type': 'enum', 'default': 'auto', 'required': False,
+             'choices': ['auto', 'AD', 'FSA', 'FD'],
+             'description': ('For method "local": how to differentiate. "auto" picks the '
+                             "backend's own analytic arm and fails where there is none; "
+                             '"AD" is the exact CasADi jacobian (casadi_python); "FSA" is '
+                             'Myokit CVODES forward sensitivities (cellml_only + '
+                             'CVODE_myokit + do_ad); "FD" is central finite differences, '
+                             'which works on any backend that runs a forward simulation, at '
+                             '2M simulations for M parameters.')},
             # Only read by method 'local' with gradient_method 'FD'. Declared because it is
             # not a tuning detail: on Lotka-Volterra, moving it from 1e-3 to 1e-2 changes a
             # sensitivity coefficient by up to 48%, since `max` of an oscillating trace is a

--- a/src/sensitivity_analysis/sensitivityAnalysis.py
+++ b/src/sensitivity_analysis/sensitivityAnalysis.py
@@ -314,13 +314,24 @@ class SensitivityAnalysis():
         if sa_options is not None:
             self.set_sa_options(sa_options)
 
+        from parsers.PrimitiveParsers import (apply_modifier_identity_nominals,
+                                              param_entry_labels)
+
         engine = self._build_local_engine().param_id
-        param_names = [n[0] if isinstance(n, list) else n
-                       for n in engine.param_id_info["param_names"]]
-        nominal = engine.sim_helper.get_init_param_vals(param_names)
+        # One column per calibrated variable (theta). Labels, not first-member qnames: a
+        # grouped or modifier entry's sensitivity is d/dtheta over all its members, and the
+        # arms key their result dicts the same way -- a mismatched key here would silently
+        # read 0.0 for every grouped column.
+        param_names = param_entry_labels(engine.param_id_info)
+        first_member_names = [n[0] if isinstance(n, list) else n
+                              for n in engine.param_id_info["param_names"]]
+        nominal = engine.sim_helper.get_init_param_vals(first_member_names)
         nominal = np.asarray(
             [float(v[0]) if isinstance(v, (list, tuple, np.ndarray)) else float(v)
              for v in nominal], dtype=float)
+        # A modifier's slot is theta, not a model value: evaluate at the operation's
+        # identity (scale -> 1.0), where every target sits at its resolved baseline.
+        apply_modifier_identity_nominals(engine.param_id_info, nominal)
 
         # 'analytic' (the default) keeps the backend's own sensitivity; 'FD' opts into
         # central finite differences, the only local SA available on a backend with no

--- a/tests/test_fd_observable_sensitivities.py
+++ b/tests/test_fd_observable_sensitivities.py
@@ -185,12 +185,93 @@ def test_the_analytic_aliases_do_not_divert_to_fd(alias):
 # The option is declared, so downstream tools can offer it
 # ---------------------------------------------------------------------------
 def test_gradient_method_is_in_the_analysis_schema():
+    """The arms carry their own names -- AD / FSA, matching gradient_sources() and the Laplace
+    gradient_source -- because only an explicit name can be offered, disabled, or reported back
+    by a UI. 'analytic' is still accepted in code as a legacy spelling of 'auto', but is no
+    longer advertised."""
     from parsers.PrimitiveParsers import ANALYSIS_OPTIONS
 
     opts = {o["name"]: o for o in ANALYSIS_OPTIONS["sensitivity_analysis"]["options"]}
     assert "gradient_method" in opts
-    assert opts["gradient_method"]["choices"] == ["analytic", "FD"]
-    assert opts["gradient_method"]["default"] == "analytic"
+    assert opts["gradient_method"]["choices"] == ["auto", "AD", "FSA", "FD"]
+    assert opts["gradient_method"]["default"] == "auto"
+
+
+# ---------------------------------------------------------------------------
+# Explicit arm names: each reaches the arm it names, or errors naming the
+# mismatch -- never a silent reinterpretation (a caller that asked for FSA and
+# silently got something else cannot check what ran).
+# ---------------------------------------------------------------------------
+def test_ad_reaches_the_casadi_arm(monkeypatch):
+    from param_id import paramID
+
+    pid = paramID.OpencorParamID.__new__(paramID.OpencorParamID)
+    pid.model_type = "casadi_python"
+    pid.param_id_info = {"param_names": [["a/x"]]}
+    called = []
+    monkeypatch.setattr(paramID.casadi_backend, "get_observable_sensitivities",
+                        lambda p, v: called.append(p) or {})
+    pid.get_observable_sensitivities([1.0], gradient_method="AD")
+    assert called == [pid]
+
+
+def test_fsa_reaches_the_myokit_arm(monkeypatch):
+    from param_id import paramID
+
+    class _FsaHelper:
+        def enable_fsa(self, deps, indeps):
+            return []
+
+    pid = paramID.OpencorParamID.__new__(paramID.OpencorParamID)
+    pid.model_type = "cellml_only"
+    pid.do_ad = True
+    pid.sim_helper = _FsaHelper()
+    called = []
+    monkeypatch.setattr(paramID.fsa_backend, "observable_feature_sensitivities",
+                        lambda p, v: called.append(p) or {})
+    pid.get_observable_sensitivities([1.0], gradient_method="FSA")
+    assert called == [pid]
+
+
+def test_ad_on_a_myokit_run_raises_naming_the_mismatch():
+    from param_id.paramID import OpencorParamID
+
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.model_type = "cellml_only"
+    pid.solver_info = {"solver": "CVODE_myokit"}
+    with pytest.raises(ValueError, match="'AD' needs model_type 'casadi_python'"):
+        pid.get_observable_sensitivities([1.0], gradient_method="AD")
+
+
+def test_fsa_on_a_casadi_run_raises_naming_whats_missing():
+    from param_id.paramID import OpencorParamID
+
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.model_type = "casadi_python"
+    pid.solver_info = {"solver": "casadi_integrator"}
+    pid.sim_helper = object()   # no enable_fsa
+    with pytest.raises(ValueError, match="'FSA' is not available") as excinfo:
+        pid.get_observable_sensitivities([1.0], gradient_method="FSA")
+    msg = str(excinfo.value)
+    assert "model_type is 'casadi_python'" in msg
+    assert "CVODE_myokit" in msg
+    assert "do_ad" in msg
+
+
+def test_fsa_without_do_ad_names_the_missing_flag():
+    from param_id.paramID import OpencorParamID
+
+    class _FsaHelper:
+        def enable_fsa(self, deps, indeps):
+            return []
+
+    pid = OpencorParamID.__new__(OpencorParamID)
+    pid.model_type = "cellml_only"
+    pid.solver_info = {"solver": "CVODE_myokit"}
+    pid.sim_helper = _FsaHelper()
+    pid.do_ad = False
+    with pytest.raises(ValueError, match="do_ad must be true"):
+        pid.get_observable_sensitivities([1.0], gradient_method="FSA")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fsa_grouped_sensitivities.py
+++ b/tests/test_fsa_grouped_sensitivities.py
@@ -1,0 +1,262 @@
+"""The FSA chain rule for grouped and modifier params_for_id entries.
+
+Since #376 ``set_param_vals`` moves every member of a grouped row, so on the Myokit/FSA path
+the cost is a function of all members. The gradient must follow:
+
+    ungrouped            dJ/dp
+    shared-value group   dJ/dtheta = sum_i  dJ/dp_i
+    scale modifier       dJ/dtheta = sum_i (dJ/dp_i) * baseline_i
+
+These tests discriminate **by construction**, not empirically: an FSA-vs-FD comparison on a
+real model cannot catch a first-member-only gradient when the members' influences differ by
+orders of magnitude (on 3compartment [aortic_root/C, par/C] the wrong and right answers agree
+to 1e-5 relative). Here the member sensitivities are synthetic and comparable, so the plain
+sum, the weighted sum, and the first member alone are three numbers far apart.
+"""
+import numpy as np
+import pytest
+
+from param_id import fsa_backend
+from parsers.PrimitiveParsers import (
+    apply_modifier_identity_nominals, modifier_weights_by_index, param_entry_labels)
+
+
+# Two members with *comparable* influence -- see the module docstring for why this matters.
+_S_A = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+_S_B = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
+_TRACE = np.array([0.5, 0.6, 0.7, 0.8, 0.9])
+
+
+class _FakeSimHelper:
+    def __init__(self, sens_map, eligible):
+        self._sens_map = sens_map            # {dep_name: {member: trace}}
+        self._fsa_eligible_param_names = list(eligible)
+        self._fsa_chain_rule_map = {}
+        self._fsa_sensitivities_history = [object()]   # one sub-experiment
+        self.enable_fsa_received = None
+
+    def enable_fsa(self, dependent_names, independent_param_names):
+        self.enable_fsa_received = list(independent_param_names)
+        return []
+
+    def get_sensitivities(self, dependent_names, param_names, sensitivities=None):
+        return {d: {p: self._sens_map[d][p].copy()
+                    for p in param_names if p in self._sens_map.get(d, {})}
+                for d in dependent_names}
+
+
+class _FakePid:
+    """The surface fsa_backend calls back into, over one observable ('v') in one
+    sub-experiment, with cost J = sum(v) and feature mean(v) -- both linear in the trace, so
+    the central directional difference is exact and the expected numbers are integers."""
+
+    def __init__(self, param_id_info, eligible=('a/C', 'b/C')):
+        self.param_id_info = param_id_info
+        self.obs_info = {"operands": [['v']], "const_idx_to_obs_idx": [0]}
+        self.protocol_info = {"num_experiments": 1, "num_sub_per_exp": [1],
+                              "sim_times": [[1.0]]}
+        self.sim_helper = _FakeSimHelper({'v': {'a/C': _S_A, 'b/C': _S_B}}, eligible)
+
+    def get_cost_obs_and_pred_from_params(self, param_vals, reset=True, only_one_exp=0):
+        return 0.0, [[[_TRACE.copy()]]], []
+
+    def get_cost_from_operands(self, operands, exp_idx=0, sub_idx=0):
+        return float(np.sum(operands[0][0]))
+
+    def get_cost_from_params(self, param_vals):
+        raise AssertionError("the analytic path must not fall back to full-cost FD here")
+
+    def _total_weighted_obs_denominator(self):
+        return 1.0
+
+    def _observable_label(self, obs_idx):
+        return f"obs{obs_idx}"
+
+    def get_obs_output_dict(self, operands):
+        return {'const': [float(np.mean(operands[0][0]))]}
+
+
+def _grouped_info():
+    return {"param_names": [['a/C', 'b/C']], "param_labels": ['a/C+b/C']}
+
+
+def _modifier_info(baselines=(2.0, 0.5)):
+    return {"param_names": [['a/C', 'b/C']], "param_labels": ['theta_C'],
+            "modifiers": [{"index": 0, "name": "theta_C", "operation": 'scale',
+                           "targets": ['a/C', 'b/C'], "baselines": list(baselines)}]}
+
+
+# dJ/dp_i for J = sum(v) is sum(S_i).
+_DJ_DA = float(np.sum(_S_A))    # 15
+_DJ_DB = float(np.sum(_S_B))    # 150
+
+
+# ------------------------------------------------------------------ setup / flattening
+
+
+@pytest.mark.unit
+def test_every_member_reaches_enable_fsa():
+    """The bug was structural: only n[0] of each group was handed to CVODES, so no column ever
+    existed for the other members. All members must be independents."""
+    info = {"param_names": [['a/C', 'b/C'], ['heart/R']],
+            "param_labels": ['a/C+b/C', 'heart/R']}
+    pid = _FakePid(info)
+    fsa_backend.ensure_setup(pid)
+    assert pid.sim_helper.enable_fsa_received == ['a/C', 'b/C', 'heart/R']
+    assert pid._fsa_param_names_flat == ['a/C', 'b/C', 'heart/R']
+    assert pid._fsa_entry_members == [[('a/C', 1.0), ('b/C', 1.0)], [('heart/R', 1.0)]]
+
+
+@pytest.mark.unit
+def test_modifier_members_carry_their_baselines_as_weights():
+    pid = _FakePid(_modifier_info(baselines=(2.0, 0.5)))
+    fsa_backend.ensure_setup(pid)
+    assert pid._fsa_entry_members == [[('a/C', 2.0), ('b/C', 0.5)]]
+
+
+@pytest.mark.unit
+def test_unresolved_baselines_refuse_setup():
+    """A weight guessed at is a gradient silently wrong, the exact failure this work removes."""
+    info = _modifier_info()
+    info["modifiers"][0]["baselines"] = None
+    with pytest.raises(ValueError, match="baselines"):
+        fsa_backend.ensure_setup(_FakePid(info))
+
+
+@pytest.mark.unit
+def test_modifier_weights_by_index_ignores_plain_entries():
+    assert modifier_weights_by_index(_grouped_info()) == {}
+    assert modifier_weights_by_index(_modifier_info()) == {0: [2.0, 0.5]}
+
+
+# ------------------------------------------------------------------ the chain rule itself
+
+
+@pytest.mark.unit
+def test_a_shared_value_group_gradient_is_the_plain_sum():
+    pid = _FakePid(_grouped_info())
+    grad = fsa_backend.get_jac_cost(pid, np.array([1.0]))
+    assert grad == pytest.approx([_DJ_DA + _DJ_DB])          # 165, not 15
+
+
+@pytest.mark.unit
+def test_a_modifier_gradient_is_the_baseline_weighted_sum():
+    pid = _FakePid(_modifier_info(baselines=(2.0, 0.5)))
+    grad = fsa_backend.get_jac_cost(pid, np.array([1.0]))
+    assert grad == pytest.approx([2.0 * _DJ_DA + 0.5 * _DJ_DB])   # 105, not 15 or 165
+
+
+@pytest.mark.unit
+def test_the_first_member_alone_is_not_the_answer():
+    """The pre-fix behaviour, asserted unreachable. Kept explicit because the natural
+    empirical test (FSA vs FD on a real model) could not tell these apart."""
+    for info in (_grouped_info(), _modifier_info()):
+        grad = fsa_backend.get_jac_cost(_FakePid(info), np.array([1.0]))
+        assert grad[0] != pytest.approx(_DJ_DA)
+
+
+@pytest.mark.unit
+def test_an_ungrouped_entry_is_unchanged():
+    info = {"param_names": [['a/C']], "param_labels": ['a/C']}
+    grad = fsa_backend.get_jac_cost(_FakePid(info), np.array([1.0]))
+    assert grad == pytest.approx([_DJ_DA])
+
+
+@pytest.mark.unit
+def test_a_partially_ineligible_entry_falls_back_to_fd_as_a_whole():
+    """With one member's column missing, sum_i w_i * S_i would silently drop that member's
+    contribution -- the entry must leave the analytic path entirely."""
+    pid = _FakePid(_grouped_info(), eligible=('a/C',))   # b/C has no CVODES column
+
+    fd_calls = []
+
+    def fd_cost(param_vals):
+        fd_calls.append(np.array(param_vals, dtype=float))
+        return 7.0 * float(param_vals[0])
+    pid.get_cost_from_params = fd_cost
+
+    grad = fsa_backend.get_jac_cost(pid, np.array([1.0]))
+    assert grad == pytest.approx([7.0])
+    assert fd_calls, "expected the full-cost FD fallback to run"
+
+
+# ------------------------------------------------------------------ observable sensitivities
+
+
+@pytest.mark.unit
+def test_observable_sensitivities_combine_members_and_key_by_label():
+    pid = _FakePid(_modifier_info(baselines=(2.0, 0.5)))
+    sens = fsa_backend.observable_feature_sensitivities(pid, np.array([1.0]))
+    # feature = mean(v), so d(feature)/dtheta = mean(2*S_A + 0.5*S_B) = 2*3 + 0.5*30 = 21.
+    assert set(sens.keys()) == {"obs0"}
+    assert sens["obs0"] == {"theta_C": pytest.approx(21.0)}
+
+
+@pytest.mark.unit
+def test_grouped_observable_sensitivities_key_by_the_joined_label():
+    pid = _FakePid(_grouped_info())
+    sens = fsa_backend.observable_feature_sensitivities(pid, np.array([1.0]))
+    assert sens["obs0"] == {"a/C+b/C": pytest.approx(np.mean(_S_A) + np.mean(_S_B))}
+
+
+# ------------------------------------------------------------------ labels and nominals
+
+
+@pytest.mark.unit
+def test_param_entry_labels_reads_param_labels_and_falls_back():
+    assert param_entry_labels(_modifier_info()) == ['theta_C']
+    # A param_id_info from before #355 has no param_labels: derive, joining groups.
+    assert param_entry_labels({"param_names": [['a/C', 'b/C'], ['heart/R']]}) \
+        == ['a/C+b/C', 'heart/R']
+
+
+@pytest.mark.unit
+def test_the_casadi_arm_still_refuses_modifiers():
+    """CasADi cannot express a grouped row until theta is substituted symbolically
+    (_create_param_subset refuses them), so its modifier refusal stays -- with a message that
+    names the working alternatives."""
+    from param_id.paramID import OpencorParamID
+
+    class _Stub(OpencorParamID):
+        def __init__(self):
+            pass
+
+    pid = _Stub()
+    pid.model_type = 'casadi_python'
+    pid.param_id_info = _modifier_info()
+    with pytest.raises(NotImplementedError, match="CasADi"):
+        pid.get_observable_sensitivities(np.array([1.0]))
+
+
+@pytest.mark.unit
+def test_the_fsa_arm_no_longer_refuses_modifiers(monkeypatch):
+    from param_id import paramID
+
+    class _Stub(paramID.OpencorParamID):
+        def __init__(self):
+            pass
+
+    pid = _Stub()
+    pid.model_type = 'cellml_only'
+    pid.do_ad = True
+    pid.param_id_info = _modifier_info()
+    pid.sim_helper = _FakeSimHelper({'v': {'a/C': _S_A, 'b/C': _S_B}}, ['a/C', 'b/C'])
+
+    called = []
+    monkeypatch.setattr(paramID.fsa_backend, 'observable_feature_sensitivities',
+                        lambda p, v: called.append(p) or {})
+    pid.get_observable_sensitivities(np.array([1.0]))
+    assert called == [pid]
+
+
+@pytest.mark.unit
+def test_a_modifier_nominal_is_the_operation_identity_not_a_model_value():
+    """get_init_param_vals over first members would put the first target's default in theta's
+    slot -- and theta = 1.2e-8 scales every target by 1.2e-8. Identity theta (scale -> 1.0)
+    leaves every target at its baseline, which is what 'nominal' means."""
+    info = {"param_names": [['heart/R'], ['a/C', 'b/C']], "param_labels": ['heart/R', 'th'],
+            "modifiers": [{"index": 1, "name": "th", "operation": 'scale',
+                           "targets": ['a/C', 'b/C'], "baselines": [1.0, 2.0]}]}
+    nominal = np.array([3.5, 1.2e-8])
+    apply_modifier_identity_nominals(info, nominal)
+    assert nominal == pytest.approx([3.5, 1.0])

--- a/tests/test_param_id.py
+++ b/tests/test_param_id.py
@@ -5153,3 +5153,100 @@ def test_offline_pre_time_multisub_casadi_ad_gradient(
 
     _assert_gradient_matches_fd(inner, p)
     runner.close_simulation()
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_param_id_3compartment_modifier_calibration_fsa(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
+    """A modifier parameter driven through a real calibration (#378 shipped unit tests only).
+
+    One theta scales both compliances (aortic_root/C, par/C) while q_lv_init calibrates
+    normally, on cellml_only + CVODE_myokit + sp_minimize + do_ad -- so the L-BFGS-B gradient
+    comes from the CVODES FSA chain rule over the modifier's members (a column per member,
+    combined with baseline weights). Checks the end-to-end contract:
+    param_modifiers.json lands in the output dir with the model-default baselines, and the
+    reported theta is a dimensionless value inside its own bounds -- interpretable against
+    those baselines, not a raw compliance.
+    """
+    import json
+
+    rank = mpi_comm.Get_rank()
+
+    params_doc = {
+        'version': 1,
+        'params': [
+            {'name': 'q_lv_init', 'targets': ['global/q_lv_init'],
+             'min': 200e-6, 'max': 1500e-6, 'name_for_plotting': 'q_{sbv}'},
+            {'name': 'C_scale', 'modifies': ['aortic_root/C', 'par/C'],
+             'operation': 'scale', 'min': 0.5, 'max': 2.0,
+             'name_for_plotting': r'\theta_{C}'},
+        ],
+    }
+    params_path = os.path.join(temp_output_dir, '3compartment_modifier_params_for_id.json')
+    if rank == 0:
+        with open(params_path, 'w') as f:
+            json.dump(params_doc, f)
+    mpi_comm.Barrier()
+
+    config = base_user_inputs.copy()
+    config.update({
+        'file_prefix': '3compartment',
+        'input_param_file': '3compartment_parameters.csv',
+        'model_type': 'cellml_only',
+        'solver': 'CVODE_myokit',
+        'param_id_method': 'sp_minimize',
+        'do_ad': True,
+        'pre_time': 2,
+        'sim_time': 1,
+        'dt': 0.01,
+        'DEBUG': True,
+        'do_mcmc': False,
+        'plot_predictions': False,
+        'do_ia': False,
+        'solver_info': {'MaximumStep': 0.001, 'MaximumNumberOfSteps': 5000},
+        'param_id_obs_path': os.path.join(resources_dir, '3compartment_obs_data.json'),
+        # os.path.join(resources_dir, <absolute path>) resolves to the absolute path, the same
+        # way every test's absolute param_id_obs_path passes through its own join.
+        'params_for_id_file': params_path,
+        'param_id_output_dir': temp_output_dir,
+        'generated_models_dir': temp_generated_models_dir,
+        # A loose tolerance: the point is the path through the FSA chain rule and the output
+        # contract, not the optimum. L-BFGS-B stops after a few iterations.
+        'debug_optimiser_options': {'cost_convergence': 1e-2},
+    })
+
+    _ensure_cellml_model_generated(config, mpi_comm)
+    run_param_id(config)
+
+    if rank == 0:
+        out_dir = os.path.join(temp_output_dir, 'sp_minimize_3compartment_3compartment_obs_data')
+        best_cost = float(np.load(os.path.join(out_dir, 'best_cost.npy')))
+        assert np.isfinite(best_cost) and best_cost >= 0, \
+            f'expected a finite, non-negative best cost, got {best_cost}'
+
+        best_params = np.load(os.path.join(out_dir, 'best_param_vals.npy')).ravel()
+        assert best_params.shape[0] == 2, best_params
+        q_lv, theta = float(best_params[0]), float(best_params[1])
+        assert 200e-6 <= q_lv <= 1500e-6, f'q_lv_init out of bounds: {q_lv}'
+        # theta is dimensionless; a raw compliance (~1e-8) landing here would mean the
+        # modifier slot was treated as a model value.
+        assert 0.5 <= theta <= 2.0, f'theta out of bounds: {theta}'
+
+        # The record that makes theta interpretable: without baselines, best_param_vals alone
+        # does not say what any compliance ended up at.
+        modifiers_path = os.path.join(out_dir, 'param_modifiers.json')
+        assert os.path.exists(modifiers_path), \
+            f'param_modifiers.json should land in the output dir: {modifiers_path}'
+        with open(modifiers_path) as f:
+            modifiers = json.load(f)
+        assert len(modifiers) == 1
+        mod = modifiers[0]
+        assert mod['name'] == 'C_scale'
+        assert mod['operation'] == 'scale'
+        assert mod['targets'] == ['aortic_root/C', 'par/C']
+        # Model defaults from 3compartment_parameters.csv (C_aortic_root, C_par).
+        assert mod['baselines'] == pytest.approx([1.2028e-8, 3.09077e-10], rel=1e-6), \
+            f'baselines should be the model defaults, got {mod["baselines"]}'
+    mpi_comm.Barrier()

--- a/tests/test_param_modifiers.py
+++ b/tests/test_param_modifiers.py
@@ -50,10 +50,14 @@ def test_the_operation_vocabulary_is_exported_as_data():
     assert 'scale' in ops
     assert DEFAULT_PARAM_MODIFIER_OPERATION in ops
     meta = ops['scale']
-    for key in ('description', 'applies_to', 'dimensionless', 'default_min', 'default_max'):
+    for key in ('description', 'applies_to', 'dimensionless', 'default_min', 'default_max',
+                'identity'):
         assert key in meta, key
     assert meta['dimensionless'] is True
     assert meta['default_min'] < meta['default_max']
+    # The identity is what local SA evaluates at: for scale, theta=1 leaves every target at
+    # its baseline.
+    assert meta['identity'] == 1.0
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What

Since #376, `set_param_vals` moves **every** member of a grouped `params_for_id` row, but both local-sensitivity arms flattened a group to its **first member**. On the Myokit/FSA path the cost was therefore a function of all members while the gradient tracked only the first — the exact cost-vs-gradient mismatch #376 refused to introduce for CasADi, live and silent on FSA.

This PR makes the FSA arm exact for all three cases:

```
ungrouped            dJ/dp
shared-value group   dJ/dtheta = sum_i  dJ/dp_i
scale modifier       dJ/dtheta = sum_i (dJ/dp_i) * baseline_i
```

### How

- `ensure_setup` hands **every member qname** to `enable_fsa` (a CVODES column per member) and records a per-entry `(member, weight)` list — weight 1 for shared-value groups, the resolved baseline for scale modifiers (`modifier_weights_by_index`).
- Perturbing theta by `h` moves member *i* by `w_i * h`, so the directional derivative runs along the **combined** sensitivity `sum_i w_i * S_i` (`combined_entry_sensitivities`). The perturbation machinery itself is unchanged; the three cases fall out of the weights. Both `get_jac_cost` and `observable_feature_sensitivities` use the combination.
- An entry with any FSA-ineligible member falls back to full-cost FD **as a whole** (theta FD is exact for groups since the cost path expands theta).
- The modifier refusal (`_refuse_sensitivities_for_modifiers`) now guards only the CasADi arm, which still cannot express a grouped row (`_create_param_subset`); symbolic substitution there is follow-up work.

### Reporting keyed by entry label

Sensitivity dicts are now keyed by `param_entry_labels` (new accessor; `param_labels` with a fallback for older dicts): a grouped entry's number is d/dtheta over all members, and keying it by one member's qname reported it as a different quantity. Both consumers (local SA matrix, Laplace FIM) and the multi-start CSV headers read the same labels. Ungrouped rows are unchanged (label == qname).

### Modifier fixes surfaced by a real calibration

Driving a modifier through an actual 3compartment calibration (below) surfaced three latent #378 gaps, all fixed here:

1. **Ragged x0**: `get_init_param_vals` returns a *list* per multi-name entry, and `np.asarray` over that crashed every optimiser's x0 handling (`sp_minimize` + any grouped row was broken since #376). `param_init` is now flat, one slot per theta.
2. **Modifier x0/nominal semantics**: theta's start (and local-SA nominal) is now the operation's **identity** (`scale` → 1.0, new introspectable `identity` field in `PARAM_MODIFIER_OPERATIONS`), not the first target's model default — which would have scaled every target by ~1e-8.
3. **`param_modifiers.json` saved with `baselines: null`**: the parse-time save runs before a simulation helper exists. The calibration run now re-saves once baselines are resolved (`save_param_modifiers`, idempotent).

### gradient_method speaks the arm names (CUFLynx ask)

`get_observable_sensitivities` now accepts `'AD'` and `'FSA'` alongside `'FD'`/`'auto'`/`'analytic'` — the same vocabulary as `gradient_sources()` and the Laplace `gradient_source` — validating each against the backend rather than silently reinterpreting: `'AD'` off `casadi_python` raises naming the mismatch; `'FSA'` without `cellml_only` + `CVODE_myokit` + `do_ad` raises naming exactly what is missing. The `sa_options` schema advertises `['auto', 'AD', 'FSA', 'FD']` (default `auto`); `'analytic'` stays accepted in code as a legacy spelling but is no longer advertised. (Requested in `handover_CA_gradient_method_names.md`; included here because it edits the same dispatch the chain-rule work restructured.)

## Tests

- `tests/test_fsa_grouped_sensitivities.py` — unit tests that **discriminate by construction** (synthetic member sensitivities of comparable magnitude): the flattened member list reaching `enable_fsa`, plain-sum vs baseline-weighted-sum gradients, first-member-alone asserted unreachable, whole-entry FD fallback, label keying, identity nominals, refusal placement. An FSA-vs-FD test on a real model cannot catch this bug (measured: wrong and right answers agree to 1e-5 relative on 3compartment `[aortic_root/C, par/C]`).
- `tests/test_param_id.py::test_param_id_3compartment_modifier_calibration_fsa` — the real-calibration modifier run (#378 shipped unit tests only): theta scaling both compliances through `sp_minimize` + `do_ad` on `CVODE_myokit`, asserting `param_modifiers.json` lands with the model-default baselines and theta stays a dimensionless value in bounds.
- `tests/test_fd_observable_sensitivities.py` — each gradient_method spelling reaches the arm it names; mismatched pairs raise naming the mismatch/missing pieces.
- All unit tests verified failing against the pre-fix code (the buggy gradient returns exactly the first member's derivative).
- Full suite run: 599 passed, 7 failed — the six failures already present on `upstream/master` (SN_simple python codegen, AADC 35.1% deviation ×3, AADC untapeable DID-NOT-RAISE) plus one `inspect.getsource` artifact from editing sources while the suite ran, verified passing standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
