### PR TITLE
feat: restore bdf_kernel — C++ kernel replay (rebase of #381)

### DIFF
--- a/src/param_id/aadc_backend.py
+++ b/src/param_id/aadc_backend.py
@@ -963,7 +963,6 @@ def _cost_and_grad_bdf_kernel(pid, param_vals):
     n_sub = max(1, int(np.ceil(dt / max_step)))
     idt = dt / n_sub
     jac_lag = int(sim_helper.solver_info.get('jac_lag', 10))
-    newton_iters = int(sim_helper.solver_info.get('newton_iters', 0))
 
     param_names_raw = pid.param_id_info["param_names"]
     param_names = [pn[0] if isinstance(pn, (list, tuple)) else pn for pn in param_names_raw]
@@ -1014,17 +1013,24 @@ def _cost_and_grad_bdf_kernel(pid, param_vals):
         op_code = op_map.get(operation, -1)
         if kind == 'state' and si is not None and op_code >= 0:
             obs_list.append((0, si, 0, op_code, gt, std, w * scale / weighted_obs_denom, 1.0))
+        elif kind == 'var' and si is not None and op_code >= 0:
+            var_raw_idx = sim_helper.var_name_to_idx.get(op_name, si)
+            obs_list.append((1, si, var_raw_idx, op_code, gt, std, w * scale / weighted_obs_denom, 1.0))
         const_idx += 1
 
     states = list(sim_helper.states[:n])
     param_values = [float(param_vals[i]) for i in range(n_p)]
+
+    compute_variables_fn = None
+    if hasattr(sim_helper.model, 'compute_variables'):
+        compute_variables_fn = sim_helper.model.compute_variables
 
     cost, grad_list = aadc._aadc_core.bdf_record_and_evaluate(
         sim_helper.model.compute_rates,
         states, variables_all,
         list(ad_indices), param_values,
         total_steps, pre_steps, n_sub, idt,
-        obs_list, None, jac_lag, newton_iters
+        obs_list, compute_variables_fn, jac_lag
     )
 
     grad = np.array([float(g) for g in grad_list])

--- a/src/param_id/aadc_native/bdf_loop.cpp
+++ b/src/param_id/aadc_native/bdf_loop.cpp
@@ -118,55 +118,6 @@ private:
     std::vector<aadc::ExtVarIndex> rhs_idx_, out_idx_;
 };
 
-// Step kernel ExtFunc: wraps a step kernel (compute_rates + BDF step) with constant t and J_diag.
-// Gradient flows through x and p only (t and J_diag are off-tape constants).
-class StepExtFunc : public aadc::ConstStateExtFunc {
-public:
-    std::shared_ptr<Functions> kern;
-    std::vector<Argument> kx,kp; Argument kt; std::vector<Argument> kj;
-    std::vector<Result> kr;
-    std::vector<aadc::ExtVarIndex> tx,tp,to;
-    double t_val; std::vector<double> j_val;
-    mutable std::shared_ptr<WorkSpace> ws;
-    int n_, np_;
-
-    StepExtFunc(std::shared_ptr<Functions> k,
-        const std::vector<Argument>& kx_, const std::vector<Argument>& kp_,
-        Argument kt_, const std::vector<Argument>& kj_, const std::vector<Result>& kr_,
-        const std::vector<aadc::ExtVarIndex>& tx_, const std::vector<aadc::ExtVarIndex>& tp_,
-        const std::vector<aadc::ExtVarIndex>& to_,
-        double tv, const std::vector<double>& jv, std::shared_ptr<WorkSpace> w)
-        : kern(k), kx(kx_), kp(kp_), kt(kt_), kj(kj_), kr(kr_),
-          tx(tx_), tp(tp_), to(to_), t_val(tv), j_val(jv), ws(w),
-          n_(kx_.size()), np_(kp_.size()) {}
-
-    template<typename M> void forward(M* v) const {
-        for (int a=0;a<aadc::mmSize<M>();a++) {
-            for (int i=0;i<n_;i++) aadc::toDblPtr(ws->val(kx[i]))[0]=aadc::toDblPtr(v[tx[i]])[a];
-            for (int k=0;k<np_;k++) aadc::toDblPtr(ws->val(kp[k]))[0]=aadc::toDblPtr(v[tp[k]])[a];
-            aadc::toDblPtr(ws->val(kt))[0]=t_val;
-            for (int i=0;i<n_;i++) aadc::toDblPtr(ws->val(kj[i]))[0]=j_val[i];
-            kern->forward(*ws);
-            for (int i=0;i<n_;i++) aadc::toDblPtr(v[to[i]])[a]=aadc::toDblPtr(ws->val(kr[i]))[0];
-        }
-    }
-    template<class M> void reverse(const M* v, M* d) const {
-        for (int a=0;a<aadc::mmSize<M>();a++) {
-            for (int i=0;i<n_;i++) aadc::toDblPtr(ws->val(kx[i]))[0]=aadc::toDblPtr(v[tx[i]])[a];
-            for (int k=0;k<np_;k++) aadc::toDblPtr(ws->val(kp[k]))[0]=aadc::toDblPtr(v[tp[k]])[a];
-            aadc::toDblPtr(ws->val(kt))[0]=t_val;
-            for (int i=0;i<n_;i++) aadc::toDblPtr(ws->val(kj[i]))[0]=j_val[i];
-            kern->forward(*ws);
-            ws->resetDiff();
-            for (int i=0;i<n_;i++) aadc::toDblPtr(ws->diff(kr[i]))[0]=aadc::toDblPtr(d[to[i]])[a];
-            kern->reverse(*ws);
-            for (int i=0;i<n_;i++) aadc::toDblPtr(d[tx[i]])[a]+=aadc::toDblPtr(ws->diff(kx[i]))[0];
-            for (int k=0;k<np_;k++) aadc::toDblPtr(d[tp[k]])[a]+=aadc::toDblPtr(ws->diff(kp[k]))[0];
-            // t and J_diag: no gradient (constants for AD)
-        }
-    }
-};
-
 // Static cache
 static struct {
     std::shared_ptr<Functions> funcs;
@@ -226,7 +177,7 @@ py::tuple bdf_record_and_evaluate(
     int total_subs = total_steps * n_sub;
 
     if (!cache.funcs || cache.total_subs != total_subs || cache.newton_mode != newton_iters) {
-        // ---- Record f-kernel (compute_rates only, for Jacobian computation) ----
+        // ---- Record kernel ----
         auto kernel = std::make_shared<Functions>();
         kernel->startRecording();
         std::vector<idouble> kx(n); std::vector<Argument> kxa(n);
@@ -234,46 +185,17 @@ py::tuple bdf_record_and_evaluate(
         std::vector<idouble> kv(n_vars); std::vector<Argument> kpa(n_p);
         for (int i=0;i<n_vars;i++) { double v=py_variables[i].cast<double>(); kv[i]=(v==v)?v:0.0; }
         for (int k=0;k<n_p;k++) { kv[pidx[k]]=py_param_values[k].cast<double>(); kpa[k]=kv[pidx[k]].markAsInput(); }
-        idouble kt(0.0); Argument kta = kt.markAsInput();
         py::list pkx(n),pkr(n),pkv(n_vars);
         for (int i=0;i<n;i++) pkx[i]=py::cast(kx[i]);
         for (int i=0;i<n;i++) pkr[i]=py::cast(idouble(0.0));
         for (int i=0;i<n_vars;i++) pkv[i]=py::cast(kv[i]);
-        compute_rates_fn(py::cast(kt),pkx,pkr,pkv);
+        compute_rates_fn(py::cast(idouble(0.0)),pkx,pkr,pkv);
         std::vector<Result> krr(n);
         for (int i=0;i<n;i++) {
             auto o=pkr[i]; idouble rv=py::isinstance<idouble>(o)?o.cast<idouble>():idouble(o.cast<double>());
             krr[i]=rv.markAsOutput();
         }
         kernel->stopRecording();
-
-        // ---- Record step kernel (compute_rates + semi-implicit, ONE step) ----
-        // Inputs: x(n), p(n_p), t(1), J_diag(n). Outputs: x_new(n).
-        // This kernel is replayed 22000 times — NO idouble arithmetic on main tape.
-        auto step_kernel = std::make_shared<Functions>();
-        step_kernel->startRecording();
-        std::vector<idouble> sx(n); std::vector<Argument> sxa(n);
-        for (int i=0;i<n;i++) { sx[i]=py_states[i].cast<double>(); sxa[i]=sx[i].markAsInput(); }
-        std::vector<idouble> sv(n_vars); std::vector<Argument> spa(n_p);
-        for (int i=0;i<n_vars;i++) { double v=py_variables[i].cast<double>(); sv[i]=(v==v)?v:0.0; }
-        for (int k=0;k<n_p;k++) { sv[pidx[k]]=py_param_values[k].cast<double>(); spa[k]=sv[pidx[k]].markAsInput(); }
-        idouble st(0.0); Argument sta = st.markAsInput();
-        std::vector<idouble> sj(n); std::vector<Argument> sja(n);
-        for (int i=0;i<n;i++) { sj[i]=0.0; sja[i]=sj[i].markAsInput(); }
-        // Call compute_rates within step kernel recording
-        py::list spkx(n),spkr(n),spkv(n_vars);
-        for (int i=0;i<n;i++) spkx[i]=py::cast(sx[i]);
-        for (int i=0;i<n;i++) spkr[i]=py::cast(idouble(0.0));
-        for (int i=0;i<n_vars;i++) spkv[i]=py::cast(sv[i]);
-        compute_rates_fn(py::cast(st),spkx,spkr,spkv);
-        // Semi-implicit: x_new[i] = x[i] + dt*f[i] / (1 - dt*J[i])
-        std::vector<Result> sxr(n);
-        for (int i=0;i<n;i++) {
-            auto o=spkr[i]; idouble fi=py::isinstance<idouble>(o)?o.cast<idouble>():idouble(o.cast<double>());
-            idouble xnew = sx[i] + idouble(idt)*fi / (idouble(1.0) - idouble(idt)*sj[i]);
-            sxr[i] = xnew.markAsOutput();
-        }
-        step_kernel->stopRecording();
 
         // ---- Record compute_variables kernel (for var observables) ----
         bool has_var_obs = false;
@@ -346,138 +268,132 @@ py::tuple bdf_record_and_evaluate(
         std::map<Key,Acc> accs;
         for (auto&o:obs) accs[{o.kind,o.si,o.op}]=Acc{};
 
-        // Pre-allocate workspaces
-        auto jac_ws = kernel->createWorkSpace();
-        auto step_ws = step_kernel->createWorkSpace();
-        auto loop_ws = kernel->createWorkSpace();  // for Newton f-kernel replays
-        std::vector<double> dJ_val(n, 0.0);
+        std::vector<idouble> dJ(n,idouble(0.0));
+        auto jac_ws = kernel->createWorkSpace();  // reused for all Jacobian computations
+        auto loop_ws = kernel->createWorkSpace();  // reused for all forward evals in loop
         std::vector<std::vector<double>> cached_LU(n, std::vector<double>(n, 0.0));
         std::vector<int> cached_piv(n);
         for (int i=0;i<n;i++) { cached_piv[i]=i; cached_LU[i][i]=1.0; }
-
         int sc=0;
-        int cp_interval = 100;
+        int cp_interval = 100; // checkpoint every 100 sub-steps
         for (int step=0;step<total_steps;step++) {
             for (int sub=0;sub<n_sub;sub++) {
                 if (sc > 0 && sc % cp_interval == 0)
                     idouble::CheckPoint();
+                // Helper: call kernel ExtFunc, put f(y,p) on tape, return rates
+                auto call_kernel = [&](std::vector<idouble>& y) -> std::vector<idouble> {
+                    std::vector<idouble> r(n);
+                    std::vector<aadc::ExtVarIndex> txi(n),tpi(n_p),toi(n);
+                    for (int i=0;i<n;i++) txi[i]=aadc::ExtVarIndex(y[i],true,true);
+                    for (int k=0;k<n_p;k++) tpi[k]=aadc::ExtVarIndex(pid2[k],true,true);
+                    for (int i=0;i<n;i++){r[i]=idouble(0.0);toi[i]=aadc::ExtVarIndex(r[i],false,true);}
+                    aadc::addConstStateExtFunction(std::make_shared<KernelExtFunc>(kernel,kxa,kpa,krr,txi,tpi,toi,loop_ws));
+                    for (int i=0;i<n;i++) loop_ws->setVal(kxa[i],y[i].val);
+                    for (int k2=0;k2<n_p;k2++) loop_ws->setVal(kpa[k2],pid2[k2].val);
+                    kernel->forward(*loop_ws);
+                    for (int i=0;i<n;i++) r[i].val=aadc::toDblPtr(loop_ws->val(krr[i]))[0];
+                    return r;
+                };
 
-                double t_val = sc * idt;
-
-                // Compute diagonal J off-tape via kernel reverse AD (every jac_lag steps)
-                if (sc%jac_lag==0) {
-                    for (int i=0;i<n;i++) jac_ws->setVal(kxa[i], x[i].val);
+                // Helper: compute Jacobian off-tape via kernel reverse AD
+                // Row i of J: set adjoint f_i = 1, reverse, read x_j adjoints
+                // 27 reverse passes = full 27×27 Jacobian, exact (no FD approximation)
+                auto compute_jacobian = [&](const std::vector<idouble>& y, const std::vector<double>& f0) {
+                    std::vector<std::vector<double>> J(n, std::vector<double>(n, 0.0));
+                    for (int i=0;i<n;i++) jac_ws->setVal(kxa[i], y[i].val);
                     for (int k2=0;k2<n_p;k2++) jac_ws->setVal(kpa[k2], pid2[k2].val);
-                    jac_ws->setVal(kta, t_val);
                     kernel->forward(*jac_ws);
                     for (int i=0;i<n;i++) {
                         jac_ws->resetDiff();
                         jac_ws->setDiff(krr[i], 1.0);
                         kernel->reverse(*jac_ws);
-                        dJ_val[i] = aadc::toDblPtr(jac_ws->diff(kxa[i]))[0];
+                        for (int j=0;j<n;j++)
+                            J[i][j] = aadc::toDblPtr(jac_ws->diff(kxa[j]))[0];
+                    }
+                    return J;
+                };
+
+                // Helper: LU factorize (I - dt*J) off-tape, return L,U,piv
+                // Simple partial pivoting LU
+                auto lu_factorize = [&](const std::vector<std::vector<double>>& J) {
+                    std::vector<std::vector<double>> A(n, std::vector<double>(n));
+                    std::vector<int> piv(n);
+                    for (int i=0;i<n;i++) { piv[i]=i; for (int j=0;j<n;j++) A[i][j]=(i==j?1.0:0.0)-idt*J[i][j]; }
+                    for (int col=0;col<n;col++) {
+                        // partial pivot
+                        int mx=col; for (int r=col+1;r<n;r++) if (std::abs(A[r][col])>std::abs(A[mx][col])) mx=r;
+                        if (mx!=col) { std::swap(A[col],A[mx]); std::swap(piv[col],piv[mx]); }
+                        for (int r=col+1;r<n;r++) {
+                            A[r][col]/=A[col][col];
+                            for (int c=col+1;c<n;c++) A[r][c]-=A[r][col]*A[col][c];
+                        }
+                    }
+                    return std::make_pair(A, piv);
+                };
+
+                // Compute diagonal J via kernel reverse AD (off-tape, for semi-implicit predictor)
+                auto rates0_ref = call_kernel(x);
+                if (sc%jac_lag==0) {
+                    for (int i=0;i<n;i++) jac_ws->setVal(kxa[i], x[i].val);
+                    for (int k2=0;k2<n_p;k2++) jac_ws->setVal(kpa[k2], pid2[k2].val);
+                    kernel->forward(*jac_ws);
+                    for (int i=0;i<n;i++) {
+                        jac_ws->resetDiff();
+                        jac_ws->setDiff(krr[i], 1.0);
+                        kernel->reverse(*jac_ws);
+                        dJ[i] = idouble(aadc::toDblPtr(jac_ws->diff(kxa[i]))[0]);
                     }
                 }
 
                 if (newton_iters == 0) {
-                    // ---- SEMI-IMPLICIT: step kernel approach ----
-                    // ONE reference node per step, no idouble arithmetic on main tape
-                    std::vector<idouble> xnew(n);
-                    std::vector<aadc::ExtVarIndex> txi(n), tpi(n_p), toi(n);
-                    for (int i=0;i<n;i++) txi[i]=aadc::ExtVarIndex(x[i],true,true);
-                    for (int k2=0;k2<n_p;k2++) tpi[k2]=aadc::ExtVarIndex(pid2[k2],true,true);
-                    for (int i=0;i<n;i++){xnew[i]=idouble(0.0);toi[i]=aadc::ExtVarIndex(xnew[i],false,true);}
-
-                    aadc::addConstStateExtFunction(std::make_shared<StepExtFunc>(
-                        step_kernel, sxa, spa, sta, sja, sxr,
-                        txi, tpi, toi, t_val, dJ_val, step_ws));
-
-                    for (int i=0;i<n;i++) step_ws->setVal(sxa[i], x[i].val);
-                    for (int k2=0;k2<n_p;k2++) step_ws->setVal(spa[k2], pid2[k2].val);
-                    step_ws->setVal(sta, t_val);
-                    for (int i=0;i<n;i++) step_ws->setVal(sja[i], dJ_val[i]);
-                    step_kernel->forward(*step_ws);
-                    for (int i=0;i<n;i++) xnew[i].val=aadc::toDblPtr(step_ws->val(sxr[i]))[0];
-                    x = xnew;
+                    // Semi-implicit step
+                    for (int i=0;i<n;i++)
+                        x[i]=x[i]+idouble(idt)*rates0_ref[i]/(idouble(1.0)-idouble(idt)*dJ[i]);
                 } else {
-                    // ---- NEWTON: f-kernel + LUSolveExtFunc approach ----
-                    // Semi-implicit predictor via step kernel
+                    // Full Newton with semi-implicit predictor
                     std::vector<idouble> y(n);
-                    {
-                        std::vector<aadc::ExtVarIndex> txi(n), tpi(n_p), toi(n);
-                        for (int i=0;i<n;i++) txi[i]=aadc::ExtVarIndex(x[i],true,true);
-                        for (int k2=0;k2<n_p;k2++) tpi[k2]=aadc::ExtVarIndex(pid2[k2],true,true);
-                        for (int i=0;i<n;i++){y[i]=idouble(0.0);toi[i]=aadc::ExtVarIndex(y[i],false,true);}
-                        aadc::addConstStateExtFunction(std::make_shared<StepExtFunc>(
-                            step_kernel, sxa, spa, sta, sja, sxr,
-                            txi, tpi, toi, t_val, dJ_val, step_ws));
-                        for (int i=0;i<n;i++) step_ws->setVal(sxa[i], x[i].val);
-                        for (int k2=0;k2<n_p;k2++) step_ws->setVal(spa[k2], pid2[k2].val);
-                        step_ws->setVal(sta, t_val);
-                        for (int i=0;i<n;i++) step_ws->setVal(sja[i], dJ_val[i]);
-                        step_kernel->forward(*step_ws);
-                        for (int i=0;i<n;i++) y[i].val=aadc::toDblPtr(step_ws->val(sxr[i]))[0];
-                    }
+                    for (int i=0;i<n;i++)
+                        y[i]=x[i]+idouble(idt)*rates0_ref[i]/(idouble(1.0)-idouble(idt)*dJ[i]);
 
-                    // Full Jacobian + LU (off-tape, every jac_lag steps)
+                    // Compute full Jacobian at y and LU off-tape (constants)
+                    std::vector<double> f0(n);
+                    { for (int i=0;i<n;i++) loop_ws->setVal(kxa[i],y[i].val);
+                      for (int k2=0;k2<n_p;k2++) loop_ws->setVal(kpa[k2],pid2[k2].val);
+                      kernel->forward(*loop_ws);
+                      for (int i=0;i<n;i++) f0[i]=aadc::toDblPtr(loop_ws->val(krr[i]))[0];
+                    }
                     if (sc%jac_lag==0) {
-                        std::vector<std::vector<double>> J(n, std::vector<double>(n, 0.0));
-                        for (int i=0;i<n;i++) jac_ws->setVal(kxa[i], y[i].val);
-                        for (int k2=0;k2<n_p;k2++) jac_ws->setVal(kpa[k2], pid2[k2].val);
-                        jac_ws->setVal(kta, t_val);
-                        kernel->forward(*jac_ws);
-                        for (int i=0;i<n;i++) {
-                            jac_ws->resetDiff();
-                            jac_ws->setDiff(krr[i], 1.0);
-                            kernel->reverse(*jac_ws);
-                            for (int j=0;j<n;j++)
-                                J[i][j] = aadc::toDblPtr(jac_ws->diff(kxa[j]))[0];
-                        }
-                        // LU factorize (I - dt*J)
-                        cached_LU.assign(n, std::vector<double>(n));
-                        cached_piv.resize(n);
-                        for (int i=0;i<n;i++) { cached_piv[i]=i; for (int j=0;j<n;j++) cached_LU[i][j]=(i==j?1.0:0.0)-idt*J[i][j]; }
-                        for (int col=0;col<n;col++) {
-                            int mx=col; for (int r=col+1;r<n;r++) if (std::abs(cached_LU[r][col])>std::abs(cached_LU[mx][col])) mx=r;
-                            if (mx!=col) { std::swap(cached_LU[col],cached_LU[mx]); std::swap(cached_piv[col],cached_piv[mx]); }
-                            for (int r=col+1;r<n;r++) {
-                                cached_LU[r][col]/=cached_LU[col][col];
-                                for (int c=col+1;c<n;c++) cached_LU[r][c]-=cached_LU[r][col]*cached_LU[col][c];
-                            }
-                        }
+                        auto J = compute_jacobian(y, f0);
+                        auto [LU_new, piv_new] = lu_factorize(J);
+                        cached_LU = LU_new;
+                        cached_piv = piv_new;
                     }
 
-                    // Newton iterations: f(y) via f-kernel + LUSolveExtFunc
+                    // Newton iterations
                     for (int nit=0; nit<newton_iters; nit++) {
-                        // f(y) on tape via KernelExtFunc
-                        std::vector<idouble> fy(n);
-                        {
-                            std::vector<aadc::ExtVarIndex> txi(n),tpi(n_p),toi(n);
-                            for (int i=0;i<n;i++) txi[i]=aadc::ExtVarIndex(y[i],true,true);
-                            for (int k2=0;k2<n_p;k2++) tpi[k2]=aadc::ExtVarIndex(pid2[k2],true,true);
-                            for (int i=0;i<n;i++){fy[i]=idouble(0.0);toi[i]=aadc::ExtVarIndex(fy[i],false,true);}
-                            aadc::addConstStateExtFunction(std::make_shared<KernelExtFunc>(kernel,kxa,kpa,krr,txi,tpi,toi,loop_ws));
-                            for (int i=0;i<n;i++) loop_ws->setVal(kxa[i],y[i].val);
-                            for (int k2=0;k2<n_p;k2++) loop_ws->setVal(kpa[k2],pid2[k2].val);
-                            loop_ws->setVal(kta, t_val);
-                            kernel->forward(*loop_ws);
-                            for (int i=0;i<n;i++) fy[i].val=aadc::toDblPtr(loop_ws->val(krr[i]))[0];
-                        }
-                        // F = y - x - dt*f(y)
+                        auto fy = call_kernel(y);  // f(y) on tape
+                        // F = y - x - dt*f(y), on tape
                         std::vector<idouble> F(n);
                         for (int i=0;i<n;i++) F[i]=y[i]-x[i]-idouble(idt)*fy[i];
-                        // LU solve via ExtFunc
+                        // dy = LU_solve(F) via ExtFunc (off-tape LU, constant coefficients)
                         std::vector<idouble> dy(n);
                         {
                             std::vector<aadc::ExtVarIndex> rhs_ei(n), out_ei(n);
                             for (int i=0;i<n;i++) rhs_ei[i]=aadc::ExtVarIndex(F[i],true,true);
                             for (int i=0;i<n;i++){dy[i]=idouble(0.0);out_ei[i]=aadc::ExtVarIndex(dy[i],false,true);}
                             aadc::addConstStateExtFunction(std::make_shared<LUSolveExtFunc>(n,cached_LU,cached_piv,rhs_ei,out_ei));
+                            // Compute values for dy
                             std::vector<double> bv(n);
                             for (int i=0;i<n;i++) bv[i]=F[cached_piv[i]].val;
-                            for (int i=1;i<n;i++) for (int j=0;j<i;j++) bv[i]-=cached_LU[i][j]*bv[j];
-                            for (int i=n-1;i>=0;i--) { for (int j=i+1;j<n;j++) bv[i]-=cached_LU[i][j]*bv[j]; bv[i]/=cached_LU[i][i]; }
+                            for (int i=1;i<n;i++)
+                                for (int j=0;j<i;j++) bv[i]-=cached_LU[i][j]*bv[j];
+                            for (int i=n-1;i>=0;i--) {
+                                for (int j=i+1;j<n;j++) bv[i]-=cached_LU[i][j]*bv[j];
+                                bv[i]/=cached_LU[i][i];
+                            }
                             for (int i=0;i<n;i++) dy[i].val=bv[i];
                         }
+                        // y = y - dy, on tape
                         for (int i=0;i<n;i++) y[i]=y[i]-dy[i];
                     }
                     x = y;

--- a/tests/test_bdf_kernel.py
+++ b/tests/test_bdf_kernel.py
@@ -1,0 +1,223 @@
+"""
+Tests for bdf_kernel (C++ kernel replay via aadc.bdf_record_and_evaluate).
+
+Verifies:
+  1. Cost matches: bdf_kernel cost ≈ scipy BDF cost (same observables)
+  2. Gradient matches: bdf_kernel gradient ≈ FD gradient
+  3. Speed: bdf_kernel vs scipy BDF forward+gradient
+  4. Calibration: bdf_kernel-calibrated params ≈ scipy BDF-calibrated params
+
+Uses the 3compartment stiff model from test_aadc_vs_casadi_3compartment.py.
+"""
+import os
+import sys
+import time
+
+import numpy as np
+import pytest
+
+_TEST_ROOT = os.path.join(os.path.dirname(__file__), '..')
+_SRC_DIR = os.path.join(_TEST_ROOT, 'src')
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+from solver_wrappers import get_simulation_helper
+from scripts.script_generate_with_new_architecture import generate_with_new_architecture
+from utilities.utility_funcs import get_default_inp_data_dict
+
+_DT = 0.001
+_SIM_TIME = 1.0
+
+
+@pytest.fixture(scope="module")
+def aadc_model(tmp_path_factory):
+    """Generate aadc_python 3compartment model."""
+    base = str(tmp_path_factory.mktemp("bdf_kernel"))
+    resources = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "resources"))
+    d = os.path.join(base, "aadc")
+    os.makedirs(d, exist_ok=True)
+    inp = get_default_inp_data_dict("3compartment", "3compartment_parameters.csv", resources)
+    inp.update({
+        "model_type": "aadc_python",
+        "generated_models_dir": d,
+        "solver": "aadc_semi_implicit",
+        "solver_info": {"method": "bdf"},
+    })
+    assert generate_with_new_architecture(False, inp), "generation failed"
+    return {
+        "py": os.path.join(d, "3compartment", "3compartment.py"),
+        "cellml": os.path.join(d, "3compartment", "3compartment.cellml"),
+    }
+
+
+def _make_sim(model_path, method='bdf', dt=_DT, sim_time=_SIM_TIME):
+    return get_simulation_helper(
+        model_path=model_path, solver='aadc_semi_implicit', model_type='aadc_python',
+        dt=dt, sim_time=sim_time, pre_time=0.0, solver_info={'method': method},
+    )
+
+
+def _pick_param_and_obs(sim):
+    """Pick one param and one state for gradient test."""
+    vi = sim.model.VARIABLE_INFO
+    pidx = next((i for i, info in enumerate(vi) if 'e_lv_a' in info['name'].lower()),
+                next(i for i, info in enumerate(vi)))
+    sidx = next((i for i, info in enumerate(sim.model.STATE_INFO) if 'q_lv' in info['name'].lower()),
+                0)
+    return pidx, sidx
+
+
+# ---- Test 1: bdf_kernel cost matches scipy BDF cost ----
+@pytest.mark.integration
+def test_bdf_kernel_cost_matches_scipy_bdf(aadc_model):
+    """bdf_kernel and scipy BDF should produce similar cost for same observables."""
+    aadc = pytest.importorskip("aadc")
+    if not hasattr(aadc, 'bdf_record_and_evaluate'):
+        pytest.skip("bdf_record_and_evaluate not available in this AADC build")
+
+    sim = _make_sim(aadc_model["py"], method='bdf')
+    sim.run()
+    pidx, sidx = _pick_param_and_obs(sim)
+
+    # Get final state value from scipy BDF
+    final_state_scipy = float(sim.state_traj[sidx, -1])
+
+    # Now compute cost via bdf_kernel
+    n = sim.STATE_COUNT
+    states = list(sim.states[:n])
+    variables = list(sim._numeric_variables_all)
+    for ci, idx in enumerate(sim.constant_indices):
+        variables[idx] = sim.variables[ci]
+
+    # Observable: (kind=0, state_idx, var_idx=0, op=0=mean, gt=final_state, std=0.01, weight=1, scale=1)
+    obs_list = [(0, sidx, 0, 0, final_state_scipy, 0.01, 1.0, 1.0)]
+
+    max_step = float(sim.solver_info.get('max_step', 0.001))
+    n_sub = max(1, int(np.ceil(sim.dt / max_step)))
+    total_steps = int(sim.sim_time / sim.dt)
+
+    cost, grads = aadc.bdf_record_and_evaluate(
+        sim.model.compute_rates,
+        states, variables,
+        [], [],  # no params for cost-only test
+        total_steps, 0, n_sub, sim.dt / n_sub,
+        obs_list, None, 10)
+
+    print(f"\n  scipy BDF final state[{sidx}]: {final_state_scipy:.6e}")
+    print(f"  bdf_kernel cost: {cost:.6e}")
+    # Cost should be small if bdf_kernel forward matches scipy BDF
+    # (cost = weighted (mean_state - gt)^2, gt = scipy result)
+    assert cost < 1.0, f"bdf_kernel cost={cost:.4f} too high (forward drift from scipy BDF)"
+
+
+# ---- Test 2: bdf_kernel gradient vs FD ----
+@pytest.mark.integration
+def test_bdf_kernel_gradient_vs_fd(aadc_model):
+    """bdf_kernel gradient should match finite differences."""
+    aadc = pytest.importorskip("aadc")
+    if not hasattr(aadc, 'bdf_record_and_evaluate'):
+        pytest.skip("bdf_record_and_evaluate not available")
+
+    sim = _make_sim(aadc_model["py"], method='bdf', sim_time=0.3)
+    sim.run()
+    pidx, sidx = _pick_param_and_obs(sim)
+
+    n = sim.STATE_COUNT
+    states = list(sim.states[:n])
+    variables = list(sim._numeric_variables_all)
+    for ci, idx in enumerate(sim.constant_indices):
+        variables[idx] = sim.variables[ci]
+
+    pval = float(variables[pidx])
+    target = float(sim.state_traj[sidx, -1])
+    obs_list = [(0, sidx, 0, 0, target * 0.9, 0.01, 1.0, 1.0)]  # target off by 10% to get nonzero grad
+
+    max_step = float(sim.solver_info.get('max_step', 0.001))
+    n_sub = max(1, int(np.ceil(sim.dt / max_step)))
+    total_steps = int(0.3 / sim.dt)
+    idt = sim.dt / n_sub
+
+    def eval_cost(pv):
+        variables[pidx] = pv
+        cost, _ = aadc.bdf_record_and_evaluate(
+            sim.model.compute_rates,
+            states, variables,
+            [pidx], [pv],
+            total_steps, 0, n_sub, idt,
+            obs_list, None, 10)
+        return cost
+
+    # AD gradient
+    variables[pidx] = pval
+    cost_ad, grad_ad = aadc.bdf_record_and_evaluate(
+        sim.model.compute_rates,
+        states, variables,
+        [pidx], [pval],
+        total_steps, 0, n_sub, idt,
+        obs_list, None, 10)
+    g_ad = float(grad_ad[0]) if len(grad_ad) > 0 else 0.0
+
+    # FD gradient
+    h = abs(pval) * 1e-5 if pval != 0 else 1e-5
+    g_fd = (eval_cost(pval + h) - eval_cost(pval - h)) / (2 * h)
+
+    print(f"\n  bdf_kernel gradient: AD={g_ad:.6e}  FD={g_fd:.6e}")
+    if abs(g_fd) > 1e-30:
+        ratio = g_ad / g_fd
+        print(f"  ratio: {ratio:.4f}")
+        assert abs(ratio - 1.0) < 0.05, f"AD/FD ratio = {ratio:.4f}, expected ~1.0"
+    else:
+        assert abs(g_ad) < 1e-10
+
+
+# ---- Test 3: Speed benchmark ----
+@pytest.mark.integration
+@pytest.mark.slow
+def test_bdf_kernel_speed_vs_scipy_bdf(aadc_model):
+    """bdf_kernel should be faster than scipy BDF for cost+gradient evaluation."""
+    aadc = pytest.importorskip("aadc")
+    if not hasattr(aadc, 'bdf_record_and_evaluate'):
+        pytest.skip("bdf_record_and_evaluate not available")
+
+    sim = _make_sim(aadc_model["py"], method='bdf')
+    sim.run()
+    pidx, sidx = _pick_param_and_obs(sim)
+
+    n = sim.STATE_COUNT
+    states = list(sim.states[:n])
+    variables = list(sim._numeric_variables_all)
+    for ci, idx in enumerate(sim.constant_indices):
+        variables[idx] = sim.variables[ci]
+    pval = float(variables[pidx])
+    target = float(sim.state_traj[sidx, -1])
+    obs_list = [(0, sidx, 0, 0, target, 0.01, 1.0, 1.0)]
+    max_step = float(sim.solver_info.get('max_step', 0.001))
+    n_sub = max(1, int(np.ceil(sim.dt / max_step)))
+    total_steps = int(_SIM_TIME / sim.dt)
+    idt = sim.dt / n_sub
+
+    # bdf_kernel timing (cost + gradient)
+    n_runs = 3
+    t0 = time.perf_counter()
+    for _ in range(n_runs):
+        aadc.bdf_record_and_evaluate(
+            sim.model.compute_rates, states, variables,
+            [pidx], [pval], total_steps, 0, n_sub, idt,
+            obs_list, None, 10)
+    t_kernel = (time.perf_counter() - t0) / n_runs
+
+    # scipy BDF timing (forward only, no gradient)
+    t0 = time.perf_counter()
+    for _ in range(n_runs):
+        sim2 = _make_sim(aadc_model["py"], method='bdf')
+        sim2.run()
+    t_scipy = (time.perf_counter() - t0) / n_runs
+
+    print(f"\n  bdf_kernel (cost+grad): {t_kernel:.3f}s")
+    print(f"  scipy BDF (forward):    {t_scipy:.3f}s")
+    print(f"  bdf_kernel includes gradient; scipy does not")
+    if t_scipy > 0:
+        print(f"  Ratio: {t_scipy/t_kernel:.1f}x")
+
+    # Just report, don't gate on speed
+    assert t_kernel < 60, f"bdf_kernel took {t_kernel:.1f}s — sanity check failed"


### PR DESCRIPTION
Rebase of #381 (`lakshtanov:feat/bdf-kernel-restore`) onto current master — supersedes #381, whose branch could not be updated in place. The bdf_kernel commit keeps @lakshtanov's authorship.

## What changed in the rebase

#381 carried two commits written against a pre-#379/#380 master:

- **`25d4698` (backend-agnostic AD wiring) — dropped**: its content is already on master via the earlier AADC PRs (`AadcBackend`, the `aadc` math-backend mode, backend-agnostic `get_cost`/`get_gradient`) and has evolved since; replaying it would have reverted newer work.
- **`9e46cbd` (bdf_kernel restore) — kept**, resolved against master rather than replayed wholesale. The PR's `aadc_backend.py` predated #346's method/strategy split and would have reverted `resolve_gradient_strategy` and the schema-derived `TAPE_CONSISTENT_METHODS`; the rebase keeps master's dispatch and applies only the kernel fixes:
  - new `bdf_record_and_evaluate` call signature (`compute_variables_fn`, no `newton_iters`)
  - `var`-kind observable support (previously state observables only)
  - `bdf_loop.cpp` updated to the PR's version
  - `tests/test_bdf_kernel.py` added (3 tests: cost match vs scipy BDF, gradient AD/FD, speed)

## Test results (this machine)

- The 3 new kernel tests **skip**: no released AADC wheel (1.8.0 or 1.8.2 — both checked) exports `_aadc_core.bdf_record_and_evaluate`. It exists only in Matlogica's in-house build, so "no compilation needed" does not hold for pip users yet. Selecting the kernel strategy today falls back to `bdf_tape` with a warning (correct numbers, no 13.5×).
- Schema/solver-info tests: 59 passed.
- AADC calibration tests (`test_param_id.py -k aadc`): 6/7 passed; the one failure is `test_aadc_gradient_rejects_untapeable_observables`, pre-existing on master.

## Follow-ups (not blocking this PR)

1. **AADC release**: the speedup becomes real only when an AADC wheel ships `bdf_record_and_evaluate`. @lakshtanov — is that slated for an upcoming release? Until then the kernel tests skip everywhere but your build.
2. **Calibration-test coverage** (Finbar's ask on #372): a calibration driven through the kernel can only be added once the entry point is in a released wheel; today it would silently exercise the tape fallback instead.
3. **Grouped rows**: `_cost_and_grad_bdf_kernel` (like the rest of the AADC arm) flattens a grouped `params_for_id` row to its first member (`pn[0] if isinstance(...)`) — the same bug class #380 just fixed for the Myokit/FSA arm. Worth an issue on the AADC arm as a whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
