### PR TITLE
fix(sa): add the missing @classmethod on init_from_all_dicts

### DIFF
--- a/src/sensitivity_analysis/sensitivityAnalysis.py
+++ b/src/sensitivity_analysis/sensitivityAnalysis.py
@@ -162,7 +162,11 @@ class SensitivityAnalysis():
         sa._inp_data_dict = inp_data_dict
         return sa
 
+    @classmethod
     def init_from_all_dicts(cls, inp_data_dict, obs_data_dict, params_for_id_dict, sa_options):
+        """Build a fully-configured `SensitivityAnalysis` from the four input dicts (issue #369:
+        without the decorator this was an instance method, so calling it on the class -- its only
+        sensible use -- raised a TypeError)."""
         sa = cls.init_from_dict(inp_data_dict)
         sa.set_ground_truth_data(obs_data_dict)
         sa.set_params_for_id(params_for_id_dict)

--- a/tests/test_sensitivity_analysis.py
+++ b/tests/test_sensitivity_analysis.py
@@ -434,3 +434,25 @@ def test_sobolSA_generate_samples_supports_both_sample_types():
         assert samples.ndim == 2 and samples.shape[1] == 2, (sample_type, samples.shape)
         assert samples.shape[0] > 0, sample_type
         assert np.all(np.isfinite(samples)), sample_type
+
+
+@pytest.mark.unit
+def test_init_from_all_dicts_is_a_classmethod(monkeypatch):
+    """Regression for #369: the decorator was missing, so the method was an *instance* method
+    and calling it on the class -- its only sensible use -- raised a TypeError before any of
+    its body ran."""
+    from types import SimpleNamespace
+    from sensitivity_analysis.sensitivityAnalysis import SensitivityAnalysis
+
+    received = {}
+    stub = SimpleNamespace(
+        set_ground_truth_data=lambda v: received.setdefault('obs', v),
+        set_params_for_id=lambda v: received.setdefault('params', v),
+        set_sa_options=lambda v: received.setdefault('sa', v),
+    )
+    monkeypatch.setattr(SensitivityAnalysis, 'init_from_dict',
+                        classmethod(lambda cls, d: received.setdefault('inp', d) and stub or stub))
+
+    out = SensitivityAnalysis.init_from_all_dicts({'file_prefix': 'x'}, 'obs', 'params', 'sa')
+    assert out is stub
+    assert received == {'inp': {'file_prefix': 'x'}, 'obs': 'obs', 'params': 'params', 'sa': 'sa'}


### PR DESCRIPTION
One-line fix for #369 (verified still broken on master): `SensitivityAnalysis.init_from_all_dicts` lacked `@classmethod`, so calling it on the class — its only sensible use — raised a TypeError. Regression test included; verified failing before the fix and passing after.

Fixes #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)