### PR TITLE
fix(fsa): diagnose #387 — the CVODES sensitivity tolerance floor, with closed-form and modifier-equivalence tests

### DIFF
--- a/resources/affine_modifier.cellml
+++ b/resources/affine_modifier.cellml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The *modifier* half of the modifier-equivalence pair (CUFLynx #208).
+
+Two decoupled decays, one rate constant each:
+
+    dx/dt = -k1 * x    x(0) = 2.0
+    dy/dt = -k2 * y    y(0) = 3.0
+
+k1 and k2 are independent constants, defaulting to exactly the coefficients
+`affine_native.cellml` multiplies by theta, so a params_for_id scale modifier
+over (affine/k1, affine/k2) reproduces that model's theta: CA resolves the
+baselines to these defaults, and theta = 1 is the same point of the same system.
+
+Decoupled on purpose. The obvious pairing (dx/dt = k1 - k2*x) makes the steady
+state k1/k2 independent of theta, so scaling both members leaves theta's effect
+as the small remainder of two large opposing terms: the chain-rule sum then
+amplifies each member's integration error about sixfold, and no tolerance can
+be tightened past it. Here each observable depends on one member only, so the
+combination is well conditioned and an exact claim about it means something.
+
+The rates differ by a factor of 6.5 so that a swapped or duplicated weight is
+unmistakable rather than a rounding difference.
+-->
+<model xmlns="http://www.cellml.org/cellml/2.0#" name="affine_modifier">
+
+  <component name="environment">
+    <variable name="time" units="second" interface="public"/>
+  </component>
+
+  <component name="affine">
+    <variable name="t"  units="second"        interface="public"/>
+    <!-- the two parameters a scale modifier drives together -->
+    <variable name="k1" units="dimensionless" initial_value="0.7314"/>
+    <variable name="k2" units="dimensionless" initial_value="0.1129"/>
+    <!-- states -->
+    <variable name="x"  units="dimensionless" initial_value="2.0" interface="public"/>
+    <variable name="y"  units="dimensionless" initial_value="3.0" interface="public"/>
+
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+
+      <!-- dx/dt = -k1*x -->
+      <apply>
+        <eq/>
+        <apply><diff/><bvar><ci>t</ci></bvar><ci>x</ci></apply>
+        <apply>
+          <minus/>
+          <apply><times/><ci>k1</ci><ci>x</ci></apply>
+        </apply>
+      </apply>
+
+      <!-- dy/dt = -k2*y -->
+      <apply>
+        <eq/>
+        <apply><diff/><bvar><ci>t</ci></bvar><ci>y</ci></apply>
+        <apply>
+          <minus/>
+          <apply><times/><ci>k2</ci><ci>y</ci></apply>
+        </apply>
+      </apply>
+
+    </math>
+  </component>
+
+  <connection component_1="environment" component_2="affine">
+    <map_variables variable_1="time" variable_2="t"/>
+  </connection>
+
+</model>

--- a/resources/affine_native.cellml
+++ b/resources/affine_native.cellml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The *native* half of the modifier-equivalence pair (CUFLynx #208).
+
+One constant, theta, drives two rate constants through an affine combination
+written into the model's own math:
+
+    k1 = theta * c1        c1 = 0.7314
+    k2 = theta * c2        c2 = 0.1129
+    dx/dt = -k1 * x        x(0) = 2.0
+    dy/dt = -k2 * y        y(0) = 3.0
+
+So d(anything)/d(theta) here is computed by the solver directly, with no
+modifier machinery involved at all. `affine_modifier.cellml` is the same system
+with k1 and k2 as independent constants defaulting to exactly c1 and c2, driven
+by a params_for_id scale modifier instead. At theta = 1 the two are the same
+point of the same system, so every sensitivity must agree.
+
+The pair is deliberately solvable in closed form:
+
+    x(T) = x0 * exp(-theta*c1*T)   =>   d ln(x)/d ln(theta) = -c1*T exactly
+    y(T) = y0 * exp(-theta*c2*T)   =>   d ln(y)/d ln(theta) = -c2*T exactly
+
+independent of x0, y0 and of the solver, so the tests can assert the true
+answer rather than only that the two paths agree with each other.
+-->
+<model xmlns="http://www.cellml.org/cellml/2.0#" name="affine_native">
+
+  <component name="environment">
+    <variable name="time" units="second" interface="public"/>
+  </component>
+
+  <component name="affine">
+    <variable name="t"     units="second"        interface="public"/>
+    <!-- the one calibrated quantity -->
+    <variable name="theta" units="dimensionless" initial_value="1"/>
+    <!-- the affine coefficients -->
+    <variable name="c1"    units="dimensionless" initial_value="0.7314"/>
+    <variable name="c2"    units="dimensionless" initial_value="0.1129"/>
+    <!-- the rate constants theta computes -->
+    <variable name="k1"    units="dimensionless"/>
+    <variable name="k2"    units="dimensionless"/>
+    <!-- states -->
+    <variable name="x"     units="dimensionless" initial_value="2.0" interface="public"/>
+    <variable name="y"     units="dimensionless" initial_value="3.0" interface="public"/>
+
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+
+      <!-- k1 = theta * c1 -->
+      <apply>
+        <eq/>
+        <ci>k1</ci>
+        <apply><times/><ci>theta</ci><ci>c1</ci></apply>
+      </apply>
+
+      <!-- k2 = theta * c2 -->
+      <apply>
+        <eq/>
+        <ci>k2</ci>
+        <apply><times/><ci>theta</ci><ci>c2</ci></apply>
+      </apply>
+
+      <!-- dx/dt = -k1*x -->
+      <apply>
+        <eq/>
+        <apply><diff/><bvar><ci>t</ci></bvar><ci>x</ci></apply>
+        <apply>
+          <minus/>
+          <apply><times/><ci>k1</ci><ci>x</ci></apply>
+        </apply>
+      </apply>
+
+      <!-- dy/dt = -k2*y -->
+      <apply>
+        <eq/>
+        <apply><diff/><bvar><ci>t</ci></bvar><ci>y</ci></apply>
+        <apply>
+          <minus/>
+          <apply><times/><ci>k2</ci><ci>y</ci></apply>
+        </apply>
+      </apply>
+
+    </math>
+  </component>
+
+  <connection component_1="environment" component_2="affine">
+    <map_variables variable_1="time" variable_2="t"/>
+  </connection>
+
+</model>

--- a/resources/affine_obs_data.json
+++ b/resources/affine_obs_data.json
@@ -1,0 +1,38 @@
+{
+  "protocol_info": {
+    "pre_times": [0.0],
+    "sim_times": [[4]],
+    "params_to_change": {}
+  },
+  "prediction_items": [],
+  "data_items": [
+    {
+      "variable": "x_end",
+      "name_for_plotting": "x_{end}",
+      "data_type": "constant",
+      "operation": "min",
+      "operands": ["affine/x"],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 0.15,
+      "std": 0.05,
+      "experiment_idx": 0,
+      "subexperiment_idx": 0,
+      "plot_type": "horizontal"
+    },
+    {
+      "variable": "y_end",
+      "name_for_plotting": "y_{end}",
+      "data_type": "constant",
+      "operation": "min",
+      "operands": ["affine/y"],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 1.8,
+      "std": 0.2,
+      "experiment_idx": 0,
+      "subexperiment_idx": 0,
+      "plot_type": "horizontal"
+    }
+  ]
+}

--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -54,7 +54,48 @@ def apply_cvodes_tolerances(simulation, solver_info, fsa_enabled):
     abs_tol = atol if atol is not None else CA_DEFAULT_ABS_TOL
     rel_tol = rtol if rtol is not None else CA_DEFAULT_REL_TOL
     simulation.set_tolerance(abs_tol=abs_tol, rel_tol=rel_tol)
+    if fsa_enabled:
+        warn_if_sensitivities_are_under_resolved(rel_tol)
     return abs_tol, rel_tol
+
+
+# Below this relative tolerance the CVODES *sensitivities* get worse, not better -- see
+# warn_if_sensitivities_are_under_resolved. Measured on an analytically-solvable model
+# (tests/test_fsa_analytic_accuracy.py): rel 1e-8 gives a cost gradient accurate to ~1e-7,
+# rel 1e-12 to only ~3e-3.
+FSA_MIN_SAFE_REL_TOL = 1e-9
+
+
+def warn_if_sensitivities_are_under_resolved(rel_tol):
+    """Warn when a tightened `rtol` will *degrade* the FSA gradient (issue #387).
+
+    Myokit configures CVODES with a finite-difference (DQ) sensitivity right-hand side
+    (``CVodeSensInit(..., NULL, ...)``) and never calls ``CVodeSetSensErrCon``, so the
+    sensitivity variables are **excluded from the local error test**: the step size is chosen
+    to control the states alone, and nothing controls the sensitivities. CVODES sizes the DQ
+    perturbation as ``sqrt(max(rtol, uround)) * pbar``, so tightening rtol shrinks that
+    perturbation (more cancellation noise per evaluation) *and* takes more steps (more
+    evaluations to accumulate it) -- the two effects compound and the sensitivities drift.
+
+    Measured on ``affine_native.cellml``, one parameter, cost gradient vs a finite difference
+    of the cost: rel 1e-8 -> 9e-8, rel 1e-10 -> 3e-7, rel 1e-12 -> 3e-3. The states over the
+    same sweep stay accurate to ~1e-11 throughout, which is why this is so easy to miss: the
+    trajectory looks better and better while the gradient quietly gets worse.
+
+    Warn rather than clamp: an explicitly-set tolerance is a deliberate user choice, and a
+    forward-only run at rel 1e-12 is perfectly reasonable. Bounding ``MaximumStep`` recovers
+    much of the loss when a tight tolerance is genuinely needed (1e-12 with MaximumStep 1e-3
+    measured 1.7e-5).
+    """
+    if rel_tol is not None and rel_tol < FSA_MIN_SAFE_REL_TOL:
+        warnings.warn(
+            f"FSA (do_ad) gradients with solver_info rtol={rel_tol:g}: below "
+            f"{FSA_MIN_SAFE_REL_TOL:g} the CVODES sensitivities get *less* accurate as rtol "
+            f"tightens, because Myokit excludes them from the local error test and sizes its "
+            f"finite-difference sensitivity RHS by sqrt(rtol). The states stay accurate, so "
+            f"this is invisible in the trajectory. Prefer rtol >= "
+            f"{FSA_MIN_SAFE_REL_TOL:g} for gradient-based calibration, or bound "
+            f"solver_info MaximumStep to compensate (issue #387).")
 
 
 def stability_hint(solver_info, effective_tolerances):

--- a/tests/test_fsa_analytic_accuracy.py
+++ b/tests/test_fsa_analytic_accuracy.py
@@ -1,0 +1,300 @@
+"""FSA accuracy against closed-form truth, and modifier-vs-native equivalence (issue #387).
+
+CA's other FSA/modifier tests check *internal consistency*: that the gradient matches a finite
+difference of CA's own cost, or that two CA code paths agree. Those cannot catch an error
+shared by both sides. This file pins CA's numbers against an **analytically solvable model**,
+and against the same system written two equivalent ways:
+
+* ``affine_native.cellml``   -- one constant ``theta`` scales two rate constants *in the
+  model's own math* (``k1 = theta*c1``, ``k2 = theta*c2``), so the solver differentiates
+  through the scaling directly and no modifier machinery is involved.
+* ``affine_modifier.cellml`` -- ``k1``/``k2`` are independent constants defaulting to exactly
+  ``c1``/``c2``, driven by a params_for_id ``scale`` modifier over both.
+
+At ``theta = 1`` these are the same point of the same system, so every cost, feature and
+gradient must agree -- which is the multi-target modifier chain rule (#380/#383) checked
+against a model that computes the same thing without it.
+
+Both are solvable in closed form:
+
+    x(T) = x0*exp(-theta*c1*T)   =>   d ln x/d ln theta = -c1*T   exactly
+    y(T) = y0*exp(-theta*c2*T)   =>   d ln y/d ln theta = -c2*T   exactly
+
+independent of x0, y0 and of the solver, so the assertions are the true answer rather than
+"the two paths agree with each other".
+
+Provenance: the fixture pair and the closed-form assertions come from CUFLynx #208, moved here
+because the behaviour they pin is CA's arithmetic, not CUFLynx's seams -- and because CUFLynx
+CI has no Myokit, so a numerical claim there never actually runs.
+"""
+import json
+import os
+
+import numpy as np
+import pytest
+
+from param_id.paramID import CVS0DParamID
+
+_C1 = 0.7314          # affine/k1 default, and the native model's c1
+_C2 = 0.1129          # affine/k2 default, and the native model's c2
+_X0, _Y0 = 2.0, 3.0
+_T_END = 4.0
+_DT = 0.01
+
+# Ground truths/stds for the two `min` observables (x and y decay, so min is the end value).
+_GT_X, _STD_X = 0.15, 0.05
+_GT_Y, _STD_Y = 1.8, 0.2
+
+
+def _obs_doc():
+    def item(var, operand, gt, std):
+        return {"variable": var, "name_for_plotting": var, "data_type": "constant",
+                "operation": "min", "operands": [operand], "unit": "dimensionless",
+                "weight": 1.0, "value": gt, "std": std,
+                "experiment_idx": 0, "subexperiment_idx": 0, "plot_type": "horizontal"}
+    return {"protocol_info": {"pre_times": [0.0], "sim_times": [[_T_END]],
+                              "params_to_change": {}},
+            "prediction_items": [],
+            "data_items": [item("x_end", "affine/x", _GT_X, _STD_X),
+                           item("y_end", "affine/y", _GT_Y, _STD_Y)]}
+
+
+_NATIVE_PARAMS = {'version': 1, 'params': [
+    {'name': 'theta', 'targets': ['affine/theta'], 'min': 0.2, 'max': 5.0,
+     'name_for_plotting': 'theta'}]}
+
+# The modifier arm: ONE calibrated theta scaling BOTH rate constants. Its baselines are the
+# model defaults c1 and c2, so theta = 1 reproduces the native model exactly.
+_MODIFIER_PARAMS = {'version': 1, 'params': [
+    {'name': 'theta', 'modifies': ['affine/k1', 'affine/k2'], 'modifier': 'scale',
+     'min': 0.2, 'max': 5.0, 'name_for_plotting': 'theta'}]}
+
+
+def _write(tmp_path, name, doc):
+    path = os.path.join(str(tmp_path), name)
+    with open(path, 'w') as f:
+        json.dump(doc, f)
+    return path
+
+
+def _engine(tmp_path, resources_dir, model, params_doc, solver_info=None, dt=_DT):
+    """A param-id engine on one of the affine fixtures, FSA gradients enabled."""
+    out_dir = os.path.join(str(tmp_path), f'out_{model}')
+    os.makedirs(out_dir, exist_ok=True)
+    outer = CVS0DParamID(
+        model_path=os.path.join(resources_dir, f'affine_{model}.cellml'),
+        model_type='cellml_only', param_id_method='sp_minimize', file_name_prefix='affine',
+        params_for_id_path=_write(tmp_path, f'{model}_params.json', params_doc),
+        param_id_obs_path=_write(tmp_path, f'{model}_obs.json', _obs_doc()),
+        sim_time=_T_END, pre_time=0.0, dt=dt,
+        solver_info=solver_info or {'solver': 'CVODE_myokit'},
+        do_ad=True, DEBUG=True, param_id_output_dir=out_dir)
+    engine = outer.param_id
+    engine.output_dir = out_dir
+    return engine
+
+
+@pytest.fixture
+def native(tmp_path, resources_dir):
+    return _engine(tmp_path, resources_dir, 'native', _NATIVE_PARAMS)
+
+
+@pytest.fixture
+def modifier(tmp_path, resources_dir):
+    return _engine(tmp_path, resources_dir, 'modifier', _MODIFIER_PARAMS)
+
+
+def _features(engine, theta):
+    """The scalar observables at theta, in const order (x_end, y_end)."""
+    _, operands_list, _ = engine.get_cost_obs_and_pred_from_params(
+        np.array([float(theta)]), reset=True, only_one_exp=0)
+    return np.asarray(engine.get_obs_output_dict(operands_list[0])['const'], dtype=float)
+
+
+def _cost_fd(engine, theta, h=1e-6):
+    """Central difference of CA's own cost -- the operational truth a calibration descends."""
+    plus = float(engine.get_cost_from_params(np.array([theta + h])))
+    minus = float(engine.get_cost_from_params(np.array([theta - h])))
+    return (plus - minus) / (2.0 * h)
+
+
+# --------------------------------------------------------------- fixture validation
+
+
+@pytest.mark.integration
+def test_the_two_models_are_the_same_system_at_theta_one(native, modifier):
+    """Fixture validation: if the pair ever stops describing one system, every equivalence
+    assertion below becomes vacuous, so check it directly."""
+    assert _features(native, 1.0) == pytest.approx(_features(modifier, 1.0), rel=1e-9)
+    assert float(native.get_cost_from_params(np.array([1.0]))) == pytest.approx(
+        float(modifier.get_cost_from_params(np.array([1.0]))), rel=1e-9)
+
+
+@pytest.mark.integration
+def test_the_features_match_the_closed_form(native):
+    """x(T) = x0*exp(-theta*c1*T); min over a decaying trace is the end value."""
+    x_end, y_end = _features(native, 1.0)
+    # rel 1e-4: this is the *state* accuracy at CA's default CVODE_myokit tolerances
+    # (rel 1e-6 / abs 1e-8 since #379), not a claim about the sensitivities.
+    assert x_end == pytest.approx(_X0 * np.exp(-_C1 * _T_END), rel=1e-4)
+    assert y_end == pytest.approx(_Y0 * np.exp(-_C2 * _T_END), rel=1e-4)
+
+
+# --------------------------------------------------------------- closed-form sensitivities
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize('arm', ['native', 'modifier'])
+def test_output_sensitivities_match_the_closed_form(arm, tmp_path, resources_dir):
+    """d ln(Y)/d ln(theta) = -c*T exactly, for both the in-model scaling and the modifier.
+
+    The elasticity is the sharp form: it removes x0/y0 and any solver scaling, so a wrong
+    chain-rule weight (the #380 failure mode) shows up immediately.
+    """
+    params = _NATIVE_PARAMS if arm == 'native' else _MODIFIER_PARAMS
+    engine = _engine(tmp_path, resources_dir, arm, params)
+    theta = 1.0
+    sens = engine.get_observable_sensitivities(np.array([theta]), gradient_method='FSA')
+    features = _features(engine, theta)
+
+    # obs_info order is the data_items order: x_end, y_end.
+    labels = [engine._observable_label(i)
+              for i in engine.obs_info['const_idx_to_obs_idx']]
+    key = 'theta' if arm == 'modifier' else 'affine/theta'
+    for label, feature, c in zip(labels, features, (_C1, _C2)):
+        d_abs = sens[label][key]
+        elasticity = d_abs * theta / feature
+        assert elasticity == pytest.approx(-c * _T_END, rel=1e-5), (
+            f'{arm} {label}: d ln/d ln theta = {elasticity}, expected {-c * _T_END}')
+
+
+# --------------------------------------------------------------- the cost gradient
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize('arm', ['native', 'modifier'])
+def test_the_fsa_cost_gradient_matches_a_finite_difference_of_the_cost(
+        arm, tmp_path, resources_dir):
+    """The gradient a do_ad calibration actually descends, against differencing CA's own cost.
+
+    Issue #387 reported this as wrong by 1e-3..1e-1; at CA's default FSA tolerances it is
+    accurate to ~1e-6. See test_tightening_tolerances_past_the_sensitivity_floor_is_refused
+    for the configuration that does break it, and why.
+    """
+    params = _NATIVE_PARAMS if arm == 'native' else _MODIFIER_PARAMS
+    engine = _engine(tmp_path, resources_dir, arm, params)
+    theta = 1.0
+    _, grad = engine.get_cost_and_jac_fsa(np.array([theta]))
+    assert float(grad[0]) == pytest.approx(_cost_fd(engine, theta), rel=1e-4)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize('arm', ['native', 'modifier'])
+def test_the_cost_gradient_is_the_chain_rule_over_its_own_sensitivities(
+        arm, tmp_path, resources_dir):
+    """dJ/dtheta must equal sum_k dJ/d(feature_k) * d(feature_k)/dtheta, built from CA's *own*
+    output sensitivities.
+
+    This is issue #387's decisive check: the cost arm and the feature arm share the same
+    sensitivity traces, so any disagreement is in the cost reconstruction alone (and any
+    agreement localises a residual error to the traces, which the closed-form tests above
+    then pin).
+    """
+    params = _NATIVE_PARAMS if arm == 'native' else _MODIFIER_PARAMS
+    engine = _engine(tmp_path, resources_dir, arm, params)
+    theta = 1.0
+    key = 'theta' if arm == 'modifier' else 'affine/theta'
+
+    _, grad = engine.get_cost_and_jac_fsa(np.array([theta]))
+    sens = engine.get_observable_sensitivities(np.array([theta]), gradient_method='FSA')
+    features = _features(engine, theta)
+    labels = [engine._observable_label(i)
+              for i in engine.obs_info['const_idx_to_obs_idx']]
+
+    # cost = sum_k w_k * (feature_k - gt_k)^2 / std_k^2, divided by the weighted denominator.
+    denom = float(engine._total_weighted_obs_denominator())
+    by_hand = 0.0
+    for label, feature, gt, std in zip(labels, features,
+                                       (_GT_X, _GT_Y), (_STD_X, _STD_Y)):
+        by_hand += 2.0 * (feature - gt) / (std ** 2) * sens[label][key]
+    by_hand /= denom
+
+    assert float(grad[0]) == pytest.approx(by_hand, rel=1e-6)
+
+
+@pytest.mark.integration
+def test_the_modifier_reproduces_the_native_gradient(native, modifier):
+    """One theta scaling two model constants must give the same cost gradient whether the
+    scaling is written into the CellML math or applied by CA's scale modifier.
+
+    This is the multi-target modifier chain rule (sum_i baseline_i * dJ/dp_i, #380/#383)
+    checked against a model that computes the same derivative without any modifier.
+    """
+    theta = 1.0
+    _, grad_native = native.get_cost_and_jac_fsa(np.array([theta]))
+    _, grad_modifier = modifier.get_cost_and_jac_fsa(np.array([theta]))
+    assert float(grad_modifier[0]) == pytest.approx(float(grad_native[0]), rel=1e-5)
+    # ... and both against the operational truth, so agreeing on a wrong value cannot pass.
+    assert float(grad_modifier[0]) == pytest.approx(_cost_fd(modifier, theta), rel=1e-4)
+
+
+@pytest.mark.integration
+def test_the_modifier_gradient_sums_both_targets(tmp_path, resources_dir):
+    """The modifier's derivative is sum_i baseline_i * dJ/dp_i -- dropping either target (the
+    pre-#380 first-member-only bug) leaves a materially different number, so assert the sum
+    against per-target gradients obtained by calibrating k1 and k2 as free parameters."""
+    free = {'version': 1, 'params': [
+        {'name': 'k1', 'targets': ['affine/k1'], 'min': 0.05, 'max': 5.0},
+        {'name': 'k2', 'targets': ['affine/k2'], 'min': 0.01, 'max': 2.0}]}
+    free_engine = _engine(tmp_path, resources_dir, 'modifier', free)
+    _, grad_free = free_engine.get_cost_and_jac_fsa(np.array([_C1, _C2]))
+
+    mod_engine = _engine(tmp_path, resources_dir, 'modifier', _MODIFIER_PARAMS)
+    _, grad_mod = mod_engine.get_cost_and_jac_fsa(np.array([1.0]))
+
+    expected = _C1 * float(grad_free[0]) + _C2 * float(grad_free[1])
+    assert float(grad_mod[0]) == pytest.approx(expected, rel=1e-5)
+    # the first-member-only value must be clearly distinguishable, or this test proves nothing
+    first_only = _C1 * float(grad_free[0])
+    assert abs(first_only - expected) > 0.01 * abs(expected)
+
+
+# --------------------------------------------------------------- the tolerance floor (#387)
+
+
+@pytest.mark.integration
+def test_tightening_rtol_past_the_floor_degrades_the_gradient_and_warns(
+        tmp_path, resources_dir):
+    """The configuration issue #387 was actually measured under, pinned as known behaviour.
+
+    Myokit excludes the CVODES sensitivity variables from the local error test and uses a
+    finite-difference sensitivity RHS sized by sqrt(rtol), so rtol=1e-12 makes the *gradient*
+    worse while the *states* stay exact. CA warns; this asserts both the warning and the
+    degradation it is warning about, so the day Myokit fixes its side, this test fails and
+    the guard can be dropped.
+    """
+    from solver_wrappers.myokit_helper import FSA_MIN_SAFE_REL_TOL
+
+    tight = {'solver': 'CVODE_myokit', 'rtol': 1e-12, 'atol': 1e-12}
+    engine = _engine(tmp_path, resources_dir, 'native', _NATIVE_PARAMS, solver_info=tight)
+    # The warning belongs to enabling FSA, which happens on the first gradient call (the
+    # simulation is rebuilt with sensitivities then), not to constructing the helper.
+    with pytest.warns(UserWarning, match='less. accurate as rtol'):
+        _, grad = engine.get_cost_and_jac_fsa(np.array([1.0]))
+    rel_err = abs(float(grad[0]) - _cost_fd(engine, 1.0)) / abs(_cost_fd(engine, 1.0))
+    assert rel_err > 1e-4, (
+        f'rtol=1e-12 no longer degrades the FSA gradient (rel err {rel_err:.2e}) -- if Myokit '
+        f'now error-controls its sensitivities, drop the rtol < {FSA_MIN_SAFE_REL_TOL:g} '
+        f'warning and this test')
+
+
+@pytest.mark.integration
+def test_the_default_tolerances_do_not_warn_and_are_accurate(tmp_path, resources_dir):
+    """The other half: at CA's defaults there is nothing to warn about, and the gradient is
+    accurate -- so the warning cannot become background noise on ordinary runs."""
+    import warnings as _warnings
+    engine = _engine(tmp_path, resources_dir, 'native', _NATIVE_PARAMS)
+    with _warnings.catch_warnings():
+        _warnings.simplefilter('error', UserWarning)
+        _, grad = engine.get_cost_and_jac_fsa(np.array([1.0]))
+    assert float(grad[0]) == pytest.approx(_cost_fd(engine, 1.0), rel=1e-4)


### PR DESCRIPTION
## Investigated — the diagnosis in the report is wrong, and the real cause is a solver-tolerance trap

**The cost gradient and the output sensitivities do not disagree.** Building `dJ/dtheta` by hand from CA's *own* output sensitivity reproduces `get_jac_cost` to ~1e-14, at every tolerance I tried. The report's item 3 (chain-rule-by-hand matching truth while the cost gradient did not) does not reproduce; those two numbers appear to have been computed at different solver settings.

**Both are accurate at CA's default tolerances.** Cost gradient vs a central difference of CA's own cost, on the `affine` fixture:

| solver_info | rel err |
|---|---|
| no rtol/atol (FSA auto-tightens to 1e-8) | **9.4e-08** |
| rtol 1e-6 / atol 1e-8 (#379 schema defaults) | 2.7e-06 |
| rtol/atol 1e-8 | 9.4e-08 |
| rtol/atol 1e-10 | 2.7e-07 |
| **rtol/atol 1e-12** ← what the report measured | **2.9e-03** |
| rtol/atol 1e-12 + `MaximumStep` 1e-3 | 1.7e-05 |

The 1e-3 error was **caused by setting rtol=atol=1e-12**, which the reporter did believing tighter is more accurate. For CVODES sensitivities under Myokit's configuration it is the opposite. (This also explains their observation that 1e-14 was worse still — read as "past the floor", it was actually the same monotone degradation.)

## Root cause (Myokit-side)

Pointwise against the closed form `dx/dk1 = -2t·exp(-k1·t)`, at rtol=1e-12:

```
max|x - x_exact|    = 2.7e-11     <- states: excellent
max|S - S_exact|    = 1.1e-02     <- sensitivities: 9 orders worse
```

and `S` is exact at t=0.01 (5e-9), drifting monotonically to 1.1e-3 relative by t=4. Two things in `myokit/_sim/cvodessim.c` produce that:

1. `CVodeSensInit(cvode_mem, ns, CV_SIMULTANEOUS, NULL, sy)` — the `NULL` means CVODES builds the sensitivity RHS by **internal finite differences**, with perturbation `sqrt(max(rtol, uround))·pbar`. Tightening rtol *shrinks* that perturbation → more cancellation noise per evaluation.
2. **`CVodeSetSensErrCon` is never called**, so it defaults to `SUNFALSE`: the sensitivity variables are **excluded from the local error test**. The step size is chosen to control the states alone; nothing controls the sensitivities, and tighter rtol also means more steps over which the DQ noise accumulates.

The two compound. (`pbar` *is* correctly set to `|p|`, so scaling is not the issue.)

## Fix

CA cannot reach `CVodeSetSensErrCon`, so `apply_cvodes_tolerances` now **warns** when FSA is enabled with `rtol < 1e-9`, naming the mechanism and pointing at `MaximumStep` as the compensating knob. Warn rather than clamp: an explicit tolerance is a deliberate choice, and a forward-only run at 1e-12 is perfectly reasonable — it is only the gradient that suffers.

## Tests

New `tests/test_fsa_analytic_accuracy.py` plus the `affine_native` / `affine_modifier` / `affine_obs_data` fixture pair (moved from CUFLynx #208, which owns neither the arithmetic nor a Myokit CI). 12 tests:

- fixture validation (both models are one system at theta=1) and the closed-form features;
- **closed-form output sensitivities** `d ln Y/d ln theta = -c·T` for both arms;
- the FSA cost gradient vs a finite difference of the cost, both arms;
- the chain-rule identity `dJ/dtheta = Σ_k dJ/d(feature_k)·d(feature_k)/dtheta` from CA's own sensitivities — issue #387's decisive check, now permanent;
- **one theta scaling two model constants gives the same gradient whether the scaling is written into the CellML math or applied by CA's `scale` modifier** — the multi-target chain rule (#380/#383) checked against a model that computes it without modifiers, plus an assertion that the sum over both targets differs materially from the first-member-only value (the pre-#380 bug);
- the tolerance floor pinned as known behaviour, so the day Myokit error-controls its sensitivities, the test fails and the guard can be dropped.

## Follow-ups

- Worth reporting upstream to Myokit: `CVodeSetSensErrCon(cvode_mem, SUNTRUE)` (and eventually an analytic sensitivity RHS) would remove this entirely.
- CUFLynx branch `test/move-fsa-claims-to-ca` moves the two CA-owned tests here, demotes its `rel=3e-3` cost-bar assertion to a 1% smoke check (it was encoding CA's accuracy as an accepted bound in their suite), and drops its test tolerance from 1e-12 to 1e-8.
