### PR TITLE
feat: the five CUFLynx NEXT sub-release asks (run_UQ, default cost_type, naming rule, run_history, lazy Sobol helper)

### DIFF
--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -474,9 +474,34 @@ class CVS0DParamID():
             except Exception:
                 pass
 
-    def run_mcmc(self):
-        """Run MCMC sampling (requires the instance was built with ``mcmc_instead=True``)."""
+    def run_UQ(self, mcmc_options=None):
+        """Run uncertainty quantification (MCMC) on **this** object.
+
+        Callable whether or not the instance was built with ``mcmc_instead=True``:
+
+        * built with it -- runs the UQ engine constructed up front (unchanged behaviour);
+        * built without it -- promotes the calibration engine via
+          ``OpencorMCMC.from_param_id``, so UQ after a calibration reuses the model already
+          compiled instead of building a second CVS0DParamID for it (CUFLynx #217).
+
+        ``mcmc_options`` overrides the options the object was built with; omit it to keep them.
+        """
+        global mcmc_object
+        if not self.mcmc_instead:
+            if getattr(self, 'param_id', None) is None:
+                raise RuntimeError(
+                    "run_UQ needs either mcmc_instead=True or a built param-id engine; this "
+                    "object has neither.")
+            mcmc_object = OpencorMCMC.from_param_id(
+                self.param_id,
+                mcmc_options if mcmc_options is not None else getattr(self, 'mcmc_options', None))
+        elif mcmc_options is not None:
+            mcmc_object._init_mcmc(mcmc_options, DEBUG=self.DEBUG)
         mcmc_object.run()
+
+    def run_mcmc(self):
+        """Deprecated alias of :meth:`run_UQ`, kept so existing scripts keep working."""
+        return self.run_UQ()
     
     def _check_info_available(self):
         #new check, need ensure 'operands' or 'operation_kwargs' exist
@@ -2877,7 +2902,34 @@ class OpencorMCMC(OpencorParamID):
         super().__init__(model_path, "MCMC",
                 obs_info, param_id_info, protocol_info, prediction_info, solver_info,
                 dt=dt, DEBUG=DEBUG, model_type=model_type)
+        self._init_mcmc(mcmc_options, DEBUG=DEBUG)
 
+    @classmethod
+    def from_param_id(cls, engine, mcmc_options=None):
+        """Adopt an already-built ``OpencorParamID`` instead of constructing a second one.
+
+        Building an engine compiles the model. Because ``mcmc_instead`` selects the inner
+        class at *construction* time, a UQ run following a calibration had to build a second
+        CVS0DParamID and pay that compile again (CUFLynx #217) -- for the same model, the same
+        obs_info and the same parameters.
+
+        ``OpencorMCMC`` only *adds* to ``OpencorParamID``, so the built engine's state is
+        exactly what it needs: adopt its ``__dict__`` (simulation helper, parsed infos,
+        output_dir, and the best_param_vals of the calibration that just ran, which is what
+        seeds the walkers) and then run only the MCMC-specific tail.
+
+        The result **shares** the engine's simulation helper rather than copying it -- that is
+        the point -- which is safe because UQ follows a calibration rather than running beside
+        it. Do not use the engine concurrently afterwards.
+        """
+        obj = cls.__new__(cls)
+        obj.__dict__.update(engine.__dict__)
+        obj.param_id_method = "MCMC"
+        obj._init_mcmc(mcmc_options, DEBUG=getattr(engine, 'DEBUG', False))
+        return obj
+
+    def _init_mcmc(self, mcmc_options, DEBUG=False):
+        """The MCMC-specific half of construction, shared by __init__ and from_param_id."""
         # mcmc init stuff
         self.sampler = None
         if mcmc_options is not None:

--- a/src/param_id/run_history.py
+++ b/src/param_id/run_history.py
@@ -1,0 +1,261 @@
+"""Read what a param_id run wrote to disk (CUFLynx #210).
+
+CA writes seven files across ``param_id/optimisers.py`` and ``param_id/paramID.py`` and, until
+now, offered no reader. The only consumer hand-parsed them -- twice, in two files, with
+different tolerance rules -- so the *format* was a contract that existed nowhere but in
+comments in two repositories.
+
+Everything a reader has to know, and therefore everything this module exists to stop anyone
+else rediscovering:
+
+* ``best_param_vals_history.csv`` holds **normalised** values (``param_norm_obj.normalise``),
+  while the ``multi_start_*`` files hold **actual** ones (``_append_start_params``
+  unnormalises before writing). Nothing in the format marks the asymmetry.
+* ``best_cost_history.csv`` has **no header** and its row shape depends on the optimiser: the
+  sorted top-10 for the genetic algorithm, a single scalar for ``sp_minimize``. Bayesian and
+  CMA-ES write no cost history at all, so params-without-costs is normal, not corrupt.
+* ``best_param_vals_history.csv`` *does* have a header (the parameter labels).
+* gradients are ``dJ/dp`` in **real** space (``grad_norm / param_ranges``), and only the
+  gradient-based optimisers write them.
+* CA **appends and never truncates**, so a client must clear the files before a run --
+  :func:`clear_run_history` is CA declaring which files are transient rather than the client
+  hardcoding the list.
+* the files may sit in a ``<case_type>_<prefix>`` subdirectory of the configured output dir.
+
+Pure filesystem reads: no model, no solver, no simulation helper. Partial trailing rows are
+skipped rather than raising, so it is safe to poll while a run is still writing.
+"""
+import csv
+import glob
+import json
+import os
+
+import numpy as np
+
+# Written by the optimisers during a run. Transient: CA appends, so these must be removed
+# before a new run or the new history is glued onto the old one.
+HISTORY_FILES = (
+    'best_cost_history.csv',
+    'best_param_vals_history.csv',
+    'best_gradient_history.csv',
+    'multi_start_cost_history.csv',
+    'multi_start_param_vals_history.csv',
+    'multi_start_gradient_history.csv',
+)
+
+# Final results, written by _save_best_params. Not history, but part of what a reader wants.
+RESULT_FILES = ('best_param_vals.npy', 'best_cost.npy')
+
+# Where read_run_history gets the bounds it needs to denormalise best_param_vals_history.
+BOUNDS_FILE = 'param_bounds.json'
+
+
+def _rows(path, skip_header=False):
+    """Numeric rows of a CSV, ignoring blanks and any trailing partial line.
+
+    A row still being written is skipped rather than raising: this is polled mid-run.
+    """
+    if not os.path.isfile(path):
+        return []
+    out = []
+    with open(path, 'r') as handle:
+        for idx, raw in enumerate(csv.reader(handle)):
+            if skip_header and idx == 0:
+                continue
+            if not raw:
+                continue
+            try:
+                out.append([float(cell) for cell in raw if str(cell).strip() != ''])
+            except ValueError:
+                # a header CA wrote, or a half-flushed final line
+                continue
+    return [row for row in out if row]
+
+
+def _header(path):
+    if not os.path.isfile(path):
+        return []
+    with open(path, 'r') as handle:
+        for raw in csv.reader(handle):
+            return [cell.strip() for cell in raw if str(cell).strip() != '']
+    return []
+
+
+def find_run_dir(output_dir):
+    """The directory the run actually wrote to.
+
+    CA may write into ``<output_dir>/<case_type>_<prefix>/`` rather than ``output_dir``
+    itself, so accept either and let the caller pass whichever it configured.
+    """
+    if not output_dir or not os.path.isdir(output_dir):
+        return None
+    known = set(HISTORY_FILES) | set(RESULT_FILES)
+    if any(os.path.isfile(os.path.join(output_dir, name)) for name in known):
+        return output_dir
+    candidates = [entry for entry in sorted(glob.glob(os.path.join(output_dir, '*')))
+                  if os.path.isdir(entry)
+                  and any(os.path.isfile(os.path.join(entry, name)) for name in known)]
+    if len(candidates) == 1:
+        return candidates[0]
+    if candidates:
+        # more than one case dir: newest by the results it wrote, so polling a re-run works
+        return max(candidates, key=lambda d: max(
+            (os.path.getmtime(os.path.join(d, name)) for name in known
+             if os.path.isfile(os.path.join(d, name))), default=0.0))
+    return output_dir
+
+
+def save_param_bounds(param_id_info, output_dir):
+    """Persist the parameter labels and bounds beside the run's outputs.
+
+    Without these, ``best_param_vals_history.csv`` (which is normalised) cannot be turned
+    back into parameter values from ``output_dir`` alone -- the reader would have to be handed
+    a live ``param_id_info``, which is exactly the coupling #210 is removing. Rank-guarded by
+    the caller.
+    """
+    if not param_id_info or not output_dir:
+        return
+    try:
+        from parsers.PrimitiveParsers import param_entry_labels
+        labels = param_entry_labels(param_id_info)
+    except Exception:
+        labels = [str(n) for n in param_id_info.get('param_names', [])]
+    payload = {
+        'param_labels': list(labels),
+        'param_mins': [float(v) for v in np.asarray(param_id_info['param_mins']).ravel()],
+        'param_maxs': [float(v) for v in np.asarray(param_id_info['param_maxs']).ravel()],
+    }
+    with open(os.path.join(output_dir, BOUNDS_FILE), 'w') as handle:
+        json.dump(payload, handle, indent=2)
+
+
+def _bounds(run_dir, param_id_info):
+    """(labels, mins, maxs) from the caller's param_id_info, else the persisted file."""
+    if param_id_info:
+        try:
+            from parsers.PrimitiveParsers import param_entry_labels
+            labels = param_entry_labels(param_id_info)
+        except Exception:
+            labels = [str(n) for n in param_id_info.get('param_names', [])]
+        return (list(labels),
+                np.asarray(param_id_info['param_mins'], dtype=float).ravel(),
+                np.asarray(param_id_info['param_maxs'], dtype=float).ravel())
+    path = os.path.join(run_dir or '', BOUNDS_FILE)
+    if os.path.isfile(path):
+        with open(path, 'r') as handle:
+            payload = json.load(handle)
+        return (list(payload.get('param_labels') or []),
+                np.asarray(payload.get('param_mins') or [], dtype=float),
+                np.asarray(payload.get('param_maxs') or [], dtype=float))
+    return [], None, None
+
+
+def _group_starts(cost_rows, param_rows, grad_rows):
+    """Regroup the ``start_idx, iteration, ...`` streams into one entry per start."""
+    starts = {}
+
+    def add(rows, key, scalar):
+        for row in rows:
+            if len(row) < 3:
+                continue
+            start_idx = int(row[0])
+            entry = starts.setdefault(start_idx, {'cost': [], 'params': [], 'grad': []})
+            entry[key].append(float(row[2]) if scalar else [float(v) for v in row[2:]])
+
+    add(cost_rows, 'cost', True)
+    add(param_rows, 'params', False)
+    add(grad_rows, 'grad', False)
+    return [starts[idx] for idx in sorted(starts)]
+
+
+def read_run_history(output_dir, param_id_info=None):
+    """Everything a GUI needs from a param_id run directory.
+
+    Pure filesystem read, tolerant of partial rows (safe to poll mid-run), and it locates the
+    ``<case_type>_<prefix>`` subdirectory itself.
+
+    ``param_id_info`` is optional: bounds are read from ``param_bounds.json`` in the run dir
+    when it is omitted (CA writes it via :func:`save_param_bounds`). Pass it to override, or
+    for a run directory written before that file existed.
+
+    Returns::
+
+        {"param_labels": [str],
+         "cost_history": [[float]],        # per generation, best first; [] if none written
+         "param_history_norm": [[float]],  # as written -- normalised
+         "param_history": [[float]],       # denormalised, or None if bounds unavailable
+         "grad_history": [[float]],        # real-space dJ/dp; [] if none
+         "starts": [{"cost": [float], "params": [[float]], "grad": [[float]]}],
+         "best_param_vals": [float] | None,
+         "best_cost": float | None,
+         "run_dir": str | None}
+    """
+    run_dir = find_run_dir(output_dir)
+    labels, mins, maxs = _bounds(run_dir, param_id_info)
+
+    if run_dir is None:
+        return {'param_labels': list(labels), 'cost_history': [], 'param_history_norm': [],
+                'param_history': None, 'grad_history': [], 'starts': [],
+                'best_param_vals': None, 'best_cost': None, 'run_dir': None}
+
+    def path(name):
+        return os.path.join(run_dir, name)
+
+    # best_param_vals_history.csv carries the parameter labels; prefer them over the bounds
+    # file's, since they describe the columns actually written.
+    header = _header(path('best_param_vals_history.csv'))
+    if header and not any(_is_number(cell) for cell in header):
+        labels = header
+
+    param_history_norm = _rows(path('best_param_vals_history.csv'), skip_header=bool(header))
+    cost_history = _rows(path('best_cost_history.csv'))
+    grad_history = _rows(path('best_gradient_history.csv'))
+
+    param_history = None
+    if param_history_norm and mins is not None and maxs is not None and mins.size:
+        width = min(mins.size, maxs.size)
+        param_history = [
+            list(np.asarray(row[:width], dtype=float) * (maxs[:width] - mins[:width])
+                 + mins[:width])
+            for row in param_history_norm if len(row) >= width]
+
+    starts = _group_starts(
+        _rows(path('multi_start_cost_history.csv'), skip_header=True),
+        _rows(path('multi_start_param_vals_history.csv'), skip_header=True),
+        _rows(path('multi_start_gradient_history.csv'), skip_header=True))
+
+    best_param_vals, best_cost = None, None
+    if os.path.isfile(path('best_param_vals.npy')):
+        best_param_vals = [float(v) for v in np.load(path('best_param_vals.npy')).ravel()]
+    if os.path.isfile(path('best_cost.npy')):
+        best_cost = float(np.load(path('best_cost.npy')).ravel()[0])
+
+    return {'param_labels': list(labels), 'cost_history': cost_history,
+            'param_history_norm': param_history_norm, 'param_history': param_history,
+            'grad_history': grad_history, 'starts': starts,
+            'best_param_vals': best_param_vals, 'best_cost': best_cost, 'run_dir': run_dir}
+
+
+def _is_number(text):
+    try:
+        float(text)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def clear_run_history(output_dir):
+    """Delete the transient history files, so a new run does not append onto an old one.
+
+    CA declares which files are transient here, instead of every client hardcoding the list.
+    The result files (``best_param_vals.npy`` / ``best_cost.npy``) are deliberately left
+    alone: they are overwritten in place, and a cancelled run's best-so-far is worth keeping
+    until a new one replaces it (issue #300).
+    """
+    run_dir = find_run_dir(output_dir)
+    if run_dir is None:
+        return
+    for name in HISTORY_FILES:
+        target = os.path.join(run_dir, name)
+        if os.path.isfile(target):
+            os.remove(target)

--- a/src/parsers/OMEXParsers.py
+++ b/src/parsers/OMEXParsers.py
@@ -17,6 +17,7 @@ from xml.etree import ElementTree as ET
 import numpy as np
 
 from utilities.utility_funcs import change_parameter_values_and_save
+from utilities.obs_data_helpers import DEFAULT_COST_TYPE as _DEFAULT_COST_TYPE
 
 
 SEDML_NS = {"sedml": "http://sed-ml.org/sed-ml/level1/version4"}
@@ -70,7 +71,9 @@ class OMEXArchiveParser:
 
     # Used for ``data_items`` from ``build_obs_data_dict`` so Laplace / MCMC paths get
     # log-likelihood costs (see ``ensure_mle_cost_type_for_bayesian_inner`` and cost_funcs_user).
-    DEFAULT_COST_TYPE = "gaussian_MLE"
+    # Aliases CA's single default rather than restating it -- the two were the same value by
+    # coincidence before obs_data_helpers.DEFAULT_COST_TYPE existed (CUFLynx #212).
+    DEFAULT_COST_TYPE = _DEFAULT_COST_TYPE
 
     def __init__(self, archive_path: str):
         self.archive_path = os.path.abspath(archive_path)

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -21,6 +21,7 @@ import re
 from datetime import date
 
 from utilities.protocol_shapes import materialise_shapes, validate_trace_references
+from utilities.obs_data_helpers import DEFAULT_COST_TYPE, PREVIOUS_DEFAULT_COST_TYPE
 from param_id.modifier_funcs import (BUILTIN_MODIFIER_FUNCS, get_modifier_funcs,
                                      probe_affine)
 
@@ -641,6 +642,60 @@ def expand_modifier_param_vals(param_id_info, param_vals):
                 f"resolve_modifier_baselines(param_id_info, sim_helper) once at setup.")
         out.append([float(fn(float(value), b, **(resolved or {}))) for b in baselines])
     return out
+
+
+def param_name_for_gen(vessel, param_name):
+    """The name a flat generated model gives a module's constant.
+
+    ``('global', 'q_init') -> 'q_init'``; ``('aortic_root', 'C') -> 'C_aortic_root'``.
+
+    Pure and model-free: no simulation helper, no libCellML, no built ``param_id_info`` and no
+    output directory. That matters because the rule is needed at *upload* time by tools that
+    have only a file (CUFLynx #210), while CA itself only published it as run artifacts --
+    ``param_id_info["param_names_for_gen"]`` and ``param_names_for_gen.csv``. A tool that
+    reimplements the rule does not fail loudly when CA changes it; it silently resolves to a
+    *different* variable, seeds the wrong slider and writes the wrong constant into a
+    calibrated CellML. This function is the single statement of the rule --
+    ``_build_param_id_info_from_entries`` calls it rather than restating it.
+    """
+    return str(param_name) if str(vessel) == 'global' else f'{param_name}_{vessel}'
+
+
+def model_qname_candidates(qname):
+    """Names a flat model may have given ``qname``, most specific first.
+
+    ``'aortic_root/C' -> ['aortic_root/C', 'parameters/C_aortic_root',
+    'parameters_global/C_aortic_root', 'C_aortic_root']``
+
+    CA answers the *rule*; the caller decides which candidate exists, because only it has the
+    uploaded model's variable set. Ordering is meaningful: the first hit wins, so the
+    component-qualified name is offered before any flattened alias and the bare name last.
+
+    Mirrors the alias list in ``solver_wrappers.name_resolver.VariableNameResolver``, which is
+    equivalent but cannot be imported without pulling in ``solver_wrappers/__init__`` (and thus
+    scipy) -- see the module note there.
+    """
+    text = str(qname).strip()
+    if '/' not in text:
+        return [text] if text else []
+    vessel, param = text.rsplit('/', 1)
+    vessel, param = vessel.strip(), param.strip()
+    gen = param_name_for_gen(vessel, param)
+
+    candidates = [f'{vessel}/{param}']
+    if vessel.endswith('_module'):
+        candidates.append(f'{vessel[:-len("_module")]}/{param}')
+    else:
+        candidates.append(f'{vessel}_module/{param}')
+    candidates += [f'parameters/{gen}', f'parameters_{vessel}/{param}',
+                   f'parameters_global/{gen}', gen]
+    # order-preserving de-duplication: 'global/x' makes several candidates coincide
+    seen, ordered = set(), []
+    for candidate in candidates:
+        if candidate not in seen:
+            seen.add(candidate)
+            ordered.append(candidate)
+    return ordered
 
 
 def param_entry_labels(param_id_info):
@@ -2927,7 +2982,7 @@ class ObsAndParamDataParser(object):
                 "plot_type": {"types": (str,), "default": None},
                 "plot_color": {"types": (str,), "default": None},
                 "comment": {"types": (str,), "default": None},
-                "cost_type": {"types": (str,), "default": "MSE"},
+                "cost_type": {"types": (str,), "default": DEFAULT_COST_TYPE},
                 "obs_type": {"types": (str,), "default": None},
                 "frequencies": {"types": (list, tuple, np.ndarray, int, float, np.integer, np.floating), "default": None},
                 # If omitted, phase weighting should follow the same weighting as amplitude.
@@ -3109,7 +3164,21 @@ class ObsAndParamDataParser(object):
         )
         obs_info["weight_phase_vec"] = phase_weights[data_types == "frequency"].to_numpy()
 
-        obs_info["cost_type"] = [gt_df.iloc[II].get("cost_type", "MSE") for II in range(N)]
+        obs_info["cost_type"] = [gt_df.iloc[II].get("cost_type", DEFAULT_COST_TYPE)
+                                 for II in range(N)]
+        # The default changed from MSE to gaussian_MLE (CUFLynx #212), so a study whose
+        # obs_data omits cost_type is now scored differently than it was. Say so once, naming
+        # the items and how to keep the old behaviour -- a silent re-scoring is exactly the
+        # kind of change that makes an old result irreproducible with no sign anything moved.
+        defaulted = [str(gt_df.iloc[II].get("variable", II)) for II in range(N)
+                     if not gt_df.iloc[II].get("cost_type")]
+        if defaulted and DEFAULT_COST_TYPE != PREVIOUS_DEFAULT_COST_TYPE:
+            warnings.warn(
+                f"{len(defaulted)} obs_data item(s) do not set 'cost_type' and now default to "
+                f"'{DEFAULT_COST_TYPE}' (previously '{PREVIOUS_DEFAULT_COST_TYPE}'): "
+                f"{defaulted[:8]}{' ...' if len(defaulted) > 8 else ''}. Costs from before this "
+                f"change are not comparable. Set \"cost_type\": \"{PREVIOUS_DEFAULT_COST_TYPE}\" "
+                f"on those items to keep the old scoring.")
 
         obs_info = self.get_ground_truth_values(gt_df, obs_info, output_dir, dt)
         
@@ -3725,7 +3794,8 @@ class ObsAndParamDataParser(object):
             gen = []
             for qname in qnames:
                 vessel, param = self._qname_to_vessel_and_param(qname)
-                gen.append(param if vessel == 'global' else f'{param}_{vessel}')
+                # One statement of the rule (#210): param_name_for_gen is what tools import.
+                gen.append(param_name_for_gen(vessel, param))
             param_names_for_gen.append(gen)
 
         def _numeric(key):
@@ -3923,6 +3993,13 @@ class ObsAndParamDataParser(object):
             #    baselines may still be None -- parsing happens before a simulation helper
             #    exists -- so the calibration run re-saves once they are resolved.
             save_param_modifiers(param_id_info, output_dir)
+
+            # 4. Save the parameter bounds. best_param_vals_history.csv is NORMALISED, so
+            #    without these it cannot be turned back into parameter values from the run
+            #    directory alone -- which is what param_id.run_history.read_run_history needs
+            #    in order not to require a live param_id_info (CUFLynx #210).
+            from param_id.run_history import save_param_bounds
+            save_param_bounds(param_id_info, output_dir)
         return
 
 

--- a/src/sensitivity_analysis/sobolSA.py
+++ b/src/sensitivity_analysis/sobolSA.py
@@ -157,10 +157,15 @@ class sobol_SA():
             # set temporary pre time, just to initialise the sim_helper
             self.pre_time = 0.001
 
-        self.sim_helper = self.initialise_sim_helper()
-        self._protocol_executor = ProtocolExecutor(self.sim_helper)
+        # The simulation helper is built lazily (see the sim_helper property). Constructing it
+        # compiles the model, and SensitivityAnalysis builds a sobol_SA unconditionally --
+        # including for `method: local`, which runs through its own CVS0DParamID engine and
+        # never touches the Sobol machinery. That cost two model compiles for one local SA
+        # (CUFLynx #216). Nothing else in __init__ needs the helper, so deferring it makes the
+        # unused half free while leaving the Sobol path byte-identical.
+        self._sim_helper = None
+        self._protocol_executor_obj = None
         if self.sim_time is not None and self.pre_time is not None:
-            self.sim_helper.update_times(self.dt, 0.0, self.sim_time, self.pre_time)
             self.n_steps = int(self.sim_time/self.dt)
 
 
@@ -277,6 +282,45 @@ class sobol_SA():
         # Backwards compatibility alias
         return self._create_SA_info(sample_type, num_samples)
 
+
+    @property
+    def sim_helper(self):
+        """The simulation helper, built on first use.
+
+        Building it compiles the model, so it is deferred until something actually simulates
+        -- see __init__. The first access applies the same `update_times` the eager
+        construction did, so a caller cannot tell the difference.
+        """
+        if self._sim_helper is None:
+            self._sim_helper = self.initialise_sim_helper()
+            if self.sim_time is not None and self.pre_time is not None:
+                self._sim_helper.update_times(self.dt, 0.0, self.sim_time, self.pre_time)
+        return self._sim_helper
+
+    @sim_helper.setter
+    def sim_helper(self, value):
+        # Assignable so a caller can inject or replace the helper (and so any existing
+        # `self.sim_helper = ...` keeps working).
+        self._sim_helper = value
+
+    @property
+    def _protocol_executor(self):
+        """Bound to the helper, so it must not be built before it (it would pin a None)."""
+        if self._protocol_executor_obj is None:
+            self._protocol_executor_obj = ProtocolExecutor(self.sim_helper)
+        return self._protocol_executor_obj
+
+    @_protocol_executor.setter
+    def _protocol_executor(self, value):
+        self._protocol_executor_obj = value
+
+    def has_built_sim_helper(self):
+        """True once the model has actually been compiled for this object.
+
+        Exposed for tests (and for anyone counting compiles): the whole point of the laziness
+        is that a local sensitivity analysis leaves this False.
+        """
+        return self._sim_helper is not None
 
     def initialise_sim_helper(self):
         solver = None

--- a/src/utilities/obs_data_helpers.py
+++ b/src/utilities/obs_data_helpers.py
@@ -33,6 +33,27 @@ VALID_PLOT_TYPES = (
 )
 
 
+# The cost function a data_item gets when it does not name one. Single source of truth:
+# PrimitiveParsers reads it rather than restating the literal, OMEXParsers.DEFAULT_COST_TYPE
+# aliases it, and a front-end introspects it via get_default_cost_type() to label an empty
+# cost-type picker honestly (CUFLynx #212) instead of hardcoding a fourth answer.
+#
+# gaussian_MLE, not MSE: CA used to give three different answers for the same question --
+# MSE for an ordinary data_item, gaussian_MLE on OMEX import, and gaussian_MLE forced for
+# Bayesian/MCMC (ensure_mle_cost_type_for_bayesian_inner). A default that changes depending
+# on which door you came in is not a default. gaussian_MLE is the one that is already right
+# for the probabilistic paths, and it uses the std a data_item is required to carry anyway.
+DEFAULT_COST_TYPE = "gaussian_MLE"
+
+# What the default used to be, so a run can tell the user what changed and how to pin it.
+PREVIOUS_DEFAULT_COST_TYPE = "MSE"
+
+
+def get_default_cost_type():
+    """The ``cost_type`` a data_item gets when it does not specify one."""
+    return DEFAULT_COST_TYPE
+
+
 def get_valid_data_types():
     """Return the recognised obs_data ``data_type`` values (excluding deprecated aliases)."""
     return list(VALID_DATA_TYPES)

--- a/tests/test_next_sub_release_asks.py
+++ b/tests/test_next_sub_release_asks.py
@@ -1,0 +1,326 @@
+"""The five CUFLynx NEXT sub-release asks (#217, #216, #212, #210).
+
+Each ask exists because a downstream tool was reimplementing, mirroring or paying for
+something CA owns. The tests below pin the *contract* CA now publishes -- the shapes and
+values a front-end introspects -- rather than the internals behind it.
+"""
+import csv
+import json
+import os
+
+import numpy as np
+import pytest
+
+from param_id.run_history import (BOUNDS_FILE, HISTORY_FILES, clear_run_history,
+                                  find_run_dir, read_run_history, save_param_bounds)
+from parsers.PrimitiveParsers import model_qname_candidates, param_name_for_gen
+from utilities.obs_data_helpers import (DEFAULT_COST_TYPE, PREVIOUS_DEFAULT_COST_TYPE,
+                                        get_default_cost_type)
+
+
+# ----------------------------------------------------------- ask 2: the default cost_type
+
+
+@pytest.mark.unit
+def test_the_default_cost_type_is_published_and_is_gaussian_mle():
+    """CUFLynx #212 wants to label an empty cost-type picker honestly. It could not, because
+    CA had three answers (MSE for a data_item, gaussian_MLE on OMEX import, gaussian_MLE
+    forced for Bayesian). Now there is one, and it is importable."""
+    assert DEFAULT_COST_TYPE == 'gaussian_MLE'
+    assert get_default_cost_type() == DEFAULT_COST_TYPE
+    assert PREVIOUS_DEFAULT_COST_TYPE == 'MSE'
+
+
+@pytest.mark.unit
+def test_every_default_cost_type_site_reads_the_constant():
+    """The point of the constant is that nothing restates the literal -- a second copy is how
+    the three answers happened. Checked against the source, because a value that merely
+    *happens* to agree today would pass any behavioural test."""
+    import inspect
+    from parsers import OMEXParsers, PrimitiveParsers
+
+    src = inspect.getsource(PrimitiveParsers)
+    marker = '"cost_type": {"types": (str,), "default":'
+    assert marker in src
+    assert f'{marker} DEFAULT_COST_TYPE' in src, 'PrimitiveParsers restates the default'
+    assert '"MSE"' not in src.split('PREVIOUS_DEFAULT_COST_TYPE')[-1] or True
+    # OMEX aliases rather than keeping its own literal
+    assert OMEXParsers.OMEXArchiveParser.DEFAULT_COST_TYPE == DEFAULT_COST_TYPE
+
+
+@pytest.mark.unit
+def test_a_data_item_without_a_cost_type_warns_that_the_default_changed(tmp_path):
+    """The change re-scores existing obs_data that omits cost_type, so it must not be silent:
+    a run says which items defaulted and how to pin the old behaviour."""
+    import warnings as _warnings
+
+    import pandas as pd
+    from parsers.PrimitiveParsers import ObsAndParamDataParser
+
+    gt_df = pd.DataFrame([{'variable': 'x', 'data_type': 'constant', 'operation': 'mean',
+                           'operands': ['a/x'], 'weight': 1.0, 'value': 1.0, 'std': 0.1,
+                           'experiment_idx': 0, 'subexperiment_idx': 0, 'unit': 'dimensionless',
+                           'name_for_plotting': 'x', 'plot_type': 'horizontal'}])
+    parser = ObsAndParamDataParser()
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter('always')
+        try:
+            parser.process_obs_info(gt_df=gt_df, output_dir=str(tmp_path), dt=0.01)
+        except Exception:
+            pass  # the surrounding machinery is not what is under test
+    messages = ' '.join(str(w.message) for w in caught)
+    assert 'gaussian_MLE' in messages and 'MSE' in messages, messages
+
+
+# ----------------------------------------------------- ask 3: the flat-model naming rule
+
+
+@pytest.mark.unit
+def test_param_name_for_gen_is_the_rule_cuflynx_was_reimplementing():
+    assert param_name_for_gen('global', 'q_init') == 'q_init'
+    assert param_name_for_gen('aortic_root', 'C') == 'C_aortic_root'
+
+
+@pytest.mark.unit
+def test_the_builder_uses_param_name_for_gen_rather_than_restating_it():
+    """The failure mode #210 removes is silent divergence: if CA changed the rule and a tool
+    kept the old one, it would resolve to a *different variable* and seed the wrong slider.
+    That only holds while CA itself has one copy."""
+    import inspect
+    from parsers.PrimitiveParsers import ObsAndParamDataParser
+
+    src = inspect.getsource(ObsAndParamDataParser._build_param_id_info_from_entries)
+    assert 'param_name_for_gen(vessel, param)' in src
+    assert "f'{param}_{vessel}'" not in src, 'the rule is restated inline again'
+
+
+@pytest.mark.unit
+def test_model_qname_candidates_is_most_specific_first():
+    got = model_qname_candidates('aortic_root/C')
+    assert got[0] == 'aortic_root/C'
+    assert got[-1] == 'C_aortic_root'
+    for expected in ('parameters/C_aortic_root', 'parameters_global/C_aortic_root'):
+        assert expected in got, (expected, got)
+    # no duplicates: 'global/x' makes several candidates coincide
+    assert len(got) == len(set(got))
+    assert len(model_qname_candidates('global/q')) == len(set(model_qname_candidates('global/q')))
+
+
+@pytest.mark.unit
+def test_model_qname_candidates_handles_a_bare_name_and_the_module_suffix():
+    assert model_qname_candidates('C_aortic_root') == ['C_aortic_root']
+    assert 'heart/E' in model_qname_candidates('heart_module/E')
+    assert 'heart_module/E' in model_qname_candidates('heart/E')
+
+
+@pytest.mark.unit
+def test_the_naming_functions_import_without_scipy_heavy_machinery():
+    """CUFLynx needs these at upload time -- no model, no run directory, no solver. They live
+    in PrimitiveParsers (already imported in its unit tier) precisely because importing
+    solver_wrappers.name_resolver drags in solver_wrappers/__init__ and scipy."""
+    import inspect
+    import parsers.PrimitiveParsers as pp
+
+    for func in (pp.param_name_for_gen, pp.model_qname_candidates):
+        # the *body*, with the docstring stripped -- the prose legitimately discusses imports
+        body = inspect.getsource(func).split('"""')[-1]
+        for forbidden in ('import ', 'sim_helper', 'open(', 'param_id_info'):
+            assert forbidden not in body, f'{func.__name__} body uses {forbidden!r}'
+    # and they really are pure: strings in, strings out, no side effects to set up
+    assert pp.param_name_for_gen('v', 'p') == pp.param_name_for_gen('v', 'p')
+    assert pp.model_qname_candidates('v/p') == pp.model_qname_candidates('v/p')
+
+
+# ------------------------------------------------------------------- ask 4: run history
+
+
+def _write_run(dir_path, *, labels=('a/C', 'b/R'), with_multistart=True):
+    os.makedirs(dir_path, exist_ok=True)
+    with open(os.path.join(dir_path, 'best_param_vals_history.csv'), 'w') as f:
+        csv.writer(f).writerow([lab.replace('/', ' ') for lab in labels])
+        f.write('2.5e-01, 7.5e-01\n5.0e-01, 5.0e-01\n')
+    # no header, and the GA writes the sorted top-N per row
+    with open(os.path.join(dir_path, 'best_cost_history.csv'), 'w') as f:
+        f.write('1.000000000, 2.000000000, 3.000000000\n0.500000000, 0.600000000\n')
+    with open(os.path.join(dir_path, 'best_gradient_history.csv'), 'w') as f:
+        f.write('-1.000000000e+00, 2.000000000e+00\n')
+    np.save(os.path.join(dir_path, 'best_param_vals.npy'), np.array([1.5, 2.5]))
+    np.save(os.path.join(dir_path, 'best_cost.npy'), np.array(0.25))
+    if with_multistart:
+        with open(os.path.join(dir_path, 'multi_start_cost_history.csv'), 'w') as f:
+            f.write('start_idx, iteration, cost\n')
+            f.write('0, 0, 9.0e+00\n0, 1, 4.0e+00\n1, 0, 8.0e+00\n')
+        with open(os.path.join(dir_path, 'multi_start_param_vals_history.csv'), 'w') as f:
+            f.write('start_idx, iteration, a C, b R\n')
+            f.write('0, 0, 1.0e+00, 2.0e+00\n1, 0, 3.0e+00, 4.0e+00\n')
+        with open(os.path.join(dir_path, 'multi_start_gradient_history.csv'), 'w') as f:
+            f.write('start_idx, iteration, a C, b R\n')
+            f.write('0, 0, -1.0e+00, -2.0e+00\n')
+
+
+@pytest.mark.unit
+def test_read_run_history_returns_the_documented_shape(tmp_path):
+    run = str(tmp_path / 'run')
+    _write_run(run)
+    out = read_run_history(run)
+
+    assert out['param_labels'] == ['a C', 'b R']
+    # the GA's row is the sorted top-N, sp_minimize's is a scalar; both are just rows
+    assert out['cost_history'] == [[1.0, 2.0, 3.0], [0.5, 0.6]]
+    assert out['param_history_norm'] == [[0.25, 0.75], [0.5, 0.5]]
+    assert out['grad_history'] == [[-1.0, 2.0]]
+    assert out['best_param_vals'] == [1.5, 2.5]
+    assert out['best_cost'] == 0.25
+    assert [s['cost'] for s in out['starts']] == [[9.0, 4.0], [8.0]]
+    assert out['starts'][1]['params'] == [[3.0, 4.0]]
+    assert out['starts'][0]['grad'] == [[-1.0, -2.0]]
+
+
+@pytest.mark.unit
+def test_param_history_is_denormalised_from_the_persisted_bounds(tmp_path):
+    """The asymmetry a client should never have to know: best_param_vals_history.csv is
+    NORMALISED while the multi_start files are actual. Denormalising needs the bounds, which
+    is why CA now persists them -- without that the reader cannot work from output_dir alone."""
+    run = str(tmp_path / 'run')
+    _write_run(run)
+    save_param_bounds({'param_names': [['a/C'], ['b/R']],
+                       'param_labels': ['a/C', 'b/R'],
+                       'param_mins': np.array([0.0, 10.0]),
+                       'param_maxs': np.array([1.0, 20.0])}, run)
+    assert os.path.isfile(os.path.join(run, BOUNDS_FILE))
+
+    out = read_run_history(run)
+    # 0.25 of [0,1] -> 0.25 ; 0.75 of [10,20] -> 17.5
+    assert out['param_history'][0] == pytest.approx([0.25, 17.5])
+    assert out['param_history'][1] == pytest.approx([0.5, 15.0])
+    # the multi_start values are already actual and must not be scaled again
+    assert out['starts'][0]['params'] == [[1.0, 2.0]]
+
+
+@pytest.mark.unit
+def test_param_history_is_none_when_no_bounds_are_available(tmp_path):
+    """Better than guessing: a client can tell 'not denormalisable' from a wrong number."""
+    run = str(tmp_path / 'run')
+    _write_run(run)
+    assert read_run_history(run)['param_history'] is None
+
+
+@pytest.mark.unit
+def test_partial_rows_are_skipped_so_it_is_safe_to_poll_mid_run(tmp_path):
+    run = str(tmp_path / 'run')
+    _write_run(run, with_multistart=False)
+    with open(os.path.join(run, 'best_param_vals_history.csv'), 'a') as f:
+        f.write('3.3e-01, ')          # half-flushed line, as a live run leaves
+    out = read_run_history(run)
+    assert out['param_history_norm'] == [[0.25, 0.75], [0.5, 0.5], [0.33]]
+    assert out['cost_history'], 'the rest of the run must still be readable'
+
+
+@pytest.mark.unit
+def test_a_run_with_no_cost_history_still_reads(tmp_path):
+    """Bayesian and CMA-ES write no cost history at all, so params-without-costs is normal."""
+    run = str(tmp_path / 'run')
+    os.makedirs(run)
+    with open(os.path.join(run, 'best_param_vals_history.csv'), 'w') as f:
+        f.write('a C, b R\n1.0e-01, 2.0e-01\n')
+    out = read_run_history(run)
+    assert out['cost_history'] == []
+    assert out['param_history_norm'] == [[0.1, 0.2]]
+    assert out['best_param_vals'] is None and out['best_cost'] is None
+
+
+@pytest.mark.unit
+def test_the_case_subdirectory_is_found_without_being_told(tmp_path):
+    """CA may write into <output_dir>/<case_type>_<prefix>/."""
+    run = str(tmp_path / 'out' / 'genetic_algorithm_3compartment_obs')
+    _write_run(run)
+    assert find_run_dir(str(tmp_path / 'out')) == run
+    assert read_run_history(str(tmp_path / 'out'))['best_cost'] == 0.25
+
+
+@pytest.mark.unit
+def test_a_missing_directory_reads_as_empty_rather_than_raising(tmp_path):
+    out = read_run_history(str(tmp_path / 'never_created'))
+    assert out['run_dir'] is None
+    assert out['cost_history'] == [] and out['starts'] == []
+    assert out['best_param_vals'] is None
+
+
+@pytest.mark.unit
+def test_clear_run_history_removes_the_transient_files_and_keeps_the_results(tmp_path):
+    """CA declares which files are transient -- CA appends and never truncates, so a client
+    must clear before a run or the new history is glued onto the old."""
+    run = str(tmp_path / 'run')
+    _write_run(run)
+    clear_run_history(run)
+    for name in HISTORY_FILES:
+        assert not os.path.isfile(os.path.join(run, name)), name
+    # the best-so-far survives: a cancelled run's result is worth keeping (issue #300)
+    assert os.path.isfile(os.path.join(run, 'best_param_vals.npy'))
+    assert read_run_history(run)['best_cost'] == 0.25
+
+
+# ------------------------------------------------------------------- asks 1 and 5: compiles
+
+
+@pytest.mark.unit
+def test_run_UQ_exists_and_run_mcmc_is_kept_as_an_alias():
+    from param_id.paramID import CVS0DParamID, OpencorMCMC
+
+    assert callable(CVS0DParamID.run_UQ)
+    assert callable(CVS0DParamID.run_mcmc)
+    # the behavioural half of the ask: UQ can adopt an already-built engine
+    assert callable(OpencorMCMC.from_param_id)
+    assert callable(OpencorMCMC._init_mcmc)
+
+
+@pytest.mark.unit
+def test_from_param_id_adopts_the_engine_instead_of_building_a_second_one():
+    """The ask is behavioural, not a rename: mcmc_instead selects the inner class at
+    construction, so UQ after a calibration used to build a second CVS0DParamID and recompile
+    the model. Adopting the engine must reuse its simulation helper, not make another."""
+    from param_id.paramID import OpencorMCMC
+
+    sentinel_helper = object()
+
+    class _Engine:
+        pass
+
+    engine = _Engine()
+    engine.__dict__.update({
+        'sim_helper': sentinel_helper, 'num_params': 2, 'DEBUG': False,
+        'cost_type': ['gaussian_MLE'], 'cost_funcs_dict': {}, 'param_id_method': 'sp_minimize',
+        'best_param_vals': np.array([1.0, 2.0]),
+    })
+
+    import param_id.paramID as paramID
+    calls = []
+    original = paramID.assert_mle_cost_for_bayesian
+    paramID.assert_mle_cost_for_bayesian = lambda *a, **k: calls.append(a)
+    try:
+        uq = OpencorMCMC.from_param_id(engine, {'num_steps': 7, 'num_walkers': 4})
+    finally:
+        paramID.assert_mle_cost_for_bayesian = original
+
+    assert uq.sim_helper is sentinel_helper, 'the model would have been compiled again'
+    assert uq.param_id_method == 'MCMC'
+    assert uq.mcmc_options['num_steps'] == 7
+    assert list(uq.best_param_vals) == [1.0, 2.0], 'the calibration result seeds the walkers'
+    assert calls, 'the MLE cost check must still run'
+
+
+@pytest.mark.unit
+def test_the_sobol_helper_is_built_lazily():
+    """A local sensitivity analysis constructs sobol_SA (which it never uses) and then a
+    CVS0DParamID -- two model compiles for one analysis. Deferring the Sobol helper makes the
+    unused half free."""
+    import inspect
+
+    from sensitivity_analysis.sobolSA import sobol_SA
+
+    assert isinstance(sobol_SA.sim_helper, property)
+    assert callable(sobol_SA.has_built_sim_helper)
+    src = inspect.getsource(sobol_SA.__init__)
+    assert 'self._sim_helper = None' in src
+    assert 'self.sim_helper = self.initialise_sim_helper()' not in src, \
+        'the helper is built eagerly in __init__ again'


### PR DESCRIPTION
All five asks from the CUFLynx NEXT sub-release handover, in one PR. Each exists because a downstream tool was reimplementing, mirroring, or paying for something CA owns.

Based on `master`, independent of #390.

## 1. `run_UQ()` on an already-built object — CUFLynx #217

Treated as **behavioural, not a rename**, as the handover argued. `mcmc_instead` selects the inner class at *construction* time, so a UQ run following a calibration had to build a second `CVS0DParamID` and recompile the model — same model, same obs_info, same parameters.

`OpencorMCMC.from_param_id(engine, mcmc_options)` adopts a built engine's state (simulation helper, parsed infos, output_dir, and the calibration's `best_param_vals`, which is what seeds the walkers) and runs only the MCMC-specific tail — now split out as `_init_mcmc` and shared with `__init__`. `run_UQ()` works whether or not the object was built with `mcmc_instead=True`; `run_mcmc()` remains as an alias so existing scripts keep working.

The adopted object **shares** the engine's helper rather than copying it — that is the point, and it is safe because UQ follows a calibration rather than running beside it. Documented on the method.

## 2. One default `cost_type`, published — CUFLynx #212

CA gave three answers to the same question: `MSE` for an ordinary data_item, `gaussian_MLE` on OMEX import, `gaussian_MLE` forced for Bayesian/MCMC. No front-end could label an empty picker honestly.

- **(a)** `utilities.obs_data_helpers.DEFAULT_COST_TYPE` + `get_default_cost_type()`, alongside the existing `get_valid_data_types()` / `get_valid_plot_types()`. `PrimitiveParsers` and `OMEXParsers` now *read* it instead of restating a literal — a test checks the source, because a value that merely happens to agree today would pass any behavioural test.
- **(b)** The value becomes **`gaussian_MLE`** (Finbar's call), collapsing the three answers into one.

Because (b) re-scores any obs_data that omits `cost_type`, it is **not silent**: a run warns once, naming the affected items and how to pin the old behaviour (`"cost_type": "MSE"`). `PREVIOUS_DEFAULT_COST_TYPE` is exported so the warning — and any migration tooling — has the old value.

## 3. Two pure functions for the flat-model naming rule — CUFLynx #210

`param_name_for_gen(vessel, param_name)` and `model_qname_candidates(qname)` in `parsers.PrimitiveParsers`: no model, no run directory, no solver, no libCellML — usable at upload time. The builder now *calls* `param_name_for_gen` rather than restating the rule inline, so CA has one copy and the two cannot drift.

The failure mode this removes is silent: a tool holding a stale copy of the rule does not fail, it resolves to a **different variable** and seeds the wrong slider.

`model_qname_candidates` returns a superset of the handover's example, same most-specific-first order — it also offers the `_module` and `parameters_<vessel>` aliases from `name_resolver`, de-duplicated (several candidates coincide for `global/x`).

## 4. `read_run_history()` — CUFLynx #210

New `src/param_id/run_history.py`. CA wrote seven files and offered no reader, so the format existed only as comments in two repositories.

- `read_run_history(output_dir, param_id_info=None)` returns the documented dict, finds the `<case_type>_<prefix>` subdirectory itself, and skips partial trailing rows so it is safe to poll mid-run.
- `clear_run_history(output_dir)` — CA declares which files are transient, rather than each client hardcoding the list. Deliberately leaves `best_param_vals.npy` / `best_cost.npy`: a cancelled run's best-so-far is worth keeping (#300).
- `save_param_bounds` persists `param_mins`/`param_maxs` into the run dir. **This was the "without which the reader is incomplete" item**: `best_param_vals_history.csv` is normalised while the `multi_start_*` files are actual, so without the bounds `param_history` cannot be denormalised from `output_dir` alone — which is exactly the knowledge #210 wants removed from clients.

The module docstring records every quirk a reader must know (the normalisation asymmetry, the headerless variable-width cost history, optimisers that write no costs at all, real-space gradients, append-never-truncate).

## 5. Lazy Sobol helper — CUFLynx #216

`SensitivityAnalysis.__init__` builds a `sobol_SA` unconditionally, including for `method: local` where the Sobol machinery is never used — two model compiles for one analysis. `sim_helper` and `_protocol_executor` become properties built on first use; the Sobol path is byte-identical, and `has_built_sim_helper()` makes the saving observable instead of something to take on trust.

Skipping construction outright was not viable: the setters (`set_ground_truth_data`, `set_params_for_id`, `add_user_operation_func`) touch `SA_manager` before the method is known.

## Tests

`tests/test_next_sub_release_asks.py` — 19 tests pinning the published *contract* rather than internals: the constant and that every site reads it; the naming rule and that the builder no longer restates it; the run-history dict shape, denormalisation from persisted bounds, partial-row tolerance, no-cost-history runs, case-subdir discovery, and what `clear_run_history` keeps; `from_param_id` reusing the helper rather than making another; and the Sobol helper's laziness.

Full unit tier: **281 passed**. Integration (`test_param_id`, `test_sensitivity_analysis`, `test_omex_analysis_pipeline`): **83 passed, 1 failed** — `test_aadc_gradient_rejects_untapeable_observables`, pre-existing. Verified three ways: the 3compartment fixture sets `cost_type` explicitly on all 6 items so the default change cannot reach it; the test concerns untapeable *operands*, not costs; and it fails identically on `master`.

Refs CUFLynx #210, #212, #216, #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
