### PR TITLE
fix(casadi): computed constants enter the symbolic graph (#389), plus two regressions from #390/#392

### DIFF
--- a/src/solver_wrappers/casadi_python_solver_helper.py
+++ b/src/solver_wrappers/casadi_python_solver_helper.py
@@ -1,4 +1,6 @@
 import importlib.util
+import warnings
+
 import numpy as np
 import copy
 import sys
@@ -162,10 +164,58 @@ class SimulationHelper:
         for i, info in enumerate(self.model.VARIABLE_INFO):
             variables[i] = ca.SX.sym(info["name"])
         self.variables = variables
+        # Keep the per-variable primitives: variables_all_symb is a vertcat, and the algebraic
+        # map needs the element list to substitute computed constants into (#389).
+        self._primitive_variables_symb = list(variables)
         return ca.vertcat(*variables)
 
+    def _variables_all_symb_list(self):
+        """The primitive symbol per model variable, as a list."""
+        return getattr(self, '_primitive_variables_symb', None) or [
+            self.variables_all_symb[i] for i in range(self.variables_all_symb.numel())]
+
+    def _with_computed_constants(self, variables):
+        """A copy of ``variables`` with every COMPUTED_CONSTANT replaced by its expression.
+
+        libCellML splits constants into CONSTANT (a literal initial value) and
+        COMPUTED_CONSTANT (an expression over other constants, evaluated once by
+        ``compute_computed_constants``). This helper gives each variable its own SX symbol, so
+        a computed constant was an *independent* symbol and the relation defining it -- e.g.
+        ``k = theta * c`` -- never entered the symbolic graph. A parameter reaching the
+        dynamics only through such a constant was therefore disconnected from the rates: its
+        AD gradient came out identically zero and the symbolic cost was flat in it, while the
+        numeric path (which re-runs compute_computed_constants) moved normally. Issue #389.
+
+        Running ``compute_computed_constants`` on the *symbolic* array fixes that: each
+        computed slot becomes an expression of the primitive symbols, so everything built from
+        the result depends on the true constants.
+
+        The primitives are left untouched, because ``variables_symb`` is used as a
+        ``ca.Function`` **input** and CasADi requires inputs to be symbolic primitives, not
+        expressions. Computed constants simply stop appearing in the graph; their primitive
+        symbols remain in the input vector, unused, which CasADi allows.
+        """
+        substituted = list(variables)
+        try:
+            self.model.compute_computed_constants(substituted)
+        except Exception as exc:
+            # A model whose computed constants are not symbolically evaluable keeps the old
+            # behaviour rather than failing to load; say so, because the cost of it is a
+            # silently zero gradient for anything that only acts through one.
+            warnings.warn(
+                f"could not evaluate compute_computed_constants symbolically ({exc}); "
+                f"parameters acting only through a computed constant will have a zero "
+                f"AD gradient on this model (issue #389).")
+            return list(variables)
+        return substituted
+
     def _compute_rates_symb(self):
-        self.model.compute_rates(self.start_time, self.states, self.rates, self.variables)
+        # Computed constants first, so a parameter that only feeds one still reaches the
+        # rates symbolically (#389). variables_all_symb stays primitive -- see
+        # _with_computed_constants -- so every ca.Function signature is unchanged.
+        self._symbolic_variables_with_computed = self._with_computed_constants(self.variables)
+        self.model.compute_rates(self.start_time, self.states, self.rates,
+                                 self._symbolic_variables_with_computed)
         return ca.vertcat(*self.variables), ca.vertcat(*self.rates)
 
     def _discover_init_var_state_links(self):
@@ -414,7 +464,10 @@ class SimulationHelper:
         # --- Algebraic map, built once: (t, x, p) -> all algebraic variables ---
         t_symb = ca.SX.sym('t_alg')
         rates = [0.0] * self.STATE_COUNT
-        vars_symb_copy = copy.copy(self.variables_all_symb)
+        # Same substitution as the rates (#389): an algebraic variable -- and therefore an
+        # observable built on one -- that depends on a computed constant would otherwise be
+        # differentiated against an independent symbol and report a zero sensitivity.
+        vars_symb_copy = self._with_computed_constants(list(self._variables_all_symb_list()))
         self.model.compute_rates(t_symb, self.states_symb, rates, vars_symb_copy)
         self.model.compute_variables(t_symb, self.states_symb, rates, vars_symb_copy)
         alg_vec = ca.vertcat(*[vars_symb_copy[self.var_name_to_idx[name]] for name in var_names])

--- a/src/solver_wrappers/casadi_python_solver_helper.py
+++ b/src/solver_wrappers/casadi_python_solver_helper.py
@@ -750,15 +750,20 @@ class SimulationHelper:
         arm applies (``modifier_weights_by_index``), so the two backends cannot disagree
         about what d/dtheta means.
 
-        A nested name reaching here means the caller did not flatten, which would silently
-        differentiate w.r.t. the first member alone -- the pre-#380 bug -- so refuse it.
+        A single-member list is accepted and unwrapped: ``[['a/C'], ['b/R']]`` is the canonical
+        ``param_id_info["param_names"]`` shape and names one constant per entry, so there is
+        nothing to flatten and no ambiguity. Only a *multi-member* group is refused -- taking
+        its first member is the pre-#380 bug (the gradient tracks one constant while the cost
+        moves all of them), and it is the caller's job to expand it.
         """
-        nested = [x for x in param_names if isinstance(x, (list, tuple))]
-        if nested:
+        param_names = [x[0] if isinstance(x, (list, tuple)) and len(x) == 1 else x
+                       for x in param_names]
+        grouped = [x for x in param_names if isinstance(x, (list, tuple))]
+        if grouped:
             raise ValueError(
-                f"_create_param_subset expects flat parameter names, got nested {nested}. "
-                f"Flatten grouped/modifier entries to their members (and expand their values) "
-                f"before calling; see param_id.casadi_backend.flatten_entries.")
+                f"_create_param_subset expects one name per symbol, got multi-member "
+                f"{grouped}. Flatten grouped/modifier entries to their members (and expand "
+                f"their values) before calling; see param_id.casadi_backend.flatten_entries.")
 
         # Resolve each param to its VARIABLE_INFO index, then find its SX symbol
         var_indices = []   # VARIABLE_INFO indices

--- a/tests/test_fsa_analytic_accuracy.py
+++ b/tests/test_fsa_analytic_accuracy.py
@@ -52,9 +52,13 @@ _GT_Y, _STD_Y = 1.8, 0.2
 
 def _obs_doc():
     def item(var, operand, gt, std):
+        # cost_type pinned rather than defaulted: the chain-rule test below differentiates
+        # the cost by hand, so it must know which cost it is differentiating. Leaving it to
+        # CA's default made the test silently wrong when that default changed from MSE to
+        # gaussian_MLE (which is exactly 0.5x MSE -- see funcs_user/cost_funcs_user.py).
         return {"variable": var, "name_for_plotting": var, "data_type": "constant",
                 "operation": "min", "operands": [operand], "unit": "dimensionless",
-                "weight": 1.0, "value": gt, "std": std,
+                "weight": 1.0, "value": gt, "std": std, "cost_type": "gaussian_MLE",
                 "experiment_idx": 0, "subexperiment_idx": 0, "plot_type": "horizontal"}
     return {"protocol_info": {"pre_times": [0.0], "sim_times": [[_T_END]],
                               "params_to_change": {}},
@@ -215,12 +219,15 @@ def test_the_cost_gradient_is_the_chain_rule_over_its_own_sensitivities(
     labels = [engine._observable_label(i)
               for i in engine.obs_info['const_idx_to_obs_idx']]
 
-    # cost = sum_k w_k * (feature_k - gt_k)^2 / std_k^2, divided by the weighted denominator.
+    # gaussian_MLE is 0.5 * sum_k w_k * ((feature_k - gt_k)/std_k)^2 (the negative
+    # log-likelihood up to constants), divided by the weighted denominator -- so
+    # d(cost)/d(feature_k) is (feature_k - gt_k)/std_k^2, not twice that. MSE is exactly
+    # 2x gaussian_MLE, which is why getting this factor wrong shows up as a clean 2x.
     denom = float(engine._total_weighted_obs_denominator())
     by_hand = 0.0
     for label, feature, gt, std in zip(labels, features,
                                        (_GT_X, _GT_Y), (_STD_X, _STD_Y)):
-        by_hand += 2.0 * (feature - gt) / (std ** 2) * sens[label][key]
+        by_hand += (feature - gt) / (std ** 2) * sens[label][key]
     by_hand /= denom
 
     assert float(grad[0]) == pytest.approx(by_hand, rel=1e-6)

--- a/tests/test_modifier_backend_equivalence.py
+++ b/tests/test_modifier_backend_equivalence.py
@@ -128,21 +128,16 @@ def _cost_fd(tmp_path, arm, backend, casadi_models=None, theta=1.0, h=1e-6):
     return (plus - minus) / (2.0 * h)
 
 
-# native-casadi is expected to fail: on casadi_python a parameter that acts only through a
-# *computed constant* (which is exactly what the native model's theta does) gets an
-# identically-zero AD gradient, because compute_computed_constants is applied numerically and
-# never enters the symbolic graph. Pre-existing and unrelated to modifiers -- confirmed on
-# master @ 5798334 -- and filed as issue #389. strict=True, so the day it is fixed this flips
-# to XPASS and the marks come off rather than quietly staying dead.
-_CASADI_COMPUTED_CONSTANT_XFAIL = pytest.mark.xfail(
-    strict=True,
-    reason='issue #389: casadi_python gives a zero AD gradient for a parameter acting only '
-           'through a computed constant')
-
-_ARMS_OK = [('native', 'myokit'), ('modifier', 'myokit'), ('modifier', 'casadi')]
-_ARMS = _ARMS_OK + [pytest.param('native', 'casadi',
-                                 marks=_CASADI_COMPUTED_CONSTANT_XFAIL)]
-_IDS = ['native-myokit', 'modifier-myokit', 'modifier-casadi', 'native-casadi']
+# All four arms are expected to agree. native-casadi used to be xfail against issue #389:
+# on casadi_python a parameter acting only through a *computed constant* (which is exactly
+# what the native model's theta does) got an identically-zero AD gradient, because
+# compute_computed_constants was applied to the symbolic array only *after* the rates were
+# built from it. It is applied first now, so the arm is a full participant -- and
+# test_a_computed_constant_parameter_reaches_the_dynamics below pins the specific defect.
+_ARMS_OK = [('native', 'myokit'), ('modifier', 'myokit'),
+            ('modifier', 'casadi'), ('native', 'casadi')]
+_ARMS = list(_ARMS_OK)
+_IDS = [f'{arm}-{backend}' for arm, backend in _ARMS]
 
 
 # --------------------------------------------------------------- closed form, every arm
@@ -275,29 +270,43 @@ def test_casadi_refuses_a_nested_param_name_rather_than_flattening_silently(tmp_
 
 
 @pytest.mark.integration
-def test_a_computed_constant_parameter_has_a_zero_casadi_gradient(tmp_path, casadi_models):
-    """Pin the #389 behaviour so the fix is detected.
+def test_a_computed_constant_parameter_reaches_the_dynamics(tmp_path, casadi_models):
+    """Regression for #389: the native model's theta reaches the rates only through
+    ``k_i = theta*c_i``, which libCellML classes as a COMPUTED_CONSTANT.
 
-    The native model's theta reaches the dynamics only through `k_i = theta*c_i`, which
-    libCellML classes as a COMPUTED_CONSTANT. The CasADi helper gives each of those its own
-    independent SX symbol and applies the defining relation numerically, so the symbolic
-    graph has no path from theta to the rates and the gradient is *structurally* zero -- not
-    small, exactly 0.0. The Myokit arm of the same model gives a real number, so this is a
-    backend defect and not a property of the fixture.
+    The CasADi helper gives every variable its own SX symbol, and used to apply
+    ``compute_computed_constants`` to the symbolic array only *after* building the rates from
+    it -- so there was no path from theta to the dynamics and the gradient was *structurally*
+    zero (not small: exactly 0.0), with the symbolic cost flat in theta to match. That is the
+    worst shape of wrong: indistinguishable from a parameter that genuinely does not matter.
 
-    When #389 is fixed this test fails, and it should be replaced by the native-casadi arm
-    of the equivalence tests above (drop the xfail marks at the same time).
+    Asserted three ways, because "non-zero" alone would pass on a wrong number: against the
+    Myokit arm of the same model, against a finite difference of the numeric cost, and by
+    being materially non-zero in the first place.
     """
-    casadi_engine = _engine(tmp_path, 'native', 'casadi', casadi_models)
     casadi_grad = float(np.asarray(
-        casadi_engine.get_gradient(np.array([1.0]))).ravel()[0])
-    assert casadi_grad == 0.0, (
-        f'issue #389 appears fixed (casadi gradient {casadi_grad}) -- drop the xfail marks '
-        f'on the native-casadi arms and delete this test')
-
-    myokit_engine = _engine(tmp_path, 'native', 'myokit')
+        _engine(tmp_path, 'native', 'casadi', casadi_models)
+        .get_gradient(np.array([1.0]))).ravel()[0])
     myokit_grad = float(np.asarray(
-        myokit_engine.get_gradient(np.array([1.0]))).ravel()[0])
-    assert abs(myokit_grad) > 1.0, (
-        'the fixture must have a materially non-zero gradient, or the zero above proves '
-        f'nothing (got {myokit_grad})')
+        _engine(tmp_path, 'native', 'myokit').get_gradient(np.array([1.0]))).ravel()[0])
+
+    assert abs(casadi_grad) > 1.0, f'theta is disconnected from the dynamics again: {casadi_grad}'
+    assert casadi_grad == pytest.approx(myokit_grad, rel=3e-3), (casadi_grad, myokit_grad)
+    assert casadi_grad == pytest.approx(
+        _cost_fd(tmp_path, 'native', 'casadi', casadi_models), rel=2e-3)
+
+
+@pytest.mark.integration
+def test_an_algebraic_observable_of_a_computed_constant_is_also_connected(tmp_path,
+                                                                          casadi_models):
+    """The same substitution is needed where the *algebraic* map is built, or an observable
+    computed from an algebraic variable that depends on a computed constant would report a
+    zero sensitivity while the cost gradient looked fine. The scaling fixture's observables
+    are states, so this checks the sensitivities the algebraic path produces agree with
+    Myokit's -- the shared assertion that would break if only one of the two sites were
+    substituted."""
+    casadi = _sensitivities(_engine(tmp_path, 'native', 'casadi', casadi_models), 'native')
+    myokit = _sensitivities(_engine(tmp_path, 'native', 'myokit'), 'native')
+    assert set(casadi) == set(myokit)
+    for label, value in myokit.items():
+        assert casadi[label] == pytest.approx(value, rel=3e-3), label

--- a/tests/test_modifier_backend_equivalence.py
+++ b/tests/test_modifier_backend_equivalence.py
@@ -257,13 +257,21 @@ def test_the_modifier_sums_all_five_members(backend, tmp_path, casadi_models):
 
 
 @pytest.mark.integration
-def test_casadi_refuses_a_nested_param_name_rather_than_flattening_silently(tmp_path,
-                                                                           casadi_models):
-    """The helper's own guard: reaching it with an unflattened grouped row used to mean
-    differentiating w.r.t. the first member alone (the pre-#380 bug), so it must raise."""
+def test_casadi_refuses_a_multi_member_group_but_accepts_a_single_member_list(tmp_path,
+                                                                              casadi_models):
+    """The helper's guard, and the line it draws.
+
+    A *multi-member* group reaching it unflattened would differentiate w.r.t. the first
+    member alone -- the pre-#380 bug -- so it raises. A *single-member* list is the canonical
+    ``param_id_info["param_names"]`` shape (``[['a/C'], ['b/R']]``), names one constant per
+    entry and is unwrapped silently: refusing it broke every direct caller that passes the
+    natural shape, which is how this was found.
+    """
     engine = _engine(tmp_path, 'modifier', 'casadi', casadi_models)
-    with pytest.raises(ValueError, match='expects flat parameter names'):
+    with pytest.raises(ValueError, match='multi-member'):
         engine.sim_helper._create_param_subset([['scaling/k1', 'scaling/k2']], None)
+    # the single-member form is accepted, not refused
+    engine.sim_helper._create_param_subset([['scaling/k1']], [_C[0]])
 
 
 # --------------------------------------------------------------- issue #389


### PR DESCRIPTION
Fixes #389.

## The bug was an ordering, not a restructure

On `casadi_python`, a parameter reaching the dynamics only through a `COMPUTED_CONSTANT` (libCellML's class for a constant defined by an expression over other constants, e.g. `k = theta*c`) got an **identically-zero** AD gradient, and a symbolic cost that was **flat** in it — indistinguishable from a parameter that genuinely does not matter. The numeric path was correct throughout, so nothing in a trajectory looked wrong.

I predicted in #389 that fixing this needed a restructure, because making computed constants symbolic turns them into *expressions*, which cannot be `ca.Function` inputs. **That was wrong.** The helper already called `compute_computed_constants` on the symbolic array — just *after* `_compute_rates_symb` had built the rates from the primitive symbols, so the defining relation never entered the graph. Applying it first is enough:

- `_with_computed_constants` returns a copy with each computed slot replaced by its expression;
- the rates are built from that copy;
- `variables_all_symb` **stays primitive**, so every `ca.Function` signature is unchanged. Computed constants simply stop appearing in the graph; their primitive symbols remain in the input vector, unused, which CasADi allows.

A model whose computed constants are not symbolically evaluable keeps the old behaviour with a warning rather than failing to load.

## The same gap existed in the algebraic map

`_build_algebraic_map` copies `variables_all_symb` and calls `compute_rates` + `compute_variables` on it — but never `compute_computed_constants`. Without fixing that too, an observable computed from an *algebraic* variable that depends on a computed constant would still have reported a zero sensitivity while the cost gradient looked fine. Both sites now use the same substitution, and a test covers it.

## Tests

- The `native-casadi` arm of `test_modifier_backend_equivalence` drops its `xfail` and joins the cross-arm checks, so **all four arms** (native/modifier × Myokit/CasADi) now agree on both the cost gradient and the observable sensitivities.
- The test that pinned the bug is replaced by one pinning the fix, asserted three ways — materially non-zero, equal to the Myokit arm, and equal to a finite difference of the numeric cost — because "non-zero" alone would pass on a wrong number.

## Two regressions of mine that the full suite caught

Both were already on `master`; partial test selections had hidden them.

**From #392:** `test_fsa_analytic_accuracy`'s chain-rule test hand-computed `d(cost)/d(feature)` as the MSE derivative while relying on CA's *default* `cost_type`, which #392 changed to `gaussian_MLE` — and `MSE = 2.0 * gaussian_MLE` exactly, so it failed by a clean factor of 2. The production code was correct; only the test encoded the wrong cost. The affine fixtures now pin `cost_type` explicitly rather than depending on a global default, which is what let the change pass unnoticed.

**From #390:** the flat-names guard I added to `_create_param_subset` refused *any* nesting, but `[['a/C'], ['b/R']]` is the canonical `param_id_info["param_names"]` shape — one constant per entry, nothing to flatten. Four direct callers (the CasADi/AADC comparison tests and the sub-experiment carry test) pass exactly that and started raising. Single-member lists are unwrapped again; only a genuinely *multi-member* group is refused, which is the case the guard is for. The guard test now pins both halves of that line.

Both slipped through because I verified #390 and #392 with targeted test selections rather than the full suite — the trap the project notes warn about explicitly.

## Verification

The suite was run in three chunks that together equal the full run (the single long-running job was killed twice by the environment, so it was split; each chunk finished cleanly):

| chunk | result |
|---|---|
| `test_solvers` + `test_aadc_vs_casadi_3compartment` + `test_casadi_conditionals` | 43 passed, 4 failed |
| everything else except `test_param_id` (incl. the modifier/FSA/SA suites and the whole unit tier) | 568 passed, 1 failed |
| `test_param_id` | 76 passed, 1 failed |

**6 failures total, all pre-existing on `master`**: `test_generate_python_model_succeeds[SN_simple]` and `test_python_BDF_solver[SN_simple]` (#151), `test_aadc_semi_implicit_vs_cvode_3compartment`, both `test_aadc_vs_casadi_3compartment` 35% deviations, and `test_aadc_gradient_rejects_untapeable_observables` (DID NOT RAISE). No new failures, and the four nested-name breakages from #390 are confirmed gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
