### PR TITLE
fix(parsers): derive the solver->consumer map (#330) and read parameters.csv by header (#159)

### DIFF
--- a/src/parsers/ModelParsers.py
+++ b/src/parsers/ModelParsers.py
@@ -17,6 +17,12 @@ import os
 generator_resources_dir_path = os.path.join(os.path.dirname(__file__), '../generators/resources')
 base_dir = os.path.join(os.path.dirname(__file__), '../..')
 
+# The columns a {prefix}_parameters.csv must provide. They are looked up by header name, so a file
+# may list them in any order and may carry extra columns (FTU_wCVS_parameters.csv has a 'comp_env'
+# column, for instance) without shifting the ones that matter -- see issue #159. 'const_type' is
+# deliberately absent: it is supplied by the module config, not by the CSV.
+_REQUIRED_PARAMETER_COLUMNS = ('variable_name', 'units', 'value', 'data_reference')
+
 
 class CSV0DModelParser(object):
     '''
@@ -537,33 +543,49 @@ class CSV0DModelParser(object):
                 required_params_unique.append(entry)
         required_params = np.array(required_params_unique)
 
+        # Read each row by column NAME, not position (issue #159). The rows come out of
+        # get_data_as_nparray as a structured array whose fields are the CSV's own headers in the
+        # CSV's own order, so flattening a row into a list and indexing it positionally silently
+        # assumed one particular column layout. A parameters.csv carrying an extra column -- e.g.
+        # resources/FTU_wCVS_parameters.csv, which has 'comp_env' between units and value -- then
+        # shifted every field right of it: the parameter's value became the comp_env string and
+        # its data_reference became the value, with no error raised.
+        missing_columns = [name for name in _REQUIRED_PARAMETER_COLUMNS
+                           if name not in (parameters_array_orig.dtype.names or ())]
+        if missing_columns:
+            print('')
+            print(f'ERROR: {self.parameter_filename} is missing the required column(s) '
+                  f'{missing_columns}. \n'
+                  f'Required columns are {list(_REQUIRED_PARAMETER_COLUMNS)}; the file has '
+                  f'{list(parameters_array_orig.dtype.names or ())}. \n'
+                  f'Columns are matched by header name, so any additional columns are ignored '
+                  f'and their order does not matter, exiting \n')
+            print('')
+            exit()
+
         parameters_list = []
 
         for idx, param_tuple in enumerate(required_params):
-            actually_exit = False
-            try:
-                new_entry = parameters_array_orig[np.where(parameters_array_orig["variable_name"] ==
-                                                                       param_tuple[0])][0]
-                new_entry = [item for item in new_entry]
-                if new_entry[1] != param_tuple[1]:
-                    print('')
-                    print(f'ERROR: units of {new_entry[1]} in parameters.csv file does not \n'
-                          f'match with units of {param_tuple[1]} in module_config.json file \n'
-                          f'for param {new_entry[0]}, exiting \n')
-                    print('')
-                    actually_exit = True
-                    exit()
-
-                new_entry.insert(2, param_tuple[2])
-                parameters_list.append(new_entry)
-                # overwrite 2 index with local or global, it doesn't matter where the
-            except:
+            matches = parameters_array_orig[
+                np.where(parameters_array_orig["variable_name"] == param_tuple[0])]
+            if len(matches) == 0:
                 # the other entries apart from name in this row are left empty
-                new_entry = ([param_tuple[0], param_tuple[1], param_tuple[2],
-                                     'EMPTY_MUST_BE_FILLED', 'EMPTY_MUST_BE_FILLED'])
-                parameters_list.append(new_entry)
-                if actually_exit:
-                    exit()
+                parameters_list.append([param_tuple[0], param_tuple[1], param_tuple[2],
+                                        'EMPTY_MUST_BE_FILLED', 'EMPTY_MUST_BE_FILLED'])
+                continue
+
+            row = matches[0]
+            if row['units'] != param_tuple[1]:
+                print('')
+                print(f'ERROR: units of {row["units"]} in parameters.csv file does not \n'
+                      f'match with units of {param_tuple[1]} in module_config.json file \n'
+                      f'for param {row["variable_name"]}, exiting \n')
+                print('')
+                exit()
+
+            # const_type comes from the module config (local or global), not from the CSV.
+            parameters_list.append([row['variable_name'], row['units'], param_tuple[2],
+                                    row['value'], row['data_reference']])
         if len(parameters_list) == 0:
             return np.empty((len(parameters_list)),
                                     dtype=[('variable_name', 'U80'), ('units', 'U80'),('const_type', 'U80'),

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -243,13 +243,32 @@ _SI_RTOL = {'name': 'rtol', 'type': 'float', 'default': 1e-8, 'required': False,
             'description': 'Relative integration tolerance.'}
 _SI_ATOL = {'name': 'atol', 'type': 'float', 'default': 1e-8, 'required': False,
             'description': 'Absolute integration tolerance.'}
-# CVODE-family backends (opencor, and the cpp CVODE/RK4/PETSC) share the same fields.
+# The OpenCOR CVODE backend, which forwards solver_info straight into OpenCOR's own
+# odeSolverProperties() (rtol/atol translated to RelativeTolerance/AbsoluteTolerance).
 _CVODE_FAMILY_SOLVER_INFO = [
     {'name': 'MaximumStep', 'type': 'float', 'default': 0.001, 'required': False,
      'description': 'Maximum integrator step size.'},
     {'name': 'MaximumNumberOfSteps', 'type': 'int', 'default': 5000, 'required': False,
      'description': 'Maximum number of internal integrator steps per output step.'},
     _SI_RTOL, _SI_ATOL,
+]
+
+# Derived, so the migration below and the model_type menu cannot name different sets of solvers.
+_CPP_SOLVERS = frozenset(SOLVER_SCHEMA['solvers_by_model_type']['cpp'])
+
+# The cpp solvers (CVODE/RK4/PETSC) are not run through a SimulationHelper at all: their
+# solver_info is baked into the emitted C++ by the cpp branch of
+# script_generate_with_new_architecture, which forwards exactly two values to CVSCppGenerator --
+# `dt_solver` (a framework key) as the solver step, and `MaximumNumberOfSteps` as mxsteps. The
+# generated C++ hardcodes its tolerances (`sunrealtype reltol = 1e-7; ... abstol = 1e-9;`, with a
+# standing TODO in CVSCppGenerator) and has no maximum-step-size knob, so advertising
+# MaximumStep/rtol/atol here made a downstream tool (e.g. CUFLynx) render three controls the user
+# could set with no effect and no way to tell -- the same reasoning as the notes on 'CVODE_myokit'
+# and 'aadc_semi_implicit'. They are listed again here the day the generator reads them; configs
+# that already set them are migrated with a warning, not rejected (migrate_legacy_solver_info_keys).
+_CPP_SOLVER_INFO = [
+    {'name': 'MaximumNumberOfSteps', 'type': 'int', 'default': 5000, 'required': False,
+     'description': 'Maximum number of internal integrator steps (emitted as CVODE mxsteps).'},
 ]
 
 # CVODE_myokit is deliberately NOT in that family. myokit.Simulation exposes only
@@ -293,9 +312,9 @@ _SOLVE_IVP_SOLVER_INFO = [
 SOLVER_INFO_FIELDS = {
     'CVODE_opencor': _CVODE_FAMILY_SOLVER_INFO,
     'CVODE_myokit': _MYOKIT_SOLVER_INFO,
-    'CVODE': _CVODE_FAMILY_SOLVER_INFO,
-    'RK4': _CVODE_FAMILY_SOLVER_INFO,
-    'PETSC': _CVODE_FAMILY_SOLVER_INFO,
+    'CVODE': _CPP_SOLVER_INFO,
+    'RK4': _CPP_SOLVER_INFO,
+    'PETSC': _CPP_SOLVER_INFO,
     'solve_ivp': _SOLVE_IVP_SOLVER_INFO,
     'user_defined': _SOLVE_IVP_SOLVER_INFO,
     'casadi_integrator': [
@@ -2184,6 +2203,26 @@ def migrate_legacy_solver_info_keys(solver_name, solver_info):
                 'control accuracy.',
             )
             solver_info.pop('MaximumNumberOfSteps', None)
+    elif solver_name in _CPP_SOLVERS:
+        # Nothing to migrate onto: the generated C++ takes its step from the framework key
+        # 'dt_solver' and hardcodes its tolerances. Dropping loudly beats rejecting, so a
+        # config written for a CVODE backend still runs -- it just says what stopped applying.
+        if 'MaximumStep' in solver_info:
+            _warn_dropped_solver_info_key(
+                solver_name, 'MaximumStep',
+                'The generated C++ integrates at a fixed step; use the framework key '
+                "'dt_solver' to set it.",
+            )
+            solver_info.pop('MaximumStep', None)
+        for tol_key in ('rtol', 'atol'):
+            if tol_key in solver_info:
+                _warn_dropped_solver_info_key(
+                    solver_name, tol_key,
+                    'The generated C++ currently hardcodes its tolerances '
+                    '(reltol 1e-7 / abstol 1e-9 in CVSCppGenerator), so this value would '
+                    'not reach the solver.',
+                )
+                solver_info.pop(tol_key, None)
 
     return solver_info
 

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -2412,6 +2412,13 @@ class CSVFileParser(object):
         else:
             csv_dataframe = pd.read_csv(filename, dtype=str, header=None)
 
+        # Strip the header names as well as the values. Callers address these columns by name
+        # (issue #159), so a stray space after a comma in the header row would otherwise make a
+        # column unfindable under the name the user can see in their file.
+        if has_header:
+            csv_dataframe = csv_dataframe.rename(
+                columns=lambda name: name.strip() if isinstance(name, str) else name)
+
         for column_name in csv_dataframe.columns:
             csv_dataframe[column_name] = csv_dataframe[column_name].str.strip()
 

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -4,6 +4,7 @@
 * #99  -- ``*_parameters_unfinished.csv`` must be written to the configured ``resources_dir``.
 * #155 -- the duplicated input-flow BC modules were removed from the microvasculature config.
 * #157 -- solver Make files are copied into each generated model directory.
+* #159 -- parameter CSV columns are read by header name, not by position.
 * #167 -- sensitivity-analysis plot filenames are sanitised (no ``{}``/spaces/backslashes).
 
 These are deliberately light-weight: heavy optional deps are imported inside the test bodies so a
@@ -147,3 +148,100 @@ def test_sanitize_for_filename_strips_unsafe_characters():
     assert sanitize_for_filename('***') == 'output'
     # already-safe names are preserved (dots and dashes are allowed)
     assert sanitize_for_filename('flow_rate-1.0') == 'flow_rate-1.0'
+
+
+# ---------------------------------------------------------------------------
+# #159 -- parameter CSV columns are matched by header, not by position
+# ---------------------------------------------------------------------------
+def _reduce(tmp_path, header, rows, variables_and_units=None):
+    """Run __reduce_parameters_array over a hand-written parameters CSV.
+
+    Builds the parser with __new__ so only the two attributes this method needs are set -- the
+    real __init__ would parse a whole model.
+    """
+    import pandas as pd
+    from parsers.ModelParsers import CSV0DModelParser
+    from parsers.PrimitiveParsers import CSVFileParser
+
+    csv_path = tmp_path / 'x_parameters.csv'
+    csv_path.write_text('\n'.join([header] + rows) + '\n')
+
+    if variables_and_units is None:
+        # one required constant, 'R', which gets the vessel name appended -> 'R_vessel'
+        variables_and_units = [['R', 'Js_per_m6', 'access', 'constant']]
+    vessels_df = pd.DataFrame([{'name': 'vessel',
+                                'variables_and_units': variables_and_units}])
+
+    parser = CSV0DModelParser.__new__(CSV0DModelParser)
+    parser.parameter_filename = str(csv_path)
+    parser.csv_parser = CSVFileParser()
+
+    parameters_array_orig = parser.csv_parser.get_data_as_nparray(str(csv_path), True)
+    return parser._CSV0DModelParser__reduce_parameters_array(
+        parameters_array_orig, vessels_df)
+
+
+def test_parameters_csv_extra_column_does_not_shift_the_value(tmp_path):
+    """The bug: rows were flattened into a positional list, so any column the code did not expect
+    shifted every field to its right.
+
+    resources/FTU_wCVS_parameters.csv is a real file with a 'comp_env' column between units and
+    value; before the fix its parameter values parsed as the comp_env string ('heart') and its
+    data_references as the values.
+    """
+    out = _reduce(tmp_path,
+                  'variable_name,units,comp_env,value,data_reference',
+                  ['R_vessel,Js_per_m6,heart,1333000,Blanco_2013'])
+    assert out['value'][0] == '1333000', 'the comp_env column was read as the value'
+    assert out['data_reference'][0] == 'Blanco_2013'
+    assert out['units'][0] == 'Js_per_m6'
+    assert out['const_type'][0] == 'constant'
+
+
+def test_parameters_csv_columns_may_be_in_any_order(tmp_path):
+    """Header-based reading means column order is not part of the file format."""
+    reordered = _reduce(tmp_path,
+                        'data_reference,value,variable_name,units',
+                        ['Blanco_2013,1333000,R_vessel,Js_per_m6'])
+    canonical = _reduce(tmp_path,
+                        'variable_name,units,value,data_reference',
+                        ['R_vessel,Js_per_m6,1333000,Blanco_2013'])
+    for field in ('variable_name', 'units', 'const_type', 'value', 'data_reference'):
+        assert reordered[field][0] == canonical[field][0], field
+
+
+def test_parameters_csv_header_whitespace_is_tolerated(tmp_path):
+    """A space after a comma in the header row must not make a column unfindable under the name
+    the user can see in their file."""
+    out = _reduce(tmp_path,
+                  'variable_name, units, value, data_reference',
+                  ['R_vessel,Js_per_m6,1333000,Blanco_2013'])
+    assert out['value'][0] == '1333000'
+    assert out['units'][0] == 'Js_per_m6'
+
+
+def test_parameters_csv_missing_required_column_is_reported(tmp_path):
+    """Positional reading turned a missing column into a silent EMPTY_MUST_BE_FILLED; by name it
+    is a named error."""
+    with pytest.raises(SystemExit):
+        _reduce(tmp_path,
+                'variable_name,units,value',
+                ['R_vessel,Js_per_m6,1333000'])
+
+
+def test_parameters_csv_missing_row_still_flags_it_as_unfilled(tmp_path):
+    """Unchanged behaviour: a required parameter with no row in the CSV is carried through as
+    EMPTY_MUST_BE_FILLED so the unfinished-parameters file can list it."""
+    out = _reduce(tmp_path,
+                  'variable_name,units,value,data_reference',
+                  ['something_else,Js_per_m6,1333000,Blanco_2013'])
+    assert out['variable_name'][0] == 'R_vessel'
+    assert out['value'][0] == 'EMPTY_MUST_BE_FILLED'
+
+
+def test_parameters_csv_unit_mismatch_still_exits(tmp_path):
+    """Unchanged behaviour: units that disagree with the module config are a hard error."""
+    with pytest.raises(SystemExit):
+        _reduce(tmp_path,
+                'variable_name,units,value,data_reference',
+                ['R_vessel,m3,1333000,Blanco_2013'])

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -1,3 +1,4 @@
+import ast
 import pathlib
 import warnings
 
@@ -172,51 +173,254 @@ def test_schema_settings_are_actually_read_by_the_code():
         'Either wire the option up or remove it from PARAM_ID_METHODS.')
 
 
-# Which module actually consumes each solver's solver_info. A setting must appear in *its own*
-# solver's consumer, not merely somewhere in src/: protocol_runner.py relays every key into
-# get_simulation_helper's solver_info whether or not the backend does anything with it, so a
-# repo-wide search counts a pass-through as a read (issue #330).
-_SOLVER_CONSUMERS = {
-    'CVODE_myokit': ['solver_wrappers/myokit_helper.py'],
-    'CVODE_opencor': ['solver_wrappers/opencor_helper.py'],
-    'solve_ivp': ['solver_wrappers/python_solver_helper.py'],
-    'user_defined': ['solver_wrappers/python_solver_helper.py'],
-    'casadi_integrator': ['solver_wrappers/casadi_python_solver_helper.py'],
-    # AADC settings are split: integrator knobs in the helper, gradient knobs (jac_lag,
-    # gradient_strategy) in the tape/kernel paths of aadc_backend.
-    'aadc_semi_implicit': ['solver_wrappers/aadc_python_solver_helper.py',
-                           'param_id/aadc_backend.py'],
+# ---------------------------------------------------------------------------
+# Per-solver, consumption-aware schema check (issue #330)
+# ---------------------------------------------------------------------------
+# A setting must be read by *its own* solver's backend, not merely appear somewhere in src/:
+# protocol_runner.py relays every key into get_simulation_helper's solver_info whether or not the
+# backend does anything with it, so a repo-wide substring search counts a pass-through as a read.
+#
+# The solver -> backend-module mapping below is DERIVED from get_simulation_helper's own dispatch
+# rather than hand-written. A hand-maintained map is the very failure mode this check exists to
+# prevent: it drifts silently, and a solver whose entry went stale gets checked against the wrong
+# file -- or, if its entry is simply missing, is not checked at all.
+
+_SRC_DIR = pathlib.Path(__file__).resolve().parent.parent / 'src'
+_RELAY_FILES = ('protocol_runners/protocol_runner.py', 'parsers/PrimitiveParsers.py')
+
+# Genuine cross-module consumers, listed explicitly because they are not reachable from the
+# factory's dispatch. Keep this list short and justified -- every entry is a hole in the
+# derivation.
+_EXTRA_CONSUMERS = {
+    # AADC's settings are split: the integrator knobs are read by the helper the factory returns,
+    # but the gradient knobs (jac_lag, gradient_strategy) are read by the tape/kernel gradient
+    # paths, which the forward-solve helper never touches.
+    'aadc_semi_implicit': ['param_id/aadc_backend.py'],
 }
 
-_RELAY_FILES = ('protocol_runners/protocol_runner.py', 'parsers/PrimitiveParsers.py')
+# Solvers with no Python backend at all, so the factory has nothing to dispatch to. cpp models are
+# never run through a SimulationHelper: solver_info is baked into the emitted C++ by the cpp branch
+# of script_generate_with_new_architecture, which hands the values to CVSCppGenerator. Those two
+# files are therefore the real consumer, and the fields are checked against them exactly as a
+# helper module would be -- this is a different consumer, not an exemption.
+_GENERATED_CODE_CONSUMERS = {
+    solver: ['scripts/script_generate_with_new_architecture.py',
+             'generators/CVSCppGenerator.py']
+    for solver in ('CVODE', 'RK4', 'PETSC')
+}
+
+
+def _import_aliases(tree):
+    """{local alias: src-relative module path} for `from x.y import Z as Alias` imports."""
+    aliases = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for name in node.names:
+                if name.asname:
+                    aliases[name.asname] = node.module.replace('.', '/') + '.py'
+    return aliases
+
+
+def _local_string_lists(func):
+    """{var: [strings]} for `name = ['a', 'b']` assignments inside `func`.
+
+    The dispatch tests membership against these (`solver in casadi_solvers`), so resolving them
+    is what lets the derivation see solvers that are not compared to a literal.
+    """
+    out = {}
+    for node in ast.walk(func):
+        if isinstance(node, ast.Assign) and isinstance(node.value, (ast.List, ast.Tuple)):
+            values = [e.value for e in node.value.elts
+                      if isinstance(e, ast.Constant) and isinstance(e.value, str)]
+            if values and len(values) == len(node.value.elts):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        out[target.id] = values
+    return out
+
+
+def _derive_solver_consumers():
+    """Read solver -> backend module out of `get_simulation_helper`'s if/elif dispatch."""
+    factory_path = _SRC_DIR / 'solver_wrappers' / '__init__.py'
+    tree = ast.parse(factory_path.read_text())
+    aliases = _import_aliases(tree)
+    func = next(n for n in ast.walk(tree)
+                if isinstance(n, ast.FunctionDef) and n.name == 'get_simulation_helper')
+    string_lists = _local_string_lists(func)
+
+    def solvers_matched_by(test):
+        """The solver names a branch condition selects (`== 'x'` or `in some_list`)."""
+        names = []
+        for node in ast.walk(test):
+            if not isinstance(node, ast.Compare):
+                continue
+            if not (isinstance(node.left, ast.Name) and node.left.id == 'solver'):
+                continue
+            for op, comparator in zip(node.ops, node.comparators):
+                if isinstance(op, ast.Eq) and isinstance(comparator, ast.Constant):
+                    names.append(comparator.value)
+                elif isinstance(op, ast.In):
+                    if isinstance(comparator, ast.Name):
+                        names.extend(string_lists.get(comparator.id, []))
+                    elif isinstance(comparator, (ast.List, ast.Tuple)):
+                        names.extend(e.value for e in comparator.elts
+                                     if isinstance(e, ast.Constant))
+        return names
+
+    def modules_returned_by(body):
+        """The helper modules a branch constructs and returns."""
+        modules = []
+        for stmt in body:
+            for node in ast.walk(stmt):
+                if isinstance(node, ast.Return) and isinstance(node.value, ast.Call) \
+                        and isinstance(node.value.func, ast.Name) \
+                        and node.value.func.id in aliases:
+                    modules.append(aliases[node.value.func.id])
+        return modules
+
+    consumers = {}
+
+    def walk_chain(statements):
+        for stmt in statements:
+            if isinstance(stmt, ast.If):
+                modules = modules_returned_by(stmt.body)
+                for solver in solvers_matched_by(stmt.test):
+                    for module in modules:
+                        consumers.setdefault(solver, [])
+                        if module not in consumers[solver]:
+                            consumers[solver].append(module)
+                walk_chain(stmt.orelse)  # the elif chain
+
+    walk_chain(func.body)
+    return consumers
+
+
+def _setting_names_read(source):
+    """String constants used as a *setting name* in `source`, via the AST rather than a substring
+    search.
+
+    A substring search over the file text counts a name that only appears in a docstring, a
+    comment or an error message -- myokit_helper's own docstring lists 'Key supported solver_info
+    keys', which would vouch for a key nothing reads. Only these positions count:
+
+      solver_info['x'] / opts['x'] = ...     subscript
+      solver_info.get('x') / .pop('x')       lookup
+      'x' in solver_info                     membership
+      key == 'x'                             the translating forwarders (rtol -> RelativeTolerance)
+      [... 'x' ...] / {'x': default}         key allow-lists and default blocks
+
+    Comments and docstrings are not any of these, so they stop counting as evidence.
+    """
+    names = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Constant) \
+                and isinstance(node.slice.value, str):
+            names.add(node.slice.value)
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
+                and node.func.attr in ('get', 'pop') and node.args \
+                and isinstance(node.args[0], ast.Constant) \
+                and isinstance(node.args[0].value, str):
+            names.add(node.args[0].value)
+        elif isinstance(node, ast.Compare):
+            for op, comparator in zip(node.ops, node.comparators):
+                if isinstance(op, (ast.In, ast.NotIn)) and isinstance(node.left, ast.Constant) \
+                        and isinstance(node.left.value, str):
+                    names.add(node.left.value)
+                elif isinstance(op, ast.Eq):
+                    for side in (node.left, comparator):
+                        if isinstance(side, ast.Constant) and isinstance(side.value, str):
+                            names.add(side.value)
+        elif isinstance(node, ast.Dict):
+            for key in node.keys:
+                if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                    names.add(key.value)
+        elif isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+            for element in node.elts:
+                if isinstance(element, ast.Constant) and isinstance(element.value, str):
+                    names.add(element.value)
+    return names
+
+
+def _consumers_by_solver():
+    """The full solver -> consumer-module map: derived, plus the two documented additions."""
+    consumers = {solver: list(modules)
+                 for solver, modules in _derive_solver_consumers().items()}
+    for solver, extra in _EXTRA_CONSUMERS.items():
+        consumers.setdefault(solver, []).extend(extra)
+    for solver, modules in _GENERATED_CODE_CONSUMERS.items():
+        consumers.setdefault(solver, []).extend(modules)
+    return consumers
+
+
+@pytest.mark.unit
+def test_solver_consumer_map_is_derived_from_the_factory_dispatch():
+    """Guard on the derivation itself.
+
+    If get_simulation_helper is restructured so the AST walk stops recognising its dispatch, the
+    map silently empties and every per-solver check below passes vacuously. Pin that the
+    derivation still finds each solver the factory really dispatches, and that it resolves to the
+    backend that solver actually uses.
+    """
+    derived = _derive_solver_consumers()
+    assert derived, ('the dispatch in get_simulation_helper could not be read; '
+                     'test_each_solver_setting_is_read_by_that_solvers_consumer would pass '
+                     'vacuously')
+    # Spot-check the two shapes the dispatch uses: `solver == 'x'` and `solver in some_list`.
+    assert derived['CVODE_myokit'] == ['solver_wrappers/myokit_helper.py']
+    assert derived['casadi_integrator'] == ['solver_wrappers/casadi_python_solver_helper.py']
+    # user_defined is dispatched via a list and shares the scipy helper with solve_ivp.
+    assert derived['user_defined'] == derived['solve_ivp'] \
+        == ['solver_wrappers/python_solver_helper.py']
+    for solver, modules in derived.items():
+        assert solver in SOLVER_INFO_FIELDS, (
+            'get_simulation_helper dispatches solver ' + solver + ' but SOLVER_INFO_FIELDS does '
+            'not declare its settings, so a front-end cannot build its form')
+        for module in modules:
+            assert (_SRC_DIR / module).exists(), module
+
+
+@pytest.mark.unit
+def test_every_advertised_solver_has_a_consumer_to_check_against():
+    """No solver may sit outside the check.
+
+    Before #330 the cpp solvers were exempt, which is how they came to advertise MaximumStep,
+    rtol and atol that the generated C++ never reads. An unmapped solver is not a small gap: it
+    is a solver whose entire settings form is unverified.
+    """
+    unmapped = sorted(set(SOLVER_INFO_FIELDS) - set(_consumers_by_solver()))
+    assert not unmapped, (
+        'solvers advertising settings with no consumer to check them against: ' + str(unmapped)
+        + '. Add the backend to get_simulation_helper (preferred, since the map is derived from '
+        'it), or record the consumer in _EXTRA_CONSUMERS / _GENERATED_CODE_CONSUMERS with a '
+        'comment saying why the derivation cannot see it.')
 
 
 @pytest.mark.unit
 def test_each_solver_setting_is_read_by_that_solvers_consumer():
-    """Per-solver, consumption-aware version of the check above (issue #330).
+    """Per-solver, consumption-aware version of the repo-wide check above (issue #330).
 
     A solver_info setting is CUFLynx's contract: it renders a control for it. If the backend that
     owns the solver never reads the key, the user gets a control that silently does nothing --
     and the repo-wide check cannot see that, because it only asks whether the *name* appears
     anywhere in src/, and every key appears in the relay in protocol_runner.py. That is how
-    CVODE_myokit came to advertise MaximumNumberOfSteps: myokit.Simulation exposes only
-    set_max_step_size / set_min_step_size / set_tolerance, so the value went nowhere.
+    CVODE_myokit came to advertise MaximumNumberOfSteps (myokit.Simulation exposes only
+    set_max_step_size / set_min_step_size / set_tolerance) and how the cpp solvers came to
+    advertise MaximumStep/rtol/atol (the emitted C++ hardcodes its tolerances and steps at
+    dt_solver).
 
-    The cpp solvers (CVODE/RK4/PETSC) are deliberately not mapped: their solver_info is consumed
-    by generated C++ rather than a Python backend, so there is no module to grep. They remain
-    covered by the repo-wide check only, and that gap is recorded here rather than hidden.
+    CVODE_opencor forwards solver_info wholesale into OpenCOR's odeSolverProperties() instead of
+    reading each key by name, so its evidence is the alias branches (rtol -> RelativeTolerance)
+    and its default block rather than four separate lookups. That is still a read of the name in
+    code, which is what _setting_names_read requires.
     """
-    src_dir = pathlib.Path(__file__).resolve().parent.parent / 'src'
-
     phantom = {}
-    for solver, consumers in _SOLVER_CONSUMERS.items():
-        text = ''
+    for solver, consumers in _consumers_by_solver().items():
+        read = set()
         for rel in consumers:
-            path = src_dir / rel
+            path = _SRC_DIR / rel
             assert path.exists(), 'consumer file missing for ' + solver + ': ' + rel
-            text += path.read_text(errors='ignore')
-        missing = [f['name'] for f in SOLVER_INFO_FIELDS[solver]
-                   if '"' + f['name'] + '"' not in text and "'" + f['name'] + "'" not in text]
+            read |= _setting_names_read(path.read_text(errors='ignore'))
+        missing = [f['name'] for f in SOLVER_INFO_FIELDS[solver] if f['name'] not in read]
         if missing:
             phantom[solver] = missing
 
@@ -229,12 +433,40 @@ def test_each_solver_setting_is_read_by_that_solvers_consumer():
 
 @pytest.mark.unit
 def test_the_relay_does_not_count_as_reading_a_setting():
-    """Guard on the guard: if protocol_runner ever became a mapped consumer, the per-solver check
-    above would silently degrade back into the repo-wide one it replaced."""
+    """Guard on the guard: if a relay ever became a mapped consumer, the per-solver check above
+    would silently degrade back into the repo-wide one it replaced.
+
+    protocol_runner.py setdefault()s every key into the solver_info it forwards, so it mentions
+    all of them while consuming none.
+    """
     for relay in _RELAY_FILES:
-        for consumers in _SOLVER_CONSUMERS.values():
+        for solver, consumers in _consumers_by_solver().items():
             assert relay not in consumers, (
-                relay + ' relays solver_info wholesale and must never be treated as a consumer')
+                relay + ' relays solver_info wholesale and must never be treated as a consumer '
+                '(mapped for ' + solver + ')')
+
+
+@pytest.mark.unit
+def test_a_setting_named_only_in_prose_does_not_count_as_read():
+    """The second gap #330 records: the old check was a substring search over the file text, so a
+    key mentioned in a docstring, a comment or an error message vouched for itself."""
+    prose_only = '''
+"""MaximumNumberOfSteps is supported by this backend."""
+# MaximumStep is also mentioned here
+def run(solver_info):
+    raise ValueError("set rtol to fix this")
+'''
+    assert _setting_names_read(prose_only) == set()
+
+    genuinely_read = '''
+def run(solver_info):
+    a = solver_info["MaximumStep"]
+    b = solver_info.get("rtol")
+    if "atol" in solver_info:
+        pass
+    return a, b
+'''
+    assert {'MaximumStep', 'rtol', 'atol'} <= _setting_names_read(genuinely_read)
 
 
 def test_analysis_options_schema_well_formed():
@@ -470,12 +702,45 @@ def test_myokit_rejects_maximum_number_of_steps_after_migration():
 
 
 def test_cpp_rk4_accepts_maximum_number_of_steps():
+    """MaximumNumberOfSteps is the one integrator key the cpp path really forwards: the generate
+    script reads it and CVSCppGenerator emits it as CVODE's mxsteps."""
     validate_solver_info('RK4', {
         'solver': 'RK4',
         'method': 'RK4',
-        'MaximumStep': 0.001,
+        'dt_solver': 1e-4,
         'MaximumNumberOfSteps': 5000,
     })
+
+
+@pytest.mark.parametrize('solver', ['CVODE', 'RK4', 'PETSC'])
+def test_cpp_solvers_reject_settings_the_generated_code_never_reads(solver):
+    """The generated C++ steps at dt_solver and hardcodes reltol 1e-7 / abstol 1e-9, so
+    MaximumStep/rtol/atol reached nothing. Advertising them made CUFLynx draw three dead
+    controls (issue #330)."""
+    for dead_key, value in [('MaximumStep', 0.001), ('rtol', 1e-8), ('atol', 1e-8)]:
+        with pytest.raises(ValueError, match=dead_key):
+            validate_solver_info(solver, {'solver': solver, dead_key: value})
+
+
+@pytest.mark.parametrize('solver', ['CVODE', 'RK4', 'PETSC'])
+def test_cpp_legacy_tolerance_keys_are_migrated_with_a_warning_not_rejected(solver, capsys):
+    """A config written for a CVODE backend must keep running -- it just has to say which of its
+    settings stopped applying, rather than failing validation on the way in."""
+    migrated = migrate_legacy_solver_info_keys(solver, {
+        'solver': solver,
+        'dt_solver': 1e-4,
+        'MaximumStep': 0.001,
+        'MaximumNumberOfSteps': 5000,
+        'rtol': 1e-8,
+        'atol': 1e-8,
+    })
+    assert set(migrated) == {'solver', 'dt_solver', 'MaximumNumberOfSteps'}
+    validate_solver_info(solver, migrated)  # the migrated config is accepted
+
+    warned = capsys.readouterr().out
+    for dropped in ('MaximumStep', 'rtol', 'atol'):
+        assert dropped in warned, dropped + ' was dropped silently'
+    assert 'dt_solver' in warned, 'the MaximumStep warning should name the setting to use instead'
 
 
 def test_solve_ivp_rejects_maximum_step_keys():


### PR DESCRIPTION
Closes #330. Closes #159.

Two independent fixes, both in the parsers, kept in one PR because they are small and touch adjacent files.

## #330 — the schema-vs-code check was still not per-solver in the way the issue asked

The per-solver check landed already, but with the two gaps the issue named:

**1. The solver → backend-module map was hand-written.** That is the failure mode the check exists to prevent: it drifts silently, and a solver whose entry goes stale gets checked against the wrong file — or, if the entry is simply missing, is not checked at all. It is now **derived** by reading `get_simulation_helper`'s own `if/elif` dispatch (AST walk resolving both `solver == 'x'` and `solver in some_list`), so adding a backend to the factory wires it into the check for free.

Two documented additions remain, each with a comment saying why the derivation cannot see it:
- `aadc_semi_implicit` → `param_id/aadc_backend.py` (gradient knobs are read by the tape/kernel paths, not the forward-solve helper)
- the cpp solvers → the generate script + `CVSCppGenerator` (no Python backend exists to dispatch to)

**2. "Read" was a substring search over the file text**, so a key named only in a docstring, a comment or an error message vouched for itself — `myokit_helper`'s own docstring lists supported `solver_info` keys. It is now an AST walk counting only genuine setting-name positions: subscript, `.get`/`.pop`, membership, an equality branch (the translating forwarders, `rtol` → `RelativeTolerance`), and key allow-lists / default blocks.

### Closing the cpp exemption surfaced three phantom settings

The cpp solvers were previously exempt, and that is exactly how they came to advertise settings nothing reads. The emitted C++ steps at `dt_solver` and **hardcodes its tolerances**:

```c
sunrealtype reltol = 1e-7; // TODO get this from user_inputs.yaml too
sunrealtype abstol = 1e-9; // TODO get this from user_inputs.yaml too
```

So `MaximumStep`, `rtol` and `atol` reached nothing while CUFLynx rendered a control for each. `CVODE`/`RK4`/`PETSC` now advertise only `MaximumNumberOfSteps` — the one integrator key the generate script really forwards, as CVODE's `mxsteps`. They go back the day the generator reads them.

Existing configs are **migrated with a warning naming what stopped applying, not rejected** — the same treatment #329 gave `CVODE_myokit`:

```
WARNING: solver_info key 'MaximumStep' is not supported by solver 'RK4' and was ignored.
The generated C++ integrates at a fixed step; use the framework key 'dt_solver' to set it.
```

### New guards

- the derivation must still recognise the dispatch, or every per-solver check would pass vacuously
- every advertised solver must have a consumer to check against (no silent exemptions)
- a relay may never be treated as a consumer
- a setting named only in prose does not count as read

## #159 — parameters.csv was read by column position

`__reduce_parameters_array` flattened each row of the structured array into a positional list:

```python
new_entry = [item for item in new_entry]
if new_entry[1] != param_tuple[1]:      # "units"
new_entry.insert(2, param_tuple[2])
parameters_array['value'] = np.array(parameters_list)[:, 3]
```

The fields of that array are the CSV's own headers **in the CSV's own order**, so any extra column shifted every field to its right.

`resources/FTU_wCVS_parameters.csv` is a shipped file with a `comp_env` column between `units` and `value`. Its parameters parsed as:

| field | parsed | should be |
|---|---|---|
| value | `heart` | `1050` |
| data_reference | `1050` | `known` |

Nothing raised — the row still had a plausible shape, so a model would be built from component-name strings in place of numbers. A column count that ended up inconsistent instead hit the generic `parameters rows are of non consistent length` exit, which does not say why.

Rows are now addressed by name, so **column order stops being part of the file format** and extra columns are ignored. Missing required columns are named in the error rather than becoming `EMPTY_MUST_BE_FILLED` or an `IndexError`, and `get_data_as_dataframe` strips header names as well as values so `variable_name, units` in a header row still resolves under the name the user can see.

The bare `except:` around the row lookup is narrowed to the empty-match case it was really guarding — that catch-all is what swallowed the units-mismatch `exit()` and forced the `actually_exit` re-raise dance.

## Tests

Six new tests in `tests/test_issue_fixes.py` for #159; three of them fail before the fix (extra column corrupts the value, reordered columns exit, missing column raises `IndexError`) and three pin unchanged behaviour (missing row → `EMPTY_MUST_BE_FILLED`, unit mismatch → exit, header whitespace tolerated). Four new tests in `tests/test_solver_info_validation.py` for #330, plus parametrised cpp migration/validation coverage.

Verified `not slow and not compare_optimisers`: 587 passed, 1 failed. The failure is `test_python_BDF_solver[SN_simple]`, which is the known SN-under-libCellML-Analyser limitation (#151, recorded in CLAUDE.md) and fails identically on this branch with the source changes stashed.
