### PR TITLE
fix(cpp): emit solver_info rtol/atol into the generated C++ (#398)

### DIFF
--- a/src/generators/CVSCppGenerator.py
+++ b/src/generators/CVSCppGenerator.py
@@ -44,8 +44,9 @@ class CVS0DCppGenerator(object):
     '''
 
 
-    def __init__(self, model, generated_model_subdir, file_prefix, resources_dir=None, 
+    def __init__(self, model, generated_model_subdir, file_prefix, resources_dir=None,
                  solver='CVODE', dtSample=1e-3, dtSolver=1e-4, nMaxSteps=5000,
+                 reltol=1e-7, abstol=1e-9,
                  couple_to_1d=False, cpp_generated_models_dir=None,
                  model_1d_config_path=None, create_main_0d=False,
                  conn_1d_0d_info=None, DEBUG=False):
@@ -110,6 +111,12 @@ class CVS0DCppGenerator(object):
         self.dtSample = dtSample
         self.dtSolver = dtSolver
         self.nMaxSteps = nMaxSteps
+        # solver_info's rtol/atol, emitted into the generated C++ (issue #398). They used to be
+        # literals in the emitted source, so a cpp user could only change the accuracy of a run by
+        # hand-editing generated code -- and the schema advertised rtol/atol settings that reached
+        # nothing.
+        self.reltol = reltol
+        self.abstol = abstol
 
         # these are for delayed variables
         self.variables_to_delay = []
@@ -681,6 +688,204 @@ class CVS0DCppGenerator(object):
         # This is for if we want to use a cellml file that it already annotated, i.e, one we didn't annotate.
         # TODO TEST THIS
         self.annotated_model_file_path = annotated_model_file_path
+
+    def _build_solver_init_function(self):
+        """The generated `Model0d::set_ode_solver` body, as source text.
+
+        Split out of generate_cpp so the emitted solver configuration can be checked without
+        generating a whole model: the tolerances it writes are user settings (issue #398), and
+        a setting is only real if it reaches the code that runs.
+        """
+        solverInitFunction = """ 
+void Model0d::set_ode_solver(std::string ODEsolver)
+{
+    solver_0d = ODEsolver;
+    """
+
+        if self.solver == 'CVODE':
+            solverInitFunction += f"""
+    // Create our SUNDIALS context object.
+    SUNContext_Create(SUN_COMM_NULL, &context);
+    // Create our CVODE solver.
+    solver = CVodeCreate(CV_BDF, context);
+    // Initialise our CVODE solver.
+    y = N_VMake_Serial(STATE_COUNT, states, context);
+    CVodeInit(solver, func, voi, y);
+    // Set our user data.
+    userData = new UserOdeData(variables, std::bind(&Model0d::computeRates, this, std::placeholders::_1, 
+                                                    std::placeholders::_2, std::placeholders::_3, 
+                                                    std::placeholders::_4, std::placeholders::_5), solver);
+    CVodeSetUserData(solver, userData);
+    // Set our maximum number of internal steps (default 500).
+    long int mxsteps = {self.nMaxSteps};
+    CVodeSetMaxNumSteps(solver, mxsteps);
+    // Set our maximum absolute step size.
+    sunrealtype hmax = {self.dtSolver};
+    CVodeSetMaxStep(solver, hmax);
+    // Set our linear solver.
+    // Create matrix object.
+    matrix = SUNDenseMatrix(STATE_COUNT, STATE_COUNT, context);
+    // Create linear solver object.
+    linearSolver = SUNLinSol_Dense(y, matrix, context);
+    // Attach linear solver module
+    CVodeSetLinearSolver(solver, linearSolver, matrix);
+    // Set our scalar relative and absolute tolerances (solver_info rtol/atol).
+    sunrealtype reltol = {self.reltol};
+    sunrealtype abstol = {self.abstol};
+    CVodeSStolerances(solver, reltol, abstol);
+"""
+        elif self.solver == 'PETSC':
+            solverInitFunction += f"""
+    // Set up PETSc TS ODE solver (fixed-step for now)
+    PetscErrorCode ierr;
+
+    // Create solution vector
+    ierr = VecCreate(PETSC_COMM_WORLD, &y);
+    std::cout << "set_ode_solver :: VecCreate "<< ierr << std::endl;
+    ierr = VecSetSizes(y, PETSC_DECIDE, STATE_COUNT);
+    std::cout << "set_ode_solver :: VecSetSizes "<< ierr << std::endl;
+    ierr = VecSetFromOptions(y);
+    std::cout << "set_ode_solver :: VecSetFromOptions "<< ierr << std::endl;
+
+    // Create TS
+    ierr = TSCreate(PETSC_COMM_WORLD, &ts); // create the timestepper (TS) object
+    std::cout << "set_ode_solver :: TSCreate "<< ierr << std::endl;
+    ierr = TSSetProblemType(ts, TS_NONLINEAR); // TSProblemType is one of TS_LINEAR or TS_NONLINEAR
+    std::cout << "set_ode_solver :: TSSetProblemType "<< ierr << std::endl;
+    ierr = TSSetRHSFunction(ts, NULL, TSRHSfunc, this); // set the RHS function
+    // 'this' --> pointer to your Model0d object; PETSc stores it, so that every time it calls TSRHSfunc, it passes that same pointer as ctx.
+    std::cout << "set_ode_solver :: TSSetRHSFunction "<< ierr << std::endl;
+    ierr = TSSetSolution(ts, y);
+    std::cout << "set_ode_solver :: TSSetSolution "<< ierr << std::endl; 
+
+
+#ifdef SOLVER_CN
+    ierr = TSSetType(ts, TSCN); // set the solution method: Crank-Nicolson
+    std::cout << "set_ode_solver :: TSSetType "<< ierr << std::endl;
+    ierr = TSSetTimeStep(ts, {self.dtSolver}); // set the initial time step
+    std::cout << "set_ode_solver :: TSSetTimeStep "<< ierr << std::endl;
+    ierr = TSSetMaxSteps(ts, 10000000000000); // maximum number of time steps
+    std::cout << "set_ode_solver :: TSSetMaxSteps "<< ierr << std::endl;
+    // ierr = TSSetMaxTime(ts, 10.);
+    // std::cout << "set_ode_solver :: TSSetMaxTime "<< ierr << std::endl;
+    // No other options needed
+#endif
+
+#ifdef SOLVER_BDF1
+    ierr = TSSetType(ts, TSBDF); // set the solution method: backward differentiation formula (BDF)
+    std::cout << "set_ode_solver :: TSSetType "<< ierr << std::endl;
+    ierr = TSBDFSetOrder(ts, 1);
+    std::cout << "set_ode_solver :: TSBDFSetOrder "<< ierr << std::endl;
+    ierr = TSSetTimeStep(ts, {self.dtSolver}); // set the initial time step
+    std::cout << "set_ode_solver :: TSSetTimeStep "<< ierr << std::endl;
+    ierr = TSSetMaxSteps(ts, 10000000000000); // maximum number of time steps
+    std::cout << "set_ode_solver :: TSSetMaxSteps "<< ierr << std::endl;
+    // ierr = TSSetMaxTime(ts, 10.);
+    // std::cout << "set_ode_solver :: TSSetMaxTime "<< ierr << std::endl;
+
+    // Options for matrix-free BDF1
+    PetscOptionsSetValue(NULL, "-ts_adapt_type", "none");
+    PetscOptionsSetValue(NULL, "-ts_bdf_single_jacobian", NULL);
+    PetscOptionsSetValue(NULL, "-snes_mf_operator", NULL);
+#endif
+
+#ifdef SOLVER_BDF2
+    ierr = TSSetType(ts, TSBDF); // set the solution method: backward differentiation formula (BDF)
+    std::cout << "set_ode_solver :: TSSetType "<< ierr << std::endl;
+    ierr = TSBDFSetOrder(ts, 2);
+    std::cout << "set_ode_solver :: TSBDFSetOrder "<< ierr << std::endl;
+    ierr = TSSetTimeStep(ts, {self.dtSolver}); // set the initial time step
+    std::cout << "set_ode_solver :: TSSetTimeStep "<< ierr << std::endl;
+    ierr = TSSetMaxSteps(ts, 10000000000000); // maximum number of time steps
+    std::cout << "set_ode_solver :: TSSetMaxSteps "<< ierr << std::endl;
+    // ierr = TSSetMaxTime(ts, 10.);
+    // std::cout << "set_ode_solver :: TSSetMaxTime "<< ierr << std::endl;
+
+    // Options for matrix-free BDF2
+    PetscOptionsSetValue(NULL, "-ts_adapt_type", "none");
+    PetscOptionsSetValue(NULL, "-ts_bdf_single_jacobian", NULL);
+    PetscOptionsSetValue(NULL, "-snes_mf_operator", NULL);
+#endif 
+
+    // Tolerances
+    // in order: scalar absolute tolerances, vector of absolute tolerances, scalar relative tolerances, vector of relative tolerances
+    // (solver_info rtol/atol)
+    double reltol = {self.reltol};
+    double abstol = {self.abstol};
+    ierr = TSSetTolerances(ts, abstol, NULL, reltol, NULL);
+    std::cout << "set_ode_solver :: TSSetTolerances "<< ierr << std::endl;
+
+    // Nonlinear solver
+    ierr = TSGetSNES(ts, &snes); // return the SNES (nonlinear solver) associated with the TS (timestepper) context (valid only for nonlinear problems)
+    std::cout << "set_ode_solver :: TSGetSNES "<< ierr << std::endl;
+    ierr = SNESSetType(snes, SNESNEWTONLS); // set the algorithm/method to be used to solve the nonlinear system with the given SNES
+    std::cout << "set_ode_solver :: SNESSetType "<< ierr << std::endl;
+
+    // Linear solver (dense)
+    ierr = SNESGetKSP(snes, &ksp); // return the KSP (linear solver) context for the SNES solver
+    std::cout << "set_ode_solver :: SNESGetKSP "<< ierr << std::endl;
+    ierr = KSPSetType(ksp, KSPGMRES); // GMRES // set the algorithm/method to be used to solve the linear system with the given KSP
+    // ierr = KSPSetType(ksp, KSPFGMRES); // flexible GMRES
+    // ierr = KSPSetType(ksp, KSPPREONLY); // KSPPREONLY: method that applies ONLY the preconditioner exactly once.
+    std::cout << "set_ode_solver :: KSPSetType "<< ierr << std::endl;
+
+    // Preconditioner
+    ierr = KSPGetPC(ksp, &pc); // return a pointer to the preconditioner (PC) context with the KSP
+    std::cout << "set_ode_solver :: KSPGetPC "<< ierr << std::endl;
+
+    // Build PC for a particular preconditioner type
+#ifdef SOLVER_CN
+    // ierr = PCSetType(pc, PCNONE);
+    // ierr = PCSetType(pc, PCJACOBI); // PCJACOBI: Jacobi, i.e. diagonal scaling preconditioning.
+    // ierr = PCSetType(pc, PCLU); // PCLU: this uses a direct solver, based on LU factorization, as a preconditioner.
+    ierr = PCSetType(pc, PCILU);
+    std::cout << "set_ode_solver :: PCSetType "<< ierr << std::endl;
+#endif 
+
+#ifdef SOLVER_BDF1
+    // ierr = PCSetType(pc, PCNONE);
+    ierr = PCSetType(pc, PCJACOBI); // PCJACOBI: Jacobi, i.e. diagonal scaling preconditioning.
+    // ierr = PCSetType(pc, PCLU); // PCLU: this uses a direct solver, based on LU factorization, as a preconditioner.
+    std::cout << "set_ode_solver :: PCSetType "<< ierr << std::endl;
+#endif
+
+#ifdef SOLVER_BDF2
+    // ierr = PCSetType(pc, PCNONE);
+    ierr = PCSetType(pc, PCJACOBI); // PCJACOBI: Jacobi, i.e. diagonal scaling preconditioning.
+    // ierr = PCSetType(pc, PCLU); // PCLU: this uses a direct solver, based on LU factorization, as a preconditioner.
+    std::cout << "set_ode_solver :: PCSetType "<< ierr << std::endl;
+#endif
+
+    ierr = TSSetFromOptions(ts); // set various TS parameters from the options database
+    std::cout << "set_ode_solver :: TSSetFromOptions "<< ierr << std::endl;
+    ierr = TSSetUp(ts); // set up the internal data structures for the later use of TS
+    std::cout << "set_ode_solver :: TSSetUp "<< ierr << std::endl;
+
+    // User data
+    userData = new UserOdeData(variables, std::bind(&Model0d::computeRates, this,
+        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+        std::placeholders::_4, std::placeholders::_5));
+    userData->tOld = voi;
+
+"""
+        else:
+            solverInitFunction += """
+    states0 = createStatesArray(); // store initial state, before evolving to the next time level
+    k1 = createStatesArray(); // same size as states, should really be different function
+    k2 = createStatesArray(); // same size as states, should really be different function
+    k3 = createStatesArray(); // same size as states, should really be different function
+    k4 = createStatesArray(); // same size as states, should really be different function
+    // Runge-Kutta 4 weights
+    wRK4[0] = 1./6.;
+    wRK4[1] = 1./3.;
+    wRK4[2] = 1./3.;
+    wRK4[3] = 1./6.;
+"""
+        solverInitFunction += """
+}
+"""
+        return solverInitFunction
+
 
     def generate_cpp(self):
 
@@ -2010,193 +2215,7 @@ Model0d::Model0d() :
         # print(postClassInit) 
 
 
-        solverInitFunction = """ 
-void Model0d::set_ode_solver(std::string ODEsolver)
-{
-    solver_0d = ODEsolver;
-    """
-
-        if self.solver == 'CVODE':
-            solverInitFunction += f"""
-    // Create our SUNDIALS context object.
-    SUNContext_Create(SUN_COMM_NULL, &context);
-    // Create our CVODE solver.
-    solver = CVodeCreate(CV_BDF, context);
-    // Initialise our CVODE solver.
-    y = N_VMake_Serial(STATE_COUNT, states, context);
-    CVodeInit(solver, func, voi, y);
-    // Set our user data.
-    userData = new UserOdeData(variables, std::bind(&Model0d::computeRates, this, std::placeholders::_1, 
-                                                    std::placeholders::_2, std::placeholders::_3, 
-                                                    std::placeholders::_4, std::placeholders::_5), solver);
-    CVodeSetUserData(solver, userData);
-    // Set our maximum number of internal steps (default 500).
-    long int mxsteps = {self.nMaxSteps};
-    CVodeSetMaxNumSteps(solver, mxsteps);
-    // Set our maximum absolute step size.
-    sunrealtype hmax = {self.dtSolver};
-    CVodeSetMaxStep(solver, hmax);
-    // Set our linear solver.
-    // Create matrix object.
-    matrix = SUNDenseMatrix(STATE_COUNT, STATE_COUNT, context);
-    // Create linear solver object.
-    linearSolver = SUNLinSol_Dense(y, matrix, context);
-    // Attach linear solver module
-    CVodeSetLinearSolver(solver, linearSolver, matrix);
-    // Set our scalar relative and absolute tolerances.
-    sunrealtype reltol = 1e-7; // TODO get this from user_inputs.yaml too
-    sunrealtype abstol = 1e-9; // TODO get this from user_inputs.yaml too
-    CVodeSStolerances(solver, reltol, abstol); 
-"""
-        elif self.solver == 'PETSC':
-            solverInitFunction += f"""
-    // Set up PETSc TS ODE solver (fixed-step for now)
-    PetscErrorCode ierr;
-
-    // Create solution vector
-    ierr = VecCreate(PETSC_COMM_WORLD, &y);
-    std::cout << "set_ode_solver :: VecCreate "<< ierr << std::endl;
-    ierr = VecSetSizes(y, PETSC_DECIDE, STATE_COUNT);
-    std::cout << "set_ode_solver :: VecSetSizes "<< ierr << std::endl;
-    ierr = VecSetFromOptions(y);
-    std::cout << "set_ode_solver :: VecSetFromOptions "<< ierr << std::endl;
-
-    // Create TS
-    ierr = TSCreate(PETSC_COMM_WORLD, &ts); // create the timestepper (TS) object
-    std::cout << "set_ode_solver :: TSCreate "<< ierr << std::endl;
-    ierr = TSSetProblemType(ts, TS_NONLINEAR); // TSProblemType is one of TS_LINEAR or TS_NONLINEAR
-    std::cout << "set_ode_solver :: TSSetProblemType "<< ierr << std::endl;
-    ierr = TSSetRHSFunction(ts, NULL, TSRHSfunc, this); // set the RHS function
-    // 'this' --> pointer to your Model0d object; PETSc stores it, so that every time it calls TSRHSfunc, it passes that same pointer as ctx.
-    std::cout << "set_ode_solver :: TSSetRHSFunction "<< ierr << std::endl;
-    ierr = TSSetSolution(ts, y);
-    std::cout << "set_ode_solver :: TSSetSolution "<< ierr << std::endl; 
-
-
-#ifdef SOLVER_CN
-    ierr = TSSetType(ts, TSCN); // set the solution method: Crank-Nicolson
-    std::cout << "set_ode_solver :: TSSetType "<< ierr << std::endl;
-    ierr = TSSetTimeStep(ts, {self.dtSolver}); // set the initial time step
-    std::cout << "set_ode_solver :: TSSetTimeStep "<< ierr << std::endl;
-    ierr = TSSetMaxSteps(ts, 10000000000000); // maximum number of time steps
-    std::cout << "set_ode_solver :: TSSetMaxSteps "<< ierr << std::endl;
-    // ierr = TSSetMaxTime(ts, 10.);
-    // std::cout << "set_ode_solver :: TSSetMaxTime "<< ierr << std::endl;
-    // No other options needed
-#endif
-
-#ifdef SOLVER_BDF1
-    ierr = TSSetType(ts, TSBDF); // set the solution method: backward differentiation formula (BDF)
-    std::cout << "set_ode_solver :: TSSetType "<< ierr << std::endl;
-    ierr = TSBDFSetOrder(ts, 1);
-    std::cout << "set_ode_solver :: TSBDFSetOrder "<< ierr << std::endl;
-    ierr = TSSetTimeStep(ts, {self.dtSolver}); // set the initial time step
-    std::cout << "set_ode_solver :: TSSetTimeStep "<< ierr << std::endl;
-    ierr = TSSetMaxSteps(ts, 10000000000000); // maximum number of time steps
-    std::cout << "set_ode_solver :: TSSetMaxSteps "<< ierr << std::endl;
-    // ierr = TSSetMaxTime(ts, 10.);
-    // std::cout << "set_ode_solver :: TSSetMaxTime "<< ierr << std::endl;
-
-    // Options for matrix-free BDF1
-    PetscOptionsSetValue(NULL, "-ts_adapt_type", "none");
-    PetscOptionsSetValue(NULL, "-ts_bdf_single_jacobian", NULL);
-    PetscOptionsSetValue(NULL, "-snes_mf_operator", NULL);
-#endif
-
-#ifdef SOLVER_BDF2
-    ierr = TSSetType(ts, TSBDF); // set the solution method: backward differentiation formula (BDF)
-    std::cout << "set_ode_solver :: TSSetType "<< ierr << std::endl;
-    ierr = TSBDFSetOrder(ts, 2);
-    std::cout << "set_ode_solver :: TSBDFSetOrder "<< ierr << std::endl;
-    ierr = TSSetTimeStep(ts, {self.dtSolver}); // set the initial time step
-    std::cout << "set_ode_solver :: TSSetTimeStep "<< ierr << std::endl;
-    ierr = TSSetMaxSteps(ts, 10000000000000); // maximum number of time steps
-    std::cout << "set_ode_solver :: TSSetMaxSteps "<< ierr << std::endl;
-    // ierr = TSSetMaxTime(ts, 10.);
-    // std::cout << "set_ode_solver :: TSSetMaxTime "<< ierr << std::endl;
-
-    // Options for matrix-free BDF2
-    PetscOptionsSetValue(NULL, "-ts_adapt_type", "none");
-    PetscOptionsSetValue(NULL, "-ts_bdf_single_jacobian", NULL);
-    PetscOptionsSetValue(NULL, "-snes_mf_operator", NULL);
-#endif 
-
-    // Tolerances
-    // in order: scalar absolute tolerances, vector of absolute tolerances, scalar relative tolerances, vector of relative tolerances
-    double reltol = 1e-7; // TODO get this from user_inputs.yaml too
-    double abstol = 1e-9; // TODO get this from user_inputs.yaml too
-    ierr = TSSetTolerances(ts, abstol, NULL, reltol, NULL); 
-    std::cout << "set_ode_solver :: TSSetTolerances "<< ierr << std::endl;
-
-    // Nonlinear solver
-    ierr = TSGetSNES(ts, &snes); // return the SNES (nonlinear solver) associated with the TS (timestepper) context (valid only for nonlinear problems)
-    std::cout << "set_ode_solver :: TSGetSNES "<< ierr << std::endl;
-    ierr = SNESSetType(snes, SNESNEWTONLS); // set the algorithm/method to be used to solve the nonlinear system with the given SNES
-    std::cout << "set_ode_solver :: SNESSetType "<< ierr << std::endl;
-
-    // Linear solver (dense)
-    ierr = SNESGetKSP(snes, &ksp); // return the KSP (linear solver) context for the SNES solver
-    std::cout << "set_ode_solver :: SNESGetKSP "<< ierr << std::endl;
-    ierr = KSPSetType(ksp, KSPGMRES); // GMRES // set the algorithm/method to be used to solve the linear system with the given KSP
-    // ierr = KSPSetType(ksp, KSPFGMRES); // flexible GMRES
-    // ierr = KSPSetType(ksp, KSPPREONLY); // KSPPREONLY: method that applies ONLY the preconditioner exactly once.
-    std::cout << "set_ode_solver :: KSPSetType "<< ierr << std::endl;
-
-    // Preconditioner
-    ierr = KSPGetPC(ksp, &pc); // return a pointer to the preconditioner (PC) context with the KSP
-    std::cout << "set_ode_solver :: KSPGetPC "<< ierr << std::endl;
-
-    // Build PC for a particular preconditioner type
-#ifdef SOLVER_CN
-    // ierr = PCSetType(pc, PCNONE);
-    // ierr = PCSetType(pc, PCJACOBI); // PCJACOBI: Jacobi, i.e. diagonal scaling preconditioning.
-    // ierr = PCSetType(pc, PCLU); // PCLU: this uses a direct solver, based on LU factorization, as a preconditioner.
-    ierr = PCSetType(pc, PCILU);
-    std::cout << "set_ode_solver :: PCSetType "<< ierr << std::endl;
-#endif 
-
-#ifdef SOLVER_BDF1
-    // ierr = PCSetType(pc, PCNONE);
-    ierr = PCSetType(pc, PCJACOBI); // PCJACOBI: Jacobi, i.e. diagonal scaling preconditioning.
-    // ierr = PCSetType(pc, PCLU); // PCLU: this uses a direct solver, based on LU factorization, as a preconditioner.
-    std::cout << "set_ode_solver :: PCSetType "<< ierr << std::endl;
-#endif
-
-#ifdef SOLVER_BDF2
-    // ierr = PCSetType(pc, PCNONE);
-    ierr = PCSetType(pc, PCJACOBI); // PCJACOBI: Jacobi, i.e. diagonal scaling preconditioning.
-    // ierr = PCSetType(pc, PCLU); // PCLU: this uses a direct solver, based on LU factorization, as a preconditioner.
-    std::cout << "set_ode_solver :: PCSetType "<< ierr << std::endl;
-#endif
-
-    ierr = TSSetFromOptions(ts); // set various TS parameters from the options database
-    std::cout << "set_ode_solver :: TSSetFromOptions "<< ierr << std::endl;
-    ierr = TSSetUp(ts); // set up the internal data structures for the later use of TS
-    std::cout << "set_ode_solver :: TSSetUp "<< ierr << std::endl;
-
-    // User data
-    userData = new UserOdeData(variables, std::bind(&Model0d::computeRates, this,
-        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-        std::placeholders::_4, std::placeholders::_5));
-    userData->tOld = voi;
-
-"""
-        else:
-            solverInitFunction += """
-    states0 = createStatesArray(); // store initial state, before evolving to the next time level
-    k1 = createStatesArray(); // same size as states, should really be different function
-    k2 = createStatesArray(); // same size as states, should really be different function
-    k3 = createStatesArray(); // same size as states, should really be different function
-    k4 = createStatesArray(); // same size as states, should really be different function
-    // Runge-Kutta 4 weights
-    wRK4[0] = 1./6.;
-    wRK4[1] = 1./3.;
-    wRK4[2] = 1./3.;
-    wRK4[3] = 1./6.;
-"""
-        solverInitFunction += """
-}
-"""
+        solverInitFunction = self._build_solver_init_function()
         
         # print("#################################################")
         # print("solverInitFunction")

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -258,17 +258,23 @@ _CPP_SOLVERS = frozenset(SOLVER_SCHEMA['solvers_by_model_type']['cpp'])
 
 # The cpp solvers (CVODE/RK4/PETSC) are not run through a SimulationHelper at all: their
 # solver_info is baked into the emitted C++ by the cpp branch of
-# script_generate_with_new_architecture, which forwards exactly two values to CVSCppGenerator --
-# `dt_solver` (a framework key) as the solver step, and `MaximumNumberOfSteps` as mxsteps. The
-# generated C++ hardcodes its tolerances (`sunrealtype reltol = 1e-7; ... abstol = 1e-9;`, with a
-# standing TODO in CVSCppGenerator) and has no maximum-step-size knob, so advertising
-# MaximumStep/rtol/atol here made a downstream tool (e.g. CUFLynx) render three controls the user
-# could set with no effect and no way to tell -- the same reasoning as the notes on 'CVODE_myokit'
-# and 'aadc_semi_implicit'. They are listed again here the day the generator reads them; configs
-# that already set them are migrated with a warning, not rejected (migrate_legacy_solver_info_keys).
+# script_generate_with_new_architecture, which forwards these values to CVSCppGenerator (plus the
+# framework key `dt_solver`, which becomes the solver step).
+#
+# 'MaximumStep' is deliberately absent: the generated C++ integrates at the fixed `dt_solver`, so
+# there is no maximum-step-size knob for it to control. Advertising a setting nothing reads makes
+# a downstream tool (e.g. CUFLynx) render a control the user can change with no effect and no way
+# to tell -- the same reasoning as the notes on 'CVODE_myokit' and 'aadc_semi_implicit'. Configs
+# that already set it are migrated with a warning, not rejected (migrate_legacy_solver_info_keys).
+# rtol/atol used to be absent for the same reason; they came back once the generator stopped
+# hardcoding them (#398). The defaults are the literals the generator used to emit.
 _CPP_SOLVER_INFO = [
     {'name': 'MaximumNumberOfSteps', 'type': 'int', 'default': 5000, 'required': False,
      'description': 'Maximum number of internal integrator steps (emitted as CVODE mxsteps).'},
+    {**_SI_RTOL, 'default': 1e-7,
+     'description': 'Relative integration tolerance (emitted as the generated solver\'s reltol).'},
+    {**_SI_ATOL, 'default': 1e-9,
+     'description': 'Absolute integration tolerance (emitted as the generated solver\'s abstol).'},
 ]
 
 # CVODE_myokit is deliberately NOT in that family. myokit.Simulation exposes only
@@ -2205,8 +2211,9 @@ def migrate_legacy_solver_info_keys(solver_name, solver_info):
             solver_info.pop('MaximumNumberOfSteps', None)
     elif solver_name in _CPP_SOLVERS:
         # Nothing to migrate onto: the generated C++ takes its step from the framework key
-        # 'dt_solver' and hardcodes its tolerances. Dropping loudly beats rejecting, so a
-        # config written for a CVODE backend still runs -- it just says what stopped applying.
+        # 'dt_solver'. Dropping loudly beats rejecting, so a config written for a CVODE backend
+        # still runs -- it just says what stopped applying. rtol/atol are NOT dropped here: the
+        # generator emits them into the solver since #398.
         if 'MaximumStep' in solver_info:
             _warn_dropped_solver_info_key(
                 solver_name, 'MaximumStep',
@@ -2214,15 +2221,6 @@ def migrate_legacy_solver_info_keys(solver_name, solver_info):
                 "'dt_solver' to set it.",
             )
             solver_info.pop('MaximumStep', None)
-        for tol_key in ('rtol', 'atol'):
-            if tol_key in solver_info:
-                _warn_dropped_solver_info_key(
-                    solver_name, tol_key,
-                    'The generated C++ currently hardcodes its tolerances '
-                    '(reltol 1e-7 / abstol 1e-9 in CVSCppGenerator), so this value would '
-                    'not reach the solver.',
-                )
-                solver_info.pop(tol_key, None)
 
     return solver_info
 

--- a/src/scripts/script_generate_with_new_architecture.py
+++ b/src/scripts/script_generate_with_new_architecture.py
@@ -158,6 +158,11 @@ def generate_with_new_architecture(do_generation_with_fit_parameters=False,
         dtSample = inp_data_dict['dt']
         dtSolver = solver_info['dt_solver']
         nMaxSteps = solver_info['MaximumNumberOfSteps']
+        # The generated C++ used to hardcode its tolerances, so these were the one part of
+        # solver_info a cpp user could not set (issue #398). The defaults are the literals that
+        # used to be emitted, so a config that sets neither generates exactly what it did before.
+        reltol = solver_info.get('rtol', 1e-7)
+        abstol = solver_info.get('atol', 1e-9)
 
         if inp_data_dict['couple_to_1d']:
             # object from class CVS0DCppGenerator
@@ -192,6 +197,7 @@ def generate_with_new_architecture(do_generation_with_fit_parameters=False,
             code_generator = CVS0DCppGenerator(model, generated_models_subdir, file_prefix, #XXX
                                             resources_dir=resources_dir, solver=solver_cpp, 
                                             dtSample=dtSample, dtSolver=dtSolver, nMaxSteps=nMaxSteps,
+                                            reltol=reltol, abstol=abstol,
                                             couple_to_1d=inp_data_dict['couple_to_1d'],
                                             cpp_generated_models_dir=cpp_generated_models_dir,
                                             model_1d_config_path=model_1d_config_path,
@@ -227,7 +233,8 @@ def generate_with_new_architecture(do_generation_with_fit_parameters=False,
                 print("Check point 1B")
             code_generator = CVS0DCppGenerator(model, generated_models_subdir, file_prefix,
                                             resources_dir=resources_dir, solver=solver_cpp,
-                                            dtSample=dtSample, dtSolver=dtSolver, nMaxSteps=nMaxSteps)
+                                            dtSample=dtSample, dtSolver=dtSolver, nMaxSteps=nMaxSteps,
+                                            reltol=reltol, abstol=abstol)
             if DEBUG:
                 print("Check point 2B")
 

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -5,6 +5,7 @@
 * #155 -- the duplicated input-flow BC modules were removed from the microvasculature config.
 * #157 -- solver Make files are copied into each generated model directory.
 * #159 -- parameter CSV columns are read by header name, not by position.
+* #398 -- solver_info rtol/atol reach the generated C++ instead of being hardcoded.
 * #167 -- sensitivity-analysis plot filenames are sanitised (no ``{}``/spaces/backslashes).
 
 These are deliberately light-weight: heavy optional deps are imported inside the test bodies so a
@@ -245,3 +246,64 @@ def test_parameters_csv_unit_mismatch_still_exits(tmp_path):
         _reduce(tmp_path,
                 'variable_name,units,value,data_reference',
                 ['R_vessel,m3,1333000,Blanco_2013'])
+
+
+# ---------------------------------------------------------------------------
+# #398 -- solver_info rtol/atol reach the generated C++
+# ---------------------------------------------------------------------------
+def _cpp_solver_init(solver, reltol=1e-7, abstol=1e-9):
+    """The emitted set_ode_solver body, built without generating a whole model."""
+    from generators.CVSCppGenerator import CVS0DCppGenerator
+
+    gen = CVS0DCppGenerator.__new__(CVS0DCppGenerator)
+    gen.solver = solver
+    gen.reltol = reltol
+    gen.abstol = abstol
+    gen.dtSolver = 1e-4
+    gen.nMaxSteps = 5000
+    return gen._build_solver_init_function()
+
+
+@pytest.mark.parametrize('solver', ['CVODE', 'PETSC'])
+def test_cpp_generator_emits_the_configured_tolerances(solver):
+    """The two tolerance literals in the emitted C++ carried a standing
+    'TODO get this from user_inputs.yaml too'; a cpp user could only change the accuracy of a run
+    by hand-editing generated code."""
+    emitted = _cpp_solver_init(solver, reltol=1.5e-9, abstol=2.5e-11)
+    assert 'reltol = 1.5e-09' in emitted, emitted
+    assert 'abstol = 2.5e-11' in emitted, emitted
+    # the values that used to be baked in are gone unless the user asks for them
+    assert 'reltol = 1e-7' not in emitted
+    assert 'abstol = 1e-9' not in emitted
+    assert 'TODO get this from user_inputs' not in emitted
+
+
+@pytest.mark.parametrize('solver', ['CVODE', 'PETSC'])
+def test_cpp_generator_defaults_reproduce_the_previous_output(solver):
+    """A config that sets neither tolerance must generate exactly what it did before, so wiring
+    the settings up does not silently change anybody's existing model."""
+    emitted = _cpp_solver_init(solver)
+    assert 'reltol = 1e-07' in emitted, emitted
+    assert 'abstol = 1e-09' in emitted, emitted
+
+
+def test_cpp_rk4_has_no_tolerances_to_configure():
+    """RK4 is a fixed-step scheme with no tolerance knobs -- it must not grow one just because
+    the settings now exist."""
+    emitted = _cpp_solver_init('RK4')
+    assert 'reltol' not in emitted
+    assert 'abstol' not in emitted
+    assert 'wRK4' in emitted, 'expected the RK4 branch'
+
+
+def test_generate_script_reads_tolerances_from_solver_info():
+    """The generator only gets the user's values if the cpp branch of the generate script passes
+    them, and the defaults there are what keeps existing configs byte-identical."""
+    import inspect
+    from scripts import script_generate_with_new_architecture as gen_script
+
+    source = inspect.getsource(gen_script.generate_with_new_architecture)
+    assert "solver_info.get('rtol', 1e-7)" in source
+    assert "solver_info.get('atol', 1e-9)" in source
+    # both CVS0DCppGenerator constructions (coupled and uncoupled) must forward them
+    assert source.count('reltol=reltol, abstol=abstol') == 2

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -713,17 +713,28 @@ def test_cpp_rk4_accepts_maximum_number_of_steps():
 
 
 @pytest.mark.parametrize('solver', ['CVODE', 'RK4', 'PETSC'])
-def test_cpp_solvers_reject_settings_the_generated_code_never_reads(solver):
-    """The generated C++ steps at dt_solver and hardcodes reltol 1e-7 / abstol 1e-9, so
-    MaximumStep/rtol/atol reached nothing. Advertising them made CUFLynx draw three dead
-    controls (issue #330)."""
-    for dead_key, value in [('MaximumStep', 0.001), ('rtol', 1e-8), ('atol', 1e-8)]:
-        with pytest.raises(ValueError, match=dead_key):
-            validate_solver_info(solver, {'solver': solver, dead_key: value})
+def test_cpp_solvers_reject_the_setting_the_generated_code_never_reads(solver):
+    """The generated C++ integrates at the fixed dt_solver, so there is no maximum-step-size knob
+    for MaximumStep to control. Advertising it made CUFLynx draw a dead control (issue #330)."""
+    with pytest.raises(ValueError, match='MaximumStep'):
+        validate_solver_info(solver, {'solver': solver, 'MaximumStep': 0.001})
 
 
 @pytest.mark.parametrize('solver', ['CVODE', 'RK4', 'PETSC'])
-def test_cpp_legacy_tolerance_keys_are_migrated_with_a_warning_not_rejected(solver, capsys):
+def test_cpp_solvers_accept_tolerances_now_that_the_generator_emits_them(solver):
+    """rtol/atol were removed in #330 because the emitted C++ hardcoded its tolerances; #398
+    wired them through, so they are a real setting again."""
+    validate_solver_info(solver, {
+        'solver': solver,
+        'dt_solver': 1e-4,
+        'MaximumNumberOfSteps': 5000,
+        'rtol': 1e-8,
+        'atol': 1e-10,
+    })
+
+
+@pytest.mark.parametrize('solver', ['CVODE', 'RK4', 'PETSC'])
+def test_cpp_maximum_step_is_migrated_with_a_warning_not_rejected(solver, capsys):
     """A config written for a CVODE backend must keep running -- it just has to say which of its
     settings stopped applying, rather than failing validation on the way in."""
     migrated = migrate_legacy_solver_info_keys(solver, {
@@ -732,15 +743,17 @@ def test_cpp_legacy_tolerance_keys_are_migrated_with_a_warning_not_rejected(solv
         'MaximumStep': 0.001,
         'MaximumNumberOfSteps': 5000,
         'rtol': 1e-8,
-        'atol': 1e-8,
+        'atol': 1e-10,
     })
-    assert set(migrated) == {'solver', 'dt_solver', 'MaximumNumberOfSteps'}
+    # MaximumStep goes; the tolerances stay, because the generator emits them (#398).
+    assert set(migrated) == {'solver', 'dt_solver', 'MaximumNumberOfSteps', 'rtol', 'atol'}
     validate_solver_info(solver, migrated)  # the migrated config is accepted
 
     warned = capsys.readouterr().out
-    for dropped in ('MaximumStep', 'rtol', 'atol'):
-        assert dropped in warned, dropped + ' was dropped silently'
+    assert 'MaximumStep' in warned, 'MaximumStep was dropped silently'
     assert 'dt_solver' in warned, 'the MaximumStep warning should name the setting to use instead'
+    for kept in ('rtol', 'atol'):
+        assert kept not in warned, kept + ' is wired up and must not warn'
 
 
 def test_solve_ivp_rejects_maximum_step_keys():


### PR DESCRIPTION
Closes #398.

> **Stacked on #397.** This branch contains #397's two commits, so its diff will shrink to just the last commit once #397 merges. Please merge #397 first.

## The problem

The generated solver configuration carried its tolerances as literals, with a standing TODO:

```c
sunrealtype reltol = 1e-7; // TODO get this from user_inputs.yaml too
sunrealtype abstol = 1e-9; // TODO get this from user_inputs.yaml too
CVodeSStolerances(solver, reltol, abstol);
```

So the accuracy of a cpp run could only be changed by hand-editing generated code — and #397 had to drop `rtol`/`atol` from the cpp schema, because CUFLynx was rendering two controls that reached nothing.

## The fix

The cpp branch of the generate script reads them from `solver_info` and passes them to `CVS0DCppGenerator` alongside `nMaxSteps` — for **both** the coupled and uncoupled constructions — and **both** the CVODE and PETSc code paths emit them.

`rtol`/`atol` go back into `_CPP_SOLVER_INFO`, and their migration branch is removed. `MaximumStep` stays dropped-with-a-warning: the generated C++ steps at `dt_solver` and has no maximum-step-size knob, so there is still nothing for it to control.

**Existing models are byte-identical.** The defaults are the literals that used to be baked in (`1e-7` / `1e-9`), so a config that sets neither tolerance generates exactly what it did before. RK4 is untouched — it is fixed-step and has no tolerances to configure.

The per-solver schema check from #397 now verifies this wiring on its own: it requires each advertised field to appear in the cpp consumer files, so the schema cannot get ahead of the code again.

## One refactor

`generate_cpp` is ~2900 lines, and the tolerance emission sits in the middle of it, so asserting what gets emitted would otherwise mean running a full model generation (the only cpp generation test is marked `slow`). The `solverInitFunction` block is split out into `_build_solver_init_function`. It interpolated only `self.solver`, `self.nMaxSteps`, `self.dtSolver`, `self.reltol` and `self.abstol` — nothing from `generate_cpp`'s scope — so the extraction is closed, and the emitted solver configuration is now assertable in the fast suite.

## Tests

Five new tests in `tests/test_issue_fixes.py`:
- the configured tolerances appear in the emitted C++, and the old literals and the TODO are gone (CVODE and PETSc)
- the defaults reproduce the previous output exactly, for both paths
- RK4 grows no tolerances just because the settings now exist
- the generate script really reads them from `solver_info`, with the old literals as defaults, and forwards them at both construction sites

Plus updated cpp coverage in `tests/test_solver_info_validation.py`: tolerances are accepted, `MaximumStep` is still rejected, and the migration drops only `MaximumStep` while leaving `rtol`/`atol` alone and silent.

Verified `not slow and not compare_optimisers`: 596 passed, 1 failed — `test_python_BDF_solver[SN_simple]`, the known libCellML-Analyser limitation (#151, recorded in CLAUDE.md), which fails identically with the source changes stashed.

## Unrelated pre-existing breakage found

`test_generate_cpp_model_succeeds` (marked `slow`, so it is not in the default run) fails on master with `KeyError: 'dt_solver'` — `get_solver_info_default('cpp')` does not seed the key that `script_generate_with_new_architecture` requires. It fails identically with this branch's changes stashed, so it is not caused here and is not fixed here; filed separately as #399.
