### PR TITLE
fix(mpi): a serial run never opens MPI (#396)

### DIFF
--- a/src/identifiabilty_analysis/identifiabilityAnalysis.py
+++ b/src/identifiabilty_analysis/identifiabilityAnalysis.py
@@ -30,7 +30,14 @@ import paperPlotSetup
 from utility_funcs import calculate_hessian
 paperPlotSetup.Setup_Plot(3)
 from parsers.PrimitiveParsers import scriptFunctionParser
-from mpi4py import MPI
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). get_MPI hands back the real
+# mpi4py.MPI under mpiexec -- a multi-rank run is unchanged -- and a one-rank
+# stub otherwise, so a serial run never opens MPI at all.
+from utilities.mpi_utils import get_MPI as _get_MPI
+
+MPI = _get_MPI()
 import re
 from numpy import genfromtxt
 from importlib import import_module

--- a/src/param_id/optimisers.py
+++ b/src/param_id/optimisers.py
@@ -6,7 +6,14 @@ genetic algorithm, bayesian optimisation, and scipy minimizers.
 '''
 
 import numpy as np
-from mpi4py import MPI
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). get_MPI hands back the real
+# mpi4py.MPI under mpiexec -- a multi-rank run is unchanged -- and a one-rank
+# stub otherwise, so a serial run never opens MPI at all.
+from utilities.mpi_utils import get_MPI as _get_MPI
+
+MPI = _get_MPI()
 import math
 import os
 import csv

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -31,7 +31,14 @@ paperPlotSetup.Setup_Plot(3)
 from solver_wrappers import get_simulation_helper
 from protocol_runners.protocol_executor import ProtocolExecutor
 from parsers.PrimitiveParsers import scriptFunctionParser
-from mpi4py import MPI
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). get_MPI hands back the real
+# mpi4py.MPI under mpiexec -- a multi-rank run is unchanged -- and a one-rank
+# stub otherwise, so a serial run never opens MPI at all.
+from utilities.mpi_utils import get_MPI as _get_MPI
+
+MPI = _get_MPI()
 import re
 from numpy import genfromtxt
 from importlib import import_module

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -25,13 +25,14 @@ from utilities.obs_data_helpers import DEFAULT_COST_TYPE, PREVIOUS_DEFAULT_COST_
 from param_id.modifier_funcs import (BUILTIN_MODIFIER_FUNCS, get_modifier_funcs,
                                      probe_affine)
 
-try:
-    from mpi4py import MPI
-    mpi_available = True
-    rank = MPI.COMM_WORLD.Get_rank()
-except:
-    mpi_available = False
-    rank=0
+# Rank only -- no collectives here. Importing mpi4py for it initialised MPI and
+# registered an atexit MPI_Finalize in every process that merely parsed a config,
+# and that finalise aborts on macOS when a NIC goes away (#396). mpi_utils
+# answers without opening MPI when nothing launched this process.
+from utilities import mpi_utils as _mpi_utils
+
+mpi_available = _mpi_utils.mpi_available()
+rank = _mpi_utils.rank()
 
 root_dir = os.path.join(os.path.dirname(__file__), '../..')
 sys.path.append(os.path.join(root_dir, 'src'))

--- a/src/scripts/heart_paper_plots.py
+++ b/src/scripts/heart_paper_plots.py
@@ -7,8 +7,15 @@ Created on 29/10/2021
 import sys
 import os
 import numpy as np
-from mpi4py import MPI
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). Placed after the sys.path
+# bootstrap above, which is what makes `utilities` importable. Under mpiexec
+# get_MPI hands back the real mpi4py.MPI, so a multi-rank run is unchanged.
+from utilities.mpi_utils import get_MPI as _get_MPI
+
+MPI = _get_MPI()
 sys.path.append(os.path.join(os.path.dirname(__file__), '../utilities'))
 import matplotlib
 import matplotlib.pyplot as plt

--- a/src/scripts/identifiability_run_script.py
+++ b/src/scripts/identifiability_run_script.py
@@ -6,9 +6,16 @@ Created on 29/10/2021
 
 import sys
 import os
-from mpi4py import MPI
 root_dir = os.path.join(os.path.dirname(__file__), '../..')
 sys.path.append(os.path.join(root_dir, 'src'))
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). Placed after the sys.path
+# bootstrap above, which is what makes `utilities` importable. Under mpiexec
+# get_MPI hands back the real mpi4py.MPI, so a multi-rank run is unchanged.
+from utilities.mpi_utils import get_MPI as _get_MPI
+
+MPI = _get_MPI()
 from param_id.paramID import CVS0DParamID, ensure_mle_cost_type_for_bayesian_inner
 import traceback
 import yaml

--- a/src/scripts/param_id_run_script.py
+++ b/src/scripts/param_id_run_script.py
@@ -6,9 +6,16 @@ Created on 29/10/2021
 
 import sys
 import os
-from mpi4py import MPI
 root_dir = os.path.join(os.path.dirname(__file__), '../..')
 sys.path.append(os.path.join(root_dir, 'src'))
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). Placed after the sys.path
+# bootstrap above, which is what makes `utilities` importable. Under mpiexec
+# get_MPI hands back the real mpi4py.MPI, so a multi-rank run is unchanged.
+from utilities.mpi_utils import get_MPI as _get_MPI
+
+MPI = _get_MPI()
 from param_id.paramID import CVS0DParamID, ensure_mle_cost_type_for_bayesian_inner, mcmc_object
 import traceback
 import yaml

--- a/src/scripts/plot_param_id_script.py
+++ b/src/scripts/plot_param_id_script.py
@@ -6,12 +6,19 @@ Created on 29/10/2021
 
 import sys
 import os
-from mpi4py import MPI
 from distutils import util
 import re
 
 root_dir = os.path.join(os.path.dirname(__file__), '../..')
 sys.path.append(os.path.join(root_dir, 'src'))
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). Placed after the sys.path
+# bootstrap above, which is what makes `utilities` importable. Under mpiexec
+# get_MPI hands back the real mpi4py.MPI, so a multi-rank run is unchanged.
+from utilities.mpi_utils import get_MPI as _get_MPI
+
+MPI = _get_MPI()
 
 user_inputs_dir = os.path.join(root_dir, 'user_run_files')
 

--- a/src/scripts/run_multiple_param_id.py
+++ b/src/scripts/run_multiple_param_id.py
@@ -6,11 +6,18 @@ Created on 29/10/2021
 
 import sys
 import os
-from mpi4py import MPI
 from distutils import util, dir_util
 
 root_dir = os.path.join(os.path.dirname(__file__), '../..')
 sys.path.append(os.path.join(root_dir, 'src'))
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). Placed after the sys.path
+# bootstrap above, which is what makes `utilities` importable. Under mpiexec
+# get_MPI hands back the real mpi4py.MPI, so a multi-rank run is unchanged.
+from utilities.mpi_utils import get_MPI as _get_MPI
+
+MPI = _get_MPI()
 
 from param_id.paramID import CVS0DParamID
 from scripts.read_and_insert_parameters import insert_parameters

--- a/src/scripts/sensitivity_analysis_run_script.py
+++ b/src/scripts/sensitivity_analysis_run_script.py
@@ -1,13 +1,19 @@
 import sys
 import os
-from mpi4py import MPI
 root_dir = os.path.join(os.path.dirname(__file__), '../..')
 sys.path.append(os.path.join(root_dir, 'src'))
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). Placed after the sys.path
+# bootstrap above, which is what makes `utilities` importable. Under mpiexec
+# get_MPI hands back the real mpi4py.MPI, so a multi-rank run is unchanged.
+from utilities.mpi_utils import get_MPI as _get_MPI
 from sensitivity_analysis.sensitivityAnalysis import SensitivityAnalysis
 import traceback
 import yaml
 from parsers.PrimitiveParsers import YamlFileParser
-from mpi4py import MPI
+
+MPI = _get_MPI()
 
 def run_SA(inp_data_dict=None):
 

--- a/src/scripts/sequential_param_id_run_script.py
+++ b/src/scripts/sequential_param_id_run_script.py
@@ -6,13 +6,20 @@ Created on 26/04/2022
 
 import sys
 import os
-from mpi4py import MPI
 import time
 import numpy as np
 from distutils import util, dir_util
 
 root_dir = os.path.join(os.path.dirname(__file__), '../..')
 sys.path.append(os.path.join(root_dir, 'src'))
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). Placed after the sys.path
+# bootstrap above, which is what makes `utilities` importable. Under mpiexec
+# get_MPI hands back the real mpi4py.MPI, so a multi-rank run is unchanged.
+from utilities.mpi_utils import get_MPI as _get_MPI
+
+MPI = _get_MPI()
 
 user_inputs_dir = os.path.join(root_dir, 'user_run_files')
 

--- a/src/sensitivity_analysis/sensitivityAnalysis.py
+++ b/src/sensitivity_analysis/sensitivityAnalysis.py
@@ -24,7 +24,14 @@ import matplotlib.ticker as tick
 import paperPlotSetup
 paperPlotSetup.Setup_Plot(3)
 from parsers.PrimitiveParsers import scriptFunctionParser
-from mpi4py import MPI
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). get_MPI hands back the real
+# mpi4py.MPI under mpiexec -- a multi-rank run is unchanged -- and a one-rank
+# stub otherwise, so a serial run never opens MPI at all.
+from utilities.mpi_utils import get_MPI as _get_MPI
+
+MPI = _get_MPI()
 import re
 from numpy import genfromtxt
 from importlib import import_module

--- a/src/sensitivity_analysis/sobolSA.py
+++ b/src/sensitivity_analysis/sobolSA.py
@@ -43,7 +43,14 @@ import seaborn as sns
 from parsers.PrimitiveParsers import expand_modifier_param_vals
 from parsers.PrimitiveParsers import scriptFunctionParser
 from param_id.operation_funcs import resolve_operation_kwargs, validate_operation_kwargs
-from mpi4py import MPI
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). get_MPI hands back the real
+# mpi4py.MPI under mpiexec -- a multi-rank run is unchanged -- and a one-rank
+# stub otherwise, so a serial run never opens MPI at all.
+from utilities.mpi_utils import get_MPI as _get_MPI
+
+MPI = _get_MPI()
 from parsers.PrimitiveParsers import CSVFileParser, ObsAndParamDataParser
 import csv
 from tqdm import tqdm  # make sure tqdm is installed

--- a/src/solver_wrappers/__init__.py
+++ b/src/solver_wrappers/__init__.py
@@ -25,11 +25,14 @@ try:
 except Exception:
     AadcPythonSimulationHelper = None
 
-try:
-    from mpi4py import MPI
-    _MPI_AVAILABLE = True
-except Exception:
-    _MPI_AVAILABLE = False
+# Not `from mpi4py import MPI`. This module picks a solver; it has no collectives
+# to run. That import initialised MPI and registered an atexit MPI_Finalize for
+# every consumer who merely wanted a forward solve -- and that finalise aborts on
+# macOS when a NIC goes away, on machines with no MPI installed (#396).
+# mpi_utils answers "is it installed" without opening it.
+from utilities.mpi_utils import mpi_available as _mpi_available
+
+_MPI_AVAILABLE = _mpi_available()
 
 
 def get_simulation_helper(model_path: str = None, solver: str = None, 

--- a/src/utilities/mpi_utils.py
+++ b/src/utilities/mpi_utils.py
@@ -1,0 +1,303 @@
+"""Answer "which rank am I?" without opening MPI when there is only one.
+
+Importing ``mpi4py`` calls ``MPI_Init_thread`` and registers an ``atexit`` hook
+that calls ``MPI_Finalize``. Because circulatory_autogen imported it at module
+scope in eighteen places, *any* import of CA opened MPI -- including a plain
+forward solve, in a process nothing launched with ``mpiexec``, on a machine with
+no MPI installed.
+
+That is not merely wasteful. It aborts. Reported by a CUFLynx user closing the
+app (#396)::
+
+    Abort(808576911): Fatal error in internal_Finalize: Other MPI error
+    MPIDI_OFI_mpi_finalize_hook(861):
+    flush_send_queue(830)...........:
+    MPIDI_OFI_handle_cq_error(593)..: OFI poll failed
+    (default nic=en5: Input/output error)
+
+MPI had opened a transport over a real NIC, and closing it failed because the
+NIC had gone away -- a Wi-Fi drop, a VPN, a virtual adapter disappearing. The
+user's summary was exactly right: if MPI is not in use, none of this should be
+happening.
+
+Two things here, and the distinction matters:
+
+:func:`rank` / :func:`size` / :func:`is_root` answer the common question --
+"which rank am I?" -- **without importing mpi4py at all** when no launcher
+started this process. Code that only needs those (the solver wrappers, the
+parsers) can then run entirely MPI-free.
+
+:func:`configure_mpi4py` is for the code that genuinely does collectives
+(``Bcast``, ``Scatterv``, ``Gatherv``) and therefore must have real MPI objects.
+It cannot avoid initialising MPI, so it makes the *exit* safe instead: with no
+launcher present it clears ``mpi4py.rc.finalize`` before the first import, so no
+``MPI_Finalize`` is ever called. Skipping the finalise in a process that is
+exiting is benign -- the OS reclaims the sockets -- and it is strictly safer than
+aborting in it. Under ``mpiexec`` the ranks really are talking to each other and
+Finalize does real work, so nothing is changed there.
+
+:func:`get_MPI` closes the loop for the code that *does* run collectives. CA calls
+``Bcast``/``Scatterv``/``Gatherv`` unconditionally, even at one rank, so those
+modules could not simply skip MPI. At one rank every collective has a trivial
+definition -- a broadcast from yourself is a no-op, a gather of one value is a
+list of one -- so :class:`_SerialComm` supplies them and MPI is never opened.
+Under a launcher ``get_MPI`` hands back the real ``mpi4py.MPI`` and nothing about
+a multi-rank run changes.
+"""
+
+import os
+
+#: Environment variables an MPI launcher sets in every rank it spawns. MPICH and
+#: Microsoft MPI use the ``PMI_*`` family, Open MPI the ``OMPI_*`` one; Hydra
+#: (MPICH's launcher) adds ``HYDRA_CONTROL_FD``.
+#:
+#: Probed from the environment rather than asked of MPI, because the answer is
+#: needed *before* mpi4py is imported -- once it has been, MPI is initialised and
+#: the atexit hook is registered, and the decision has already been made.
+LAUNCHER_ENV_VARS = (
+    'PMI_RANK',
+    'PMI_SIZE',
+    'PMI_FD',
+    'HYDRA_CONTROL_FD',
+    'OMPI_COMM_WORLD_RANK',
+    'OMPI_COMM_WORLD_SIZE',
+    'MPI_LOCALNRANKS',
+)
+
+
+def launched_by_mpiexec(env=None):
+    """Whether an MPI launcher spawned this process."""
+    source = os.environ if env is None else env
+    return any(var in source for var in LAUNCHER_ENV_VARS)
+
+
+def configure_mpi4py(env=None):
+    """Make the exit safe before anything imports ``mpi4py``.
+
+    Call at the top of a module that will import mpi4py for collectives. With no
+    launcher present this clears ``rc.finalize``, so the process never calls
+    ``MPI_Finalize`` -- which is where the macOS abort happens. Returns whether
+    the guard was applied.
+
+    A no-op once mpi4py has been imported, and harmless when it is absent.
+    """
+    if launched_by_mpiexec(env):
+        return False
+    try:
+        import mpi4py
+    except ImportError:
+        return False
+    mpi4py.rc.finalize = False
+    return True
+
+
+def _comm_or_none():
+    """``MPI.COMM_WORLD`` if MPI is already in play, else None.
+
+    Deliberately does not *cause* an import: it uses mpi4py only when a launcher
+    started this process, or when something else has already imported it (in
+    which case MPI is initialised anyway and asking costs nothing).
+    """
+    import sys
+
+    if not launched_by_mpiexec() and 'mpi4py.MPI' not in sys.modules:
+        return None
+    try:
+        from mpi4py import MPI
+        return MPI.COMM_WORLD
+    except Exception:
+        return None
+
+
+def rank():
+    """This process's MPI rank, or 0 when it is not part of an MPI job."""
+    comm = _comm_or_none()
+    if comm is None:
+        return 0
+    try:
+        return comm.Get_rank()
+    except Exception:
+        return 0
+
+
+def size():
+    """The number of ranks, or 1 when this is not part of an MPI job."""
+    comm = _comm_or_none()
+    if comm is None:
+        return 1
+    try:
+        return comm.Get_size()
+    except Exception:
+        return 1
+
+
+def is_root():
+    """Whether this process should do the work exactly one rank should do."""
+    return rank() == 0
+
+
+def mpi_available():
+    """Whether mpi4py can be imported at all.
+
+    Answers "is the library installed", which is what the callers using this
+    flag mean; it does not initialise MPI to find out.
+    """
+    import importlib.util
+
+    return importlib.util.find_spec('mpi4py') is not None
+
+
+# ---------------------------------------------------------------------------
+# One rank, no MPI
+# ---------------------------------------------------------------------------
+class _SerialRequest(object):
+    """Stand-in for ``MPI.Request``.
+
+    Only ``Waitall`` is used, and only on the list of non-blocking sends this
+    rank issued to *other* ranks. At one rank that list is always empty -- the
+    loop that fills it is ``for other in range(num_procs): if other != rank``,
+    which has no iterations. A non-empty list here would mean the caller sent a
+    message with nobody to send it to, so it is an error rather than a no-op.
+    """
+
+    @staticmethod
+    def Waitall(requests):
+        if requests:
+            raise RuntimeError(
+                'serial MPI stub: Waitall got %d pending request(s); at one rank '
+                'nothing can have been sent' % len(requests))
+
+
+class _SerialComm(object):
+    """``MPI.COMM_WORLD`` for a process that is the whole job.
+
+    Every collective has a trivial one-rank definition: a broadcast from
+    yourself leaves the buffer alone, a gather of your own value is a list of
+    one, a scatter to yourself is a copy. Implemented rather than skipped
+    because circulatory_autogen calls them unconditionally -- guarding every
+    call site on ``size > 1`` would be a far larger and more error-prone change
+    than defining the one-rank case once, here.
+    """
+
+    def Get_rank(self):
+        return 0
+
+    def Get_size(self):
+        return 1
+
+    def Barrier(self):
+        return None
+
+    def barrier(self):
+        return None
+
+    def bcast(self, obj, root=0):
+        return obj
+
+    def Bcast(self, buf, root=0):
+        # The root is this process, so the buffer already holds the value.
+        return None
+
+    def gather(self, obj, root=0):
+        return [obj]
+
+    def allgather(self, obj):
+        return [obj]
+
+    def Gatherv(self, sendbuf, recvbuf, root=0):
+        """``Gatherv(send, [recv, counts, displs, datatype], root)``."""
+        _copy_into(_buffer_of(recvbuf), _buffer_of(sendbuf))
+        return None
+
+    def Scatterv(self, sendbuf, recvbuf, root=0):
+        """``Scatterv([send, counts, displs, datatype], recv, root)``."""
+        _copy_into(_buffer_of(recvbuf), _buffer_of(sendbuf))
+        return None
+
+    def Allreduce(self, sendbuf, recvbuf, op=None):
+        # Reducing one value over one rank is that value.
+        _copy_into(_buffer_of(recvbuf), _buffer_of(sendbuf))
+        return None
+
+    def iprobe(self, source=None, tag=None):
+        # Nobody else exists, so there is never a message waiting.
+        return False
+
+    def recv(self, source=None, tag=None):
+        raise RuntimeError(
+            'serial MPI stub: recv() with one rank would block forever; the '
+            'caller should have found nothing to receive')
+
+    def isend(self, obj, dest=None, tag=None):
+        raise RuntimeError(
+            'serial MPI stub: isend() to rank %r with one rank has no '
+            'destination' % (dest,))
+
+
+def _buffer_of(spec):
+    """The array out of a bare buffer or an ``[buf, counts, displs, dtype]`` spec."""
+    if isinstance(spec, (list, tuple)):
+        return spec[0]
+    return spec
+
+
+def _copy_into(dest, src):
+    """``dest[:] = src``, flattened, tolerating the shape differences CA relies on.
+
+    The send and receive buffers of a one-rank Scatterv/Gatherv hold the same
+    values but need not have the same shape -- circulatory_autogen scatters a
+    flat population into a ``(n, num_params)`` receive buffer, for instance.
+    """
+    import numpy as np
+
+    dest_arr = np.asarray(dest)
+    src_flat = np.asarray(src).reshape(-1)
+    n = min(dest_arr.size, src_flat.size)
+    dest_arr.reshape(-1)[:n] = src_flat[:n]
+
+
+class _SerialMPI(object):
+    """``mpi4py.MPI`` for a process that is the whole job.
+
+    The datatype and operation constants exist only so call sites that name them
+    keep working; the one-rank collectives above never inspect them.
+    """
+
+    COMM_WORLD = _SerialComm()
+    Request = _SerialRequest
+
+    DOUBLE = 'double'
+    FLOAT = 'float'
+    INT = 'int'
+    LONG = 'long'
+    BOOL = 'bool'
+    C_BOOL = 'bool'
+
+    SUM = 'sum'
+    MIN = 'min'
+    MAX = 'max'
+    PROD = 'prod'
+    LAND = 'land'
+    LOR = 'lor'
+
+    ANY_SOURCE = -1
+    ANY_TAG = -1
+
+
+def get_MPI(env=None):
+    """The ``MPI`` module to use: the real one under a launcher, else the stub.
+
+    Import this instead of ``from mpi4py import MPI`` in modules that run
+    collectives. When no launcher started the process, nothing here imports
+    mpi4py, so MPI is never initialised and there is no ``MPI_Finalize`` to
+    abort in.
+
+    mpi4py already being imported means MPI is initialised regardless, so the
+    real module is handed back -- a stub would then be the odd one out.
+    """
+    import sys
+
+    if launched_by_mpiexec(env) or 'mpi4py.MPI' in sys.modules:
+        from mpi4py import MPI
+        return MPI
+    return _SerialMPI

--- a/tests/test_mpi_utils.py
+++ b/tests/test_mpi_utils.py
@@ -1,0 +1,268 @@
+"""A serial run must not open MPI, and must never finalise it.
+
+Importing mpi4py calls ``MPI_Init_thread`` and registers an ``atexit`` hook that
+calls ``MPI_Finalize``. CA imported it at module scope in eighteen places, so any
+import of CA opened MPI -- including a plain forward solve, in a process nothing
+launched with ``mpiexec``, on a machine with no MPI installed. Closing that
+process aborts on macOS (#396)::
+
+    Abort(808576911): Fatal error in internal_Finalize
+    MPIDI_OFI_handle_cq_error(593): OFI poll failed
+    (default nic=en5: Input/output error)
+
+**What these tests can and cannot do.** They cannot reproduce the abort: it needs
+a NIC that fails mid-flush, and no CI runner will summon one on demand. What they
+pin is the precondition -- that a serial process no longer opens MPI, and no
+longer registers the finalise that aborts. Remove either and the abort becomes
+possible again.
+
+Each check runs in a fresh interpreter, because ``mpi4py.rc`` and
+``sys.modules`` are process-global: importing mpi4py once to test it would
+change the answer for everything after.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+SRC = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src')
+
+sys.path.insert(0, SRC)
+from utilities import mpi_utils  # noqa: E402
+
+
+def _run(body, env=None):
+    """Run `body` in a fresh interpreter with CA's src importable."""
+    code = 'import sys; sys.path.insert(0, %r)\n' % SRC + textwrap.dedent(body)
+    full_env = dict(os.environ)
+    # A test runner may itself be under mpiexec; start from a clean slate so the
+    # cases below control the answer.
+    for var in mpi_utils.LAUNCHER_ENV_VARS:
+        full_env.pop(var, None)
+    full_env.update(env or {})
+    proc = subprocess.run([sys.executable, '-c', code], capture_output=True,
+                          text=True, timeout=300, env=full_env)
+    assert proc.returncode == 0, 'stdout:\n%s\nstderr:\n%s' % (proc.stdout, proc.stderr)
+    return proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Who counts as part of an MPI job
+# ---------------------------------------------------------------------------
+def test_a_bare_process_is_not_part_of_an_mpi_job():
+    assert mpi_utils.launched_by_mpiexec({}) is False
+    assert mpi_utils.launched_by_mpiexec({'PATH': '/usr/bin'}) is False
+
+
+@pytest.mark.parametrize('var', mpi_utils.LAUNCHER_ENV_VARS)
+def test_every_launcher_variable_is_recognised(var):
+    """MPICH and MS-MPI set the PMI_* family, Open MPI the OMPI_* one, Hydra adds
+    HYDRA_CONTROL_FD. Missing one would make a real multi-rank run look serial
+    and skip a finalise that is doing actual work."""
+    assert mpi_utils.launched_by_mpiexec({var: '0'}) is True
+
+
+def test_rank_and_size_answer_without_opening_mpi():
+    out = _run("""
+        import sys
+        from utilities import mpi_utils
+        r, s = mpi_utils.rank(), mpi_utils.size()
+        print(r, s, 'mpi4py.MPI' in sys.modules)
+        """)
+    assert out.split() == ['0', '1', 'False']
+
+
+def test_mpi_available_does_not_open_mpi():
+    """It answers "is the library installed", which is what the callers mean."""
+    out = _run("""
+        import sys
+        from utilities import mpi_utils
+        print(mpi_utils.mpi_available(), 'mpi4py.MPI' in sys.modules)
+        """)
+    installed, imported = out.split()
+    assert imported == 'False'
+    assert installed in ('True', 'False')
+
+
+# ---------------------------------------------------------------------------
+# The paths that must stay MPI-free
+# ---------------------------------------------------------------------------
+def test_a_forward_solve_import_never_opens_mpi():
+    """The reported bug. Importing the solver wrappers is what CUFLynx does for
+    live simulation, in the app's own process -- nothing there wants MPI."""
+    out = _run("""
+        import sys
+        from solver_wrappers import get_simulation_helper
+        print('mpi4py.MPI' in sys.modules)
+        """)
+    assert out.strip() == 'False'
+
+
+def test_parsing_a_config_never_opens_mpi():
+    out = _run("""
+        import sys
+        from parsers.PrimitiveParsers import CSVFileParser
+        print('mpi4py.MPI' in sys.modules)
+        """)
+    assert out.strip() == 'False'
+
+
+# ---------------------------------------------------------------------------
+# The paths that need MPI must still not finalise it
+# ---------------------------------------------------------------------------
+def test_the_analysis_modules_never_open_mpi_serially():
+    """paramID and the optimisers run real collectives -- Bcast, Scatterv,
+    Gatherv -- unconditionally, even at one rank. They get those from the
+    one-rank stub, so a serial calibration never initialises MPI and there is no
+    MPI_Finalize for the macOS abort to happen in."""
+    out = _run("""
+        import sys
+        import param_id.paramID  # noqa: F401
+        import param_id.optimisers as o
+        print('mpi4py.MPI' in sys.modules, o.MPI.COMM_WORLD.Get_size())
+        """)
+    assert out.split() == ['False', '1']
+
+
+@pytest.mark.skipif(not mpi_utils.mpi_available(), reason='needs mpi4py')
+def test_a_launcher_started_run_gets_the_real_mpi():
+    """Under mpiexec the ranks really are talking to each other; nothing about a
+    multi-rank run may change."""
+    out = _run("""
+        import sys
+        import param_id.optimisers as o
+        print('mpi4py.MPI' in sys.modules, type(o.MPI).__name__)
+        """, env={'PMI_RANK': '0', 'PMI_SIZE': '2'})
+    assert out.split() == ['True', 'module']
+
+
+@pytest.mark.skipif(not mpi_utils.mpi_available(), reason='needs mpi4py')
+def test_the_real_mpi_wins_if_something_else_already_imported_it():
+    """MPI is initialised either way at that point, so handing back a stub would
+    make this module the odd one out."""
+    out = _run("""
+        from mpi4py import MPI  # noqa: F401
+        from utilities.mpi_utils import get_MPI
+        print(type(get_MPI()).__name__)
+        """)
+    assert out.strip() == 'module'
+
+
+# ---------------------------------------------------------------------------
+# No module may reintroduce the import
+# ---------------------------------------------------------------------------
+def test_no_module_imports_mpi4py_at_module_scope():
+    """A single missed line undoes the whole fix, and does it silently: a module
+    that assigns ``MPI = get_MPI()`` and *also* imports mpi4py has both the stub
+    and the abort, with the later line winning. That is exactly what was left
+    behind in sensitivity_analysis_run_script.py. Nothing here is subtle enough
+    to warrant catching by hand on review.
+
+    Two files are exempt. ``obsolete/`` is not on any run path, and
+    ``generate_omex_analysis_script.py`` matches inside the *text of a script it
+    generates* -- guarding generated scripts needs their own bootstrap order
+    verified and belongs in its own change.
+    """
+    exempt = {'generate_omex_analysis_script.py'}
+    offenders = []
+    for dirpath, dirnames, filenames in os.walk(SRC):
+        dirnames[:] = [d for d in dirnames if d not in ('obsolete', '__pycache__')]
+        for name in filenames:
+            if not name.endswith('.py') or name in exempt:
+                continue
+            path = os.path.join(dirpath, name)
+            with open(path, encoding='utf-8') as handle:
+                for lineno, line in enumerate(handle, 1):
+                    # Module scope only: an import nested in a function has
+                    # already decided it needs MPI at the moment it runs.
+                    if line.startswith(('from mpi4py import', 'import mpi4py')):
+                        offenders.append('%s:%d' % (os.path.relpath(path, SRC), lineno))
+    assert offenders == [], (
+        'these import mpi4py at module scope, which initialises MPI and registers '
+        'the atexit MPI_Finalize that aborts on macOS; use '
+        'utilities.mpi_utils.get_MPI() instead: ' + ', '.join(offenders))
+
+
+# ---------------------------------------------------------------------------
+# The one-rank collectives
+#
+# Each is checked against what real MPI does at one rank, which is the whole
+# claim: a broadcast from yourself changes nothing, a gather of your own value
+# is a list of one, a scatter to yourself is a copy.
+# ---------------------------------------------------------------------------
+def test_rank_and_size():
+    comm = mpi_utils._SerialMPI.COMM_WORLD
+    assert (comm.Get_rank(), comm.Get_size()) == (0, 1)
+
+
+def test_broadcast_leaves_the_buffer_alone():
+    import numpy as np
+
+    comm = mpi_utils._SerialMPI.COMM_WORLD
+    buf = np.array([1.0, 2.0, 3.0])
+    comm.Bcast(buf, root=0)
+    assert list(buf) == [1.0, 2.0, 3.0]
+    assert comm.bcast({'a': 1}, root=0) == {'a': 1}
+
+
+def test_gathering_your_own_value_gives_a_list_of_one():
+    comm = mpi_utils._SerialMPI.COMM_WORLD
+    assert comm.gather(7, root=0) == [7]
+    assert comm.allgather({'x': 1}) == [{'x': 1}]
+
+
+def test_scatterv_reshapes_the_whole_population_into_the_receive_buffer():
+    """The shape change is the part worth pinning: CA scatters a flat population
+    into an (n, num_params) buffer, so a naive `dest[:] = src` would raise."""
+    import numpy as np
+
+    comm = mpi_utils._SerialMPI.COMM_WORLD
+    send = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    recv = np.zeros((3, 2))
+    comm.Scatterv([send, np.array([6]), None, mpi_utils._SerialMPI.DOUBLE], recv, root=0)
+    assert recv.tolist() == [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+
+
+def test_gatherv_collects_the_one_rank_contribution():
+    import numpy as np
+
+    comm = mpi_utils._SerialMPI.COMM_WORLD
+    send = np.array([[1.0, 2.0], [3.0, 4.0]])
+    recv = np.zeros(4)
+    comm.Gatherv(send, [recv, np.array([4]), None, mpi_utils._SerialMPI.DOUBLE], root=0)
+    assert recv.tolist() == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_allreduce_over_one_rank_is_the_value_itself():
+    import numpy as np
+
+    comm = mpi_utils._SerialMPI.COMM_WORLD
+    send, recv = np.array([3.0, 1.0]), np.zeros(2)
+    comm.Allreduce(send, recv, op=mpi_utils._SerialMPI.MIN)
+    assert recv.tolist() == [3.0, 1.0]
+
+
+def test_there_is_never_a_message_waiting():
+    comm = mpi_utils._SerialMPI.COMM_WORLD
+    assert comm.iprobe(source=mpi_utils._SerialMPI.ANY_SOURCE, tag=1) is False
+
+
+def test_waitall_on_nothing_is_fine_and_on_something_is_not():
+    """At one rank the send list is always empty -- the loop that fills it skips
+    `other == rank`. A non-empty list would mean a message was sent with nobody
+    to send it to, which is worth failing loudly rather than ignoring."""
+    mpi_utils._SerialMPI.Request.Waitall([])
+    with pytest.raises(RuntimeError, match='nothing can have been sent'):
+        mpi_utils._SerialMPI.Request.Waitall(['pending'])
+
+
+def test_point_to_point_refuses_rather_than_deadlocking():
+    """`recv` at one rank would block forever; saying so beats hanging a run."""
+    comm = mpi_utils._SerialMPI.COMM_WORLD
+    with pytest.raises(RuntimeError, match='block forever'):
+        comm.recv(source=0, tag=1)
+    with pytest.raises(RuntimeError, match='no'):
+        comm.isend(1, dest=1, tag=1)


### PR DESCRIPTION
Fixes #396.

## The bug

`from mpi4py import MPI` sat at module scope in eighteen places, so **importing CA
initialised MPI** and registered an `atexit MPI_Finalize` — including for a plain
forward solve, in a process nothing launched with `mpiexec`, on a machine with no
MPI installed. Closing that process aborts on macOS:

```
Abort(808576911): Fatal error in internal_Finalize: Other MPI error
MPIDI_OFI_mpi_finalize_hook(861):
flush_send_queue(830)...........:
MPIDI_OFI_handle_cq_error(593)..: OFI poll failed
(default nic=en5: Input/output error)
```

MPI had bound a real NIC and the close failed because the NIC had gone away — a
Wi-Fi drop, a VPN, a virtual adapter disappearing. Hence "during closing", and
hence the reporter's summary being exactly right: if MPI is not in use, none of
this should be happening.

`solver_wrappers/__init__.py` is the one that made this visible from CUFLynx — it
is imported **in-process** for live simulation, so every slider drag was running
in a process that had opened MPI.

## The fix

`src/utilities/mpi_utils.py` answers the question each caller actually asks.

**`rank()` / `size()` / `is_root()` / `mpi_available()`** — for code that only
needs to know which rank it is. These never import mpi4py when no launcher started
the process, so `solver_wrappers` and `PrimitiveParsers` now run entirely MPI-free.

**`get_MPI()`** — for code that runs real collectives. CA calls `Bcast`,
`Scatterv`, `Gatherv`, `gather`, `allgather` and `Allreduce` *unconditionally*,
even at one rank, so those modules could not simply skip MPI. At one rank each
collective has a trivial exact definition — a broadcast from yourself changes
nothing, a gather of your own value is a list of one, a scatter to yourself is a
copy — so `_SerialComm` supplies them and MPI is never opened. Under a launcher
`get_MPI()` returns the real `mpi4py.MPI` and a multi-rank run is untouched.

Defining the one-rank case **once** beats guarding ~15 call sites on `size > 1`,
which would have been a larger and far more error-prone change.

The point-to-point calls are unreachable at one rank: the loop that issues them is
`for other in range(num_procs): if other != rank`, which has no iterations, and the
matching receives are bounded by a count that is zero. So `recv`/`isend` raise a
clear error rather than deadlocking, and `Request.Waitall` refuses a non-empty list
instead of ignoring it — silence there would mean a message sent with nobody to
send it to.

### Rejected alternative

`mpi4py.rc.initialize = False` was **measured**, not assumed, and does not work: CA
calls `MPI.COMM_WORLD.Get_rank()` unconditionally, and with MPI uninitialised that
aborts the process outright. `rc.finalize = False` is still set for the launcher
case, so a run that does open MPI never finalises it from an `atexit` hook.

## Verification

Both paths exercised, not inferred:

| | mpi4py imported | `MPI` is | rank/size |
|---|---|---|---|
| serial | **False** | `_SerialMPI` | 0 / 1 |
| `mpiexec -n 2` | True | `module` | 0 / 2 and 1 / 2 |

CA's real **3compartment genetic-algorithm calibration** passes both serially
(which exercises the stub, including the flat → `(n, num_params)` `Scatterv`
reshape) and under `mpiexec -n 2` (which exercises real MPI, on Open MPI 4.1.2).

`tests/test_mpi_utils.py` adds **25 checks**: the launcher probe over every
launcher variable, the paths that must stay MPI-free, and each one-rank collective
against what real MPI does at one rank.

One of the 25 is a guard that **no module imports mpi4py at module scope**, because
a single missed line undoes the fix silently — a module that assigns
`MPI = get_MPI()` and *also* imports mpi4py ends up with both the stub and the
abort, the later line winning. `sensitivity_analysis_run_script.py` had two such
imports and the first pass replaced only one; the guard is what found it.

**What the tests cannot do:** reproduce the abort itself. That needs a NIC that
fails mid-flush, and no CI runner will summon one on demand. What they pin is the
precondition — that a serial process no longer opens MPI, and no longer registers
the finalise that aborts. Remove either and the abort becomes possible again.

## Not touched

`generate_omex_analysis_script.py`, whose match is inside the *text of a script it
generates*. Guarding generated scripts needs their own bootstrap order verified and
belongs in its own change. `src/obsolete/` is not on any run path.
