### PR TITLE
feat(uq): KDE and Poisson likelihood cost functions (#367 step 2)

### DIFF
--- a/funcs_user/cost_funcs_user.py
+++ b/funcs_user/cost_funcs_user.py
@@ -99,6 +99,72 @@ def multimodal_gaussian(output, prob_dist_params, weight):
     return cost
 
 
+@is_MLE
+def kernel_density_estimation(output, prob_dist_params, weight):
+    """Negative log-likelihood under a kernel density estimate of the observed samples.
+
+    For a target that is known only as a set of measurements rather than as a named
+    distribution: the samples are turned into a smooth density with
+    ``scipy.stats.gaussian_kde`` and the model output is scored against it. Unlike
+    ``multimodal_gaussian`` this needs no assumption about how many modes there are, or
+    where they sit.
+
+    prob_dist_params: ``{"data_points": [...], "bandwidth": <optional>}``. ``bandwidth`` is
+    passed straight to gaussian_kde's ``bw_method`` ('scott', 'silverman', a scalar, or a
+    callable), defaulting to Scott's rule.
+    """
+    if hasattr(output, "__len__") and np.size(output) > 1:
+        raise ValueError(
+            "kernel_density_estimation cost function is not implemented for series data")
+
+    if not isinstance(prob_dist_params, dict) or "data_points" not in prob_dist_params:
+        raise ValueError(
+            "prob_dist_params for kernel_density_estimation in obs_data.json must be a dict "
+            "with a 'data_points' entry (and optionally 'bandwidth')")
+
+    data_points = np.asarray(prob_dist_params["data_points"], dtype=float)
+    if data_points.size == 0:
+        raise ValueError(
+            "data_points for kernel_density_estimation in obs_data.json cannot be empty")
+
+    from scipy.stats import gaussian_kde
+
+    kde = gaussian_kde(data_points, bw_method=prob_dist_params.get("bandwidth", "scott"))
+    # logpdf returns an array even for one point; the cost must be a plain scalar so the
+    # weighted sum over observables stays 0-d.
+    return float(-np.ravel(kde.logpdf(np.ravel(output)))[0] * weight)
+
+
+@is_MLE
+def poisson_MLE(output, prob_dist_params, weight):
+    """Poisson negative log-likelihood contribution, for count data.
+
+    The model output is the rate (lambda); ``prob_dist_params['k']`` is the observed count.
+    The constant ``log(k!)`` is dropped -- it does not depend on the parameters, so it shifts
+    every cost by the same amount and changes no optimum.
+
+    NLL = lambda - k*log(lambda), so it is minimised at lambda == k. (#367 had the sign the
+    other way round, i.e. the log-likelihood, which an optimiser would have driven *away*
+    from the data.)
+    """
+    if not isinstance(prob_dist_params, dict) or "k" not in prob_dist_params:
+        raise ValueError(
+            "prob_dist_params for poisson_MLE in obs_data.json must be a dict with a 'k' "
+            "entry (the observed count)")
+
+    # A Poisson rate is positive; clip so a parameter set that drives it to zero costs a lot
+    # rather than producing -inf/nan and poisoning the whole cost.
+    lam = np.clip(output, 1e-12, None)
+    k = prob_dist_params["k"]
+
+    cost = (lam - k * np.log(lam)) * weight
+
+    if hasattr(cost, "__len__"):
+        cost = np.sum(cost) / np.size(cost)
+
+    return float(cost)
+
+
 @differentiable
 def AE(output, desired_mean, std, weight):
     cost = mb.abs((output - desired_mean) / std) * weight

--- a/tests/test_uq_cost_funcs.py
+++ b/tests/test_uq_cost_funcs.py
@@ -1,0 +1,150 @@
+"""The two likelihood costs added for uncertainty quantification (from #367).
+
+Both are ``@is_MLE``, so paramID reads them as ``ln L = -cost``: the value they return must be a
+*negative* log-likelihood, positive and minimised at the best fit, matching ``gaussian_MLE``.
+That convention is what these tests pin -- getting the sign wrong does not fail loudly, it just
+makes the optimiser walk away from the data.
+"""
+import numpy as np
+import pytest
+
+from funcs_user.cost_funcs_user import (
+    cost_func_metadata, gaussian_MLE, kernel_density_estimation, poisson_MLE)
+
+
+# ---------------------------------------------------------------------------
+# registration
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_the_new_costs_are_discoverable_as_MLE_and_not_differentiable():
+    """The obs-data editor builds its cost_type menu from this metadata. Both are MLE (so they
+    are selectable for MCMC / Laplace) and neither is differentiable -- a KDE's logpdf and the
+    Poisson NLL are numpy-only, so they must not be offered as an AD cost."""
+    meta = cost_func_metadata()
+    for name in ('kernel_density_estimation', 'poisson_MLE'):
+        assert name in meta, name + ' is not registered as a cost function'
+        assert meta[name]['is_MLE'] is True
+        assert meta[name]['differentiable'] is False
+        assert meta[name]['is_combiner'] is False
+
+
+# ---------------------------------------------------------------------------
+# poisson_MLE
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_poisson_cost_is_the_negative_log_likelihood():
+    """NLL = lambda - k*log(lambda), dropping the parameter-independent log(k!)."""
+    k, lam = 4, 3.0
+    expected = lam - k * np.log(lam)
+    assert poisson_MLE(lam, {'k': k}, 1.0) == pytest.approx(expected)
+
+
+@pytest.mark.unit
+def test_poisson_cost_is_minimised_when_the_rate_matches_the_count():
+    """The sign check that matters. #367 returned k*log(lambda) - lambda -- the log-likelihood --
+    which is *maximised* at lambda == k, so minimising it would have driven the rate away from
+    the observed count in both directions."""
+    k = 4
+    at_truth = poisson_MLE(float(k), {'k': k}, 1.0)
+    for wrong_rate in (0.5, 1.0, 2.0, 8.0, 40.0):
+        assert poisson_MLE(wrong_rate, {'k': k}, 1.0) > at_truth, wrong_rate
+
+    # and it really is the minimum, not merely better than a few samples
+    rates = np.linspace(0.1, 20.0, 400)
+    costs = [poisson_MLE(r, {'k': k}, 1.0) for r in rates]
+    assert rates[int(np.argmin(costs))] == pytest.approx(k, abs=0.1)
+
+
+@pytest.mark.unit
+def test_poisson_cost_scales_with_weight_and_returns_a_scalar():
+    cost = poisson_MLE(3.0, {'k': 4}, 1.0)
+    assert poisson_MLE(3.0, {'k': 4}, 2.5) == pytest.approx(2.5 * cost)
+    assert isinstance(cost, float)
+
+
+@pytest.mark.unit
+def test_poisson_cost_survives_a_rate_driven_to_zero():
+    """An unclipped log(0) would return -inf and poison the summed cost for every other
+    observable, turning one bad parameter set into an uninformative total."""
+    cost = poisson_MLE(0.0, {'k': 4}, 1.0)
+    assert np.isfinite(cost)
+    assert cost > poisson_MLE(4.0, {'k': 4}, 1.0)
+
+
+@pytest.mark.unit
+def test_poisson_cost_requires_the_observed_count():
+    with pytest.raises(ValueError, match="'k'"):
+        poisson_MLE(3.0, {'lambda': 4}, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# kernel_density_estimation
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_kde_cost_matches_scipy_gaussian_kde():
+    gaussian_kde = pytest.importorskip('scipy.stats').gaussian_kde
+    samples = [1.0, 1.2, 0.9, 1.1, 1.05, 0.95]
+
+    expected = -float(gaussian_kde(np.asarray(samples)).logpdf([1.0])[0])
+    assert kernel_density_estimation(1.0, {'data_points': samples}, 1.0) == pytest.approx(expected)
+
+
+@pytest.mark.unit
+def test_kde_cost_is_lowest_where_the_samples_are_dense():
+    """The whole point of a KDE likelihood: the cost follows the observed sample density rather
+    than any assumed shape, so a bimodal sample set scores both modes better than the gap
+    between them -- which a single gaussian_MLE cannot do."""
+    pytest.importorskip('scipy.stats')
+    samples = list(np.concatenate([np.linspace(-1.2, -0.8, 40), np.linspace(0.8, 1.2, 40)]))
+    kwargs = {'data_points': samples}
+
+    at_left_mode = kernel_density_estimation(-1.0, kwargs, 1.0)
+    at_right_mode = kernel_density_estimation(1.0, kwargs, 1.0)
+    in_the_gap = kernel_density_estimation(0.0, kwargs, 1.0)
+
+    assert in_the_gap > at_left_mode and in_the_gap > at_right_mode
+    assert at_left_mode == pytest.approx(at_right_mode, rel=0.05), 'the modes are symmetric'
+
+
+@pytest.mark.unit
+def test_kde_cost_honours_the_bandwidth_and_the_weight():
+    pytest.importorskip('scipy.stats')
+    samples = [1.0, 1.2, 0.9, 1.1, 1.05, 0.95]
+
+    narrow = kernel_density_estimation(2.0, {'data_points': samples, 'bandwidth': 0.05}, 1.0)
+    wide = kernel_density_estimation(2.0, {'data_points': samples, 'bandwidth': 1.0}, 1.0)
+    assert narrow > wide, 'a narrower kernel must penalise a far-out point more'
+
+    cost = kernel_density_estimation(1.0, {'data_points': samples}, 1.0)
+    assert kernel_density_estimation(1.0, {'data_points': samples}, 3.0) == pytest.approx(3 * cost)
+    assert isinstance(cost, float)
+
+
+@pytest.mark.unit
+def test_kde_cost_rejects_unusable_inputs():
+    pytest.importorskip('scipy.stats')
+    with pytest.raises(ValueError, match='data_points'):
+        kernel_density_estimation(1.0, {'samples': [1.0, 2.0]}, 1.0)
+    with pytest.raises(ValueError, match='empty'):
+        kernel_density_estimation(1.0, {'data_points': []}, 1.0)
+    with pytest.raises(ValueError, match='series'):
+        kernel_density_estimation(np.array([1.0, 2.0]), {'data_points': [1.0, 2.0]}, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# consistency with the existing MLE cost
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_both_costs_share_gaussian_MLEs_sign_convention():
+    """All three are @is_MLE and are summed together into one cost, so they have to agree on
+    which direction is 'better' -- otherwise mixing them in one obs_data cancels them out."""
+    pytest.importorskip('scipy.stats')
+    samples = [1.0, 1.2, 0.9, 1.1, 1.05, 0.95]
+
+    def better_than(cost_at_truth, cost_when_wrong):
+        assert cost_when_wrong > cost_at_truth
+
+    better_than(gaussian_MLE(1.0, 1.0, 0.1, 1.0), gaussian_MLE(2.0, 1.0, 0.1, 1.0))
+    better_than(kernel_density_estimation(1.05, {'data_points': samples}, 1.0),
+                kernel_density_estimation(5.0, {'data_points': samples}, 1.0))
+    better_than(poisson_MLE(4.0, {'k': 4}, 1.0), poisson_MLE(20.0, {'k': 4}, 1.0))


### PR DESCRIPTION
Second of the stack bringing in #367 (pyMC for UQ). Original work by @MOH-Shafizadegan.

> Stacked on #402 — its commit is included here and the diff shrinks to the last commit once #402 merges.

## What

Two likelihood costs, both `@is_MLE`:

- **`kernel_density_estimation`** — scores the model output against a `gaussian_kde` of the observed samples. For a target known only as a set of measurements rather than as a named distribution. Unlike `multimodal_gaussian` it needs no assumption about how many modes there are or where they sit, which is what makes the bimodal recovery test later in the stack possible.
- **`poisson_MLE`** — the Poisson negative log-likelihood for count data.

## A sign bug fixed on the way in

Both are `@is_MLE`, so paramID reads them as `ln L = -cost` and sums them alongside `gaussian_MLE`. The sign is therefore part of the contract — and #367 had `poisson_MLE` returning

```python
cost = (k * np.log(lam) - lam) * weight     # this is the LOG-likelihood
```

which is *maximised* at `lambda == k`. Minimising it would have driven the rate **away** from the observed count in both directions, and nothing would have failed loudly — the calibration would just have converged somewhere wrong.

Corrected to `lambda - k*log(lambda)`, and pinned by a test that scans the cost curve over `lambda` and asserts the minimum sits at `k`. Reverting to #367's formula fails three of the new tests, including that one.

## Also hardened relative to #367

- The Poisson rate is clipped off zero. An unclipped `log(0)` returns `-inf`, which poisons the summed cost for *every other* observable and turns one bad parameter set into an uninformative total.
- The KDE result is coerced to a plain `float` — `logpdf` returns an array even for a single point, so the weighted sum over observables would otherwise stop being 0-d.
- The validated `data_points` array is the one handed to `gaussian_kde` (#367 revalidated it, then passed the raw list).
- Bad `prob_dist_params` raise a message naming the missing key, instead of an `IndexError` further in.

## Tests

New `tests/test_uq_cost_funcs.py`, 11 fast unit tests: both costs are discoverable as `is_MLE` and not differentiable; the Poisson NLL matches the analytic value and is minimised at `k`; the KDE cost matches `scipy.stats.gaussian_kde` directly and scores both modes of a bimodal sample set better than the gap between them; bandwidth and weight are honoured; unusable inputs raise; and all three MLE costs agree on which direction is "better" — they get summed into one cost, so a disagreement would cancel them out.

`-m unit`: 299 passed, 1 skipped.
