### PR TITLE
feat(uq): let the GA minimise a log posterior, safely (#367 step 3)

### DIFF
--- a/src/param_id/optimisers.py
+++ b/src/param_id/optimisers.py
@@ -126,6 +126,92 @@ class GeneticAlgorithmOptimiser(Optimiser):
     _POPULATION_KEYS = ('num_elite', 'num_survivors', 'num_mutations_per_survivor',
                         'num_cross_breed')
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.objective_function = self.optimiser_options.get('objective_function', 'cost')
+        if self.objective_function not in ('cost', 'likelihood'):
+            raise ValueError(
+                f"Invalid objective_function: {self.objective_function!r}. "
+                f"Must be 'cost' or 'likelihood'.")
+
+    def _objective(self, param_vals):
+        """The scalar this GA minimises, for the selected ``objective_function``.
+
+        ``'likelihood'`` is **negated**: get_lnlikelihood_lnprior_from_params returns a log
+        posterior, where higher is better, and every optimiser here minimises. Handing it over
+        unnegated (as #367 did) would have made the GA search for the *least* probable
+        parameters -- and worse, an out-of-prior point returns -inf, which minimisation would
+        score as the best point there is. Negated, that same -inf becomes +inf, which is exactly
+        the "reject and resample" signal the population loop below already handles.
+        """
+        if self.objective_function == 'likelihood':
+            return -self.param_id_obj.get_lnlikelihood_lnprior_from_params(param_vals)
+        return self.param_id_obj.get_cost_from_params(param_vals)
+
+    def _loss_has_stalled(self, cost, last_loss):
+        """Whether this generation counts towards ``max_patience``.
+
+        The absolute ``cost_convergence`` test alone is scale dependent: a likelihood objective
+        whose values sit in the hundreds never moves by less than 1e-4, so the run only ever
+        stops on the generation budget. Opting in to ``use_relative_tolerance`` also stops when
+        the *fractional* change falls below ``relative_tolerance``. Either criterion counts, so
+        turning it on can only make a run stop sooner, never later.
+        """
+        diff = abs(cost - last_loss)
+        if diff < self.optimiser_options["cost_convergence"]:
+            return True
+        if self.optimiser_options.get('use_relative_tolerance', False):
+            relative_change = diff / max(abs(last_loss), 1e-10)
+            return relative_change < self.optimiser_options.get('relative_tolerance', 1e-3)
+        return False
+
+    @staticmethod
+    def _survival_probabilities(costs):
+        """Selection weights for the non-elite population, as a normalised probability vector.
+
+        The inverse-cost rule ``cost**-1`` is kept wherever it is valid, which is every ordinary
+        calibration: it assumes a strictly positive cost, and that is what a weighted cost
+        function returns. Keeping it means this change is invisible to existing runs -- see
+        below for why that matters more than it looks.
+
+        It breaks for ``objective_function='likelihood'``, where the objective is a negative log
+        posterior. That goes negative wherever the posterior density exceeds 1, and a negative
+        weight is not a probability: np.random.choice raises, or -- with mixed signs summing
+        near zero -- silently returns nonsense. Even where it stays positive it barely
+        discriminates, because the values are large and close together (1/800 vs 1/830 is almost
+        uniform selection, i.e. a GA that has stopped selecting at all).
+
+        So that case falls back to Boltzmann selection, on costs shifted to start at zero and
+        scaled by their own spread. Both are necessary: the shift because ``exp(-cost)``
+        underflows to zero for every member once the objective passes about 745 (softmax is
+        shift invariant, so this changes no probability), and the scaling because an unscaled
+        ``exp(-cost)`` makes selection pressure depend on the objective's absolute magnitude.
+        #367 used the unscaled, unshifted form for *every* run, which on a measured 3compartment
+        GA population (costs 5.3 to 17.3) collapses the effective number of distinct survivors
+        from 5.4 of 6 to 1.3 of 6 -- near-deterministic selection, which is the diversity a GA
+        exists to keep.
+        """
+        costs = np.asarray(costs, dtype=float)
+
+        if np.all(np.isfinite(costs)) and np.all(costs > 0):
+            inverse = costs ** -1
+            total = np.sum(inverse)
+            if np.isfinite(total) and total > 0:
+                return inverse / total
+
+        finite = costs[np.isfinite(costs)]
+        if finite.size == 0:
+            return np.full(costs.shape, 1.0 / costs.size)
+        # Non-finite members must not win, and must not poison the normalisation.
+        costs = np.where(np.isfinite(costs), costs, np.max(finite))
+        spread = np.max(costs) - np.min(costs)
+        scale = spread if spread > 0 else 1.0
+        weights = np.exp(-(costs - np.min(costs)) / scale)
+        total = np.sum(weights)
+        if not np.isfinite(total) or total <= 0:
+            return np.full(costs.shape, 1.0 / costs.size)
+        return weights / total
+
     @classmethod
     def _debug_population(cls):
         """The quick-run population DEBUG substitutes, read from each option's ``debug_default``
@@ -262,7 +348,7 @@ class GeneticAlgorithmOptimiser(Optimiser):
                         success = True
                         break
                     
-                    cost_proc[II] = self.param_id_obj.get_cost_from_params(param_vals_proc[:, II])
+                    cost_proc[II] = self._objective(param_vals_proc[:, II])
                     
                     if cost_proc[II] == np.inf:
                         print('... choosing a new random point')
@@ -316,7 +402,7 @@ class GeneticAlgorithmOptimiser(Optimiser):
                 
                 #count the repeat number
                 if last_loss is not None:
-                    if abs(cost[0]-last_loss) < self.optimiser_options["cost_convergence"]:
+                    if self._loss_has_stalled(cost[0], last_loss):
                         loss_repeat_counter += 1
                     else:
                         loss_repeat_counter = 0
@@ -346,7 +432,7 @@ class GeneticAlgorithmOptimiser(Optimiser):
                         if cost[idx] > 1e25:
                             cost[idx] = 1e25
                     
-                    survive_prob = cost[num_elite:num_pop]**-1/sum(cost[num_elite:num_pop]**-1)
+                    survive_prob = self._survival_probabilities(cost[num_elite:num_pop])
                     rand_survivor_idxs = np.random.choice(np.arange(num_elite, num_pop),
                                                         size=num_survivors-num_elite, p=survive_prob)
                     param_vals_norm[:, num_elite:num_survivors] = param_vals_norm[:, rand_survivor_idxs]

--- a/src/param_id/optimisers.py
+++ b/src/param_id/optimisers.py
@@ -153,16 +153,16 @@ class GeneticAlgorithmOptimiser(Optimiser):
 
         The absolute ``cost_convergence`` test alone is scale dependent: a likelihood objective
         whose values sit in the hundreds never moves by less than 1e-4, so the run only ever
-        stops on the generation budget. Opting in to ``use_relative_tolerance`` also stops when
-        the *fractional* change falls below ``relative_tolerance``. Either criterion counts, so
+        stops on the generation budget. Opting in to ``use_relative_cost_tolerance`` also stops when
+        the *fractional* change falls below ``relative_cost_tolerance``. Either criterion counts, so
         turning it on can only make a run stop sooner, never later.
         """
         diff = abs(cost - last_loss)
         if diff < self.optimiser_options["cost_convergence"]:
             return True
-        if self.optimiser_options.get('use_relative_tolerance', False):
+        if self.optimiser_options.get('use_relative_cost_tolerance', False):
             relative_change = diff / max(abs(last_loss), 1e-10)
-            return relative_change < self.optimiser_options.get('relative_tolerance', 1e-3)
+            return relative_change < self.optimiser_options.get('relative_cost_tolerance', 1e-3)
         return False
 
     @staticmethod

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -430,6 +430,27 @@ _OPT_GA_NUM_CROSS_BREED = {
     'description': 'Genetic algorithm: cross-bred (recombined) offspring per generation. '
                    'Reduced to 10 when DEBUG is on.',
 }
+# What the GA minimises. 'likelihood' is the log posterior, negated so that lower is still
+# better -- it lets the GA search the same objective MCMC samples, which is what makes a GA a
+# usable way to find a starting point for UQ.
+_OPT_OBJECTIVE_FUNCTION = {
+    'name': 'objective_function', 'type': 'enum', 'default': 'cost', 'required': False,
+    'choices': ['cost', 'likelihood'],
+    'description': "Genetic algorithm: what to minimise. 'cost' is the weighted cost function; "
+                   "'likelihood' is the negative log posterior (log likelihood + log prior).",
+}
+_OPT_USE_RELATIVE_TOLERANCE = {
+    'name': 'use_relative_tolerance', 'type': 'bool', 'default': False, 'required': False,
+    'description': 'Genetic algorithm: also count a generation as stalled when the *fractional* '
+                   'change in cost falls below relative_tolerance, not only when the absolute '
+                   'change falls below cost_convergence. Useful when the objective is large in '
+                   'magnitude (e.g. a log posterior), where an absolute threshold never trips.',
+}
+_OPT_RELATIVE_TOLERANCE = {
+    'name': 'relative_tolerance', 'type': 'float', 'default': 1e-3, 'required': False,
+    'description': 'Genetic algorithm: the fractional cost change below which a generation '
+                   'counts as stalled. Only read when use_relative_tolerance is true.',
+}
 
 
 # Single source of truth for the prior distributions a params_for_id `prior` column may name,
@@ -1162,7 +1183,12 @@ PARAM_ID_METHODS = {
         'description': 'Gradient-free population-based global search.',
         'options': [_OPT_NUM_CALLS, _OPT_COST_CONVERGENCE, _OPT_MAX_PATIENCE,
                     _OPT_GA_NUM_ELITE, _OPT_GA_NUM_SURVIVORS,
-                    _OPT_GA_NUM_MUTATIONS_PER_SURVIVOR, _OPT_GA_NUM_CROSS_BREED],
+                    _OPT_GA_NUM_MUTATIONS_PER_SURVIVOR, _OPT_GA_NUM_CROSS_BREED,
+                    # Only the GA reads these: it is the one optimiser that can be driven by a
+                    # log-posterior (it needs no gradient of it), and the one whose selection
+                    # step had to change to cope with the negative costs that produces.
+                    _OPT_OBJECTIVE_FUNCTION, _OPT_USE_RELATIVE_TOLERANCE,
+                    _OPT_RELATIVE_TOLERANCE],
     },
     'CMA-ES': {
         'label': 'CMA-ES',

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -439,17 +439,17 @@ _OPT_OBJECTIVE_FUNCTION = {
     'description': "Genetic algorithm: what to minimise. 'cost' is the weighted cost function; "
                    "'likelihood' is the negative log posterior (log likelihood + log prior).",
 }
-_OPT_USE_RELATIVE_TOLERANCE = {
-    'name': 'use_relative_tolerance', 'type': 'bool', 'default': False, 'required': False,
+_OPT_USE_RELATIVE_COST_TOLERANCE = {
+    'name': 'use_relative_cost_tolerance', 'type': 'bool', 'default': False, 'required': False,
     'description': 'Genetic algorithm: also count a generation as stalled when the *fractional* '
-                   'change in cost falls below relative_tolerance, not only when the absolute '
+                   'change in cost falls below relative_cost_tolerance, not only when the absolute '
                    'change falls below cost_convergence. Useful when the objective is large in '
                    'magnitude (e.g. a log posterior), where an absolute threshold never trips.',
 }
-_OPT_RELATIVE_TOLERANCE = {
-    'name': 'relative_tolerance', 'type': 'float', 'default': 1e-3, 'required': False,
+_OPT_RELATIVE_COST_TOLERANCE = {
+    'name': 'relative_cost_tolerance', 'type': 'float', 'default': 1e-3, 'required': False,
     'description': 'Genetic algorithm: the fractional cost change below which a generation '
-                   'counts as stalled. Only read when use_relative_tolerance is true.',
+                   'counts as stalled. Only read when use_relative_cost_tolerance is true.',
 }
 
 
@@ -1181,14 +1181,20 @@ PARAM_ID_METHODS = {
         'label': 'Genetic algorithm',
         'gradient_based': False,
         'description': 'Gradient-free population-based global search.',
+        # This order is the order a front-end lays the form out in, so the stopping rules sit
+        # together: the relative one is the same decision as cost_convergence/max_patience, not
+        # a separate feature, and is unreadable parked at the far end past the population sizes.
         'options': [_OPT_NUM_CALLS, _OPT_COST_CONVERGENCE, _OPT_MAX_PATIENCE,
+                    # Only the GA reads these two, for the same reason it alone reads
+                    # objective_function below: a log-posterior objective sits in the hundreds
+                    # and never moves by less than an absolute threshold.
+                    _OPT_USE_RELATIVE_COST_TOLERANCE, _OPT_RELATIVE_COST_TOLERANCE,
                     _OPT_GA_NUM_ELITE, _OPT_GA_NUM_SURVIVORS,
                     _OPT_GA_NUM_MUTATIONS_PER_SURVIVOR, _OPT_GA_NUM_CROSS_BREED,
-                    # Only the GA reads these: it is the one optimiser that can be driven by a
+                    # Only the GA reads this: it is the one optimiser that can be driven by a
                     # log-posterior (it needs no gradient of it), and the one whose selection
                     # step had to change to cope with the negative costs that produces.
-                    _OPT_OBJECTIVE_FUNCTION, _OPT_USE_RELATIVE_TOLERANCE,
-                    _OPT_RELATIVE_TOLERANCE],
+                    _OPT_OBJECTIVE_FUNCTION],
     },
     'CMA-ES': {
         'label': 'CMA-ES',

--- a/tests/test_ga_objective_and_selection.py
+++ b/tests/test_ga_objective_and_selection.py
@@ -1,0 +1,198 @@
+"""The GA's objective selection and its survival weighting (from #367).
+
+Both exist so the GA can be driven by a log posterior instead of a weighted cost -- which is how
+a GA is used to find a starting point for UQ. That objective is unbounded in sign and large in
+magnitude, and the old selection step assumed neither.
+"""
+import numpy as np
+import pytest
+
+from param_id.optimisers import GeneticAlgorithmOptimiser
+
+
+class _StubEngine:
+    """Stands in for OpencorParamID: records which objective the GA asked for."""
+
+    def __init__(self, cost=3.0, log_posterior=-2.0):
+        self.cost = cost
+        self.log_posterior = log_posterior
+        self.calls = []
+
+    def get_cost_from_params(self, param_vals):
+        self.calls.append('cost')
+        return self.cost
+
+    def get_lnlikelihood_lnprior_from_params(self, param_vals):
+        self.calls.append('likelihood')
+        return self.log_posterior
+
+
+def _ga(engine=None, **options):
+    """A GA with only the attributes the objective/selection helpers touch."""
+    ga = GeneticAlgorithmOptimiser.__new__(GeneticAlgorithmOptimiser)
+    ga.param_id_obj = engine
+    ga.optimiser_options = {'cost_convergence': 1e-4, 'max_patience': 10, **options}
+    ga.objective_function = ga.optimiser_options.get('objective_function', 'cost')
+    if ga.objective_function not in ('cost', 'likelihood'):
+        raise ValueError(f"Invalid objective_function: {ga.objective_function!r}")
+    return ga
+
+
+# ---------------------------------------------------------------------------
+# objective_function
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_default_objective_is_the_cost_function():
+    engine = _StubEngine(cost=3.0)
+    assert _ga(engine)._objective(np.array([1.0])) == 3.0
+    assert engine.calls == ['cost']
+
+
+@pytest.mark.unit
+def test_likelihood_objective_is_negated_so_lower_is_still_better():
+    """The sign check that matters. get_lnlikelihood_lnprior_from_params returns a log posterior
+    (higher is better) and every optimiser here minimises, so it has to be negated. #367 handed
+    it over as-is, which would have made the GA search for the least probable parameters."""
+    engine = _StubEngine(log_posterior=-2.0)
+    ga = _ga(engine, objective_function='likelihood')
+
+    assert ga._objective(np.array([1.0])) == 2.0
+    assert engine.calls == ['likelihood']
+
+    # a better fit (higher log posterior) must give a *smaller* objective
+    better = _ga(_StubEngine(log_posterior=-0.5), objective_function='likelihood')
+    worse = _ga(_StubEngine(log_posterior=-9.0), objective_function='likelihood')
+    assert better._objective(np.array([1.0])) < worse._objective(np.array([1.0]))
+
+
+@pytest.mark.unit
+def test_an_out_of_prior_point_becomes_infinite_cost_not_the_best_point():
+    """get_lnlikelihood_lnprior_from_params returns -inf outside the prior support. Unnegated,
+    a minimiser scores that as the best point there is; negated it becomes +inf, which the
+    population loop already treats as 'reject and resample'."""
+    ga = _ga(_StubEngine(log_posterior=-np.inf), objective_function='likelihood')
+    assert ga._objective(np.array([1.0])) == np.inf
+
+
+@pytest.mark.unit
+def test_an_unknown_objective_is_rejected_at_construction():
+    with pytest.raises(ValueError, match='objective_function'):
+        _ga(_StubEngine(), objective_function='posterior')
+
+
+# ---------------------------------------------------------------------------
+# survival probabilities
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_survival_weights_are_a_valid_probability_vector_for_negative_costs():
+    """A negative log posterior goes negative wherever the posterior density exceeds 1. The old
+    cost**-1 weighting then produces negative 'probabilities', which np.random.choice rejects."""
+    costs = np.array([-5.0, -2.0, 1.0, 4.0])
+    probs = GeneticAlgorithmOptimiser._survival_probabilities(costs)
+
+    assert np.all(probs >= 0), 'a probability cannot be negative'
+    assert np.sum(probs) == pytest.approx(1.0)
+    # the old rule really would have broken here
+    old_rule = costs ** -1 / np.sum(costs ** -1)
+    assert np.any(old_rule < 0), 'the regression this replaces'
+
+
+@pytest.mark.unit
+def test_lower_cost_is_more_likely_to_survive():
+    probs = GeneticAlgorithmOptimiser._survival_probabilities(np.array([1.0, 2.0, 3.0]))
+    assert probs[0] > probs[1] > probs[2]
+    assert np.sum(probs) == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_an_ordinary_positive_cost_keeps_the_existing_inverse_cost_weighting():
+    """The change must be invisible to existing calibrations. A weighted cost function returns a
+    strictly positive cost, which is exactly where cost**-1 is valid, so that path is kept
+    byte-for-byte rather than replaced."""
+    costs = np.array([5.32062919, 8.12162795, 11.0966665, 15.81030615])
+    expected = costs ** -1 / np.sum(costs ** -1)
+    assert GeneticAlgorithmOptimiser._survival_probabilities(costs) == pytest.approx(expected)
+
+
+@pytest.mark.unit
+def test_selection_does_not_collapse_onto_the_single_best_member():
+    """Measured on a real 3compartment GA population, #367's unscaled exp(-cost) drops the
+    effective number of distinct survivors from 5.4 of 6 to 1.3 of 6 -- it selects almost
+    deterministically, which is the diversity a GA exists to keep. Guard both paths against
+    that, using perplexity (exp of the Shannon entropy) as the effective-survivor count."""
+    def perplexity(probs):
+        probs = np.asarray(probs, dtype=float)
+        probs = probs[probs > 0]
+        return float(np.exp(-np.sum(probs * np.log(probs))))
+
+    real_population = np.array([5.32062919, 8.12162795, 11.0966665,
+                                15.81030615, 16.45929783, 17.33873024])
+    naive = np.exp(-real_population) / np.sum(np.exp(-real_population))
+    assert perplexity(naive) < 2.0, 'the collapse this guards against'
+    assert perplexity(GeneticAlgorithmOptimiser._survival_probabilities(real_population)) > 4.0
+
+    # the likelihood path must stay discriminating without collapsing either
+    log_posterior_costs = np.array([-5.0, -3.0, -1.0, 2.0, 6.0])
+    probs = GeneticAlgorithmOptimiser._survival_probabilities(log_posterior_costs)
+    assert 2.0 < perplexity(probs) < len(log_posterior_costs)
+
+
+@pytest.mark.unit
+def test_survival_weights_survive_the_cost_magnitudes_a_log_posterior_reaches():
+    """exp(-cost) underflows to zero for every member once the objective passes about 745
+    (exp(-800) == 0.0), and the normalisation then divides by zero. A log posterior summed over
+    many observables reaches that easily."""
+    large = np.array([-800.0, -801.0, -802.0])  # negative, so the inverse rule cannot apply
+    with np.errstate(under='ignore', invalid='ignore'):
+        naive = np.exp(-(large - np.min(large)) * 0 - large) / np.sum(np.exp(-large))
+    assert not np.all(np.isfinite(naive)), 'the overflow/underflow this guards against'
+
+    probs = GeneticAlgorithmOptimiser._survival_probabilities(large)
+    assert np.all(np.isfinite(probs)) and np.sum(probs) == pytest.approx(1.0)
+    assert probs[2] > probs[0], 'the lowest cost must still be the most likely to survive'
+
+
+@pytest.mark.unit
+def test_a_non_finite_member_neither_wins_nor_poisons_the_others():
+    """The GA already substitutes 1e25 for a nan cost, but the selection step must be safe on
+    its own -- an inf must not become the most-favoured member via a zero weight elsewhere."""
+    probs = GeneticAlgorithmOptimiser._survival_probabilities(np.array([-2.0, 0.0, np.inf]))
+    assert np.all(np.isfinite(probs)) and np.sum(probs) == pytest.approx(1.0)
+    assert probs[0] > probs[2], 'the infinite-cost member must not be favoured'
+
+
+@pytest.mark.unit
+def test_survival_weights_fall_back_to_uniform_rather_than_nan():
+    """1e25 is the sentinel the GA already substitutes for a nan/huge cost. If every member is
+    equally hopeless the weights must still be a usable distribution."""
+    probs = GeneticAlgorithmOptimiser._survival_probabilities(np.array([np.nan, np.nan]))
+    assert np.all(np.isfinite(probs)) and np.sum(probs) == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# relative tolerance
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_absolute_tolerance_alone_is_the_default():
+    ga = _ga(_StubEngine())
+    assert ga._loss_has_stalled(1.0, 1.0 + 1e-6) is True
+    assert ga._loss_has_stalled(1.0, 2.0) is False
+
+
+@pytest.mark.unit
+def test_relative_tolerance_catches_a_stall_an_absolute_threshold_misses():
+    """A log-posterior objective sits in the hundreds, so it never moves by less than 1e-4 and
+    the run only ever stops on the generation budget."""
+    absolute_only = _ga(_StubEngine())
+    assert absolute_only._loss_has_stalled(500.0, 500.01) is False
+
+    relative = _ga(_StubEngine(), use_relative_tolerance=True, relative_tolerance=1e-3)
+    assert relative._loss_has_stalled(500.0, 500.01) is True
+    # still not stalled when the fractional change is genuinely large
+    assert relative._loss_has_stalled(500.0, 700.0) is False
+
+
+@pytest.mark.unit
+def test_relative_tolerance_does_not_divide_by_zero():
+    relative = _ga(_StubEngine(), use_relative_tolerance=True, relative_tolerance=1e-3)
+    assert relative._loss_has_stalled(1.0, 0.0) is False

--- a/tests/test_ga_objective_and_selection.py
+++ b/tests/test_ga_objective_and_selection.py
@@ -186,7 +186,7 @@ def test_relative_tolerance_catches_a_stall_an_absolute_threshold_misses():
     absolute_only = _ga(_StubEngine())
     assert absolute_only._loss_has_stalled(500.0, 500.01) is False
 
-    relative = _ga(_StubEngine(), use_relative_tolerance=True, relative_tolerance=1e-3)
+    relative = _ga(_StubEngine(), use_relative_cost_tolerance=True, relative_cost_tolerance=1e-3)
     assert relative._loss_has_stalled(500.0, 500.01) is True
     # still not stalled when the fractional change is genuinely large
     assert relative._loss_has_stalled(500.0, 700.0) is False
@@ -194,5 +194,5 @@ def test_relative_tolerance_catches_a_stall_an_absolute_threshold_misses():
 
 @pytest.mark.unit
 def test_relative_tolerance_does_not_divide_by_zero():
-    relative = _ga(_StubEngine(), use_relative_tolerance=True, relative_tolerance=1e-3)
+    relative = _ga(_StubEngine(), use_relative_cost_tolerance=True, relative_cost_tolerance=1e-3)
     assert relative._loss_has_stalled(1.0, 0.0) is False

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -78,7 +78,9 @@ def test_param_id_method_options_match_optimiser_reads():
     # Keys each optimiser reads from optimiser_options (see param_id/optimisers.py).
     assert names('genetic_algorithm') == {'num_calls_to_function', 'cost_convergence',
                                           'max_patience', 'num_elite', 'num_survivors',
-                                          'num_mutations_per_survivor', 'num_cross_breed'}
+                                          'num_mutations_per_survivor', 'num_cross_breed',
+                                          'objective_function', 'use_relative_tolerance',
+                                          'relative_tolerance'}
     assert names('CMA-ES') == {'num_calls_to_function', 'sigma0', 'cost_convergence',
                                'max_patience'}
     assert names('bayesian') == {'num_calls_to_function'}

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -79,8 +79,8 @@ def test_param_id_method_options_match_optimiser_reads():
     assert names('genetic_algorithm') == {'num_calls_to_function', 'cost_convergence',
                                           'max_patience', 'num_elite', 'num_survivors',
                                           'num_mutations_per_survivor', 'num_cross_breed',
-                                          'objective_function', 'use_relative_tolerance',
-                                          'relative_tolerance'}
+                                          'objective_function', 'use_relative_cost_tolerance',
+                                          'relative_cost_tolerance'}
     assert names('CMA-ES') == {'num_calls_to_function', 'sigma0', 'cost_convergence',
                                'max_patience'}
     assert names('bayesian') == {'num_calls_to_function'}
@@ -90,6 +90,20 @@ def test_param_id_method_options_match_optimiser_reads():
         'no_new_starts_on_convergence', 'convergence_cluster_tol_frac', 'cost_convergence'}
     # multi-start is a superset of sp_minimize's gradient-descent settings
     assert names('sp_minimize') <= names('multi_start_sp_minimize')
+
+
+def test_the_ga_stopping_rules_are_listed_together():
+    """Option order is form order in a front-end that renders this schema, so it is part of the
+    contract rather than incidental. The relative-tolerance pair is the same decision as
+    cost_convergence and max_patience -- when to stop -- and belongs with them, not parked past
+    the population sizes where a reader takes it for something unrelated."""
+    order = [opt['name'] for opt in param_id_method_options('genetic_algorithm')]
+    stopping = ['cost_convergence', 'max_patience',
+                'use_relative_cost_tolerance', 'relative_cost_tolerance']
+    first = order.index(stopping[0])
+    assert order[first:first + len(stopping)] == stopping
+    # and the switch comes before the value it gates, which reads backwards otherwise
+    assert order.index('use_relative_cost_tolerance') < order.index('relative_cost_tolerance')
 
 
 def test_solver_info_fields_schema_well_formed():


### PR DESCRIPTION
Third of the stack bringing in #367 (pyMC for UQ). Original work by @MOH-Shafizadegan.

> Stacked on #402 and #403 — their commits are included here and the diff shrinks to the last commit once those merge.

## What

`objective_function` (`'cost'` | `'likelihood'`) lets the genetic algorithm search the same objective MCMC samples — which is how a GA is used to find a starting point for UQ. Only the GA reads it: it is the one optimiser that needs no gradient of that objective.

Getting there needed two fixes.

## 1. The likelihood objective has to be negated

`get_lnlikelihood_lnprior_from_params` returns a **log posterior** — higher is better — and every optimiser here **minimises**. #367 handed it over unnegated:

```python
self.objective_method = lambda params: self.param_id_obj.get_lnlikelihood_lnprior_from_params(params)
```

That would have made the GA search for the *least* probable parameters. And worse: an out-of-prior point returns `-inf`, which a minimiser scores as **the best point there is**, so the population would have been driven straight out of the prior support. Negated, that same `-inf` becomes `+inf` — exactly the "reject and resample" signal the population loop already handles.

## 2. The survival weighting — and why I did **not** take #367's version

`cost**-1` assumes a positive cost. A negative log posterior goes negative wherever the posterior density exceeds 1, and a negative weight is not a probability. Even where it stays positive it barely discriminates: `1/800` vs `1/830` is almost uniform selection, i.e. a GA that has stopped selecting.

#367 replaced the rule with `exp(-cost)` **for every run**. Measured on a real 3compartment GA population (costs 5.32 → 17.34, taken from the existing fast GA test), using perplexity as the effective number of distinct survivors:

| rule | effective survivors (of 6) |
|---|---|
| current `cost**-1` | **5.41** |
| #367 `exp(-cost)` | **1.27** |

That is near-deterministic selection — the population diversity a GA exists to keep, gone, on every ordinary calibration. It also interacts with the GA scaling benchmark (#344).

So this PR **keeps the inverse-cost rule wherever it is valid** — every ordinary calibration, where a weighted cost function returns a strictly positive cost — and uses Boltzmann selection only as the fallback for objectives it cannot handle. The fallback is shifted to start at zero (`exp(-cost)` underflows to zero for every member past about 745, and softmax is shift-invariant so this changes no probability) and scaled by the population spread, so selection pressure does not depend on the objective's absolute magnitude.

**Existing calibrations are bit-for-bit unaffected.** The 3compartment GA test returns the identical best cost, `5.3206291895193765`, before and after.

## 3. Relative convergence tolerance

`use_relative_tolerance` / `relative_tolerance` add a fractional stall test alongside the absolute `cost_convergence` one, which a large-magnitude objective never trips (a log posterior in the hundreds never moves by less than 1e-4, so the run only ever stops on the generation budget). Either criterion counts, so enabling it can only make a run stop sooner, never later.

All three options are registered in `PARAM_ID_METHODS['genetic_algorithm']`, so CUFLynx offers them and `test_param_id_method_options_match_optimiser_reads` covers them.

## Tests

New `tests/test_ga_objective_and_selection.py`, 14 fast unit tests: the default objective is the cost function; the likelihood objective is negated so lower is still better; an out-of-prior point becomes `+inf` rather than the best point; an unknown objective is rejected; an ordinary positive cost keeps the exact inverse-cost weighting; selection does not collapse onto a single member (with #367's form asserted to be the collapse this guards against); the fallback survives log-posterior magnitudes; a non-finite member neither wins nor poisons the others; and the relative tolerance catches a stall the absolute one misses without dividing by zero.

Verified `not slow and not compare_optimisers`: **625 passed, 1 failed** — `test_python_BDF_solver[SN_simple]`, the known libCellML Analyser limitation (#151), which fails identically on master.

## Next in the stack

#193 equal feature weighting for MCMC → diagnostics → pyMC backend.
