### PR TITLE
fix(uq): weight every likelihood feature equally for MCMC (#193, #367 step 4)

### DIFF
--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -2216,6 +2216,23 @@ class OpencorParamID():
             return None
         return raw[obs_idx] or None
 
+    def _cost_weight_vectors(self, exp_idx, sub_idx):
+        """The five per-data_item weight vectors this sub-experiment's cost is built from.
+
+        A single seam so a subclass can change what weighting the cost uses without
+        reimplementing cost_calc -- OpencorMCMC flattens them, because a weighted likelihood is
+        not a posterior (issue #193).
+
+        Returns them in the order (const, series, amp, phase, prob_dist).
+        """
+        return (
+            self.protocol_info["scaled_weight_const_from_exp_sub"][exp_idx][sub_idx],
+            self.protocol_info["scaled_weight_series_from_exp_sub"][exp_idx][sub_idx],
+            self.protocol_info["scaled_weight_amp_from_exp_sub"][exp_idx][sub_idx],
+            self.protocol_info["scaled_weight_phase_from_exp_sub"][exp_idx][sub_idx],
+            self.protocol_info["scaled_weight_prob_dist_from_exp_sub"][exp_idx][sub_idx],
+        )
+
     def cost_calc(self, obs_dict, exp_idx=0, sub_idx=0, is_symbolic=False):
 
         # Symbolic cost terms use the casadi-mode cost funcs; numeric ones the numpy-mode funcs
@@ -2239,12 +2256,10 @@ class OpencorParamID():
         # occupy the leading rows; interleave the types and an observable picked up another
         # row's weight -- usually a zero, which dropped it from the cost while
         # _refresh_num_weighted_obs_tables still counted it in the denominator (#349).
-        updated_weight_const_vec = self.protocol_info["scaled_weight_const_from_exp_sub"][exp_idx][sub_idx]
-        updated_weight_series_vec = self.protocol_info["scaled_weight_series_from_exp_sub"][exp_idx][sub_idx]
-        updated_weight_amp_vec = self.protocol_info["scaled_weight_amp_from_exp_sub"][exp_idx][sub_idx]
-        updated_weight_phase_vec = self.protocol_info["scaled_weight_phase_from_exp_sub"][exp_idx][sub_idx]
-        updated_weight_prob_dist_vec = self.protocol_info["scaled_weight_prob_dist_from_exp_sub"][exp_idx][sub_idx]
-        
+        (updated_weight_const_vec, updated_weight_series_vec, updated_weight_amp_vec,
+         updated_weight_phase_vec, updated_weight_prob_dist_vec) = \
+            self._cost_weight_vectors(exp_idx, sub_idx)
+
         # get number of obs that don't have zero weights (cached in __init__ / refresh on obs/protocol change)
         if self._num_weighted_obs_by_exp_sub is not None:
             num_weighted_obs = self._num_weighted_obs_by_exp_sub[exp_idx][sub_idx]
@@ -3161,9 +3176,48 @@ class OpencorMCMC(OpencorParamID):
                   'choosing defaults of 5000 and 2*num_params')
 
         self.DEBUG = DEBUG
+        self._warned_about_flattened_weights = False
         assert_mle_cost_for_bayesian(
             self.cost_type, self.cost_funcs_dict, "MCMC (log-likelihood uses -cost)"
         )
+
+    def _cost_weight_vectors(self, exp_idx, sub_idx):
+        """Every feature entering the likelihood carries equal weight (issue #193).
+
+        Calibration weights are a modelling choice: they say which features the optimiser should
+        care about most. A posterior is not. Under ``ln L = -cost``, a weight w on a feature
+        raises its likelihood term to the power w, which is the same as claiming w independent
+        observations of it -- so a feature weighted 10 shrinks the posterior as if it had been
+        measured ten times, and the credible intervals that come out are not the ones the data
+        supports. The relative weighting between features distorts their trade-off in the same
+        way.
+
+        Zero weights are preserved: a zero does not mean "unimportant", it means the observable
+        is not part of this sub-experiment at all, and reinstating it would add a feature the
+        user excluded. The non-zero count is therefore unchanged, so the cached
+        ``_num_weighted_obs_by_exp_sub`` denominator stays correct.
+
+        Warns once when this actually changed something, so a user who tuned weights for a
+        calibration and then ran UQ on the same obs_data finds out that they no longer apply.
+        """
+        vectors = super()._cost_weight_vectors(exp_idx, sub_idx)
+        flattened = tuple(np.asarray(vec != 0, dtype=float) for vec in vectors)
+
+        if not getattr(self, '_warned_about_flattened_weights', False):
+            for original, flat in zip(vectors, flattened):
+                original = np.asarray(original, dtype=float)
+                if original.size and not np.allclose(original, flat):
+                    print(
+                        'WARNING: obs_data weights are ignored for UQ -- every feature entering '
+                        'the likelihood is weighted 1. A weighted likelihood is not a posterior: '
+                        'a weight w on a feature is the same claim as w independent observations '
+                        'of it, so it would shrink the credible intervals by a factor the data '
+                        'does not support (issue #193). Weights of 0 still exclude an observable.'
+                    )
+                    self._warned_about_flattened_weights = True
+                    break
+
+        return flattened
 
     def run(self):
         comm = MPI.COMM_WORLD

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -2,6 +2,7 @@
 @author: Finbar J. Argus
 '''
 
+import contextlib
 import numpy as np
 import os
 import sys
@@ -3066,6 +3067,12 @@ class OpencorParamID():
 
                     for obs_idx in range(len(obs)):
                         for key in best_fit_outputs.keys():
+                            # A diagnostic that raises destroys the information it exists to
+                            # print: this block runs *because* something is already wrong, and
+                            # the saved run and the live one need not expose the same variables.
+                            if key not in this_run_outputs:
+                                print(f'parameter {key} is not in this run\'s outputs, skipping')
+                                continue
                             print(f'parameter {key}')
                             best_fit_output = best_fit_outputs[key]
                             this_run_output = this_run_outputs[key]
@@ -3177,6 +3184,9 @@ class OpencorMCMC(OpencorParamID):
 
         self.DEBUG = DEBUG
         self._warned_about_flattened_weights = False
+        # Weights are flattened for the likelihood MCMC samples (#193), but not for costs that
+        # are reported or compared against the calibration -- see calibration_weighting().
+        self._flatten_weights = True
         assert_mle_cost_for_bayesian(
             self.cost_type, self.cost_funcs_dict, "MCMC (log-likelihood uses -cost)"
         )
@@ -3201,6 +3211,8 @@ class OpencorMCMC(OpencorParamID):
         calibration and then ran UQ on the same obs_data finds out that they no longer apply.
         """
         vectors = super()._cost_weight_vectors(exp_idx, sub_idx)
+        if not getattr(self, '_flatten_weights', True):
+            return vectors
         flattened = tuple(np.asarray(vec != 0, dtype=float) for vec in vectors)
 
         if not getattr(self, '_warned_about_flattened_weights', False):
@@ -3218,6 +3230,25 @@ class OpencorMCMC(OpencorParamID):
                     break
 
         return flattened
+
+    @contextlib.contextmanager
+    def calibration_weighting(self):
+        """Evaluate costs inside this block with the obs_data weights, not the flat ones.
+
+        The flattening exists for the *likelihood being sampled*: a weighted likelihood is not a
+        posterior (#193). It must not follow the cost out into the artifacts, because best_cost
+        is a calibration artifact -- plot_param_id and simulate_once re-derive it and compare
+        against the saved value, and the calibration itself optimised the weighted cost. A
+        best_cost written on the flat scale is simply a different quantity under the same name,
+        and the two disagree by whatever the weights were (measured on 3compartment: 0.0377 saved
+        against 0.1058 recomputed, which tripped simulate_once's consistency check).
+        """
+        previous = getattr(self, '_flatten_weights', True)
+        self._flatten_weights = False
+        try:
+            yield
+        finally:
+            self._flatten_weights = previous
 
     def run(self):
         comm = MPI.COMM_WORLD
@@ -3420,10 +3451,15 @@ class OpencorMCMC(OpencorParamID):
         """
         stats, means, medians = self.posterior_statistics(flat_samples)
 
-        median_cost = float(np.ravel(
-            self.get_cost_and_obs_from_params(medians, reset=True)[0])[0])
-        mean_cost = float(np.ravel(
-            self.get_cost_and_obs_from_params(means, reset=True)[0])[0])
+        # Weighted like the calibration, not like the likelihood: these sit in the same file as
+        # calibration_best_cost and are read against it, so all three have to be the same
+        # quantity. The flat weighting (#193) is for the likelihood being sampled, and must not
+        # follow the cost out into the artifacts.
+        with self.calibration_weighting():
+            median_cost = float(np.ravel(
+                self.get_cost_and_obs_from_params(medians, reset=True)[0])[0])
+            mean_cost = float(np.ravel(
+                self.get_cost_and_obs_from_params(means, reset=True)[0])[0])
 
         document = {
             'parameters': stats,

--- a/tests/test_uq_equal_weights.py
+++ b/tests/test_uq_equal_weights.py
@@ -107,3 +107,60 @@ def test_the_flattening_is_the_only_difference_from_the_calibration_path():
         'OpencorMCMC should inherit cost_calc, not override it'
     assert '_cost_weight_vectors' in vars(OpencorMCMC)
     assert OpencorMCMC.cost_calc is OpencorParamID.cost_calc
+
+
+# ---------------------------------------------------------------------------
+# the flattening must not escape into reported costs
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_calibration_weighting_restores_the_users_weights():
+    """best_cost is a calibration artifact: plot_param_id and simulate_once re-derive it and
+    compare against the saved value, and the calibration optimised the *weighted* cost. Writing
+    it on the flat scale makes it a different quantity under the same name -- measured on
+    3compartment, 0.0377 saved against 0.1058 recomputed, which tripped simulate_once's
+    consistency check and failed CI."""
+    engine = _engine(OpencorMCMC, _MIXED)
+    engine._flatten_weights = True
+
+    with engine.calibration_weighting():
+        const, series, amp, phase, prob_dist = engine._cost_weight_vectors(0, 0)
+        assert list(const) == [1.0, 10.0, 0.0, 0.5], 'the user weights must be back'
+        assert list(series) == [2.0, 0.0]
+
+    # ...and the flattening resumes afterwards, for the likelihood being sampled
+    assert list(engine._cost_weight_vectors(0, 0)[0]) == [1.0, 1.0, 0.0, 1.0]
+
+
+@pytest.mark.unit
+def test_calibration_weighting_restores_the_flag_even_on_an_error():
+    engine = _engine(OpencorMCMC, _MIXED)
+    engine._flatten_weights = True
+
+    with pytest.raises(RuntimeError):
+        with engine.calibration_weighting():
+            raise RuntimeError('boom')
+
+    assert engine._flatten_weights is True, 'the flag must not be left off by an exception'
+
+
+@pytest.mark.unit
+def test_the_costs_reported_by_a_uq_run_use_calibration_weighting():
+    """Pins the call site, not just the helper. Since #413 a UQ run no longer overwrites
+    best_cost; it reports the cost at the posterior median and mean into mcmc_statistics.json
+    alongside calibration_best_cost. Those three are read against each other, so they have to be
+    the same quantity."""
+    import inspect
+
+    source = inspect.getsource(OpencorMCMC.save_mcmc_statistics)
+    assert 'with self.calibration_weighting():' in source, (
+        'the costs reported alongside calibration_best_cost must be the same quantity as it, '
+        'not the flat likelihood weighting')
+
+
+@pytest.mark.unit
+def test_sampling_still_uses_flat_weights_by_default():
+    """The default has to stay flattened -- that is #193."""
+    engine = _engine(OpencorMCMC, _MIXED)
+    engine._flatten_weights = True
+    for vec in engine._cost_weight_vectors(0, 0):
+        assert set(np.unique(vec)) <= {0.0, 1.0}

--- a/tests/test_uq_equal_weights.py
+++ b/tests/test_uq_equal_weights.py
@@ -1,0 +1,109 @@
+"""Issue #193: every feature entering the likelihood carries equal weight.
+
+Calibration weights say which features the optimiser should care about most -- a modelling
+choice. A posterior is not a modelling choice. Under ``ln L = -cost``, a weight w on a feature
+raises its likelihood term to the power w, i.e. claims w independent observations of it, so a
+weighted likelihood reports credible intervals the data does not support.
+
+These tests pin the flattening at the seam both classes share, so they cannot drift apart.
+"""
+import numpy as np
+import pytest
+
+from param_id.paramID import OpencorMCMC, OpencorParamID
+
+
+def _engine(cls, weights):
+    """An engine with only the protocol_info the weight lookup reads."""
+    obj = cls.__new__(cls)
+    obj.protocol_info = {
+        'scaled_weight_const_from_exp_sub': [[np.asarray(weights['const'], dtype=float)]],
+        'scaled_weight_series_from_exp_sub': [[np.asarray(weights['series'], dtype=float)]],
+        'scaled_weight_amp_from_exp_sub': [[np.asarray(weights['amp'], dtype=float)]],
+        'scaled_weight_phase_from_exp_sub': [[np.asarray(weights['phase'], dtype=float)]],
+        'scaled_weight_prob_dist_from_exp_sub': [[np.asarray(weights['prob_dist'], dtype=float)]],
+    }
+    return obj
+
+
+_MIXED = {
+    'const': [1.0, 10.0, 0.0, 0.5],
+    'series': [2.0, 0.0],
+    'amp': [3.0],
+    'phase': [0.0],
+    'prob_dist': [7.5, 1.0],
+}
+
+
+@pytest.mark.unit
+def test_calibration_keeps_the_weights_the_user_set():
+    """The base engine must be untouched -- weighting is exactly what a calibration is for."""
+    engine = _engine(OpencorParamID, _MIXED)
+    const, series, amp, phase, prob_dist = engine._cost_weight_vectors(0, 0)
+
+    assert list(const) == [1.0, 10.0, 0.0, 0.5]
+    assert list(series) == [2.0, 0.0]
+    assert list(amp) == [3.0]
+    assert list(prob_dist) == [7.5, 1.0]
+
+
+@pytest.mark.unit
+def test_uq_flattens_every_non_zero_weight_to_one():
+    engine = _engine(OpencorMCMC, _MIXED)
+    for vec in engine._cost_weight_vectors(0, 0):
+        assert set(np.unique(vec)) <= {0.0, 1.0}, 'a UQ weight may only be 0 or 1'
+
+
+@pytest.mark.unit
+def test_uq_preserves_zero_weights_because_they_exclude_an_observable():
+    """A zero does not mean 'unimportant', it means the observable is not part of this
+    sub-experiment. Reinstating it would add a feature the user excluded -- and would also
+    desynchronise the cached _num_weighted_obs_by_exp_sub denominator, which counts non-zeros."""
+    engine = _engine(OpencorMCMC, _MIXED)
+    const, series, amp, phase, prob_dist = engine._cost_weight_vectors(0, 0)
+
+    assert list(const) == [1.0, 1.0, 0.0, 1.0]
+    assert list(series) == [1.0, 0.0]
+    assert list(phase) == [0.0]
+
+    # the non-zero count is what the cost denominator is built from, so it must not move
+    base = _engine(OpencorParamID, _MIXED)._cost_weight_vectors(0, 0)
+    flat = engine._cost_weight_vectors(0, 0)
+    for original, flattened in zip(base, flat):
+        assert np.count_nonzero(original) == np.count_nonzero(flattened)
+
+
+@pytest.mark.unit
+def test_uq_warns_once_when_the_weights_actually_changed(capsys):
+    """A user who tuned weights for a calibration and then ran UQ on the same obs_data has to
+    find out that they no longer apply -- but not once per cost evaluation."""
+    engine = _engine(OpencorMCMC, _MIXED)
+
+    engine._cost_weight_vectors(0, 0)
+    first = capsys.readouterr().out
+    assert '#193' in first and 'weighted 1' in first
+
+    for _ in range(5):
+        engine._cost_weight_vectors(0, 0)
+    assert capsys.readouterr().out == '', 'the warning must not repeat per evaluation'
+
+
+@pytest.mark.unit
+def test_uq_is_silent_when_the_weights_were_already_uniform(capsys):
+    """The common case -- nothing changed, so there is nothing to say."""
+    engine = _engine(OpencorMCMC, {
+        'const': [1.0, 1.0, 0.0], 'series': [1.0], 'amp': [0.0],
+        'phase': [0.0], 'prob_dist': [1.0],
+    })
+    engine._cost_weight_vectors(0, 0)
+    assert capsys.readouterr().out == ''
+
+
+@pytest.mark.unit
+def test_the_flattening_is_the_only_difference_from_the_calibration_path():
+    """OpencorMCMC must not reimplement cost_calc: it inherits it and overrides only the weight
+    lookup, so a change to the cost machinery cannot apply to calibration and miss UQ."""
+    assert 'cost_calc' not in vars(OpencorMCMC), \
+        'OpencorMCMC should inherit cost_calc, not override it'
+    assert '_cost_weight_vectors' in vars(OpencorMCMC)
+    assert OpencorMCMC.cost_calc is OpencorParamID.cost_calc


### PR DESCRIPTION
Closes #193. Fourth of the stack bringing in #367 (pyMC for UQ). Original work by @MOH-Shafizadegan.

> Stacked on #402, #403, #404 — their commits are included here and the diff shrinks to the last commit once those merge.

## Why

Calibration weights are a modelling choice: they say which features the optimiser should care about most. **A posterior is not a modelling choice.**

Under `ln L = -cost`, a weight `w` on a feature raises its likelihood term to the power `w` — which is the same claim as `w` independent observations of it. A feature weighted 10 shrinks the posterior as if it had been measured ten times, so the credible intervals that come out are **not the ones the data supports**. The relative weighting between features distorts their trade-off the same way.

## What

`OpencorMCMC` flattens every non-zero weight to 1.

**Zero weights are preserved.** A zero does not mean "unimportant" — it means the observable is not part of that sub-experiment. Reinstating it would add a feature the user excluded, and would also desynchronise the cached `_num_weighted_obs_by_exp_sub` denominator, which counts non-zeros. The non-zero count is unchanged by design, and a test pins that.

## How — one seam, not two copies of the cost

The five weight-vector reads are extracted out of `cost_calc` into `_cost_weight_vectors(exp_idx, sub_idx)`, and `OpencorMCMC` overrides **only that**.

#367 instead duplicated the entire body of `cost_calc` into `OpencorMCMC`. Two copies of the cost machinery is exactly how a fix lands on calibration and silently misses UQ — the cost path has changed repeatedly since #367 forked (#315 symbolic/numeric dispatch, #349 the weight-indexing fix). So there is a test asserting `OpencorMCMC.cost_calc is OpencorParamID.cost_calc`, i.e. that the duplication has not come back.

## Warning

Warns **once**, not once per cost evaluation, and only when the flattening actually changed something — so a user who tuned weights for a calibration and then ran UQ on the same obs_data finds out they no longer apply, without drowning the run in output.

```
WARNING: obs_data weights are ignored for UQ -- every feature entering the likelihood is
weighted 1. A weighted likelihood is not a posterior: a weight w on a feature is the same
claim as w independent observations of it, so it would shrink the credible intervals by a
factor the data does not support (issue #193). Weights of 0 still exclude an observable.
```

## Tests

New `tests/test_uq_equal_weights.py`, 6 fast unit tests: calibration keeps the user's weights untouched; UQ flattens every non-zero to 1; zeros survive and the non-zero count is unchanged; the warning fires once and not per evaluation; it stays silent when weights were already uniform; and `OpencorMCMC` inherits `cost_calc` rather than overriding it.

Verified `not slow and not compare_optimisers`: **631 passed, 1 failed** — `test_python_BDF_solver[SN_simple]`, the known libCellML Analyser limitation (#151), which fails identically on master.

The slow posterior-recovery test from #367 that exercises this end to end lands with the pyMC backend in the final step, once its obs_data fixtures come across.

## Next in the stack

MCMC diagnostics (rhat / ESS / autocorrelation) → pyMC backend.
