### PR TITLE
feat(uq): MCMC convergence diagnostics -- split R-hat, ESS, chain plots (#367 step 5)

### DIFF
--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -951,6 +951,14 @@ class CVS0DParamID():
         # Also check autocorrelation times for mcmc chain
         tau = self.calculate_autocorrelation_time(samples)
 
+        # Per-parameter posterior summary with ESS and split-R-hat, and the two chain-diagnostic
+        # plots. Printed rather than only returned: R-hat and ESS are the numbers that say
+        # whether the posterior above is trustworthy at all, so a run should not be able to
+        # finish without stating them.
+        self.print_convergence_diagnostics(samples)
+        self.plot_autocorrelation(samples)
+        self.plot_chain_avg(samples)
+
         # check geweke convergence
         if not self.DEBUG:
             # the chain is too short when running debug to do geweke diagnostics
@@ -966,6 +974,219 @@ class CVS0DParamID():
     def calculate_autocorrelation_time(self, samples):
         tau = emcee.autocorr.integrated_time(samples, quiet=True)
         return tau
+
+    # -----------------------------------------------------------------------
+    # Convergence diagnostics (issue #367)
+    # -----------------------------------------------------------------------
+    # Computed here from numpy and emcee rather than through arviz. #367 imported arviz at module
+    # level for these, which would have made every calibration run depend on it -- and arviz is
+    # not a CA dependency, so the diagnostics would then be unavailable in exactly the
+    # environments that need them. R-hat and ESS are short, standard formulas and emcee (already
+    # a dependency) supplies the autocorrelation, so nothing is gained by the dependency.
+
+    def calc_rhat(self, samples):
+        """Split-R-hat (Gelman-Rubin) per parameter, from a ``(steps, walkers, params)`` chain.
+
+        The *split* form: each walker is halved and the halves treated as separate chains, so a
+        single walker that drifts steadily is caught. Plain R-hat cannot see that -- a drifting
+        chain has a large within-chain variance, which is exactly what makes the ratio look fine.
+
+        Returns ``{param_name: rhat}``. Values near 1 indicate the walkers have mixed; the usual
+        working threshold is 1.01.
+        """
+        samples = np.asarray(samples, dtype=float)
+        num_steps, num_walkers, num_params = samples.shape
+
+        half = num_steps // 2
+        if half < 2:
+            return {name: float('nan') for name in self._param_labels(num_params)}
+
+        # (steps, walkers, params) -> (2*walkers chains, half draws, params)
+        chains = np.concatenate([samples[:half], samples[half:2 * half]], axis=1)
+        chains = np.swapaxes(chains, 0, 1)
+        num_chains = chains.shape[0]
+
+        chain_means = chains.mean(axis=1)
+        chain_vars = chains.var(axis=1, ddof=1)
+
+        within = chain_vars.mean(axis=0)
+        between = half * chain_means.var(axis=0, ddof=1) if num_chains > 1 else np.zeros(num_params)
+
+        var_plus = ((half - 1) / half) * within + between / half
+        with np.errstate(divide='ignore', invalid='ignore'):
+            rhat = np.sqrt(np.where(within > 0, var_plus / within, np.nan))
+
+        return dict(zip(self._param_labels(num_params), (float(r) for r in rhat)))
+
+    def calc_effective_sample_size(self, samples):
+        """Effective sample size per parameter: ``N / tau``, with tau the integrated
+        autocorrelation time over the pooled chain.
+
+        MCMC draws are correlated, so the number of samples overstates how much independent
+        information the chain carries. This is the number that should be quoted alongside a
+        posterior mean, not ``num_steps * num_walkers``.
+
+        Returns ``{param_name: ess}``.
+        """
+        samples = np.asarray(samples, dtype=float)
+        num_steps, num_walkers, num_params = samples.shape
+        total = num_steps * num_walkers
+
+        ess = {}
+        for name, idx in zip(self._param_labels(num_params), range(num_params)):
+            try:
+                tau = float(emcee.autocorr.integrated_time(samples[:, :, idx], quiet=True)[0])
+            except Exception:
+                tau = float('nan')
+            if not np.isfinite(tau) or tau <= 0:
+                ess[name] = float('nan')
+            else:
+                # A chain can never carry more independent information than it has draws.
+                ess[name] = float(min(total / tau, total))
+        return ess
+
+    def get_posterior_stats(self, samples):
+        """Per-parameter posterior summary: mean, sd, the 3%/97% credible bounds, ESS and R-hat.
+
+        One table rather than three separate arviz summary calls (#367 built the same dataset and
+        re-ran the summary in each of three accessors, so the expensive part ran three times).
+        """
+        samples = np.asarray(samples, dtype=float)
+        num_steps, num_walkers, num_params = samples.shape
+        flat = samples.reshape(num_steps * num_walkers, num_params)
+
+        ess = self.calc_effective_sample_size(samples)
+        rhat = self.calc_rhat(samples)
+
+        stats = {}
+        for idx, name in enumerate(self._param_labels(num_params)):
+            column = flat[:, idx]
+            stats[name] = {
+                'mean': float(np.mean(column)),
+                'sd': float(np.std(column, ddof=1)) if column.size > 1 else float('nan'),
+                'hdi_3%': float(np.percentile(column, 3)),
+                'hdi_97%': float(np.percentile(column, 97)),
+                'ess': ess[name],
+                'r_hat': rhat[name],
+            }
+        return stats
+
+    def print_convergence_diagnostics(self, samples):
+        """Print the summary table and say plainly whether the chain has converged.
+
+        A diagnostic nobody reads is not a diagnostic, and R-hat / ESS are only useful against
+        their thresholds -- so the verdict is stated rather than left to the reader.
+        """
+        stats = self.get_posterior_stats(samples)
+        print('')
+        print(f'{"parameter":<28s}{"mean":>12s}{"sd":>12s}{"3%":>12s}{"97%":>12s}'
+              f'{"ess":>10s}{"r_hat":>9s}')
+        for name, row in stats.items():
+            print(f'{name:<28s}{row["mean"]:>12.4g}{row["sd"]:>12.4g}{row["hdi_3%"]:>12.4g}'
+                  f'{row["hdi_97%"]:>12.4g}{row["ess"]:>10.1f}{row["r_hat"]:>9.3f}')
+
+        unconverged = [n for n, r in stats.items()
+                       if not np.isfinite(r['r_hat']) or r['r_hat'] > 1.01]
+        if unconverged:
+            print(f'WARNING: r_hat > 1.01 for {unconverged} -- the walkers have not mixed. '
+                  f'Run more steps before trusting the posterior.')
+        else:
+            print('All parameters have r_hat <= 1.01 (walkers mixed).')
+        return stats
+
+    def plot_autocorrelation(self, samples, num_params=None):
+        """One autocorrelation-vs-lag panel per parameter, every walker overlaid.
+
+        The +-0.1 guides are what makes the plot readable: a chain whose autocorrelation has
+        decayed inside them by the end of the trace is producing near-independent draws, and one
+        that has not is still exploring. Returns True when every walker is inside the band over
+        the last fifth of the lags, so a caller can act on it rather than only look at it.
+        """
+        if self.rank != 0:
+            return None
+        samples = np.asarray(samples, dtype=float)
+        if num_params is None:
+            num_params = samples.shape[2]
+
+        fig, axes = plt.subplots(num_params, figsize=(10, 2 * num_params), sharex=True,
+                                 squeeze=False)
+        all_bounded = True
+        labels = self._param_labels(num_params)
+        autocorr = None
+        for idx in range(num_params):
+            ax = axes[idx][0]
+            for walker in range(samples.shape[1]):
+                autocorr = emcee.autocorr.function_1d(samples[:, walker, idx])
+                ax.plot(autocorr, alpha=0.3)
+                window_size = max(1, int(0.2 * len(autocorr)))
+                if np.any(np.abs(autocorr[-window_size:]) > 0.1):
+                    all_bounded = False
+
+            ax.axhline(y=0, color='k', linestyle='--', alpha=0.7)
+            ax.axhline(y=0.1, color='r', linestyle='--', alpha=0.7, linewidth=1.5)
+            ax.axhline(y=-0.1, color='r', linestyle='--', alpha=0.7, linewidth=1.5)
+            ax.set_ylabel(f'${labels[idx]}$')
+            if autocorr is not None:
+                ax.set_xlim(0, len(autocorr))
+
+        axes[-1][0].set_xlabel('Lag')
+        fig.tight_layout()
+        fig.savefig(os.path.join(self.plot_dir,
+                                 f'mcmc_autocorrelation_{self.file_name_prefix}_'
+                                 f'{self.param_id_obs_file_prefix}.pdf'))
+        plt.close(fig)
+        return all_bounded
+
+    def plot_chain_avg(self, samples=None, window_size=10):
+        """Running mean of each walker, one panel per parameter.
+
+        Convergence shows up here as the walkers' running means coming together and flattening;
+        a walker whose mean is still moving has not finished exploring, which a corner plot of
+        the pooled chain hides by averaging it away.
+        """
+        if self.rank != 0:
+            return None
+        if samples is None:
+            chain = self.get_mcmc_samples()
+            if chain is None:
+                return None
+            _, samples, _ = chain
+        samples = np.asarray(samples, dtype=float)
+
+        num_steps, num_chains, num_params = samples.shape
+        if window_size >= num_steps:
+            print(f'Warning: chain-average window {window_size} is not shorter than the '
+                  f'{num_steps} steps available; skipping the chain average plot.')
+            return None
+
+        fig, axes = plt.subplots(num_params, figsize=(10, 2 * num_params), sharex=True,
+                                 squeeze=False)
+        window = np.ones(window_size) / window_size
+        labels = self._param_labels(num_params)
+        for idx in range(num_params):
+            ax = axes[idx][0]
+            for chain_idx in range(num_chains):
+                moving_avg = np.convolve(samples[:, chain_idx, idx], window, mode='valid')
+                ax.plot(np.arange(len(moving_avg)) + window_size - 1, moving_avg, alpha=0.5)
+            ax.set_ylabel(f'${labels[idx]}$')
+
+        axes[-1][0].set_xlabel('Step')
+        fig.tight_layout()
+        fig.savefig(os.path.join(self.plot_dir,
+                                 f'mcmc_chain_average_{self.file_name_prefix}_'
+                                 f'{self.param_id_obs_file_prefix}.pdf'))
+        plt.close(fig)
+        return True
+
+    def _param_labels(self, num_params=None):
+        """Parameter names for the diagnostic tables, falling back to indices."""
+        names = None
+        info = getattr(self, 'param_id_info', None)
+        if isinstance(info, dict):
+            names = info.get('param_names_for_plotting')
+        if names is None or (num_params is not None and len(names) != num_params):
+            return [f'param_{idx}' for idx in range(num_params or 0)]
+        return list(names)
 
     def calculate_geweke_convergence(self, samples):
         d = diagnostics.Diagnostics()

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -1178,6 +1178,284 @@ class CVS0DParamID():
         plt.close(fig)
         return True
 
+    # -----------------------------------------------------------------------
+    # Posterior-predictive plots (issue #367)
+    # -----------------------------------------------------------------------
+    # seaborn is imported lazily inside each of these. It is a CA dependency, but paramID is
+    # imported by every calibration run and none of these are on that path, so there is no
+    # reason to pay the import for a run that never plots a posterior.
+
+    def get_prior_pdf(self, param_idx, x_values):
+        """The prior density for one parameter, over ``x_values``, normalised on that range.
+
+        Derived from CA's own ``get_lnprior_from_params`` rather than reimplemented. The priors
+        are independent per parameter, so evaluating the log prior along one axis with the others
+        held at their best-fit values recovers that parameter's prior up to a constant, and the
+        constant falls out in the normalisation.
+
+        That matters because the prior vocabulary is not simply uniform/exponential/normal any
+        more: params_for_id carries ``prior_mean``, ``prior_std``, ``prior_origin`` and
+        ``prior_scale``, and an ``unbounded`` flag that suppresses the range truncation. #367
+        restated the *old* defaults here (lambda=1, sigma=(max-min)/6, mu=(max+min)/2), so a
+        plotted prior would have silently disagreed with the one actually being sampled.
+        """
+        engine = mcmc_object if self.mcmc_instead else self.param_id
+        x_values = np.asarray(x_values, dtype=float)
+
+        centre = getattr(engine, 'best_param_vals', None)
+        if centre is None:
+            mins = np.asarray(engine.param_id_info['param_mins'], dtype=float)
+            maxs = np.asarray(engine.param_id_info['param_maxs'], dtype=float)
+            centre = 0.5 * (mins + maxs)
+        centre = np.asarray(centre, dtype=float).copy()
+
+        lnprior = np.empty_like(x_values)
+        for idx, value in enumerate(x_values):
+            trial = centre.copy()
+            trial[param_idx] = value
+            lnprior[idx] = engine.get_lnprior_from_params(trial)
+
+        finite = np.isfinite(lnprior)
+        pdf = np.zeros_like(x_values)
+        if not np.any(finite):
+            return pdf
+        # Subtract the max before exponentiating: the log prior is unnormalised, so its absolute
+        # level is arbitrary and can overflow exp() outright.
+        pdf[finite] = np.exp(lnprior[finite] - np.max(lnprior[finite]))
+        area = np.trapz(pdf, x_values)
+        if area > 0:
+            pdf /= area
+        return pdf
+
+    def _posterior_predictive_values(self, flat_samples, n_sims=50):
+        """Re-simulate ``n_sims`` posterior draws and collect each observable's value.
+
+        Returns ``{name_for_plotting: {experiment_idx: [values], 'exp_data': [values]}}`` -- the
+        model's predictive distribution per feature, alongside the measurements it is answerable
+        to.
+        """
+        sim_obj = mcmc_object if self.mcmc_instead else self.param_id
+        names = self.obs_info['names_for_plotting']
+        values = {name: {} for name in names}
+
+        flat_samples = np.asarray(flat_samples, dtype=float)
+        n_actual = int(min(n_sims, len(flat_samples)))
+        if n_actual == 0:
+            return values
+        sample_indices = np.random.choice(len(flat_samples), n_actual, replace=False)
+
+        for count, sample_idx in enumerate(sample_indices, start=1):
+            _, obs_list = sim_obj.get_cost_and_obs_from_params(flat_samples[sample_idx, :],
+                                                               reset=True)
+            subexp_count = 0
+            for exp_idx in range(self.protocol_info['num_experiments']):
+                for sub_idx in range(self.protocol_info['num_sub_per_exp'][exp_idx]):
+                    if subexp_count >= len(obs_list) or obs_list[subexp_count] is None:
+                        subexp_count += 1
+                        continue
+                    obs_proc = sim_obj.get_obs_output_dict(obs_list[subexp_count])
+                    subexp_count += 1
+
+                    for obs_idx, name in enumerate(names):
+                        if (self.obs_info['experiment_idxs'][obs_idx] != exp_idx
+                                or self.obs_info['subexperiment_idxs'][obs_idx] != sub_idx):
+                            continue
+                        value = self._predictive_value(obs_proc, obs_idx)
+                        if value is not None:
+                            values[name].setdefault(exp_idx, []).append(value)
+
+            sim_obj.sim_helper.reset_and_clear()
+            print(f'Processed {count}/{n_actual} posterior samples for the predictive plots.')
+
+        self._add_measured_values(values)
+        return values
+
+    def _predictive_value(self, obs_proc, obs_idx):
+        """One observable's scalar out of a simulated obs dict, by its data_type."""
+        data_type = self.obs_info['data_types'][obs_idx]
+        try:
+            if data_type == 'constant':
+                return obs_proc['const'][obs_idx]
+            if data_type == 'series':
+                return np.max(obs_proc['series'][obs_idx])
+            if data_type == 'frequency':
+                return obs_proc['amp'][obs_idx]
+            if data_type == 'prob_dist':
+                return obs_proc['val_for_prob_dist'][obs_idx]
+        except (IndexError, KeyError, TypeError):
+            return None
+        return None
+
+    def _add_measured_values(self, values):
+        """Add the measured data each feature is answerable to, under 'exp_data'."""
+        for obs_idx, name in enumerate(self.obs_info['names_for_plotting']):
+            data_type = self.obs_info['data_types'][obs_idx]
+            measured = values[name].setdefault('exp_data', [])
+            if data_type == 'constant':
+                mean = self.obs_info['ground_truth_const'][obs_idx]
+                std = self.obs_info['std_const_vec'][obs_idx]
+                # A constant observation is a mean and a std, not samples; draw from it so the
+                # comparison is distribution against distribution rather than a line.
+                measured.extend(np.random.normal(mean, std, 20))
+            elif data_type == 'prob_dist':
+                params = self.obs_info['ground_truth_prob_dist_params'][obs_idx]
+                if isinstance(params, dict) and 'data_points' in params:
+                    measured.extend(np.asarray(params['data_points'], dtype=float))
+
+    def save_posterior_predictions(self, values):
+        """Write the predictive values to posterior_predictions.csv, long-format.
+
+        The plots below are a view of this; the csv is what someone re-plots or re-analyses
+        from without paying for the simulations again.
+        """
+        rows = []
+        for feature, by_experiment in values.items():
+            for key, vals in by_experiment.items():
+                kind = 'experimental' if key == 'exp_data' else 'simulated'
+                for value in vals:
+                    rows.append({'feature': feature, 'experiment_idx': key,
+                                 'value': value, 'data_type': kind})
+        path = os.path.join(self.output_dir, 'posterior_predictions.csv')
+        pd.DataFrame(rows).to_csv(path, index=False)
+        print(f'Saved posterior predictions to {path}')
+        return path
+
+    def plot_boxplots_for_predictions(self, flat_samples, n_sims=50, show_points=True):
+        """Violin + box + jittered points per feature: the model's predictive spread against
+        the measurements, one figure per feature, plus a summary grid.
+
+        This is the plot that answers "does the calibrated model reproduce the data, and with
+        what spread" -- which a best-fit line cannot show.
+        """
+        if self.rank != 0:
+            return None
+        import seaborn as sns
+
+        values = self._posterior_predictive_values(flat_samples, n_sims=n_sims)
+        self.save_posterior_predictions(values)
+
+        written = []
+        for feature, by_experiment in values.items():
+            ordered_keys = sorted(by_experiment.keys(), key=lambda k: str(k))
+            series, labels, colors = [], [], []
+            for key in ordered_keys:
+                if not by_experiment[key]:
+                    continue
+                series.append(by_experiment[key])
+                if key == 'exp_data':
+                    labels.append('Experimental')
+                    colors.append('red')
+                else:
+                    labels.append(self._experiment_label(key))
+                    colors.append(self._experiment_color(key))
+            if not series:
+                continue
+
+            fig, ax = plt.subplots(figsize=(6.5, 4.5))
+            sns.violinplot(data=series, ax=ax, palette=colors, cut=3, inner='box',
+                           saturation=0.8)
+            for idx, collection in enumerate(ax.collections):
+                if idx < len(series):
+                    collection.set_alpha(0.35)
+                    collection.set_edgecolor('none')
+
+            for idx, vals in enumerate(series):
+                mean_v, std_v = np.mean(vals), np.std(vals)
+                ax.scatter(idx, mean_v, marker='D', color='white', edgecolor='black', s=30,
+                           zorder=4)
+                spread = np.max(vals) - np.min(vals)
+                ax.text(idx, np.max(vals) + 0.05 * spread,
+                        fr'${mean_v:.2g} \pm {std_v:.2g}$', ha='center', fontsize=9,
+                        bbox=dict(boxstyle='round,pad=0.2', fc='white', alpha=0.5, ec='none'))
+                if show_points:
+                    ax.scatter(np.random.normal(idx, 0.04, size=len(vals)), vals,
+                               color='black', s=5, alpha=0.2, zorder=2)
+
+            obs_idx = self.obs_info['names_for_plotting'].index(feature)
+            ax.set_xticks(range(len(labels)))
+            ax.set_xticklabels(labels, rotation=15)
+            ax.set_ylabel(f"{feature} ({self.obs_info['units'][obs_idx]})")
+            ax.set_title(feature)
+            sns.despine(ax=ax)
+            fig.tight_layout()
+            # Sanitised, not feature.replace(' ', '_'): a name_for_plotting is LaTeX-ish
+            # (u_{A_{R}}), and braces and slashes do not survive as a filename (#167).
+            # Imported here rather than at module level: sobolSA pulls in SALib, which a
+            # calibration-only install need not have.
+            from sensitivity_analysis.sobolSA import sanitize_for_filename
+
+            path = os.path.join(self.plot_dir, f'posterior_{sanitize_for_filename(feature)}.png')
+            fig.savefig(path, dpi=300)
+            plt.close(fig)
+            written.append(path)
+
+        # Once, after every feature -- #367 called this inside the loop, redrawing the whole
+        # grid once per feature and keeping only the last.
+        self.plot_distribution_grid(values)
+        return written
+
+    def plot_distribution_grid(self, values):
+        """One figure of KDE panels, model posterior against measurement, for every feature."""
+        if self.rank != 0:
+            return None
+        import seaborn as sns
+
+        features = list(self.obs_info['names_for_plotting'])
+        if not features:
+            return None
+        cols = min(3, len(features))
+        rows = (len(features) + cols - 1) // cols
+        fig, axes = plt.subplots(rows, cols, figsize=(cols * 4.5, rows * 4), squeeze=False)
+        flat_axes = axes.flatten()
+
+        for idx, feature in enumerate(features):
+            ax = flat_axes[idx]
+            by_experiment = values.get(feature, {})
+            model_vals = [v for key, vals in by_experiment.items() if key != 'exp_data'
+                          for v in vals]
+            self._draw_density(ax, model_vals, 'Model posterior', '#1f77b4')
+            self._draw_density(ax, by_experiment.get('exp_data', []), 'Experimental', '#d62728')
+
+            ax.set_title(feature, fontweight='bold')
+            ax.set_xlabel(f"Value ({self.obs_info['units'][idx]})")
+            ax.set_ylabel('Density')
+            ax.legend(fontsize=8, frameon=False)
+            sns.despine(ax=ax)
+
+        for empty in range(len(features), len(flat_axes)):
+            flat_axes[empty].axis('off')
+
+        fig.tight_layout()
+        path = os.path.join(self.plot_dir, 'all_features_kde_grid.png')
+        fig.savefig(path, dpi=300)
+        plt.close(fig)
+        return path
+
+    @staticmethod
+    def _draw_density(ax, data, label, color):
+        """A KDE curve, falling back to a histogram when the data has no spread to smooth."""
+        data = np.asarray(list(data), dtype=float)
+        if data.size < 2:
+            return
+        try:
+            from scipy.stats import gaussian_kde
+
+            kde = gaussian_kde(data)
+            pad = 0.5 * np.std(data)
+            grid = np.linspace(np.min(data) - pad, np.max(data) + pad, 200)
+            ax.plot(grid, kde(grid), color=color, lw=2, label=label)
+        except (np.linalg.LinAlgError, ValueError):
+            # gaussian_kde needs a non-singular covariance: identical samples raise here.
+            ax.hist(data, bins=50, density=True, alpha=0.2, color=color, label=label)
+
+    def _experiment_label(self, exp_idx):
+        labels = self.protocol_info.get('experiment_labels') or []
+        return labels[exp_idx] if exp_idx < len(labels) else f'Exp {exp_idx}'
+
+    def _experiment_color(self, exp_idx):
+        colors = self.protocol_info.get('experiment_colors') or []
+        return colors[exp_idx] if exp_idx < len(colors) else f'C{exp_idx}'
+
     def _param_labels(self, num_params=None):
         """Parameter names for the diagnostic tables, falling back to indices."""
         names = None

--- a/tests/test_uq_diagnostics.py
+++ b/tests/test_uq_diagnostics.py
@@ -1,0 +1,194 @@
+"""MCMC convergence diagnostics: split-R-hat, effective sample size, and the chain plots.
+
+Computed from numpy and emcee rather than arviz. #367 imported arviz at module level for these,
+which would have made every calibration run depend on it -- and arviz is not a CA dependency, so
+the diagnostics would have been unavailable in exactly the environments that need them.
+
+The tests below check the statistics against chains whose answer is known by construction: a
+well-mixed chain, and one whose walkers sit in different places and therefore has not converged.
+"""
+import os
+
+import numpy as np
+import pytest
+
+from param_id.paramID import CVS0DParamID
+
+
+def _plotter(tmp_path=None, num_params=2):
+    """A CVS0DParamID with only the attributes the diagnostics touch."""
+    obj = CVS0DParamID.__new__(CVS0DParamID)
+    obj.rank = 0
+    obj.param_id_info = {'param_names_for_plotting': [f'p_{i}' for i in range(num_params)]}
+    obj.file_name_prefix = 'test'
+    obj.param_id_obs_file_prefix = 'obs'
+    if tmp_path is not None:
+        obj.plot_dir = str(tmp_path)
+    return obj
+
+
+def _mixed_chain(num_steps=400, num_walkers=8, num_params=2, seed=0):
+    """Independent draws from one distribution: R-hat must be ~1."""
+    rng = np.random.default_rng(seed)
+    return rng.normal(size=(num_steps, num_walkers, num_params))
+
+
+def _unconverged_chain(num_steps=400, num_walkers=8, num_params=2, seed=0):
+    """Each walker parked around a different mean: between-chain variance dominates."""
+    rng = np.random.default_rng(seed)
+    samples = rng.normal(scale=0.05, size=(num_steps, num_walkers, num_params))
+    offsets = np.linspace(-5.0, 5.0, num_walkers)
+    return samples + offsets[None, :, None]
+
+
+# ---------------------------------------------------------------------------
+# split R-hat
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_rhat_is_about_one_for_a_well_mixed_chain():
+    rhat = _plotter().calc_rhat(_mixed_chain())
+    assert set(rhat) == {'p_0', 'p_1'}
+    for name, value in rhat.items():
+        assert 0.99 < value < 1.01, f'{name}={value}'
+
+
+@pytest.mark.unit
+def test_rhat_is_large_when_the_walkers_have_not_mixed():
+    """The diagnostic's whole job: walkers exploring different regions must not be reported as
+    converged."""
+    rhat = _plotter().calc_rhat(_unconverged_chain())
+    for name, value in rhat.items():
+        assert value > 1.5, f'{name}={value}'
+
+
+@pytest.mark.unit
+def test_rhat_splits_each_walker_so_a_drifting_chain_is_caught():
+    """The *split* in split-R-hat. A walker drifting steadily has a large within-chain variance,
+    which is exactly what makes an unsplit R-hat look fine -- so a plain ratio cannot see it."""
+    num_steps, num_walkers = 400, 6
+    rng = np.random.default_rng(1)
+    drift = np.linspace(0.0, 20.0, num_steps)[:, None, None]
+    samples = rng.normal(scale=0.1, size=(num_steps, num_walkers, 1)) + drift
+
+    rhat = _plotter(num_params=1).calc_rhat(samples)
+    assert rhat['p_0'] > 1.5, 'a steadily drifting chain has not converged'
+
+
+@pytest.mark.unit
+def test_rhat_reports_nan_rather_than_guessing_on_too_short_a_chain():
+    rhat = _plotter().calc_rhat(_mixed_chain(num_steps=2))
+    assert all(np.isnan(v) for v in rhat.values())
+
+
+# ---------------------------------------------------------------------------
+# effective sample size
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_ess_of_independent_draws_is_close_to_the_number_of_draws():
+    samples = _mixed_chain(num_steps=600, num_walkers=8)
+    ess = _plotter().calc_effective_sample_size(samples)
+    total = 600 * 8
+    for name, value in ess.items():
+        assert 0.5 * total < value <= total, f'{name}={value} of {total}'
+
+
+@pytest.mark.unit
+def test_ess_is_far_below_the_draw_count_for_a_correlated_chain():
+    """The number that matters: correlated draws carry less information than their count
+    suggests, which is why ESS rather than num_steps*num_walkers belongs next to a posterior."""
+    rng = np.random.default_rng(2)
+    num_steps, num_walkers = 2000, 4
+    samples = np.zeros((num_steps, num_walkers, 1))
+    for walker in range(num_walkers):
+        value = 0.0
+        for step in range(num_steps):
+            value = 0.98 * value + rng.normal(scale=0.1)   # strongly autocorrelated
+            samples[step, walker, 0] = value
+
+    ess = _plotter(num_params=1).calc_effective_sample_size(samples)['p_0']
+    total = num_steps * num_walkers
+    assert ess < 0.1 * total, f'ess={ess} of {total} should reflect the correlation'
+
+
+@pytest.mark.unit
+def test_ess_never_exceeds_the_number_of_draws():
+    """A chain cannot carry more independent information than it has draws, whatever the
+    autocorrelation estimate does on a short trace."""
+    ess = _plotter().calc_effective_sample_size(_mixed_chain(num_steps=30, num_walkers=4))
+    for value in ess.values():
+        assert np.isnan(value) or value <= 30 * 4
+
+
+# ---------------------------------------------------------------------------
+# summary table
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_posterior_stats_recover_a_known_mean_and_sd():
+    rng = np.random.default_rng(3)
+    samples = rng.normal(loc=5.0, scale=2.0, size=(500, 8, 1))
+    stats = _plotter(num_params=1).get_posterior_stats(samples)['p_0']
+
+    assert stats['mean'] == pytest.approx(5.0, abs=0.1)
+    assert stats['sd'] == pytest.approx(2.0, abs=0.1)
+    assert stats['hdi_3%'] < stats['mean'] < stats['hdi_97%']
+    assert set(stats) == {'mean', 'sd', 'hdi_3%', 'hdi_97%', 'ess', 'r_hat'}
+
+
+@pytest.mark.unit
+def test_the_diagnostics_say_plainly_whether_the_chain_converged(capsys):
+    """A diagnostic nobody reads is not a diagnostic: R-hat and ESS are only useful against
+    their thresholds, so the verdict is stated rather than left to the reader."""
+    _plotter().print_convergence_diagnostics(_mixed_chain())
+    assert 'r_hat <= 1.01' in capsys.readouterr().out
+
+    _plotter().print_convergence_diagnostics(_unconverged_chain())
+    warned = capsys.readouterr().out
+    assert 'WARNING' in warned and 'not mixed' in warned
+
+
+@pytest.mark.unit
+def test_diagnostics_fall_back_to_indices_when_names_do_not_match():
+    """A chain with more parameters than names must not raise or mislabel."""
+    plotter = _plotter(num_params=2)
+    stats = plotter.get_posterior_stats(_mixed_chain(num_params=3))
+    assert set(stats) == {'param_0', 'param_1', 'param_2'}
+
+
+# ---------------------------------------------------------------------------
+# plots
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_autocorrelation_plot_is_written_and_reports_whether_it_decayed(tmp_path):
+    plotter = _plotter(tmp_path)
+    bounded = plotter.plot_autocorrelation(_mixed_chain(num_steps=500))
+    assert bounded is True, 'independent draws decay inside the +-0.1 band'
+    assert any(f.startswith('mcmc_autocorrelation') for f in os.listdir(tmp_path))
+
+
+@pytest.mark.unit
+def test_autocorrelation_plot_reports_a_chain_that_has_not_decayed(tmp_path):
+    rng = np.random.default_rng(4)
+    num_steps = 400
+    samples = np.cumsum(rng.normal(size=(num_steps, 4, 1)), axis=0)   # random walk
+    assert _plotter(tmp_path, num_params=1).plot_autocorrelation(samples) is False
+
+
+@pytest.mark.unit
+def test_chain_average_plot_is_written(tmp_path):
+    assert _plotter(tmp_path).plot_chain_avg(_mixed_chain()) is True
+    assert any(f.startswith('mcmc_chain_average') for f in os.listdir(tmp_path))
+
+
+@pytest.mark.unit
+def test_chain_average_plot_skips_a_chain_shorter_than_its_window(tmp_path, capsys):
+    assert _plotter(tmp_path).plot_chain_avg(_mixed_chain(num_steps=5)) is None
+    assert 'skipping' in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_a_single_parameter_chain_still_plots(tmp_path):
+    """plt.subplots returns a bare Axes rather than an array for one row, which is a routine
+    way for per-parameter plotting to break."""
+    plotter = _plotter(tmp_path, num_params=1)
+    assert plotter.plot_autocorrelation(_mixed_chain(num_params=1)) is not None
+    assert plotter.plot_chain_avg(_mixed_chain(num_params=1)) is True

--- a/tests/test_uq_posterior_plots.py
+++ b/tests/test_uq_posterior_plots.py
@@ -1,0 +1,244 @@
+"""Posterior-predictive plots and the prior density (from #367).
+
+These answer "does the calibrated model reproduce the data, and with what spread", which a
+best-fit line cannot show. The tests below drive them from stub engines, so they exercise the
+aggregation, the file writing and the prior maths without running a simulation.
+"""
+import os
+
+import numpy as np
+import pytest
+
+from param_id.paramID import CVS0DParamID
+
+
+class _StubEngine:
+    """An OpencorParamID stand-in: returns canned observables and records resets."""
+
+    def __init__(self, values_by_call, param_id_info=None, best_param_vals=None):
+        self._values = values_by_call
+        self._call = 0
+        self.param_id_info = param_id_info or {}
+        self.best_param_vals = best_param_vals
+        self.sim_helper = self
+        self.resets = 0
+
+    def get_cost_and_obs_from_params(self, param_vals, reset=True):
+        value = self._values[self._call % len(self._values)]
+        self._call += 1
+        return 0.0, [{'const': [value]}]
+
+    def get_obs_output_dict(self, obs_item):
+        return obs_item
+
+    def reset_and_clear(self):
+        self.resets += 1
+
+    # exercised by get_prior_pdf
+    def get_lnprior_from_params(self, param_vals):
+        mins = np.asarray(self.param_id_info['param_mins'], dtype=float)
+        maxs = np.asarray(self.param_id_info['param_maxs'], dtype=float)
+        param_vals = np.asarray(param_vals, dtype=float)
+        if np.any(param_vals < mins) or np.any(param_vals > maxs):
+            return -np.inf
+        prior = self.param_id_info.get('param_prior_types', ['uniform'])[0]
+        if prior == 'normal':
+            mean = 0.5 * (mins[0] + maxs[0])
+            std = (maxs[0] - mins[0]) / 6.0
+            return -0.5 * ((param_vals[0] - mean) / std) ** 2
+        return 0.0
+
+
+def _plotter(tmp_path, engine, names=('x',), data_types=('constant',), units=('dimensionless',),
+             num_experiments=1, num_sub=(1,)):
+    obj = CVS0DParamID.__new__(CVS0DParamID)
+    obj.rank = 0
+    obj.mcmc_instead = False
+    obj.param_id = engine
+    obj.plot_dir = str(tmp_path)
+    obj.output_dir = str(tmp_path)
+    obj.obs_info = {
+        'names_for_plotting': list(names),
+        'data_types': list(data_types),
+        'units': list(units),
+        'experiment_idxs': [0] * len(names),
+        'subexperiment_idxs': [0] * len(names),
+        'ground_truth_const': [1.0] * len(names),
+        'std_const_vec': [0.1] * len(names),
+        'ground_truth_prob_dist_params': [None] * len(names),
+    }
+    obj.protocol_info = {
+        'num_experiments': num_experiments,
+        'num_sub_per_exp': list(num_sub),
+        'experiment_labels': ['baseline'],
+        'experiment_colors': ['C0'],
+    }
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# predictive values
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_each_posterior_draw_is_simulated_and_collected(tmp_path):
+    engine = _StubEngine([1.0, 2.0, 3.0])
+    plotter = _plotter(tmp_path, engine)
+
+    values = plotter._posterior_predictive_values(np.arange(3, dtype=float).reshape(3, 1),
+                                                  n_sims=3)
+
+    assert sorted(values['x'][0]) == [1.0, 2.0, 3.0]
+    assert engine.resets == 3, 'the simulation must be reset between posterior draws'
+
+
+@pytest.mark.unit
+def test_more_requested_draws_than_samples_uses_what_there_is(tmp_path):
+    """np.random.choice(replace=False) raises when asked for more than it has."""
+    engine = _StubEngine([1.0])
+    plotter = _plotter(tmp_path, engine)
+    values = plotter._posterior_predictive_values(np.zeros((2, 1)), n_sims=500)
+    assert len(values['x'][0]) == 2
+
+
+@pytest.mark.unit
+def test_a_constant_observation_is_expanded_into_a_comparable_spread(tmp_path):
+    """A constant observation is a mean and a std, not samples. Drawing from it makes the
+    comparison distribution-against-distribution rather than distribution-against-a-line."""
+    plotter = _plotter(tmp_path, _StubEngine([1.0]))
+    values = {'x': {}}
+    plotter._add_measured_values(values)
+
+    measured = values['x']['exp_data']
+    assert len(measured) == 20
+    assert np.mean(measured) == pytest.approx(1.0, abs=0.15)
+
+
+@pytest.mark.unit
+def test_prob_dist_measurements_are_used_as_given(tmp_path):
+    """A prob_dist observation already *is* samples, so it must not be re-drawn."""
+    plotter = _plotter(tmp_path, _StubEngine([1.0]), data_types=('prob_dist',))
+    plotter.obs_info['ground_truth_prob_dist_params'] = [{'data_points': [1.0, 2.0, 3.0]}]
+    values = {'x': {}}
+    plotter._add_measured_values(values)
+    assert list(values['x']['exp_data']) == [1.0, 2.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# csv + figures
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_the_predictions_are_saved_long_format(tmp_path):
+    """The csv is what someone re-plots or re-analyses from without paying for the simulations
+    again, so it has to distinguish simulated rows from measured ones."""
+    import pandas as pd
+
+    plotter = _plotter(tmp_path, _StubEngine([1.0]))
+    plotter.save_posterior_predictions({'x': {0: [1.0, 2.0], 'exp_data': [1.1]}})
+
+    df = pd.read_csv(os.path.join(tmp_path, 'posterior_predictions.csv'))
+    assert set(df.columns) == {'feature', 'experiment_idx', 'value', 'data_type'}
+    assert sorted(df['data_type'].unique()) == ['experimental', 'simulated']
+    assert len(df) == 3
+
+
+@pytest.mark.unit
+def test_the_grid_is_drawn_once_not_once_per_feature(tmp_path, monkeypatch):
+    """#367 called plot_distribution_grid inside the per-feature loop, redrawing the whole grid
+    once per feature and keeping only the last."""
+    pytest.importorskip('seaborn')
+    plotter = _plotter(tmp_path, _StubEngine([1.0, 2.0]), names=('a', 'b'),
+                       data_types=('constant', 'constant'),
+                       units=('dimensionless', 'dimensionless'))
+
+    calls = []
+    monkeypatch.setattr(type(plotter), 'plot_distribution_grid',
+                        lambda self, values: calls.append(values))
+
+    plotter.plot_boxplots_for_predictions(np.zeros((4, 1)), n_sims=2)
+    assert len(calls) == 1
+
+
+@pytest.mark.unit
+def test_a_latex_feature_name_still_produces_a_usable_filename(tmp_path):
+    """names_for_plotting are LaTeX-ish (u_{A_{R}}); braces and slashes do not survive as a
+    filename, which is the same defect #167 fixed for the sensitivity plots."""
+    pytest.importorskip('seaborn')
+    plotter = _plotter(tmp_path, _StubEngine([1.0, 2.0]), names=('u_{A_{R}} - exp0',))
+
+    written = plotter.plot_boxplots_for_predictions(np.zeros((3, 1)), n_sims=2)
+
+    assert written, 'a figure should have been written'
+    for path in written:
+        stem = os.path.basename(path)
+        for bad in '{}\\/ ,':
+            assert bad not in stem, f'{bad!r} should not survive in {stem!r}'
+        assert os.path.isfile(path)
+
+
+@pytest.mark.unit
+def test_the_kde_grid_is_written(tmp_path):
+    pytest.importorskip('seaborn')
+    plotter = _plotter(tmp_path, _StubEngine([1.0]))
+    rng = np.random.default_rng(0)
+    values = {'x': {0: list(rng.normal(size=50)), 'exp_data': list(rng.normal(size=50))}}
+
+    path = plotter.plot_distribution_grid(values)
+    assert path and os.path.isfile(path)
+
+
+@pytest.mark.unit
+def test_a_feature_with_no_spread_falls_back_to_a_histogram(tmp_path):
+    """gaussian_kde needs a non-singular covariance: identical samples raise, and a plot that
+    raises loses every other panel in the figure too."""
+    pytest.importorskip('seaborn')
+    plotter = _plotter(tmp_path, _StubEngine([1.0]))
+    values = {'x': {0: [2.0] * 30, 'exp_data': [2.0] * 30}}
+    assert plotter.plot_distribution_grid(values) is not None
+
+
+# ---------------------------------------------------------------------------
+# prior pdf
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_uniform_prior_pdf_is_flat_inside_the_bounds_and_zero_outside(tmp_path):
+    info = {'param_mins': [0.0], 'param_maxs': [2.0], 'param_prior_types': ['uniform']}
+    plotter = _plotter(tmp_path, _StubEngine([1.0], param_id_info=info,
+                                             best_param_vals=np.array([1.0])))
+
+    x = np.linspace(-1.0, 3.0, 401)
+    pdf = plotter.get_prior_pdf(0, x)
+
+    inside = (x >= 0.0) & (x <= 2.0)
+    assert np.allclose(pdf[inside], 0.5, atol=0.02), 'a uniform prior on [0, 2] has density 0.5'
+    assert np.all(pdf[~inside] == 0.0)
+
+
+@pytest.mark.unit
+def test_normal_prior_pdf_peaks_at_its_mean_and_integrates_to_one(tmp_path):
+    info = {'param_mins': [0.0], 'param_maxs': [6.0], 'param_prior_types': ['normal']}
+    plotter = _plotter(tmp_path, _StubEngine([1.0], param_id_info=info,
+                                             best_param_vals=np.array([3.0])))
+
+    x = np.linspace(0.0, 6.0, 601)
+    pdf = plotter.get_prior_pdf(0, x)
+
+    assert x[int(np.argmax(pdf))] == pytest.approx(3.0, abs=0.05)
+    assert np.trapz(pdf, x) == pytest.approx(1.0, abs=1e-6)
+
+
+@pytest.mark.unit
+def test_the_prior_pdf_comes_from_the_engines_own_prior(tmp_path):
+    """Derived from get_lnprior_from_params rather than reimplemented, so params_for_id's
+    prior_mean / prior_std / prior_origin / prior_scale and the unbounded flag are honoured --
+    #367 restated the old hardcoded defaults here, which a user's hyper-parameters would have
+    silently disagreed with."""
+    info = {'param_mins': [0.0], 'param_maxs': [2.0], 'param_prior_types': ['uniform']}
+    engine = _StubEngine([1.0], param_id_info=info, best_param_vals=np.array([1.0]))
+    plotter = _plotter(tmp_path, engine)
+
+    seen = []
+    original = engine.get_lnprior_from_params
+    engine.get_lnprior_from_params = lambda p: (seen.append(np.copy(p)), original(p))[1]
+
+    plotter.get_prior_pdf(0, np.linspace(0.0, 2.0, 11))
+    assert len(seen) == 11, 'the engine prior must be evaluated at every plotted point'


### PR DESCRIPTION
Fifth of the stack bringing in #367 (pyMC for UQ). Original work by @MOH-Shafizadegan.

> Stacked on #402–#405 — their commits are included here and the diff shrinks to the last commit once those merge.

## Why

An MCMC run reported a posterior with nothing to say whether the chain had converged, so a posterior from walkers that never mixed looked exactly like one from walkers that did.

## What

Per-parameter **split R-hat** and **effective sample size**, a summary table (mean / sd / 3% / 97% / ess / r_hat), an **autocorrelation** plot and a running **chain-average** plot. `plot_mcmc` now prints the table and states the verdict against the 1.01 R-hat threshold rather than leaving the reader to apply it — a diagnostic nobody reads is not a diagnostic.

```
parameter                           mean          sd          3%         97%       ess    r_hat
...
WARNING: r_hat > 1.01 for ['q_{sbv}', 'C_{ao}', 'E_{lvA}', 'E_{lvB}'] -- the walkers have not
mixed. Run more steps before trusting the posterior.
```

(That is the real output of the existing 3compartment MCMC test, whose DEBUG chain is 5 steps long — so the diagnostic is doing its job on the first run it saw.)

## No new dependency

#367 imported `arviz`, `seaborn` **and** `pytensor` at module level in `paramID.py` for these. `paramID.py` is imported by every calibration run, and none of those three are CA dependencies — so `paramID.py` would not have imported at all for most users, and the diagnostics would have been unavailable in exactly the environments that need them. (`arviz` is not installed in the OpenCOR pythonshell this repo runs under.)

R-hat and ESS are short, standard formulas, and `emcee` — already a dependency — supplies the autocorrelation. So they are computed directly from numpy and emcee, and the tests below actually run rather than skipping.

## Two things beyond a port

- **R-hat is the split form.** `az.summary` is split too, but the distinction is worth being explicit about: a walker drifting steadily has a large *within*-chain variance, which is exactly what makes an unsplit ratio look fine. There is a test that builds precisely that chain and asserts it is caught.
- **One summary, computed once.** #367 rebuilt the same arviz dataset and re-ran `az.summary` inside each of `get_posterior_stats`, `calc_effective_sample_size` and `calc_rhat`, so the expensive part ran three times to fill one table.

ESS is also capped at the draw count — a chain cannot carry more independent information than it has draws, whatever the autocorrelation estimator does on a short trace.

## Tests

New `tests/test_uq_diagnostics.py`, 15 fast unit tests against chains whose answer is known by construction: R-hat ≈ 1 for a well-mixed chain, > 1.5 for walkers parked in different places, > 1.5 for a steadily drifting chain, and `nan` rather than a guess on a chain too short to split; ESS ≈ the draw count for independent draws and < 10% of it for a strongly autocorrelated one, never exceeding the draw count; the summary recovers a known mean and sd; the verdict is printed both ways; labels fall back to indices when names do not match; both plots are written, the autocorrelation plot reports whether it decayed inside ±0.1, the chain-average plot skips a chain shorter than its window, and a single-parameter chain still plots (`plt.subplots` returns a bare Axes for one row, which is a routine way for per-parameter plotting to break).

Verified `not slow and not compare_optimisers`: **646 passed, 1 failed** — `test_python_BDF_solver[SN_simple]`, the known libCellML Analyser limitation (#151), which fails identically on master.

## Deliberately not included

#367's three seaborn posterior-predictive plots — `plot_boxplots_for_predictions`, `plot_distribution_grid`, `get_prior_pdf` — are **not** here. They are result presentation rather than convergence diagnostics, they need the prediction machinery to re-simulate from posterior draws, and #341 is an open decision to deprecate built-in result plotting in favour of a generated, user-editable script. Adding three more built-in plots cuts against that, so they are worth landing (or not) as their own change once #341 is settled.

## Next in the stack

The pyMC backend, and the slow posterior-recovery tests.
