### PR TITLE
feat(emulators): fit a surrogate once, then calibrate, SA, UQ and IA on it (#333)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ Runs are launched via shell scripts in `user_run_files/`, which call entry-point
 | `run_multiple_param_id.sh` | `run_multiple_param_id.py` | Batch calibration over models |
 | `run_sensitivity_analysis.sh` | `sensitivity_analysis_run_script.py` | Sobol SA (`mpiexec`) |
 | `run_identifiability_analysis.sh` | `identifiability_run_script.py` | Laplace / profile-likelihood |
+| `run_emulator_training.sh` (arg: `num_processors`, uses `mpiexec`) | `train_emulator_run_script.py` | Train a surrogate of the obs features |
 | `plot_param_id.sh` | `plot_param_id_script.py` | Plot calibration results |
 
 Other useful scripts in `src/scripts/`: `generate_obs_json.py`, `example_format_obs_data_json_file.py`, `generate_modules_files.py`, `convert_0d_to_1d.py`, `read_and_insert_parameters.py`, `generate_omex_analysis_script.py`.
@@ -70,6 +71,8 @@ Then call the same stages the scripts call, all taking that dict:
 
 **Never commit `resources/user_inputs_<yymmdd>.yaml`.** Every run archives its resolved config there via `save_dated_user_inputs` (`src/parsers/PrimitiveParsers.py`), so these files appear constantly as modified or untracked — they are per-machine run artifacts, not inputs. They bake in absolute local paths (`resources_dir`, `generated_models_dir`, and `/tmp/pytest-*` dirs when a test run writes them), so committing them adds churn and leaks one machine's layout into the repo. They are gitignored; leave them untracked, and do not `git add -A` them back in. The same goes for anything else that shows up modified purely because you ran the suite.
 
+- `do_emulation` / `use_emulator` + `emulator_settings` — **emulators (surrogate models, issue #333)**. The emulator maps theta (the params_for_id vector, one slot per entry) to the *scalar* features of the obs_data data_items, i.e. the value after the `operation` reduction — the same numbers the cost uses. `do_emulation` trains one against the solver named by `solver`; `use_emulator` makes calibration/SA/UQ/IA evaluate it. `solver` deliberately keeps meaning the truth solver, so an emulator run can be compared with it. Backend is the optional `autoemulate` (`pip install ".[emulation]"`, needs Python >=3.10,<3.13). Series/frequency observables, prediction traces and output plots are **refused** in emulator mode, not approximated.
+
 ## Discoverable schemas (keep settings machine-readable for CUFLynx)
 
 The GUI front-end **CUFLynx** auto-populates its menus and settings forms by reading discoverable schemas in `src/parsers/PrimitiveParsers.py` — it does **not** hardcode the options. **Whenever you add or change a user-configurable setting, update the matching schema in the same PR**, or CUFLynx silently won't expose it:
@@ -77,7 +80,7 @@ The GUI front-end **CUFLynx** auto-populates its menus and settings forms by rea
 - `SOLVER_SCHEMA` — model types, solvers per model type, integrator `method`s per solver, and `solver_info_fields_by_solver` (`SOLVER_INFO_FIELDS`: the `solver_info` settings per solver). `_SOLVER_INTEGRATOR_KEYS` (validation) is **derived** from `SOLVER_INFO_FIELDS`, so add a solver_info field there. Also carries per-integrator analytic-gradient suitability for a tool's Gradient menu: `ad_suitable_methods` (casadi_integrator methods that support CasADi AD — **derived** from `_CASADI_ADJOINT_METHODS`, i.e. every method except the adjoint `cvodes`/`idas`), `fsa_suitable_methods` (Myokit CVODES FSA methods per solver), and `default_method_by_solver` (advisory default integrator, e.g. `casadi_integrator` → `bdf`).
 - `PARAM_ID_METHODS` — calibration methods, each with an `options` list = the `optimiser_options` it reads. Add a new optimiser knob here.
 - `gradient_sources(model_type, solver, method=None)` — the gradient sources (FD / AD / FSA) the gradient-based methods (`sp_minimize`, `multi_start_sp_minimize`) can use for a given model, each with the `do_ad` flag it implies. There is **no** per-method "gradient" option: AD vs FD is the top-level `do_ad` flag, and which analytic backend runs follows from `model_type`/`solver` (mirrors `OpencorParamID.get_gradient`). When the integrator `method` is passed, the analytic source is additionally gated on `ad_suitable_methods`/`fsa_suitable_methods` (e.g. no CasADi AD for `cvodes`/`idas`). Keep it in step with that dispatch.
-- `ANALYSIS_OPTIONS` — the `sa_options` / `mcmc_options` / `ia_options` settings for the sensitivity / MCMC / identifiability modes.
+- `ANALYSIS_OPTIONS` — the `sa_options` / `mcmc_options` / `ia_options` / `emulator_settings` settings for the sensitivity / MCMC / identifiability / emulation modes. `emulation` is the only entry with a **`use_flag`** as well as an `enable_flag`, because it has a train step and a use step. `gradient_sources(..., use_emulator=True)` collapses to FD alone (the analytic arms differentiate the real model, which an emulator run is not evaluating). Emulator model names are a runtime registry like the cost funcs — `emulators.emulator_trainer.emulator_model_names()`.
 - Cost functions are a runtime registry (user-extensible), so they're discovered via `funcs_user.cost_funcs_user.cost_func_metadata()` (names + `is_MLE`/`is_combiner`/`differentiable` flags), not a static schema. Both this and the operation-funcs dict take an optional `external_path` (and `scriptFunctionParser` an `operation_funcs_external_path` / `cost_funcs_external_path`) so the merged set — including funcs from an external file — is introspectable.
 
 Each setting is a descriptor `{name, type, default, required, description, choices?}`. Accessors: `solver_info_fields(solver)`, `param_id_method_options(method)`, `analysis_options(mode)`, `gradient_sources(model_type, solver, method=None)`. Tests in `tests/test_solver_info_validation.py` lock every schema's shape **and** its correspondence to what the code actually reads (e.g. an option the optimiser doesn't read, or a read the schema omits, fails the suite) — extend those when you add settings.
@@ -86,11 +89,12 @@ Each setting is a descriptor `{name, type, default, required, description, choic
 
 | Dir | Contents / purpose |
 |---|---|
-| `solver_wrappers/` | `SimulationHelper` backends + `get_simulation_helper()` factory (`__init__.py`). Backends: `myokit_helper.py`, `opencor_helper.py`, `python_solver_helper.py`, `casadi_python_solver_helper.py`. `name_resolver.py` maps variable names. |
+| `solver_wrappers/` | `SimulationHelper` backends + `get_simulation_helper()` factory (`__init__.py`). Backends: `myokit_helper.py`, `opencor_helper.py`, `python_solver_helper.py`, `casadi_python_solver_helper.py`, `emulator_solver_helper.py` (answers from a trained emulator; `emulates_features = True` tells the two reduction sites to skip the obs `operation`). `name_resolver.py` maps variable names. |
 | `generators/` | `CVSCellMLGenerator.py`, `PythonGenerator.py` (libCellML Analyser, strict ODE), `CVSCppGenerator.py`, `Python1DModelFilesGenerator.py`. |
 | `param_id/` | `paramID.py` (calibration), `optimisers.py`, `differentiable.py` + `math_backend.py` + `operation_funcs.py` (AD), `plot_outputs.py`. |
 | `protocol_runners/` | `protocol_runner.py`, `protocol_executor.py` — the multi-experiment/sub-experiment simulation loop. |
 | `sensitivity_analysis/` | `sensitivityAnalysis.py`, `sobolSA.py`. |
+| `emulators/` | `emulator_trainer.py` (design -> simulate -> fit -> validate -> persist), `emulator_bundle.py` (the artefact + every refusal rule). Backend: optional `autoemulate`. |
 | `identifiabilty_analysis/` | `identifiabilityAnalysis.py` (note the dir is spelled `identifiabilty`). |
 | `parsers/` | `ModelParsers.py`, `PrimitiveParsers.py`, `OMEXParsers.py` — CSV/YAML/JSON/OMEX loading. |
 | `models/` | `LumpedModels.py` (`CVS0DModel`). `checks/LumpedModelChecks.py` validates structure/connectivity. |
@@ -147,6 +151,8 @@ Add/extend tests in `tests/` for **every feature and bugfix**; a bugfix should i
 | `test_autogeneration.py` | CSV → model generation (markers: `integration`, `slow`, `autogen_rank(idx)`) |
 | `test_param_id.py` | Calibration across optimisers (`integration`, `slow`, `mpi`, `compare_optimisers`) |
 | `test_sensitivity_analysis.py` | Sobol SA (`integration`, `mpi`) |
+| `test_emulator_settings.py`, `test_emulator_solver_helper.py` | Emulator artefact, refusals and the cost-path seam, with a stub emulator (`unit`, no autoemulate) |
+| `test_emulator_training.py` | Emulator training end-to-end (`integration`, `slow`, `mpi`; the real fit is `importorskip('autoemulate')`) |
 | `test_protocol_funcs.py`, `test_unit_conversion.py`, `test_solver_info_validation.py`, `test_casadi_conditionals.py` | Unit-level (`unit`) |
 | `test_omex_analysis_pipeline.py` | OMEX/SED-ML pipeline (`integration`, `misc_task`) |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Each setting is a descriptor `{name, type, default, required, description, choic
 | `param_id/` | `paramID.py` (calibration), `optimisers.py`, `differentiable.py` + `math_backend.py` + `operation_funcs.py` (AD), `plot_outputs.py`. |
 | `protocol_runners/` | `protocol_runner.py`, `protocol_executor.py` — the multi-experiment/sub-experiment simulation loop. |
 | `sensitivity_analysis/` | `sensitivityAnalysis.py`, `sobolSA.py`. |
-| `emulators/` | `emulator_trainer.py` (design -> simulate -> fit -> validate -> persist), `emulator_bundle.py` (the artefact + every refusal rule). Backend: optional `autoemulate`. |
+| `emulators/` | `emulator_trainer.py` (design -> simulate -> fit -> validate -> persist), `emulator_bundle.py` (the artefact + every refusal rule, plus `error_stats()` / `error_points()` -- the per-feature held-out statistics and the held-out points themselves, which is what an error analysis is drawn from). Backend: optional `autoemulate`. |
 | `identifiabilty_analysis/` | `identifiabilityAnalysis.py` (note the dir is spelled `identifiabilty`). |
 | `parsers/` | `ModelParsers.py`, `PrimitiveParsers.py`, `OMEXParsers.py` — CSV/YAML/JSON/OMEX loading. |
 | `models/` | `LumpedModels.py` (`CVS0DModel`). `checks/LumpedModelChecks.py` validates structure/connectivity. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,13 @@ docs = [
     "mkdocstrings[python]>=0.24",
     "black>=22.0.0",  # used by mkdocstrings to format rendered signatures
 ]
+# Surrogate (emulator) models -- issue #333. Optional because autoemulate pulls in torch,
+# gpytorch, pyro-ppl and lightgbm, and requires Python >=3.10,<3.13, which is narrower than
+# this project's floor. CA imports it only when do_emulation/use_emulator is set, and says so
+# by name when it is missing.
+emulation = [
+    "autoemulate>=2.1,<3",
+]
 
 [tool.pytest.ini_options]
 # Pytest configuration

--- a/src/emulators/__init__.py
+++ b/src/emulators/__init__.py
@@ -1,0 +1,32 @@
+"""Surrogate (emulator) models of the forward model -- issue #333.
+
+An emulator maps theta (the ``params_for_id`` vector) to the scalar features of the
+``obs_data.json`` data_items, i.e. the same numbers the cost is computed from. Fit it once, and
+Sobol SA, calibration, MCMC and identifiability analysis can all evaluate it instead of the
+simulator, because they all reach the model through that one mapping.
+
+Public surface:
+
+* :class:`emulators.emulator_trainer.EmulatorTrainer` -- design, simulate, fit, validate, save.
+* :class:`emulators.emulator_bundle.EmulatorBundle` -- the saved artefact and its refusal rules.
+* :func:`emulators.emulator_trainer.emulator_model_names` -- the emulator names the settings
+  accept, discovered from autoemulate rather than hardcoded.
+
+``autoemulate`` is an optional dependency; importing this package without it works, and only
+fitting (or loading a bundle fitted with it) raises.
+"""
+from emulators.emulator_bundle import (EmulatorBoundsError, EmulatorBundle,
+                                       EmulatorQualityError, fingerprint)
+from emulators.emulator_trainer import (EmulatorTrainer, autoemulate_available,
+                                        emulator_model_names, resolve_emulator_dir)
+
+__all__ = [
+    'autoemulate_available',
+    'EmulatorBoundsError',
+    'EmulatorBundle',
+    'EmulatorQualityError',
+    'EmulatorTrainer',
+    'emulator_model_names',
+    'fingerprint',
+    'resolve_emulator_dir',
+]

--- a/src/emulators/emulator_bundle.py
+++ b/src/emulators/emulator_bundle.py
@@ -1,0 +1,309 @@
+"""The trained-emulator artefact: the fitted model, its metadata, and every refusal rule.
+
+An emulator does not fail loudly. Handed parameters it was never trained on, or fitted to a
+design too small for the response it is approximating, it returns plausible numbers, and every
+Sobol index, cost and posterior computed from them inherits the error silently. So the artefact
+carries what is needed to *disprove* itself -- held-out R2 per output, the parameter box it was
+trained in, and a fingerprint of the model, parameters and protocol it was trained against --
+and CA refuses to use it when any of those disagree with the run at hand (issue #333).
+
+The bundle also owns the input/output scaling. CA parameters span many orders of magnitude
+(compliances near 1e-9 next to resistances near 1e8) and autoemulate works in float32 torch,
+where that spread destroys a kernel fit. Parameters are mapped to the unit box and features are
+standardised here, before anything reaches the emulator, and the transforms are stored in the
+metadata -- an emulator reloaded without them would predict in the wrong units.
+"""
+import hashlib
+import json
+import os
+
+import numpy as np
+
+METADATA_FILE = 'emulator_metadata.json'
+MODEL_FILE = 'emulator'          # autoemulate's saver appends .joblib
+TRAINING_DATA_FILE = 'training_data.npz'
+
+#: metadata keys that must be present for a bundle to be usable at all.
+REQUIRED_META_KEYS = ('param_entry_labels', 'param_mins', 'param_maxs', 'feature_labels',
+                      'feature_r2', 'x_scale', 'y_scale', 'fingerprint')
+
+
+def fingerprint(param_id_info, obs_info, protocol_info, model_path=None):
+    """A stable digest of everything an emulator was trained against.
+
+    Changing a parameter's bounds, adding a data_item, editing an operation, moving a
+    sub-experiment or regenerating the model all change what theta -> features *means*. None of
+    those changes make the old emulator raise on its own -- it would keep answering, about a
+    different model. Comparing this digest is what turns that into an error.
+
+    ``model_path`` is hashed by content when it exists, so a regenerated CellML invalidates the
+    emulator even if the inputs that produced it are unchanged.
+    """
+    payload = {
+        'param_labels': [str(x) for x in _param_entry_labels(param_id_info)],
+        'param_mins': _as_list(param_id_info.get('param_mins')),
+        'param_maxs': _as_list(param_id_info.get('param_maxs')),
+        'operands': _jsonable(obs_info.get('operands')),
+        'operations': _jsonable(obs_info.get('operations')),
+        'operation_kwargs': _jsonable(obs_info.get('operation_kwargs')),
+        'data_types': _jsonable(obs_info.get('data_types')),
+        'experiment_idxs': _as_list(obs_info.get('experiment_idxs')),
+        'subexperiment_idxs': _as_list(obs_info.get('subexperiment_idxs')),
+        'pre_times': _jsonable(protocol_info.get('pre_times')),
+        'sim_times': _jsonable(protocol_info.get('sim_times')),
+        'params_to_change': _jsonable(protocol_info.get('params_to_change')),
+    }
+    blob = json.dumps(payload, sort_keys=True, default=str).encode('utf-8')
+    digest = {'inputs_sha256': hashlib.sha256(blob).hexdigest()}
+    if model_path and os.path.isfile(model_path):
+        with open(model_path, 'rb') as file:
+            digest['model_sha256'] = hashlib.sha256(file.read()).hexdigest()
+    return digest
+
+
+def _param_entry_labels(param_id_info):
+    # Imported here rather than at module scope: PrimitiveParsers imports a good deal of CA,
+    # and this module is imported by the solver-wrapper factory.
+    from parsers.PrimitiveParsers import param_entry_labels
+    return param_entry_labels(param_id_info)
+
+
+def _as_list(values):
+    if values is None:
+        return None
+    return [float(v) for v in np.asarray(values, dtype=float).reshape(-1)]
+
+
+def _jsonable(value):
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (np.integer, np.floating)):
+        return value.item()
+    return value
+
+
+class EmulatorQualityError(RuntimeError):
+    """The emulator is not accurate enough, or was trained against something else."""
+
+
+class EmulatorBoundsError(RuntimeError):
+    """Evaluation was asked for outside the box the emulator was trained in."""
+
+
+class EmulatorBundle:
+    """A fitted emulator plus the metadata that makes it checkable.
+
+    Args:
+        model: the fitted emulator (an autoemulate ``Emulator``, or anything with a
+            ``predict(x)`` returning an array-like of shape ``(n, n_features)``).
+        meta: the metadata dict (see ``REQUIRED_META_KEYS``).
+        x_train / y_train: the training design and targets, in real units. Kept so the emulator
+            can be refitted, extended or audited without re-running the simulator.
+    """
+
+    def __init__(self, model, meta, x_train=None, y_train=None):
+        missing = [key for key in REQUIRED_META_KEYS if key not in meta]
+        if missing:
+            raise ValueError(f'emulator metadata is missing {missing}')
+        self.model = model
+        self.meta = meta
+        self.x_train = None if x_train is None else np.asarray(x_train, dtype=float)
+        self.y_train = None if y_train is None else np.asarray(y_train, dtype=float)
+
+        self.param_mins = np.asarray(meta['param_mins'], dtype=float)
+        self.param_maxs = np.asarray(meta['param_maxs'], dtype=float)
+        self.param_entry_labels = list(meta['param_entry_labels'])
+        self.feature_labels = list(meta['feature_labels'])
+        self._x_shift = np.asarray(meta['x_scale']['shift'], dtype=float)
+        self._x_span = np.asarray(meta['x_scale']['span'], dtype=float)
+        self._y_shift = np.asarray(meta['y_scale']['shift'], dtype=float)
+        self._y_span = np.asarray(meta['y_scale']['span'], dtype=float)
+
+    # ------------------------------------------------------------------ scaling
+
+    @staticmethod
+    def make_scale(values):
+        """Shift/span for an affine map onto a well-conditioned range.
+
+        A span of zero (a constant column -- a parameter pinned to one value, or a feature the
+        model does not respond to) would divide by zero, so it becomes 1: the column maps to a
+        constant, which is exactly what it is.
+        """
+        values = np.asarray(values, dtype=float)
+        shift = np.nanmin(values, axis=0) if values.ndim > 1 else np.nanmin(values)
+        span = (np.nanmax(values, axis=0) - shift) if values.ndim > 1 else np.nanmax(values) - shift
+        span = np.where(np.asarray(span) > 0, span, 1.0)
+        return {'shift': np.atleast_1d(shift).tolist(), 'span': np.atleast_1d(span).tolist()}
+
+    def scale_x(self, theta):
+        return (np.asarray(theta, dtype=float) - self._x_shift) / self._x_span
+
+    def unscale_y(self, y_scaled):
+        return np.asarray(y_scaled, dtype=float) * self._y_span + self._y_shift
+
+    def scale_y(self, y):
+        return (np.asarray(y, dtype=float) - self._y_shift) / self._y_span
+
+    # ------------------------------------------------------------------ checks
+
+    def check_quality(self, min_r2):
+        """Refuse an emulator whose worst held-out R2 is below ``min_r2``.
+
+        Named per feature, because "the emulator is bad" is not actionable while "max of
+        aortic_root/u has R2 0.42" tells the user which observable to add samples for.
+        """
+        if min_r2 is None:
+            return
+        worst_label, worst_r2 = None, np.inf
+        for label, r2 in zip(self.feature_labels, self.meta['feature_r2']):
+            if r2 is None or not np.isfinite(r2):
+                worst_label, worst_r2 = label, float('-inf')
+                break
+            if r2 < worst_r2:
+                worst_label, worst_r2 = label, float(r2)
+        if worst_r2 < min_r2:
+            raise EmulatorQualityError(
+                f'emulator held-out R2 for feature {worst_label!r} is {worst_r2:.4g}, below the '
+                f'configured min_r2 of {min_r2}. Increase emulator_settings.num_train_samples, '
+                f'widen emulator_settings.models, or lower min_r2 if you accept the error.')
+
+    def check_bounds(self, theta, policy='error'):
+        """Apply the out-of-training-box policy, returning the theta to evaluate.
+
+        An emulator is an interpolant; outside its design it is an extrapolation with no
+        error estimate at all. Refusing is the default for that reason.
+        """
+        theta = np.asarray(theta, dtype=float)
+        below = theta < self.param_mins
+        above = theta > self.param_maxs
+        if not (below.any() or above.any()):
+            return theta
+        offenders = [
+            f'{self.param_entry_labels[i]}={theta[i]:.6g} outside '
+            f'[{self.param_mins[i]:.6g}, {self.param_maxs[i]:.6g}]'
+            for i in range(theta.size) if below[i] or above[i]]
+        message = ('emulator evaluated outside the parameter box it was trained in: '
+                   + '; '.join(offenders))
+        if policy == 'clip':
+            return np.clip(theta, self.param_mins, self.param_maxs)
+        if policy == 'warn':
+            print(f'WARNING: {message}. Predictions there are extrapolation.')
+            return theta
+        raise EmulatorBoundsError(
+            message + '. Retrain over the wider box, or set '
+                      'emulator_settings.out_of_bounds to "warn" or "clip".')
+
+    def check_matches(self, live_fingerprint, param_entry_labels=None, feature_labels=None):
+        """Refuse a bundle trained against a different model, parameter set or protocol."""
+        if param_entry_labels is not None and list(param_entry_labels) != self.param_entry_labels:
+            raise EmulatorQualityError(
+                f'emulator was trained for parameters {self.param_entry_labels} but this run '
+                f'calibrates {list(param_entry_labels)}. Retrain the emulator.')
+        if feature_labels is not None and list(feature_labels) != self.feature_labels:
+            raise EmulatorQualityError(
+                f'emulator was trained for observables {self.feature_labels} but this run uses '
+                f'{list(feature_labels)}. Retrain the emulator.')
+        stored = self.meta['fingerprint']
+        for key, value in live_fingerprint.items():
+            if key in stored and stored[key] != value:
+                raise EmulatorQualityError(
+                    f'emulator is stale: {key} has changed since it was trained '
+                    f'({stored[key][:12]}... -> {value[:12]}...). The model, parameter bounds, '
+                    f'obs_data operations or protocol differ. Retrain the emulator, or set '
+                    f'emulator_settings.retrain_if_stale to true.')
+
+    # ------------------------------------------------------------------ predict
+
+    def predict(self, theta, out_of_bounds='error'):
+        """Predicted scalar features for one theta (1-D) or many (2-D)."""
+        theta = np.asarray(theta, dtype=float)
+        single = theta.ndim == 1
+        rows = theta.reshape(1, -1) if single else theta
+        checked = np.vstack([self.check_bounds(row, out_of_bounds) for row in rows])
+        y_scaled = self._predict_scaled(self.scale_x(checked))
+        features = self.unscale_y(y_scaled)
+        return features[0] if single else features
+
+    # ------------------------------------------------------------------ persistence
+
+    def save(self, directory):
+        """Write model, metadata and training data to ``directory``. Returns the directory."""
+        os.makedirs(directory, exist_ok=True)
+        _save_model(self.model, os.path.join(directory, MODEL_FILE))
+        with open(os.path.join(directory, METADATA_FILE), 'w') as file:
+            json.dump(self.meta, file, indent=2, default=str)
+        if self.x_train is not None and self.y_train is not None:
+            # Kept so the design can be extended or refitted without paying for the
+            # simulations again -- the expensive half of training is the runs, not the fit.
+            np.savez(os.path.join(directory, TRAINING_DATA_FILE),
+                     x_train=self.x_train, y_train=self.y_train)
+        return directory
+
+    @classmethod
+    def load(cls, directory):
+        meta_path = os.path.join(directory, METADATA_FILE)
+        if not os.path.isfile(meta_path):
+            raise FileNotFoundError(
+                f'no emulator found in {directory} ({METADATA_FILE} is missing). Train one '
+                f'first with do_emulation: true (./run_emulator_training.sh N).')
+        with open(meta_path) as file:
+            meta = json.load(file)
+        model = _load_model(os.path.join(directory, MODEL_FILE))
+        x_train = y_train = None
+        data_path = os.path.join(directory, TRAINING_DATA_FILE)
+        if os.path.isfile(data_path):
+            with np.load(data_path) as data:
+                x_train, y_train = data['x_train'], data['y_train']
+        return cls(model, meta, x_train=x_train, y_train=y_train)
+
+    def _predict_scaled(self, x_scaled):
+        """The one place the emulator backend is actually called.
+
+        autoemulate emulators return either a tensor or a torch distribution depending on
+        whether they are probabilistic, so both are reduced to a mean array here; a plain
+        object with ``predict`` (what the tests use) passes straight through.
+        """
+        raw = self.model.predict(_as_backend_input(self.model, x_scaled))
+        return _as_numpy_mean(raw).reshape(len(x_scaled), -1)
+
+
+def _save_model(model, path_without_suffix):
+    """joblib, the same container autoemulate's own serialiser uses."""
+    import joblib
+    joblib.dump(model, f'{path_without_suffix}.joblib')
+
+
+def _load_model(path_without_suffix):
+    import joblib
+    path = f'{path_without_suffix}.joblib'
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f'emulator model file {path} is missing')
+    try:
+        return joblib.load(path)
+    except ModuleNotFoundError as error:
+        # The common case is a bundle fitted with autoemulate being loaded in an environment
+        # that does not have it -- say so, rather than reporting a bare missing module.
+        raise RuntimeError(
+            f'could not load the emulator at {path}: {error}. If it was fitted with '
+            f'autoemulate, install it with `pip install "circulatory_autogen[emulation]"` '
+            f'(needs Python >=3.10,<3.13).') from error
+
+
+def _as_backend_input(model, x_scaled):
+    """torch tensor for a torch-backed emulator, plain array otherwise."""
+    if type(model).__module__.startswith('autoemulate'):
+        import torch
+        return torch.as_tensor(np.asarray(x_scaled, dtype=np.float32))
+    return np.asarray(x_scaled, dtype=float)
+
+
+def _as_numpy_mean(raw):
+    if hasattr(raw, 'mean') and not isinstance(raw, np.ndarray):
+        raw = raw.mean                     # a torch distribution (GaussianLike)
+    if hasattr(raw, 'detach'):
+        raw = raw.detach().cpu().numpy()
+    return np.asarray(raw, dtype=float)

--- a/src/emulators/emulator_bundle.py
+++ b/src/emulators/emulator_bundle.py
@@ -302,8 +302,16 @@ def _as_backend_input(model, x_scaled):
 
 
 def _as_numpy_mean(raw):
-    if hasattr(raw, 'mean') and not isinstance(raw, np.ndarray):
-        raw = raw.mean                     # a torch distribution (GaussianLike)
+    """The predicted values, whether the emulator returned a tensor or a distribution.
+
+    A probabilistic emulator (every Gaussian process, i.e. the default) returns a torch
+    distribution whose ``.mean`` is a *property* holding the prediction; a deterministic one
+    returns a tensor, whose ``.mean`` is a *method*. Distinguishing them by callability rather
+    than by type keeps this working for both without importing torch to ask.
+    """
+    mean = getattr(raw, 'mean', None)
+    if mean is not None and not callable(mean):
+        raw = mean
     if hasattr(raw, 'detach'):
         raw = raw.detach().cpu().numpy()
     return np.asarray(raw, dtype=float)

--- a/src/emulators/emulator_bundle.py
+++ b/src/emulators/emulator_bundle.py
@@ -22,6 +22,11 @@ import numpy as np
 METADATA_FILE = 'emulator_metadata.json'
 MODEL_FILE = 'emulator'          # autoemulate's saver appends .joblib
 TRAINING_DATA_FILE = 'training_data.npz'
+#: The held-out points, the simulator's answer at each and the emulator's. The
+#: per-feature statistics in the metadata say how wrong the emulator is on
+#: average; only these say *where* -- which is the question that decides whether
+#: the region a study cares about is one of the good ones (#333).
+VALIDATION_FILE = 'emulator_validation.npz'
 
 #: metadata keys that must be present for a bundle to be usable at all.
 REQUIRED_META_KEYS = ('param_entry_labels', 'param_mins', 'param_maxs', 'feature_labels',
@@ -103,9 +108,11 @@ class EmulatorBundle:
         meta: the metadata dict (see ``REQUIRED_META_KEYS``).
         x_train / y_train: the training design and targets, in real units. Kept so the emulator
             can be refitted, extended or audited without re-running the simulator.
+        validation: the held-out report from :func:`emulators.emulator_trainer._validation_report`
+            -- per-feature statistics plus the points they were computed from.
     """
 
-    def __init__(self, model, meta, x_train=None, y_train=None):
+    def __init__(self, model, meta, x_train=None, y_train=None, validation=None):
         missing = [key for key in REQUIRED_META_KEYS if key not in meta]
         if missing:
             raise ValueError(f'emulator metadata is missing {missing}')
@@ -113,6 +120,7 @@ class EmulatorBundle:
         self.meta = meta
         self.x_train = None if x_train is None else np.asarray(x_train, dtype=float)
         self.y_train = None if y_train is None else np.asarray(y_train, dtype=float)
+        self.validation = validation or {}
 
         self.param_mins = np.asarray(meta['param_mins'], dtype=float)
         self.param_maxs = np.asarray(meta['param_maxs'], dtype=float)
@@ -216,6 +224,55 @@ class EmulatorBundle:
                     f'obs_data operations or protocol differ. Retrain the emulator, or set '
                     f'emulator_settings.retrain_if_stale to true.')
 
+    # ------------------------------------------------------------------ error
+
+    def error_stats(self):
+        """Per-feature held-out error, as rows ready to tabulate or plot.
+
+        One row per feature with every statistic the metadata carries, because no
+        single one of them is sufficient on its own: R2 can be high while the
+        emulator is systematically off (``bias``), RMSE cannot be compared between
+        features in different units (``nrmse`` can), and an emulator that is good
+        almost everywhere still misleads a calibration that walks through the one
+        place it is not (``max_abs_error``).
+        """
+        rows = []
+        for i, label in enumerate(self.feature_labels):
+            rows.append({
+                'label': label,
+                'r2': _stat(self.meta.get('feature_r2'), i),
+                'rmse': _stat(self.meta.get('feature_rmse'), i),
+                'mae': _stat(self.meta.get('feature_mae'), i),
+                'bias': _stat(self.meta.get('feature_bias'), i),
+                'max_abs_error': _stat(self.meta.get('feature_max_abs_error'), i),
+                'nrmse': _stat(self.meta.get('feature_nrmse'), i),
+            })
+        return rows
+
+    def error_points(self):
+        """The held-out points: ``{theta, y_true, y_pred, residual, feature_labels,
+        param_entry_labels}``, all in real units, or ``None`` if none were saved.
+
+        This is what a parity plot (``y_pred`` against ``y_true``) and a residual
+        plot (``residual`` against a column of ``theta``) are drawn from. The
+        residual is included rather than left to the caller so that every consumer
+        agrees on its sign: **prediction minus truth**, so a positive residual
+        means the emulator reads high.
+        """
+        theta = self.validation.get('theta')
+        if theta is None or not len(np.asarray(theta)):
+            return None
+        y_true = np.asarray(self.validation['y_true'], dtype=float)
+        y_pred = np.asarray(self.validation['y_pred'], dtype=float)
+        return {
+            'theta': np.asarray(theta, dtype=float),
+            'y_true': y_true,
+            'y_pred': y_pred,
+            'residual': y_pred - y_true,
+            'feature_labels': list(self.feature_labels),
+            'param_entry_labels': list(self.param_entry_labels),
+        }
+
     # ------------------------------------------------------------------ predict
 
     def predict(self, theta, out_of_bounds='error'):
@@ -241,6 +298,21 @@ class EmulatorBundle:
             # simulations again -- the expensive half of training is the runs, not the fit.
             np.savez(os.path.join(directory, TRAINING_DATA_FILE),
                      x_train=self.x_train, y_train=self.y_train)
+        theta = self.validation.get('theta')
+        if theta is not None and len(np.asarray(theta)):
+            # Written even though the metadata already carries the statistics, and
+            # in real units: a parity plot, a residual-against-parameter plot and
+            # "which held-out point is worst" all need the points, and a consumer
+            # that had to recompute them would need the emulator, the simulator and
+            # the split -- i.e. would need to be circulatory_autogen.
+            np.savez(
+                os.path.join(directory, VALIDATION_FILE),
+                theta=np.asarray(self.validation['theta'], dtype=float),
+                y_true=np.asarray(self.validation['y_true'], dtype=float),
+                y_pred=np.asarray(self.validation['y_pred'], dtype=float),
+                feature_labels=np.asarray(self.feature_labels, dtype=object),
+                param_entry_labels=np.asarray(self.param_entry_labels, dtype=object),
+            )
         return directory
 
     @classmethod
@@ -258,7 +330,8 @@ class EmulatorBundle:
         if os.path.isfile(data_path):
             with np.load(data_path) as data:
                 x_train, y_train = data['x_train'], data['y_train']
-        return cls(model, meta, x_train=x_train, y_train=y_train)
+        return cls(model, meta, x_train=x_train, y_train=y_train,
+                   validation=_load_validation(directory))
 
     def _predict_scaled(self, x_scaled):
         """The one place the emulator backend is actually called.
@@ -269,6 +342,35 @@ class EmulatorBundle:
         """
         raw = self.model.predict(_as_backend_input(self.model, x_scaled))
         return _as_numpy_mean(raw).reshape(len(x_scaled), -1)
+
+
+def _stat(values, index):
+    """One statistic, as a float, or None when the emulator did not record it.
+
+    None rather than nan: an older bundle simply has no value for a statistic
+    added later, and that is different from a value that could not be computed.
+    """
+    try:
+        value = float(values[index])
+    except (TypeError, IndexError, ValueError):
+        return None
+    return value
+
+
+def _load_validation(directory):
+    """The held-out points, or ``{}`` when the bundle predates them / has none."""
+    path = os.path.join(directory, VALIDATION_FILE)
+    if not os.path.isfile(path):
+        return {}
+    try:
+        with np.load(path, allow_pickle=True) as data:
+            return {
+                'theta': data['theta'],
+                'y_true': data['y_true'],
+                'y_pred': data['y_pred'],
+            }
+    except Exception:  # noqa: BLE001 - a damaged extra is not a damaged emulator
+        return {}
 
 
 def _save_model(model, path_without_suffix):

--- a/src/emulators/emulator_trainer.py
+++ b/src/emulators/emulator_trainer.py
@@ -1,0 +1,457 @@
+"""Fitting an emulator of the forward model (issue #333).
+
+The expensive analyses -- Sobol SA at ``num_samples*(2M+2)`` runs, MCMC at tens of thousands,
+identifiability at a Hessian's worth -- all reach the model through one narrow interface:
+theta in, scalar observable features out. This trains a surrogate of exactly that function, so
+those analyses can evaluate it instead.
+
+The training targets come from :func:`param_id.fd_backend.observable_features`, which is the
+same function the cost is computed from. That is deliberate and load-bearing: a second
+implementation of "reduce a run to its features" would let the emulator be accurate about
+something the calibration is not fitting.
+
+The N training runs are paid up front, so the win is real for Sobol, MCMC and identifiability,
+and is *not* real for a single GA calibration, which may well be cheaper run directly.
+"""
+import os
+import warnings
+
+import numpy as np
+from scipy.stats import qmc
+
+from emulators.emulator_bundle import EmulatorBundle, fingerprint
+
+AUTOEMULATE_MISSING_MESSAGE = (
+    'autoemulate is not installed. Install it with `pip install '
+    '"circulatory_autogen[emulation]"` (it needs Python >=3.10,<3.13 and pulls in torch, '
+    'gpytorch and lightgbm).')
+
+SAMPLE_TYPES = ('sobol', 'latin_hypercube', 'random')
+
+
+def autoemulate_available():
+    """Whether the optional backend is installed, without importing it.
+
+    Deliberately a spec lookup rather than a try/except import: this module is reachable from
+    ``solver_wrappers``, which every CA run imports, and importing autoemulate drags in torch
+    -- seconds of startup for a run that may have nothing to do with emulation.
+    """
+    import importlib.util
+    return importlib.util.find_spec('autoemulate') is not None
+
+
+def _load_autoemulate():
+    """Import and return the ``AutoEmulate`` class, or raise with the install instructions."""
+    if not autoemulate_available():
+        raise RuntimeError(AUTOEMULATE_MISSING_MESSAGE)
+    from autoemulate import AutoEmulate
+    return AutoEmulate
+
+
+def emulator_model_names():
+    """The emulator names ``emulator_settings.models`` accepts, for a settings form.
+
+    Discovered from autoemulate's registry rather than hardcoded, in the same spirit as
+    ``cost_func_metadata()``; empty when autoemulate is not installed, so a tool can show the
+    setting as unavailable instead of showing a stale list.
+    """
+    if not autoemulate_available():
+        return []
+    return sorted(_load_autoemulate().list_emulators(default_only=False)['Emulator'].tolist())
+
+
+def require_autoemulate():
+    if not autoemulate_available():
+        raise RuntimeError(AUTOEMULATE_MISSING_MESSAGE)
+
+
+class EmulatorTrainer:
+    """Design -> simulate -> fit -> validate -> persist, for one param-id engine.
+
+    Args:
+        param_id: an ``OpencorParamID`` built against the **truth** solver. Passing one whose
+            sim helper is itself an emulator is rejected: it would fit a surrogate of a
+            surrogate.
+        emulator_settings: the ``emulator_settings`` block (see ``ANALYSIS_OPTIONS``).
+        comm: an MPI communicator; ``None`` means "discover one, or run serially".
+
+    There is deliberately no DEBUG shrinking here, unlike the optimiser and MCMC options.
+    ``num_train_samples`` is the one setting that decides whether the emulator is any good,
+    and quietly cutting it would produce an emulator that answers everything and is wrong --
+    the failure mode this whole feature is built to prevent. A cheap run asks for it by name.
+    """
+
+    def __init__(self, param_id, emulator_settings, comm=None):
+        if getattr(param_id.sim_helper, 'emulates_features', False):
+            raise ValueError(
+                'EmulatorTrainer was handed a param-id engine that is already running on an '
+                'emulator. Build it with use_emulator: false so training runs the real solver.')
+        self.pid = param_id
+        self.settings = dict(emulator_settings or {})
+        self.comm = comm if comm is not None else _discover_comm()
+        self.rank = self.comm.Get_rank() if self.comm is not None else 0
+        self.num_procs = self.comm.Get_size() if self.comm is not None else 1
+        self._check_observables_are_scalar()
+
+    # ------------------------------------------------------------------ construction
+
+    @classmethod
+    def init_from_dict(cls, inp_data_dict, comm=None):
+        """Build the truth-solver engine this config describes, then a trainer over it."""
+        from param_id.paramID import CVS0DParamID
+        inp = dict(inp_data_dict)
+        # The one line that stops the trainer emulating an emulator: whatever the config says
+        # about using one, training always runs the solver named by `solver:`.
+        inp['use_emulator'] = False
+        inp['do_ad'] = False
+        engine = CVS0DParamID.init_from_dict(inp)
+        if inp_data_dict.get('obs_data_dict') is not None:
+            engine.set_ground_truth_data(inp_data_dict['obs_data_dict'])
+        if inp_data_dict.get('params_for_id') is not None:
+            engine.set_params_for_id(inp_data_dict['params_for_id'])
+        trainer = cls(engine.param_id, inp_data_dict.get('emulator_settings') or {}, comm=comm)
+        trainer.output_dir = resolve_emulator_dir(inp_data_dict)
+        return trainer
+
+    def _check_observables_are_scalar(self):
+        """Refuse non-scalar data_items up front, where it is a config error rather than a
+        confusing shape mismatch a hundred simulations later."""
+        bad = {jj: dtype for jj, dtype in enumerate(self.pid.obs_info['data_types'])
+               if dtype != 'constant'}
+        if bad:
+            raise ValueError(
+                f'the emulator predicts scalar data_item features only, but obs_data.json has '
+                f'data_type(s) {sorted(set(bad.values()))} at data_item index(es) {sorted(bad)}. '
+                f'Those need the full simulated trace ("series") or its FFT ("frequency"). '
+                f'Remove them from the obs_data used for emulation, or run without an emulator.')
+
+    # ------------------------------------------------------------------ settings
+
+    def _setting(self, name, default):
+        value = self.settings.get(name, default)
+        return default if value is None else value
+
+    @property
+    def num_train_samples(self):
+        return int(self._setting('num_train_samples', 128))
+
+    @property
+    def feature_labels(self):
+        """The emulator's outputs, named exactly as the run that will use it names them."""
+        from param_id.paramID import emulated_feature_labels
+        return emulated_feature_labels(self.pid.obs_info)
+
+    # ------------------------------------------------------------------ stages
+
+    def design(self):
+        """Training points over the ``params_for_id`` box, shape ``(n_samples, num_params)``.
+
+        Deterministic given the seed, so every rank builds the identical design and no
+        broadcast is needed to agree on who evaluates which sample.
+        """
+        mins = np.asarray(self.pid.param_id_info['param_mins'], dtype=float)
+        maxs = np.asarray(self.pid.param_id_info['param_maxs'], dtype=float)
+        num_params = mins.size
+        n_samples = self.num_train_samples
+        sample_type = self._setting('sample_type', 'sobol')
+        seed = int(self._setting('random_seed', 0))
+
+        if sample_type == 'sobol':
+            with warnings.catch_warnings():
+                # Sobol warns for counts that aren't a power of two; the balance properties
+                # lost matter less here than letting the user pick a round sample count.
+                warnings.simplefilter('ignore')
+                unit = qmc.Sobol(d=num_params, scramble=True, seed=seed).random(n_samples)
+        elif sample_type == 'latin_hypercube':
+            unit = qmc.LatinHypercube(d=num_params, seed=seed).random(n_samples)
+        elif sample_type == 'random':
+            unit = np.random.default_rng(seed).random((n_samples, num_params))
+        else:
+            raise ValueError(f'unknown sample_type "{sample_type}", expected one of '
+                             f'{", ".join(SAMPLE_TYPES)}')
+
+        if bool(self._setting('log_scale_params', False)):
+            if np.any(mins <= 0):
+                raise ValueError(
+                    'log_scale_params needs every parameter min to be positive; '
+                    f'{[self.pid.param_id_info["param_mins"][i] for i in np.where(mins <= 0)[0]]} '
+                    'are not. Set it false, or raise those mins above zero.')
+            return np.exp(np.log(mins) + unit * (np.log(maxs) - np.log(mins)))
+        return mins + unit * (maxs - mins)
+
+    def evaluate(self, design):
+        """Run the truth model at every design point; returns ``(x, y)`` on rank 0.
+
+        Contiguous block split across ranks then a gather, the same shape as the Sobol
+        sampler's parallel loop. A sample whose simulation fails is dropped rather than
+        imputed: an imputed training target is a fabricated observation, and the emulator
+        would learn it as fact.
+        """
+        # Imported here rather than at module scope: this module is reachable from
+        # solver_wrappers, which every CA run imports, and fd_backend pulls in the parsers.
+        from param_id.fd_backend import observable_features
+
+        n_samples = len(design)
+        start, end = _block_for_rank(n_samples, self.rank, self.num_procs)
+        local_rows = []
+        for local_idx, theta in enumerate(design[start:end]):
+            features = observable_features(self.pid, theta)
+            if features is None or not np.all(np.isfinite(features)):
+                print(f'[emulator rank {self.rank}] sample {start + local_idx} failed; dropping it')
+                continue
+            local_rows.append((start + local_idx, np.asarray(features, dtype=float)))
+            if self.rank == 0 and (local_idx + 1) % 10 == 0:
+                print(f'[emulator] rank 0 has run {local_idx + 1}/{end - start} of its samples')
+
+        gathered = self.comm.gather(local_rows, root=0) if self.comm is not None else [local_rows]
+        if self.rank != 0:
+            return None, None
+        rows = sorted((row for chunk in gathered for row in chunk), key=lambda item: item[0])
+        if not rows:
+            raise RuntimeError('every training simulation failed; no emulator can be fitted. '
+                               'Check that the model runs at the params_for_id bounds.')
+        n_failed = n_samples - len(rows)
+        if n_failed:
+            print(f'[emulator] {n_failed}/{n_samples} training simulations failed and were dropped')
+        self._n_failed = n_failed
+        x = np.asarray([design[idx] for idx, _ in rows], dtype=float)
+        y = np.asarray([features for _, features in rows], dtype=float)
+        return x, y
+
+    def fit(self, x, y):
+        """Fit and compare emulators; returns ``(model, r2, rmse, name, x_scale, y_scale)``.
+
+        Both x and y are mapped onto a well-conditioned range first. CA parameters routinely
+        span a compliance near 1e-9 and a resistance near 1e8, and autoemulate works in float32
+        torch, where that spread alone is enough to ruin a kernel fit.
+
+        A test split is held out **here**, before fitting, and the reported R2/RMSE are scored
+        on it. Scoring on the training points instead would report a number that says how well
+        the emulator memorised the design, which is precisely the reassurance a bad emulator
+        would give.
+        """
+        require_autoemulate()
+        x_scale = EmulatorBundle.make_scale(x)
+        y_scale = EmulatorBundle.make_scale(y)
+        x_scaled = (x - np.asarray(x_scale['shift'])) / np.asarray(x_scale['span'])
+        y_scaled = (y - np.asarray(y_scale['shift'])) / np.asarray(y_scale['span'])
+
+        seed = int(self._setting('random_seed', 0))
+        x_train, y_train, x_test, y_test = _train_test_split(
+            x_scaled, y_scaled, float(self._setting('test_fraction', 0.2)), seed)
+
+        kwargs = dict(n_iter=int(self._setting('n_iter', 10)),
+                      n_splits=int(self._setting('n_splits', 5)),
+                      random_seed=seed)
+        models = _parse_models(self._setting('models', 'default'))
+        if models is not None:
+            kwargs['models'] = models
+
+        emulation = _load_autoemulate()(x_train, y_train, test_data=(x_test, y_test), **kwargs)
+        result = emulation.best_result()
+        r2, rmse = _per_feature_scores(result.model, x_test, y_test, y_scale)
+        return result.model, r2, rmse, _result_model_name(result), x_scale, y_scale
+
+    def train(self):
+        """The whole pipeline. Returns the bundle on rank 0, ``None`` elsewhere."""
+        require_autoemulate()
+        design = self.design()
+        if self.rank == 0:
+            print(f'[emulator] training on {len(design)} samples across {self.num_procs} rank(s)')
+        x, y = self.evaluate(design)
+        if self.rank != 0:
+            return None
+
+        model, r2, rmse, model_name, x_scale, y_scale = self.fit(x, y)
+        meta = {
+            'param_entry_labels': [str(label) for label in _param_labels(self.pid)],
+            'param_mins': [float(v) for v in self.pid.param_id_info['param_mins']],
+            'param_maxs': [float(v) for v in self.pid.param_id_info['param_maxs']],
+            'param_names': _jsonable_names(self.pid.param_id_info['param_names']),
+            # A modifier entry's one theta slot expands to theta * baseline per target before
+            # it reaches a solver, so the helper cannot recover theta from what it is handed
+            # and must be given it directly. It needs to know that from the metadata.
+            'has_modifiers': bool(self.pid.param_id_info.get('modifiers')),
+            'param_defaults': self._baseline_snapshot(),
+            'feature_labels': self.feature_labels,
+            'feature_r2': [float(v) for v in r2],
+            'feature_rmse': [float(v) for v in rmse],
+            'x_scale': x_scale,
+            'y_scale': y_scale,
+            'model_name': model_name,
+            'design': {'sample_type': self._setting('sample_type', 'sobol'),
+                       'num_train_samples': int(len(design)),
+                       'num_used': int(len(x)),
+                       'num_failed': int(getattr(self, '_n_failed', 0)),
+                       'random_seed': int(self._setting('random_seed', 0)),
+                       'log_scale_params': bool(self._setting('log_scale_params', False))},
+            'fingerprint': fingerprint(self.pid.param_id_info, self.pid.obs_info,
+                                       self.pid.protocol_info, self.pid.model_path),
+            'provenance': _provenance(self.pid),
+        }
+        bundle = EmulatorBundle(model, meta, x_train=x, y_train=y)
+        output_dir = getattr(self, 'output_dir', None) or os.getcwd()
+        bundle.save(output_dir)
+        print(f'[emulator] saved to {output_dir}')
+        for label, score in zip(bundle.feature_labels, meta['feature_r2']):
+            print(f'    held-out R2 {score:8.4f}   {label}')
+        return bundle
+
+    def _baseline_snapshot(self):
+        """Parameter defaults recorded from the real model, for the emulator to serve later.
+
+        ``resolve_modifier_baselines`` and the optimiser's x0 both read parameter defaults
+        before any simulation runs. The emulator has no model to read them from, so they are
+        captured here, while a real solver is still in hand.
+        """
+        helper = self.pid.sim_helper
+        names = list(self.pid.param_id_info['param_names'])
+        for modifier in self.pid.param_id_info.get('modifiers', []) or []:
+            names.extend([[target] for target in modifier.get('targets', [])])
+            names.extend([[qname] for qname in (modifier.get('inputs') or {}).values()
+                          if isinstance(qname, str)])
+        reader = getattr(helper, 'get_default_param_vals', None) or helper.get_init_param_vals
+        snapshot = {}
+        for entry in names:
+            entry_names = entry if isinstance(entry, (list, tuple)) else [entry]
+            try:
+                values = reader([list(entry_names)])[0]
+            except Exception as error:                       # pragma: no cover - model dependent
+                print(f'[emulator] could not record a default for {entry_names}: {error}')
+                continue
+            values = values if isinstance(values, (list, tuple)) else [values]
+            for name, value in zip(entry_names, values):
+                snapshot[str(name)] = float(value)
+        return snapshot
+
+
+# ---------------------------------------------------------------------- helpers
+
+def resolve_emulator_dir(inp_data_dict):
+    """Where this config's emulator lives, defaulting beside the param-id output."""
+    settings = inp_data_dict.get('emulator_settings') or {}
+    if settings.get('emulator_dir'):
+        return settings['emulator_dir']
+    # Same fallback CVS0DParamID uses for param_id_output_dir, so training and the run that
+    # uses the emulator land on the same directory even when neither names one.
+    root = inp_data_dict.get('param_id_output_dir') or os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), '..', '..', 'param_id_output')
+    prefix = inp_data_dict.get('file_prefix', 'model')
+    obs_path = inp_data_dict.get('param_id_obs_path') or ''
+    obs_prefix = os.path.splitext(os.path.basename(obs_path))[0] if obs_path else 'obs'
+    return os.path.join(root, 'emulators', f'{prefix}_{obs_prefix}')
+
+
+def _block_for_rank(n_samples, rank, num_procs):
+    """The contiguous [start, end) block of samples this rank evaluates."""
+    per_rank, remainder = divmod(n_samples, num_procs)
+    if rank < remainder:
+        start = rank * (per_rank + 1)
+        return start, start + per_rank + 1
+    start = rank * per_rank + remainder
+    return start, start + per_rank
+
+
+def _discover_comm():
+    """The world communicator when running under a launcher, else None (serial).
+
+    Imported lazily and only when mpi4py is already loaded or a launcher is present, so merely
+    training an emulator in a plain script does not open MPI.
+    """
+    try:
+        from utilities.mpi_utils import get_MPI          # available once #396 lands
+        return get_MPI().COMM_WORLD
+    except ImportError:
+        pass
+    try:
+        from mpi4py import MPI
+        return MPI.COMM_WORLD
+    except ImportError:                                  # pragma: no cover - env dependent
+        return None
+
+
+def _parse_models(models):
+    """``'default'`` -> autoemulate's own default set; otherwise a list of emulator names."""
+    if models in (None, '', 'default'):
+        return None
+    if models == 'all':
+        return emulator_model_names()
+    if isinstance(models, str):
+        return [name.strip() for name in models.split(',') if name.strip()]
+    return list(models)
+
+
+def _param_labels(pid):
+    from parsers.PrimitiveParsers import param_entry_labels
+    return param_entry_labels(pid.param_id_info)
+
+
+def _jsonable_names(param_names):
+    return [[str(name) for name in (entry if isinstance(entry, (list, tuple)) else [entry])]
+            for entry in param_names]
+
+
+def _provenance(pid):
+    import subprocess
+    provenance = {'model_path': str(pid.model_path), 'model_type': str(pid.model_type),
+                  'solver': str((pid.solver_info or {}).get('solver'))}
+    try:
+        from importlib.metadata import version
+        provenance['autoemulate_version'] = version('autoemulate')
+    except Exception:                                     # pragma: no cover - env dependent
+        pass
+    try:
+        provenance['ca_git_sha'] = subprocess.check_output(
+            ['git', 'rev-parse', 'HEAD'], cwd=os.path.dirname(os.path.abspath(__file__)),
+            stderr=subprocess.DEVNULL).decode().strip()
+    except Exception:                                     # pragma: no cover - not always a repo
+        pass
+    return provenance
+
+
+def _result_model_name(result):
+    for attr in ('model_name', 'name'):
+        if hasattr(result, attr):
+            return str(getattr(result, attr))
+    return type(getattr(result, 'model', result)).__name__
+
+
+def _train_test_split(x, y, test_fraction, seed):
+    """A seeded split, with at least one test point and at least two training points."""
+    n_samples = len(x)
+    n_test = int(round(test_fraction * n_samples))
+    n_test = max(1, min(n_test, n_samples - 2))
+    order = np.random.default_rng(seed).permutation(n_samples)
+    test_idx, train_idx = order[:n_test], order[n_test:]
+    return x[train_idx], y[train_idx], x[test_idx], y[test_idx]
+
+
+def _per_feature_scores(model, x_test, y_test, y_scale):
+    """Held-out R2 and RMSE, **per feature**.
+
+    autoemulate's summary reports one score per model, aggregated over outputs. A single
+    aggregate hides exactly the case this check exists for -- five features fitted well and one
+    badly -- since the good ones average the bad one away. RMSE is converted back to the
+    feature's real units so it can be read against the observation it approximates.
+    """
+    from emulators.emulator_bundle import _as_backend_input, _as_numpy_mean
+    y_true = np.asarray(y_test, dtype=float).reshape(len(y_test), -1)
+    n_features = y_true.shape[1]
+    try:
+        predicted = _as_numpy_mean(
+            model.predict(_as_backend_input(model, x_test))).reshape(len(x_test), -1)
+    except Exception as error:                            # pragma: no cover - backend dependent
+        print(f'[emulator] could not score the fitted emulator per feature: {error}')
+        return [float('nan')] * n_features, [float('nan')] * n_features
+
+    span = np.asarray(y_scale['span'], dtype=float)
+    r2, rmse = [], []
+    for col in range(n_features):
+        truth, pred = y_true[:, col], predicted[:, col]
+        residual = float(np.sum((truth - pred) ** 2))
+        total = float(np.sum((truth - np.mean(truth)) ** 2))
+        # A degenerate test column (every value equal) has no variance to explain; report nan
+        # rather than a 1.0 that would read as a perfect fit.
+        r2.append(1.0 - residual / total if total > 0 else float('nan'))
+        rmse.append(float(np.sqrt(residual / len(truth)) * span[col % span.size]))
+    return r2, rmse

--- a/src/emulators/emulator_trainer.py
+++ b/src/emulators/emulator_trainer.py
@@ -249,8 +249,8 @@ class EmulatorTrainer:
 
         emulation = _load_autoemulate()(x_train, y_train, test_data=(x_test, y_test), **kwargs)
         result = emulation.best_result()
-        r2, rmse = _per_feature_scores(result.model, x_test, y_test, y_scale)
-        return result.model, r2, rmse, _result_model_name(result), x_scale, y_scale
+        validation = _validation_report(result.model, x_test, y_test, x_scale, y_scale)
+        return (result.model, validation, _result_model_name(result), x_scale, y_scale)
 
     def train(self):
         """The whole pipeline. Returns the bundle on rank 0, ``None`` elsewhere."""
@@ -262,7 +262,7 @@ class EmulatorTrainer:
         if self.rank != 0:
             return None
 
-        model, r2, rmse, model_name, x_scale, y_scale = self.fit(x, y)
+        model, validation, model_name, x_scale, y_scale = self.fit(x, y)
         meta = {
             'param_entry_labels': [str(label) for label in _param_labels(self.pid)],
             'param_mins': [float(v) for v in self.pid.param_id_info['param_mins']],
@@ -274,8 +274,16 @@ class EmulatorTrainer:
             'has_modifiers': bool(self.pid.param_id_info.get('modifiers')),
             'param_defaults': self._baseline_snapshot(),
             'feature_labels': self.feature_labels,
-            'feature_r2': [float(v) for v in r2],
-            'feature_rmse': [float(v) for v in rmse],
+            'feature_r2': [float(v) for v in validation['r2']],
+            'feature_rmse': [float(v) for v in validation['rmse']],
+            # The rest of what the held-out set says, per feature: not summary
+            # enough to replace a plot, but enough to rank features by how badly
+            # the emulator does on them, which R2 alone does not (a feature can
+            # score well and still be biased). See `error_stats`.
+            'feature_mae': [float(v) for v in validation['mae']],
+            'feature_bias': [float(v) for v in validation['bias']],
+            'feature_max_abs_error': [float(v) for v in validation['max_abs_error']],
+            'feature_nrmse': [float(v) for v in validation['nrmse']],
             'x_scale': x_scale,
             'y_scale': y_scale,
             'model_name': model_name,
@@ -289,7 +297,8 @@ class EmulatorTrainer:
                                        self.pid.protocol_info, self.pid.model_path),
             'provenance': _provenance(self.pid),
         }
-        bundle = EmulatorBundle(model, meta, x_train=x, y_train=y)
+        bundle = EmulatorBundle(model, meta, x_train=x, y_train=y,
+                                validation=validation)
         output_dir = getattr(self, 'output_dir', None) or os.getcwd()
         bundle.save(output_dir)
         print(f'[emulator] saved to {output_dir}')
@@ -353,21 +362,19 @@ def _block_for_rank(n_samples, rank, num_procs):
 
 
 def _discover_comm():
-    """The world communicator when running under a launcher, else None (serial).
+    """The world communicator: the real one under a launcher, a one-rank stub otherwise.
 
-    Imported lazily and only when mpi4py is already loaded or a launcher is present, so merely
-    training an emulator in a plain script does not open MPI.
+    Through ``get_MPI`` and never ``from mpi4py import MPI``, so a serial training run never
+    opens MPI at all -- that import registers an atexit MPI_Finalize which aborts on macOS
+    when a NIC goes away (#396). The stub implements the collectives used here, so the split
+    and gather below need no serial special case.
+
+    Imported inside the function because this module is reachable from ``solver_wrappers``,
+    which every CA run imports.
     """
-    try:
-        from utilities.mpi_utils import get_MPI          # available once #396 lands
-        return get_MPI().COMM_WORLD
-    except ImportError:
-        pass
-    try:
-        from mpi4py import MPI
-        return MPI.COMM_WORLD
-    except ImportError:                                  # pragma: no cover - env dependent
-        return None
+    from utilities.mpi_utils import get_MPI  # noqa: PLC0415
+
+    return get_MPI().COMM_WORLD
 
 
 def _parse_models(models):
@@ -426,32 +433,64 @@ def _train_test_split(x, y, test_fraction, seed):
     return x[train_idx], y[train_idx], x[test_idx], y[test_idx]
 
 
-def _per_feature_scores(model, x_test, y_test, y_scale):
-    """Held-out R2 and RMSE, **per feature**.
+def _validation_report(model, x_test, y_test, x_scale, y_scale):
+    """Everything the held-out set says about the emulator, per feature.
 
-    autoemulate's summary reports one score per model, aggregated over outputs. A single
-    aggregate hides exactly the case this check exists for -- five features fitted well and one
-    badly -- since the good ones average the bad one away. RMSE is converted back to the
-    feature's real units so it can be read against the observation it approximates.
+    Returns the per-feature statistics **and the held-out points themselves** --
+    the parameters, the simulator's answer and the emulator's -- because the
+    statistics cannot answer the question a user actually has. R2 says how well the
+    emulator does on average over the design; a parity or residual plot says
+    *where* it goes wrong, which is what decides whether the region you care about
+    is one of the good ones (#333).
+
+    These points are free: training already paid to simulate them and then
+    deliberately did not fit to them. Everything is converted back to real units,
+    so a consumer never has to know the emulator was fitted in a scaled space.
     """
     from emulators.emulator_bundle import _as_backend_input, _as_numpy_mean
-    y_true = np.asarray(y_test, dtype=float).reshape(len(y_test), -1)
-    n_features = y_true.shape[1]
-    try:
-        predicted = _as_numpy_mean(
-            model.predict(_as_backend_input(model, x_test))).reshape(len(x_test), -1)
-    except Exception as error:                            # pragma: no cover - backend dependent
-        print(f'[emulator] could not score the fitted emulator per feature: {error}')
-        return [float('nan')] * n_features, [float('nan')] * n_features
 
-    span = np.asarray(y_scale['span'], dtype=float)
-    r2, rmse = [], []
+    y_true_scaled = np.asarray(y_test, dtype=float).reshape(len(y_test), -1)
+    n_features = y_true_scaled.shape[1]
+    empty = [float('nan')] * n_features
+    try:
+        predicted_scaled = _as_numpy_mean(
+            model.predict(_as_backend_input(model, x_test))).reshape(len(x_test), -1)
+    except Exception as error:  # pragma: no cover - backend dependent
+        print(f'[emulator] could not score the fitted emulator per feature: {error}')
+        return {'r2': empty, 'rmse': empty, 'mae': empty, 'bias': empty,
+                'max_abs_error': empty, 'nrmse': empty,
+                'theta': np.empty((0, 0)), 'y_true': np.empty((0, n_features)),
+                'y_pred': np.empty((0, n_features))}
+
+    y_span = np.asarray(y_scale['span'], dtype=float)
+    y_shift = np.asarray(y_scale['shift'], dtype=float)
+    x_span = np.asarray(x_scale['span'], dtype=float)
+    x_shift = np.asarray(x_scale['shift'], dtype=float)
+
+    y_true = y_true_scaled * y_span + y_shift
+    y_pred = predicted_scaled * y_span + y_shift
+    theta = np.asarray(x_test, dtype=float) * x_span + x_shift
+
+    report = {'r2': [], 'rmse': [], 'mae': [], 'bias': [], 'max_abs_error': [],
+              'nrmse': [], 'theta': theta, 'y_true': y_true, 'y_pred': y_pred}
     for col in range(n_features):
-        truth, pred = y_true[:, col], predicted[:, col]
-        residual = float(np.sum((truth - pred) ** 2))
+        truth, pred = y_true[:, col], y_pred[:, col]
+        error = pred - truth
+        residual = float(np.sum(error ** 2))
         total = float(np.sum((truth - np.mean(truth)) ** 2))
-        # A degenerate test column (every value equal) has no variance to explain; report nan
-        # rather than a 1.0 that would read as a perfect fit.
-        r2.append(1.0 - residual / total if total > 0 else float('nan'))
-        rmse.append(float(np.sqrt(residual / len(truth)) * span[col % span.size]))
-    return r2, rmse
+        # A degenerate test column (every value equal) has no variance to explain;
+        # report nan rather than a 1.0 that would read as a perfect fit.
+        report['r2'].append(1.0 - residual / total if total > 0 else float('nan'))
+        rmse = float(np.sqrt(residual / len(truth)))
+        report['rmse'].append(rmse)
+        report['mae'].append(float(np.mean(np.abs(error))))
+        # Signed, deliberately: a systematically high emulator and a noisy one can
+        # share an RMSE, and only one of them shifts every downstream cost.
+        report['bias'].append(float(np.mean(error)))
+        report['max_abs_error'].append(float(np.max(np.abs(error))))
+        # RMSE against the spread of the feature, so features in different units
+        # can be ranked against each other -- which raw RMSE cannot do, and which
+        # is the axis "which feature is the emulator worst at" needs.
+        spread = float(np.max(truth) - np.min(truth))
+        report['nrmse'].append(rmse / spread if spread > 0 else float('nan'))
+    return report

--- a/src/identifiabilty_analysis/identifiabilityAnalysis.py
+++ b/src/identifiabilty_analysis/identifiabilityAnalysis.py
@@ -170,11 +170,18 @@ class IdentifiabilityAnalysis():
 
         pid = self.param_id
         solver = pid.solver_info.get('solver') if isinstance(pid.solver_info, dict) else None
-        available = {s['value'] for s in gradient_sources(pid.model_type, solver)}
+        # use_emulator collapses this to FD alone: the analytic arms differentiate the real
+        # model, so on an emulator run they would build the Fisher information from
+        # sensitivities of a model that is not being evaluated (#333).
+        emulating = bool(getattr(pid, 'emulates_features', False))
+        available = {s['value'] for s in gradient_sources(pid.model_type, solver,
+                                                          use_emulator=emulating)}
         if gradient_source not in available:
             raise ValueError(
                 f"Laplace gradient_source '{gradient_source}' is not available for model_type "
-                f"'{pid.model_type}' / solver '{solver}'. Available: {sorted(available)}. "
+                f"'{pid.model_type}' / solver '{solver}'"
+                + (" with use_emulator: true" if emulating else "")
+                + f". Available: {sorted(available)}. "
                 "(gradient_sources(model_type, solver) lists the analytic sources per model; use "
                 "'FD' for finite differences.)")
 

--- a/src/param_id/fd_backend.py
+++ b/src/param_id/fd_backend.py
@@ -39,7 +39,7 @@ def _step(pj, pmin, pmax, h):
     return h * rng if rng > 0 else h
 
 
-def _features(pid, param_vals):
+def observable_features(pid, param_vals):
     """The scalar (const) observable features at ``param_vals``.
 
     Evaluated through the same path the cost uses, so a feature here is the
@@ -82,6 +82,49 @@ def _features(pid, param_vals):
         if k < len(consts):
             out[k] = consts[k]
     return out
+
+
+#: Public name kept as the internal one too, so existing call sites read unchanged. This is
+#: also the function an emulator is trained against (issue #333): training targets and the
+#: features the cost is computed from are then the same function, not two implementations of it.
+_features = observable_features
+
+
+def cost_gradient(pid, param_vals, h=1e-3):
+    """dJ/dtheta by central differences on the cost -- the backend-agnostic gradient.
+
+    Deliberately differentiates ``get_cost_from_params``, the same function the optimiser
+    minimises, so the jacobian and the objective cannot describe different functions. The step
+    is ``_step``'s per-parameter relative one, for the same reason it is there: CA parameters
+    span many orders of magnitude and one absolute step cannot suit them all.
+
+    Costs 2M evaluations. That is the wrong trade against a real solver -- which is why the
+    analytic arms remain the default there -- and the right one against an emulator, where an
+    evaluation is a matrix multiply.
+    """
+    param_vals = np.asarray(param_vals, dtype=float)
+    mins = np.asarray(pid.param_id_info["param_mins"], dtype=float)
+    maxs = np.asarray(pid.param_id_info["param_maxs"], dtype=float)
+
+    grad = np.zeros_like(param_vals)
+    for j in range(param_vals.size):
+        step = _step(float(param_vals[j]), mins[j], maxs[j], h)
+        # Kept inside [min, max], and the denominator is the span actually used. At a bound
+        # the difference simply becomes one-sided. This matters for an emulator, which is only
+        # valid inside its training box: without it, a gradient evaluated at a bound would ask
+        # the emulator to extrapolate and (rightly) be refused mid-optimisation.
+        upper = min(float(param_vals[j]) + step, float(maxs[j]))
+        lower = max(float(param_vals[j]) - step, float(mins[j]))
+        span = upper - lower
+        if span <= 0:
+            grad[j] = 0.0
+            continue
+        p_plus = param_vals.copy()
+        p_plus[j] = upper
+        p_minus = param_vals.copy()
+        p_minus[j] = lower
+        grad[j] = (pid.get_cost_from_params(p_plus) - pid.get_cost_from_params(p_minus)) / span
+    return grad
 
 
 def observable_feature_sensitivities(pid, param_vals, h=1e-3):

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -77,6 +77,7 @@ from param_id.operation_funcs import resolve_operation_kwargs, validate_operatio
 from param_id.cost_kwargs import call_cost_func, validate_cost_kwargs
 from parsers.PrimitiveParsers import (apply_modifier_identity_nominals,
                                       expand_modifier_param_vals,
+                                      param_entry_labels,
                                       resolve_modifier_baselines,
                                       save_param_modifiers)
 from param_id.plot_outputs import ParamIDPlotOutputs
@@ -243,12 +244,18 @@ class CVS0DParamID():
                  do_ad=False, DEBUG=False,
                  param_id_output_dir=None, resources_dir=None, one_rank=False,
                  operation_funcs_external_path=None, cost_funcs_external_path=None,
-                 modifier_funcs_external_path=None, mcmc_options=None):
+                 modifier_funcs_external_path=None, mcmc_options=None,
+                 use_emulator=False, emulator_dir=None, emulator_settings=None):
         self.model_path = model_path
         self.param_id_method = param_id_method
         self.mcmc_instead = mcmc_instead
         self.model_type = model_type
         self.file_name_prefix = file_name_prefix
+        # Emulator mode (#333): the analyses evaluate a trained surrogate instead of the
+        # solver. `solver_info['solver']` still names the solver it was trained against.
+        self.use_emulator = bool(use_emulator)
+        self.emulator_dir = emulator_dir
+        self.emulator_settings = dict(emulator_settings or {})
         # Optional external user-func files (issue #303), threaded into the param-id engine so its
         # operation/cost dicts merge them in alongside the built-ins. modifier_funcs (issue #383)
         # follow the same pattern via the params_for_id parser.
@@ -362,7 +369,10 @@ class CVS0DParamID():
                                            self.obs_info, self.param_id_info,
                                            self.protocol_info, self.prediction_info, self.solver_info, dt=self.dt,
                                            UQ_options=self.UQ_options,
-                                           DEBUG=self.DEBUG, model_type=self.model_type)
+                                           DEBUG=self.DEBUG, model_type=self.model_type,
+                                           use_emulator=self.use_emulator,
+                                           emulator_dir=self.emulator_dir,
+                                           emulator_settings=self.emulator_settings)
             self.n_steps = mcmc_object.n_steps
         else:
             if model_type in ['cellml_only', 'python', 'casadi_python', 'aadc_python', 'python_user_defined']:
@@ -373,7 +383,10 @@ class CVS0DParamID():
                                                do_ad=do_ad, DEBUG=self.DEBUG,
                                                model_type=self.model_type,
                                                operation_funcs_external_path=self.operation_funcs_external_path,
-                                               cost_funcs_external_path=self.cost_funcs_external_path)
+                                               cost_funcs_external_path=self.cost_funcs_external_path,
+                                               use_emulator=self.use_emulator,
+                                               emulator_dir=self.emulator_dir,
+                                               emulator_settings=self.emulator_settings)
                 self.n_steps = self.param_id.n_steps
         if self.rank == 0:
             self.set_output_dir(self.output_dir)
@@ -426,13 +439,19 @@ class CVS0DParamID():
             'optimiser_options', 'DEBUG', 'param_id_output_dir', 'resources_dir',
             'one_rank', 'do_ad',
             'operation_funcs_external_path', 'cost_funcs_external_path',
-            'modifier_funcs_external_path',
+            'modifier_funcs_external_path', 'use_emulator', 'emulator_settings',
         ]
         kwargs = {key: inp_data_dict[key] for key in arg_options if key in inp_data_dict}
 
         # Support common naming used elsewhere
         if 'file_name_prefix' not in kwargs and 'file_prefix' in inp_data_dict:
             kwargs['file_name_prefix'] = inp_data_dict['file_prefix']
+
+        # Where this config's emulator lives, resolved from the same dict the trainer used, so
+        # a run finds the emulator its own settings produced without naming a path twice.
+        if kwargs.get('use_emulator'):
+            from emulators.emulator_trainer import resolve_emulator_dir
+            kwargs['emulator_dir'] = resolve_emulator_dir(inp_data_dict)
 
         return cls(**kwargs)
 
@@ -967,6 +986,10 @@ class CVS0DParamID():
     def save_prediction_data(self):
         if self.rank !=0:
             return
+        if getattr(self.param_id, 'emulates_features', False):
+            print('Prediction variables are not saved when use_emulator is set: they are '
+                  'traces, and the emulator predicts the scalar observable features only.')
+            return
         if self.prediction_info['names'] is not None:
             print('Saving prediction data')
             time_and_pred_per_exp_list = self.__get_prediction_data()
@@ -1188,6 +1211,42 @@ class CVS0DParamID():
         print(param_std)
         np.save(os.path.join(self.output_dir, 'params_std.npy'), param_std)
 
+def observable_base_label(obs_info, obs_idx):
+    """``name (operation operand)`` for one data_item -- the label before disambiguation.
+
+    A module function rather than only a method, because an emulator has to record the labels
+    of the features it was trained on and check them against the run using it (#333), and both
+    sides must spell an observable the same way or every reload would look stale.
+    """
+    name = obs_info["names_for_plotting"][obs_idx]
+    op = obs_info["operations"][obs_idx]
+    operands = obs_info["operands"][obs_idx]
+    operand = operands[0] if operands else ''
+    return f"{name} ({op} {operand})" if op else f"{name} ({operand})"
+
+
+def observable_labels(obs_info):
+    """One disambiguated label per data_item, in obs_info order. See ``_observable_label``."""
+    bases = [observable_base_label(obs_info, idx) for idx in range(obs_info["num_obs"])]
+    counts = {}
+    for base in bases:
+        counts[base] = counts.get(base, 0) + 1
+    labels = []
+    for idx, base in enumerate(bases):
+        if counts[base] == 1:
+            labels.append(base)
+        else:
+            labels.append(f'{base} [exp {obs_info["experiment_idxs"][idx]}, '
+                          f'sub {obs_info["subexperiment_idxs"][idx]}]')
+    return labels
+
+
+def emulated_feature_labels(obs_info):
+    """The labels of the scalar features an emulator is trained on, in emulator output order."""
+    labels = observable_labels(obs_info)
+    return [labels[obs_idx] for obs_idx in obs_info["const_idx_to_obs_idx"]]
+
+
 OFFLINE_PRE_TIME_INIT_STATE_ERROR = (
     "varying initial state (quantity) requires doing it from the actual initial state, so "
     "offline_pre_time can't be used. Reformulate to calibrate wrt a constant parameter rather "
@@ -1200,17 +1259,33 @@ class OpencorParamID():
     """
     Class for doing parameter identification on opencor models
     """
+
+    #: True once the sim helper is an emulator of the scalar observable features (#333). A class
+    #: attribute so it is always readable -- the cost, gradient and observable paths branch on
+    #: it, and any of them can be reached on an engine built without the full constructor.
+    emulates_features = False
+
     def __init__(self, model_path, param_id_method,
                  obs_info, param_id_info, protocol_info, prediction_info,
                  solver_info, dt=0.01,
                  optimiser_options=None, do_ad=False,
                  DEBUG=False, model_type=None,
-                 operation_funcs_external_path=None, cost_funcs_external_path=None):
+                 operation_funcs_external_path=None, cost_funcs_external_path=None,
+                 use_emulator=False, emulator_dir=None, emulator_settings=None):
 
         self.model_path = model_path
         self.param_id_method = param_id_method
         self.output_dir = None
         self.model_type = model_type
+
+        # Emulator mode (#333). `solver` still names the truth solver -- the one the emulator
+        # was trained against, and the one to compare it with -- so this is its own flag.
+        self.use_emulator = bool(use_emulator)
+        self.emulator_dir = emulator_dir
+        self.emulator_settings = dict(emulator_settings or {})
+        # Set for real once the helper exists; defined here so anything reading it during
+        # construction sees False rather than an AttributeError.
+        self.emulates_features = False
 
         self.solver_info = solver_info
         self.obs_info = obs_info
@@ -1276,6 +1351,11 @@ class OpencorParamID():
                 self.pre_time = None
 
         self.sim_helper = self.initialise_sim_helper()
+        # Cached rather than probed per evaluation: this decides, on the hot path, whether the
+        # obs `operation` still has to run. getattr keeps every real backend at False untouched.
+        self.emulates_features = bool(getattr(self.sim_helper, 'emulates_features', False))
+        if self.emulates_features:
+            self._configure_emulator()
         self._protocol_executor = ProtocolExecutor(self.sim_helper)
 
         # Resolve modifier baselines here and nowhere else: the helper exists and nothing has
@@ -1339,7 +1419,14 @@ class OpencorParamID():
         self.pred_collinearity_idx_pairs = None
 
         self.do_ad = do_ad
-        
+        if self.emulates_features and self.do_ad:
+            # Every analytic arm differentiates the real model, so AD over an emulator would
+            # descend a different function than the cost reports. get_gradient answers with
+            # finite differences on the emulator instead, which costs nothing here.
+            print('use_emulator is set, so do_ad is being turned off: gradients over an '
+                  'emulator come from finite differences on its own (near-free) evaluations.')
+            self.do_ad = False
+
         if self.obs_info is not None:
             self.cost_type = self.obs_info["cost_type"]
         else:
@@ -1431,9 +1518,42 @@ class OpencorParamID():
         solver = self.solver_info.get('solver')
         helper_cls = get_simulation_helper(solver=solver, model_type=self.model_type,
                                            model_path=self.model_path, dt=self.dt, sim_time=self.sim_time,
-                                           solver_info=self.solver_info, pre_time=self.pre_time)
+                                           solver_info=self.solver_info, pre_time=self.pre_time,
+                                           use_emulator=self.use_emulator,
+                                           emulator_dir=self.emulator_dir,
+                                           out_of_bounds=self.emulator_settings.get(
+                                               'out_of_bounds', 'error'))
         return helper_cls
-    
+
+    def _configure_emulator(self):
+        """Validate the loaded emulator against this run, and wire its outputs to the obs items.
+
+        Everything here is a refusal that has to happen *before* the first evaluation. An
+        emulator asked to answer for a model, parameter set or protocol it was not trained
+        against does not fail -- it answers, about something else -- and the resulting costs
+        and Sobol indices carry no sign of it (#333).
+        """
+        from emulators.emulator_bundle import fingerprint
+        bundle = self.sim_helper.bundle
+
+        bad = {jj: dtype for jj, dtype in enumerate(self.obs_info['data_types'])
+               if dtype != 'constant'}
+        if bad:
+            raise ValueError(
+                f'use_emulator is set, but obs_data.json has data_type(s) '
+                f'{sorted(set(bad.values()))} at data_item index(es) {sorted(bad)}. The emulator '
+                f'predicts scalar data_item features only; those need the full simulated trace '
+                f'("series") or its FFT ("frequency"). Emulating series outputs is not supported '
+                f'yet -- run with use_emulator: false, or drop those items.')
+
+        bundle.check_matches(
+            fingerprint(self.param_id_info, self.obs_info, self.protocol_info, self.model_path),
+            param_entry_labels=param_entry_labels(self.param_id_info),
+            feature_labels=emulated_feature_labels(self.obs_info))
+        bundle.check_quality(self.emulator_settings.get('min_r2', 0.9))
+        self.sim_helper.set_obs_map(self.obs_info['const_idx_to_obs_idx'],
+                                    num_obs=self.obs_info['num_obs'])
+
     def add_user_operation_func(self, func):
         if self.model_type == "casadi_python" and not is_circulatory_differentiable(func):
             raise ValueError(
@@ -1470,6 +1590,12 @@ class OpencorParamID():
         # parameter has been written, which is the property that stops theta compounding.
         if getattr(self, 'sim_helper', None) is not None:
             resolve_modifier_baselines(self.param_id_info, self.sim_helper)
+        # Re-check the emulator against the parameters it is now being asked about: the
+        # programmatic API sets these after construction, and an emulator trained for a
+        # different set (or a different box) would answer anyway.
+        if self.emulates_features:
+            self._configure_emulator()
+
     
     def set_protocol_info(self, protocol_info):
         self.protocol_info = protocol_info
@@ -1486,6 +1612,10 @@ class OpencorParamID():
         validate_operation_kwargs(self.obs_info, self.operation_funcs_dict)
         validate_cost_kwargs(self.obs_info, self.cost_funcs_dict, self.cost_type)
         self._refresh_num_weighted_obs_tables()
+        # As in set_param_id_info: the observables just changed, and the emulator's outputs
+        # are tied to the ones it was trained on, feature for feature.
+        if self.emulates_features:
+            self._configure_emulator()
 
     def set_optimiser_options(self, optimiser_options):
         self.optimiser_options = optimiser_options
@@ -1527,6 +1657,16 @@ class OpencorParamID():
             Inserted before ``.npz`` (e.g. ``"_plot"`` for plot-time dumps).
         """
         if MPI.COMM_WORLD.Get_rank() != 0:
+            return
+        if self.emulates_features:
+            # Not a failure -- the run worked, and this is the one thing an emulator of scalar
+            # features genuinely cannot give. Said plainly, at the end of a run, rather than
+            # raised from inside a save.
+            print(
+                "[param_id] the all-outputs npz is not written when use_emulator is set: the "
+                "emulator predicts the scalar observable features, not the traces they came "
+                "from. Re-run with use_emulator: false for simulated outputs."
+            )
             return
         if self.output_dir is None or self.protocol_info is None:
             print(
@@ -1711,6 +1851,13 @@ class OpencorParamID():
         # TODO: Test AD with multiple subexperiments
         if do_ad:
             reset = False
+
+        if self.emulates_features:
+            # The emulator's input is theta itself. By the time the executor calls
+            # set_param_vals these values have been expanded to one per model parameter, and a
+            # modifier entry's expansion (theta * baseline) is not the theta it was trained on
+            # -- so theta is handed over here, before any of that.
+            self.sim_helper.set_theta(param_vals)
 
         # Run the protocol loop via the shared ProtocolExecutor.
         # reset_after_experiment mirrors the original `reset` flag: when do_ad=True
@@ -2336,8 +2483,13 @@ class OpencorParamID():
             obs_val_for_prob_dist_vec = np.zeros((len(self.obs_info["ground_truth_prob_dist_params"]), ))
 
         if get_all_series:
+            if self.emulates_features:
+                raise NotImplementedError(
+                    'the series of an observable cannot be produced from an emulator: it '
+                    'predicts the scalar feature the series was reduced to, not the series. '
+                    'Re-run with use_emulator: false to plot or save simulated outputs.')
             obs_series_array_all = [None]*len(operands_outputs)
-        
+
 
         const_count = 0
         series_count = 0
@@ -2368,7 +2520,14 @@ class OpencorParamID():
 
             # use the function defined in the operation_funcs_dict to calculate the observable
             # from the operands
-            if self.obs_info["operations"][JJ] == None:
+            if self.emulates_features:
+                # The emulator predicts the feature itself, i.e. what the operation would have
+                # returned. Running the operation again would reduce an already-reduced scalar:
+                # harmless for `mean`, but `max_minus_min` of a single value is zero, and the
+                # cost would then be fitting zeros without anything looking wrong.
+                obs = float(np.asarray(operands_outputs[JJ][0]).reshape(-1)[0])
+                self.temp_results[self.obs_info["names_for_plotting"][JJ]] = obs
+            elif self.obs_info["operations"][JJ] == None:
                 obs = operands_outputs[JJ][0]
             else:
                 if self.obs_info["data_types"][JJ] != 'frequency':
@@ -2580,7 +2739,12 @@ class OpencorParamID():
     # ---- Backend-agnostic cost/gradient interface ----
 
     def get_cost(self, param_vals):
-        """Compute cost J(p), dispatching to CasADi or AADC or numpy."""
+        """Compute cost J(p), dispatching to the emulator, CasADi, AADC or numpy."""
+        if self.emulates_features:
+            # First, and before the model_type branches: a casadi_python model run on an
+            # emulator would otherwise evaluate its real symbolic graph here and quietly
+            # ignore the emulator the user asked for.
+            return float(self.get_cost_from_params(param_vals))
         if self.model_type == 'casadi_python':
             return float(self.get_cost_ca(param_vals))
         if self.model_type == 'aadc_python' and self.do_ad:
@@ -2590,7 +2754,14 @@ class OpencorParamID():
         return float(self.get_cost_from_params(param_vals))
 
     def get_gradient(self, param_vals):
-        """Compute gradient ∇J(p), dispatching to CasADi, AADC, or Myokit FSA."""
+        """Compute gradient ∇J(p), dispatching to the emulator, CasADi, AADC, or Myokit FSA."""
+        if self.emulates_features:
+            # Finite differences on the emulator's own cost -- the same function get_cost
+            # returns, which the analytic arms (all of which differentiate the real model)
+            # would not be. 2M evaluations is the wrong trade against a solver and the right
+            # one here, where an evaluation is a matrix multiply.
+            return fd_backend.cost_gradient(
+                self, param_vals, h=float(self.emulator_settings.get('fd_rel_step', 1e-3)))
         if self.model_type == 'casadi_python':
             return self.get_jac_cost_ca(param_vals)
         elif self.model_type == 'aadc_python':
@@ -2601,11 +2772,7 @@ class OpencorParamID():
             raise ValueError(f"Gradient not available for model_type={self.model_type}")
 
     def _observable_base_label(self, obs_idx):
-        name = self.obs_info["names_for_plotting"][obs_idx]
-        op = self.obs_info["operations"][obs_idx]
-        operands = self.obs_info["operands"][obs_idx]
-        operand = operands[0] if operands else ''
-        return f"{name} ({op} {operand})" if op else f"{name} ({operand})"
+        return observable_base_label(self.obs_info, obs_idx)
 
     def _ambiguous_observable_labels(self):
         """Base labels shared by more than one observable. Computed once per obs_info."""
@@ -2679,6 +2846,17 @@ class OpencorParamID():
         stopped being hardcoded.
         """
         method = (gradient_method or '').strip().upper()
+        if self.emulates_features:
+            # Over an emulator, FD is the only honest arm: the analytic ones differentiate the
+            # real model, which is not the function being evaluated. It is also free here.
+            if method not in ('', 'ANALYTIC', 'AUTO', 'FD'):
+                raise ValueError(
+                    f"gradient_method '{gradient_method}' differentiates the real model, but "
+                    f"this run evaluates an emulator (use_emulator: true). Only 'FD' is "
+                    f"available over an emulator -- and it costs 2M emulator evaluations, "
+                    f"not 2M simulations.")
+            kwargs = {} if fd_rel_step is None else {'h': float(fd_rel_step)}
+            return fd_backend.observable_feature_sensitivities(self, param_vals, **kwargs)
         if method == 'FD':
             kwargs = {} if fd_rel_step is None else {'h': float(fd_rel_step)}
             return fd_backend.observable_feature_sensitivities(self, param_vals, **kwargs)
@@ -2791,6 +2969,11 @@ class OpencorParamID():
             reset (bool, optional): if you want to reset the simulation after running.
                                     Gets changed to True for num_experiments > 1. Defaults to True.
         """
+        if self.emulates_features:
+            raise NotImplementedError(
+                'simulate_once needs the full simulated trace, which a feature emulator cannot '
+                'produce -- it predicts the scalar data_item features only. Re-run with '
+                'use_emulator: false to simulate, plot or save outputs.')
         if MPI.COMM_WORLD.Get_rank() != 0:
             print('simulate once should only be done on one rank')
             exit()
@@ -2908,10 +3091,13 @@ class OpencorMCMC(OpencorParamID):
 
     def __init__(self, model_path,
                  obs_info, param_id_info, protocol_info, prediction_info, solver_info,
-                 dt=0.01, UQ_options=None, DEBUG=False, model_type=None, mcmc_options=None):
+                 dt=0.01, UQ_options=None, DEBUG=False, model_type=None, mcmc_options=None,
+                 use_emulator=False, emulator_dir=None, emulator_settings=None):
         super().__init__(model_path, "MCMC",
                 obs_info, param_id_info, protocol_info, prediction_info, solver_info,
-                dt=dt, DEBUG=DEBUG, model_type=model_type)
+                dt=dt, DEBUG=DEBUG, model_type=model_type,
+                use_emulator=use_emulator, emulator_dir=emulator_dir,
+                emulator_settings=emulator_settings)
         self._init_mcmc(_resolve_UQ_options(UQ_options, mcmc_options), DEBUG=DEBUG)
 
     @classmethod

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -600,6 +600,16 @@ class CVS0DParamID():
             feature values. If True, a tuple ``(obs_dicts, obs_arrays)`` where
             ``obs_arrays`` holds the time-series for plotting.
         """
+        if getattr(self.param_id, 'emulates_features', False):
+            # Nothing to simulate: the emulator's features *are* the result, and
+            # they were produced by the run that just finished. Returning rather
+            # than raising matters because callers pair this with plot_outputs()
+            # in one try block -- raising here cost the run its observable errors
+            # too, which an emulator can perfectly well report (#333).
+            print('use_emulator is set, so there is no simulation to re-run for the '
+                  'best fit; the emulator predicts the observable features directly.')
+            self.best_output_calculated = True
+            return (None, None) if return_series else None
         if return_series:
             obs_dicts, obs_arrays = self.param_id.simulate_once(reset=reset, only_one_exp=only_one_exp, return_series=return_series)
             self.best_output_calculated = True
@@ -2483,11 +2493,12 @@ class OpencorParamID():
             obs_val_for_prob_dist_vec = np.zeros((len(self.obs_info["ground_truth_prob_dist_params"]), ))
 
         if get_all_series:
-            if self.emulates_features:
-                raise NotImplementedError(
-                    'the series of an observable cannot be produced from an emulator: it '
-                    'predicts the scalar feature the series was reduced to, not the series. '
-                    'Re-run with use_emulator: false to plot or save simulated outputs.')
+            # An emulator has no series to give -- it predicts the scalar the series
+            # was reduced to. That used to raise, which was too blunt: the caller
+            # (plot_outputs) wants the *features* as well, and those are exactly what
+            # an emulator does have. Hand back the features with every series None,
+            # and let the caller skip the reconstruction rather than lose the errors
+            # with it (#333).
             obs_series_array_all = [None]*len(operands_outputs)
 
 
@@ -2498,7 +2509,11 @@ class OpencorParamID():
         for JJ in range(len(operands_outputs)):
             if self.obs_info["data_types"][JJ] == 'frequency':
                 pass
-            elif get_all_series:
+            elif get_all_series and not self.emulates_features:
+                # An emulator has no series for this item; the None left in place
+                # is what says so. Running the operation's series branch on an
+                # already-reduced scalar would put a length-1 "trace" here, which
+                # a plot would draw as a single point and read as real.
                 if self.obs_info["operations"][JJ] is None:
                     obs_series_array_all[JJ] = operands_outputs[JJ][0]
                 elif hasattr(operation_funcs_dict[self.obs_info["operations"][JJ]], 'series_to_constant'):

--- a/src/param_id/plot_outputs.py
+++ b/src/param_id/plot_outputs.py
@@ -41,6 +41,9 @@ class ParamIDPlotOutputs:
 
     def plot_outputs(self) -> None:
         print("plotting best observables")
+        if getattr(self.client.param_id, "emulates_features", False):
+            self.save_emulator_outputs()
+            return
         phase = self._uses_phase()
         list_of_obs_dicts, list_of_all_series = self._fetch_best_fit_data()
         tSim_per_sub_count, sim_time_tot_per_exp, n_steps_per_sub_count = (
@@ -64,6 +67,77 @@ class ParamIDPlotOutputs:
         self.print_observable_errors(
             phase, percent_error_vec, phase_error_vec
         )
+
+    def save_emulator_outputs(self) -> None:
+        """Error vectors and error-bar pages for a run that used an emulator.
+
+        An emulator predicts the scalar features and not the traces, so the
+        reconstruction pages cannot be drawn -- but the *errors* are a comparison
+        of feature against ground truth, and those are exactly what it has. Losing
+        them along with the traces would leave a finished calibration with nothing
+        to show for itself, which is what happened before this existed (#333).
+
+        Writes the same ``percent_error_vec`` / ``error_vec_names`` files an
+        ordinary run writes, so every consumer of them -- CA's own plots, and the
+        tools that read the outputs directory -- is unchanged.
+        """
+        percent_error_vec, std_error_vec = self.emulator_error_vectors()
+        self.save_error_vectors(percent_error_vec, std_error_vec)
+        obs_names_for_plot = self._observable_names_for_error_plots()
+        self.plot_percent_error_bar_pages(obs_names_for_plot, percent_error_vec)
+        self.plot_std_error_bar_pages(obs_names_for_plot, std_error_vec)
+        print(
+            "This run used an emulator, so the reconstruction plots (which need the "
+            "simulated traces) were not drawn; the observable errors above are the "
+            "emulator's own features against the ground truth."
+        )
+
+    def emulator_error_vectors(self):
+        """Percent and std error per observable, from the emulator's features.
+
+        Only ``constant`` observables exist on this path -- CA refuses an emulator
+        study whose obs_data holds anything else -- so this is the constant branch
+        of ``plot_reconstruction_pages`` with the plotting removed, and it must
+        stay identical to it: the two numbers are the same quantity, and a run
+        should not report a different error because it drew fewer pictures.
+        """
+        obs_info = self.client.obs_info
+        param_id = self.client.param_id
+        num_obs = obs_info["num_obs"]
+        percent_error_vec = np.zeros((num_obs,))
+        std_error_vec = np.zeros((num_obs,))
+
+        _, operands_list = param_id.get_cost_and_obs_from_params(param_id.best_param_vals)
+        if not operands_list:
+            print("WARNING: the emulator produced no observables; errors not saved")
+            return percent_error_vec, std_error_vec
+
+        # One evaluation per segment, then each observable read from its own --
+        # a data_item names the experiment and sub-experiment it belongs to, and
+        # scoring it against another segment is scoring the wrong thing.
+        num_sub_per_exp = self.client.protocol_info["num_sub_per_exp"]
+        const_by_segment = {}
+        for const_idx, obs_idx in enumerate(obs_info["const_idx_to_obs_idx"]):
+            exp = int(obs_info["experiment_idxs"][obs_idx])
+            sub = int(obs_info["subexperiment_idxs"][obs_idx])
+            flat = sum(num_sub_per_exp[:exp]) + sub
+            if flat >= len(operands_list) or operands_list[flat] is None:
+                continue
+            if flat not in const_by_segment:
+                const_by_segment[flat] = np.asarray(
+                    param_id.get_obs_output_dict(operands_list[flat])["const"], dtype=float
+                )
+            consts = const_by_segment[flat]
+            if const_idx >= len(consts):
+                continue
+            ground_truth = obs_info["ground_truth_const"][const_idx]
+            percent_error_vec[obs_idx] = (
+                100 * (consts[const_idx] - ground_truth) / (ground_truth + 1e-10)
+            )
+            std_error_vec[obs_idx] = (
+                consts[const_idx] - ground_truth
+            ) / obs_info["std_const_vec"][const_idx]
+        return percent_error_vec, std_error_vec
 
     def _uses_phase(self) -> bool:
         gtp = self.client.obs_info["ground_truth_phase"]

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -1254,7 +1254,7 @@ def solver_info_fields(solver):
     return SOLVER_INFO_FIELDS.get(solver, [])
 
 
-def gradient_sources(model_type, solver=None, method=None):
+def gradient_sources(model_type, solver=None, method=None, use_emulator=False):
     """The gradient sources available for the gradient-based param-id methods (`sp_minimize`,
     `multi_start_sp_minimize`) with this `model_type` + `solver` (+ optional integrator `method`),
     for a front-end that offers a "Gradient" menu without hardcoding CA's rules.
@@ -1283,6 +1283,9 @@ def gradient_sources(model_type, solver=None, method=None):
     previously duplicated from in downstream tools (e.g. CUFLynx); keep it in step with
     get_gradient.
 
+    ``use_emulator`` (issue #333) collapses the menu to finite differences alone: the analytic
+    arms differentiate the real model, and an emulator run is not evaluating it.
+
     When ``method`` (the integrator plugin) is given, the analytic source is additionally gated on
     per-integrator suitability (``SOLVER_SCHEMA['ad_suitable_methods']`` /
     ``['fsa_suitable_methods']``): the CasADi AD descriptor is omitted for a casadi_integrator
@@ -1295,6 +1298,12 @@ def gradient_sources(model_type, solver=None, method=None):
         'description': ('Central finite differences of the cost; works for any model_type, at '
                         'the cost of extra simulations per gradient.'),
     }]
+    if use_emulator:
+        # Every analytic arm differentiates the real model, which is not the function an
+        # emulator run evaluates -- offering one would mean descending a different function
+        # than the cost reports. FD on the emulator is exact for what is being minimised, and
+        # costs 2M matrix multiplies rather than 2M simulations (#333).
+        return sources
     if model_type == 'casadi_python':
         casadi_methods = SOLVER_SCHEMA['methods_by_solver']['casadi_integrator']
         ad_suitable = SOLVER_SCHEMA['ad_suitable_methods']['casadi_integrator']
@@ -1445,6 +1454,67 @@ ANALYSIS_OPTIONS = {
              'choices': ['parabola_fit', 'numdifftools_finite_diff'],
              'description': 'Finite-difference Hessian method for the Laplace approximation '
                             '(used when gradient_source is FD).'},
+        ],
+    },
+    # Emulation is the odd one out among these modes: it has a *train* step and a *use* step,
+    # so it carries a second flag. `enable_flag` (do_emulation) trains an emulator against the
+    # solver named by `solver`; `use_flag` (use_emulator) makes calibration, SA, MCMC and IA
+    # evaluate the trained emulator instead of that solver. They are independent -- training
+    # once and then using it across several runs is the normal shape (#333).
+    'emulation': {
+        'label': 'Emulator (surrogate model)',
+        'enable_flag': 'do_emulation',
+        'use_flag': 'use_emulator',
+        'options_key': 'emulator_settings',
+        'options': [
+            {'name': 'emulator_dir', 'type': 'str', 'default': None, 'required': False,
+             'description': ('Directory holding the trained emulator. Defaults to '
+                             '<param_id_output_dir>/emulators/<file_prefix>_<obs_prefix>.')},
+            # A str rather than a list: descriptor types are scalar, and the accepted names are
+            # a runtime property of the installed autoemulate, discoverable through
+            # emulators.emulator_trainer.emulator_model_names() -- so a tool offers that list
+            # and joins the selection with commas, instead of a menu hardcoded here.
+            {'name': 'models', 'type': 'str', 'default': 'default', 'required': False,
+             'description': ('Which emulators to fit and compare: "default" for autoemulate\'s '
+                             'default set, "all" for every registered one, or a comma-separated '
+                             'list of names (see emulator_model_names()).')},
+            {'name': 'num_train_samples', 'type': 'int', 'default': 128, 'required': False,
+             'description': ('Number of simulations run to build the training set. This is the '
+                             'up-front cost the emulator has to earn back.')},
+            # enum, not str: EmulatorTrainer.design dispatches on exactly these three and
+            # raises ValueError on anything else, so a free string only defers a typo to
+            # run time -- after the model has been generated.
+            {'name': 'sample_type', 'type': 'enum', 'default': 'sobol', 'required': False,
+             'choices': ['sobol', 'latin_hypercube', 'random'],
+             'description': ('Design of experiments over the params_for_id box. Same vocabulary '
+                             'as optimiser_options.start_sampling.')},
+            {'name': 'log_scale_params', 'type': 'bool', 'default': False, 'required': False,
+             'description': ('Space the design logarithmically in each parameter. Worth setting '
+                             'when a bound spans decades; requires every min to be positive.')},
+            {'name': 'random_seed', 'type': 'int', 'default': 0, 'required': False,
+             'description': 'Seed for the design and the fit, so a training run is repeatable.'},
+            {'name': 'test_fraction', 'type': 'float', 'default': 0.2, 'required': False,
+             'description': ('Fraction of the design held out and never trained on, which is '
+                             'what the reported R2/RMSE are measured against.')},
+            {'name': 'n_splits', 'type': 'int', 'default': 5, 'required': False,
+             'description': 'Cross-validation folds autoemulate uses when comparing emulators.'},
+            {'name': 'n_iter', 'type': 'int', 'default': 10, 'required': False,
+             'description': 'Hyper-parameter settings sampled per emulator during tuning.'},
+            # The refusal that makes the rest of it safe. An emulator below this is not slower
+            # or noisier -- it is confidently wrong, and nothing downstream can tell.
+            {'name': 'min_r2', 'type': 'float', 'default': 0.9, 'required': False,
+             'description': ('Refuse to use an emulator whose worst held-out per-feature R2 is '
+                             'below this. Raise it for results you intend to publish.')},
+            # enum, not str: EmulatorBundle.check_bounds dispatches on these, and the default
+            # has to be the strict one -- outside its design an emulator is an extrapolation
+            # with no error estimate at all.
+            {'name': 'out_of_bounds', 'type': 'enum', 'default': 'error', 'required': False,
+             'choices': ['error', 'warn', 'clip'],
+             'description': ('What to do when a parameter falls outside the box the emulator '
+                             'was trained in: refuse, warn and extrapolate, or clip to the box.')},
+            {'name': 'fd_rel_step', 'type': 'float', 'default': 1e-3, 'required': False,
+             'description': ('Relative step for the finite-difference gradient over the '
+                             'emulator, which is the only gradient source an emulator has.')},
         ],
     },
 }
@@ -1666,10 +1736,14 @@ class YamlFileParser(object):
                    and inp_data_dict.get('solver', 'CVODE_myokit') == 'CVODE_myokit'
                    and inp_data_dict.get('do_ad'))
         if inp_data_dict.get('param_id_method') == 'sp_minimize' and \
-                inp_data_dict.get('model_type') not in ('casadi_python', 'aadc_python') and not _fsa_ad:
+                inp_data_dict.get('model_type') not in ('casadi_python', 'aadc_python') \
+                and not _fsa_ad and not inp_data_dict.get('use_emulator'):
+            # An emulator is exempt: its gradient comes from finite differences on its own
+            # evaluations, which is affordable in a way FD on a solver is not (#333).
             print('Parameter identification with sp_minimize requires model_type to be '
                   '"casadi_python" or "aadc_python", or "cellml_only" with solver '
-                  '"CVODE_myokit" and do_ad: true (Myokit CVODES forward sensitivity).')
+                  '"CVODE_myokit" and do_ad: true (Myokit CVODES forward sensitivity) -- or '
+                  'use_emulator: true, whose gradient is finite differences on the emulator.')
             exit()
 
         # multi_start_sp_minimize runs on any model type: it uses the AD gradient for
@@ -2083,7 +2157,31 @@ class YamlFileParser(object):
             if 'method' not in inp_data_dict['ia_options'].keys():
                 print('No method specified for identifiability analysis, setting to Laplace by default')
                 inp_data_dict['ia_options']['method'] = 'Laplace'
-        
+
+        # Emulator settings (#333). Two flags, because emulation has two steps: do_emulation
+        # trains one against the solver named by `solver`, use_emulator makes the analyses
+        # evaluate it. Defaults here must match ANALYSIS_OPTIONS['emulation'], which is what a
+        # settings form shows the user.
+        if 'do_emulation' not in inp_data_dict.keys():
+            inp_data_dict['do_emulation'] = False
+        if 'use_emulator' not in inp_data_dict.keys():
+            inp_data_dict['use_emulator'] = False
+        if inp_data_dict.get('emulator_settings') is None:
+            inp_data_dict['emulator_settings'] = {}
+        emulator_settings = inp_data_dict['emulator_settings']
+        emulator_settings.setdefault('emulator_dir', None)
+        emulator_settings.setdefault('models', 'default')
+        emulator_settings.setdefault('num_train_samples', 128)
+        emulator_settings.setdefault('sample_type', 'sobol')
+        emulator_settings.setdefault('log_scale_params', False)
+        emulator_settings.setdefault('random_seed', 0)
+        emulator_settings.setdefault('test_fraction', 0.2)
+        emulator_settings.setdefault('n_splits', 5)
+        emulator_settings.setdefault('n_iter', 10)
+        emulator_settings.setdefault('min_r2', 0.9)
+        emulator_settings.setdefault('out_of_bounds', 'error')
+        emulator_settings.setdefault('fd_rel_step', 1e-3)
+
         # Parse optimiser_options - this is the new unified way to specify options
         # Handle backwards compatibility: if ga_options or debug_ga_options is specified, merge into optimiser_options
         if 'optimiser_options' not in inp_data_dict.keys():

--- a/src/scripts/train_emulator_run_script.py
+++ b/src/scripts/train_emulator_run_script.py
@@ -15,10 +15,17 @@ import traceback
 root_dir = os.path.join(os.path.dirname(__file__), '../..')
 sys.path.append(os.path.join(root_dir, 'src'))
 
-from mpi4py import MPI
+# Not `from mpi4py import MPI`: that import initialises MPI and registers an
+# atexit MPI_Finalize, and with no launcher present that finalise is what aborts
+# on macOS when a NIC goes away (#396). Placed after the sys.path bootstrap
+# above, which is what makes `utilities` importable. Under mpiexec get_MPI hands
+# back the real mpi4py.MPI, so a multi-rank training run is unchanged.
+from utilities.mpi_utils import get_MPI as _get_MPI
 
 from emulators.emulator_trainer import EmulatorTrainer, require_autoemulate
 from parsers.PrimitiveParsers import YamlFileParser
+
+MPI = _get_MPI()
 
 
 def train_emulator(inp_data_dict=None):

--- a/src/scripts/train_emulator_run_script.py
+++ b/src/scripts/train_emulator_run_script.py
@@ -1,0 +1,56 @@
+"""Train an emulator of the model's scalar observable features (issue #333).
+
+Run through ``user_run_files/run_emulator_training.sh <num_processors>``, or directly:
+
+    mpiexec -n 4 $python_path src/scripts/train_emulator_run_script.py
+
+Reads the same ``user_inputs.yaml`` as every other stage. The training simulations use the
+solver named by ``solver:``; ``use_emulator`` is ignored here, since training always runs the
+real model.
+"""
+import os
+import sys
+import traceback
+
+root_dir = os.path.join(os.path.dirname(__file__), '../..')
+sys.path.append(os.path.join(root_dir, 'src'))
+
+from mpi4py import MPI
+
+from emulators.emulator_trainer import EmulatorTrainer, require_autoemulate
+from parsers.PrimitiveParsers import YamlFileParser
+
+
+def train_emulator(inp_data_dict=None):
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    # Checked before anything is generated or simulated: without autoemulate the training runs
+    # would all complete and then have nothing to fit.
+    require_autoemulate()
+
+    yaml_parser = YamlFileParser()
+    inp_data_dict = yaml_parser.parse_user_inputs_file(
+        inp_data_dict, obs_path_needed=True, do_generation_with_fit_parameters=False)
+
+    if rank == 0:
+        print(f'Training an emulator with {comm.Get_size()} MPI rank(s), against solver '
+              f'{inp_data_dict["solver_info"].get("solver")}')
+
+    trainer = EmulatorTrainer.init_from_dict(inp_data_dict, comm=comm)
+    bundle = trainer.train()
+    if rank == 0 and bundle is not None:
+        print('Set use_emulator: true in user_inputs.yaml to run calibration, sensitivity '
+              'analysis, UQ or identifiability analysis against it.')
+    return bundle
+
+
+if __name__ == '__main__':
+    comm = MPI.COMM_WORLD
+    try:
+        train_emulator()
+        MPI.Finalize()
+    except Exception:
+        print(traceback.format_exc())
+        comm.Abort()
+        MPI.Finalize()

--- a/src/sensitivity_analysis/sensitivityAnalysis.py
+++ b/src/sensitivity_analysis/sensitivityAnalysis.py
@@ -100,7 +100,8 @@ class SensitivityAnalysis():
                  param_id_output_dir=None, resources_dir=None, model_out_names=[],
                  solver_info={}, dt=0.01, optimiser_options={}, param_id_obs_path=None, params_for_id_path=None,
                  operation_funcs_external_path=None, cost_funcs_external_path=None,
-                 modifier_funcs_external_path=None):
+                 modifier_funcs_external_path=None,
+                 use_emulator=False, emulator_dir=None, emulator_settings=None):
 
         self.model_path = model_path
         self.model_type = model_type
@@ -127,7 +128,9 @@ class SensitivityAnalysis():
                             verbose=False, use_MPI=True, model_type=self.model_type,
                             operation_funcs_external_path=operation_funcs_external_path,
                             cost_funcs_external_path=cost_funcs_external_path,
-                            modifier_funcs_external_path=modifier_funcs_external_path)
+                            modifier_funcs_external_path=modifier_funcs_external_path,
+                            use_emulator=use_emulator, emulator_dir=emulator_dir,
+                            emulator_settings=emulator_settings)
 
         # For the local (derivative-based) method, which -- unlike Sobol -- runs through a
         # backend-agnostic param-id engine (mirroring IdentifiabilityAnalysis), not the Sobol
@@ -160,13 +163,17 @@ class SensitivityAnalysis():
             'resources_dir', 'model_out_names', 'solver_info',
             'dt', 'optimiser_options', 'param_id_obs_path', 'params_for_id_path',
             'operation_funcs_external_path', 'cost_funcs_external_path',
-            'modifier_funcs_external_path',
+            'modifier_funcs_external_path', 'use_emulator', 'emulator_settings',
         ]
         kwargs = {key: inp_data_dict[key] for key in arg_options if key in inp_data_dict}
 
         # Support common naming used elsewhere
         if 'file_name_prefix' not in kwargs and 'file_prefix' in inp_data_dict:
             kwargs['file_name_prefix'] = inp_data_dict['file_prefix']
+
+        if kwargs.get('use_emulator'):
+            from emulators.emulator_trainer import resolve_emulator_dir
+            kwargs['emulator_dir'] = resolve_emulator_dir(inp_data_dict)
 
         sa = cls(**kwargs)
         # Keep the parsed config so the local method can build a param-id engine from it.

--- a/src/sensitivity_analysis/sobolSA.py
+++ b/src/sensitivity_analysis/sobolSA.py
@@ -80,7 +80,8 @@ class sobol_SA():
                  param_id_path = None, params_for_id_path=None, use_MPI = False, verbose=False,
                  sim_time=2.0, pre_time=20.0, model_type=None,
                  operation_funcs_external_path=None, cost_funcs_external_path=None,
-                 modifier_funcs_external_path=None):
+                 modifier_funcs_external_path=None,
+                 use_emulator=False, emulator_dir=None, emulator_settings=None):
 
         """
         Initializes the Sensitivity_analysis class.
@@ -117,6 +118,12 @@ class sobol_SA():
             cost_funcs_external_path=cost_funcs_external_path)
         self.modifier_funcs_external_path = modifier_funcs_external_path
         self.operation_funcs_dict = self.sfp.get_operation_funcs_dict(mode)
+
+        # Emulator mode (#333). `solver_info['solver']` still names the truth solver -- the one
+        # the emulator was trained against -- so this is its own flag rather than a solver name.
+        self.use_emulator = bool(use_emulator)
+        self.emulator_dir = emulator_dir
+        self.emulator_settings = dict(emulator_settings or {})
 
         self.obs_and_param_parser = None
         self.gt_df = None
@@ -302,7 +309,30 @@ class sobol_SA():
             self._sim_helper = self.initialise_sim_helper()
             if self.sim_time is not None and self.pre_time is not None:
                 self._sim_helper.update_times(self.dt, 0.0, self.sim_time, self.pre_time)
+            if getattr(self._sim_helper, 'emulates_features', False):
+                self._configure_emulator(self._sim_helper)
         return self._sim_helper
+
+    def _configure_emulator(self, helper):
+        """Validate the emulator against this analysis, and map its outputs to the data_items.
+
+        Sobol reads a surrogate ``num_samples*(2M+2)`` times without ever touching the model,
+        so an emulator trained against different bounds, observables or protocol would produce
+        a complete, plausible set of indices for a different problem (#333).
+        """
+        from emulators.emulator_bundle import fingerprint
+        bad = {jj: dtype for jj, dtype in enumerate(self.obs_info['data_types'])
+               if dtype != 'constant'}
+        if bad:
+            raise ValueError(
+                f'use_emulator is set, but obs_data.json has data_type(s) '
+                f'{sorted(set(bad.values()))} at data_item index(es) {sorted(bad)}. The emulator '
+                f'predicts scalar data_item features only.')
+        helper.bundle.check_matches(
+            fingerprint(self.param_id_info, self.obs_info, self.protocol_info, self.model_path))
+        helper.bundle.check_quality(self.emulator_settings.get('min_r2', 0.9))
+        helper.set_obs_map(self.obs_info['const_idx_to_obs_idx'],
+                           num_obs=len(self.obs_info['operations']))
 
     @sim_helper.setter
     def sim_helper(self, value):
@@ -346,6 +376,9 @@ class sobol_SA():
             sim_time=self.sim_time,
             solver_info=self.solver_info,
             pre_time=self.pre_time,
+            use_emulator=self.use_emulator,
+            emulator_dir=self.emulator_dir,
+            out_of_bounds=self.emulator_settings.get('out_of_bounds', 'error'),
         )
 
     def set_output_dir(self, path):
@@ -414,8 +447,15 @@ class sobol_SA():
         local_outputs = []
 
         # Create a single progress bar for rank 0 only to avoid noisy output from all ranks
+        emulates_features = bool(getattr(self.sim_helper, 'emulates_features', False))
+
         with tqdm(total=len(local_samples), desc=f"Rank {self.rank}", position=self.rank, leave=True, disable=self.rank != 0) as pbar:
             for param_vals in local_samples:
+
+                if emulates_features:
+                    # The emulator's input is theta itself, before the expansion below turns a
+                    # modifier's single slot into one value per model parameter.
+                    self.sim_helper.set_theta(param_vals)
 
                 # Delegate the multi-experiment / multi-subexperiment loop to
                 # ProtocolExecutor.  continue_on_failure=True preserves existing
@@ -432,6 +472,14 @@ class sobol_SA():
                     self._rank0_print(
                         f"[MPI Rank {self.rank}] Simulation failed for params: {param_vals}"
                     )
+
+                if emulates_features:
+                    # The emulator predicts each data_item's feature directly, so the operation
+                    # must not run again: it would reduce an already-reduced scalar, and
+                    # max_minus_min of one value is zero.
+                    local_outputs.append(list(self.sim_helper.get_predicted_features()))
+                    pbar.update(1)
+                    continue
 
                 features = []
                 for j in range(len(self.obs_info["operations"])):

--- a/src/solver_wrappers/__init__.py
+++ b/src/solver_wrappers/__init__.py
@@ -57,6 +57,12 @@ except Exception as _exc:
     AadcPythonSimulationHelper = None
     _record_import_error('AADC', _exc)
 
+try:
+    from solver_wrappers.emulator_solver_helper import SimulationHelper as EmulatorSimulationHelper
+except Exception as _exc:
+    EmulatorSimulationHelper = None
+    _record_import_error('emulator', _exc)
+
 # Not `from mpi4py import MPI`. This module picks a solver; it has no collectives
 # to run. That import initialised MPI and registered an atexit MPI_Finalize for
 # every consumer who merely wanted a forward solve -- and that finalise aborts on
@@ -67,9 +73,11 @@ from utilities.mpi_utils import mpi_available as _mpi_available
 _MPI_AVAILABLE = _mpi_available()
 
 
-def get_simulation_helper(model_path: str = None, solver: str = None, 
-                          model_type: str = None, dt: float = None, sim_time: float = None, 
-                          solver_info: dict = None, pre_time: float = 0.0):
+def get_simulation_helper(model_path: str = None, solver: str = None,
+                          model_type: str = None, dt: float = None, sim_time: float = None,
+                          solver_info: dict = None, pre_time: float = 0.0,
+                          use_emulator: bool = False, emulator_dir: str = None,
+                          emulator_bundle=None, out_of_bounds: str = 'error'):
     """Create a `SimulationHelper` for the requested solver.
 
     Returns the appropriate backend (OpenCOR, Myokit, SciPy, or CasADi) based on
@@ -92,6 +100,14 @@ def get_simulation_helper(model_path: str = None, solver: str = None,
         sim_time: Logged simulation duration (s).
         solver_info: Solver config dict (e.g. ``MaximumStep``, ``method``).
         pre_time: Unlogged steady-state spin-up duration (s).
+        use_emulator: Answer from a trained emulator instead of integrating (issue #333).
+            ``solver`` keeps naming the *truth* solver -- the one an emulator was trained
+            against, and the one to compare its answers with -- so this is a separate flag
+            rather than another solver name.
+        emulator_dir: Directory holding the trained emulator, when ``use_emulator``.
+        emulator_bundle: An already-loaded ``EmulatorBundle``, used instead of reading
+            ``emulator_dir``.
+        out_of_bounds: What the emulator does off its training box: 'error', 'warn' or 'clip'.
 
     Returns:
         SimulationHelper: The backend instance for the requested solver.
@@ -100,6 +116,18 @@ def get_simulation_helper(model_path: str = None, solver: str = None,
         ValueError: If the solver is unknown or incompatible with ``model_type``.
         RuntimeError: If the requested backend is not installed.
     """
+    if use_emulator:
+        if EmulatorSimulationHelper is None:
+            # Same reason-carrying message as every other backend (#410): "not
+            # available" hides the difference between "autoemulate is missing"
+            # and "the import itself raised", and only one of those is an install.
+            raise RuntimeError(
+                _unavailable_message('emulator', 'use_emulator')
+                + ' Install it with `pip install "circulatory_autogen[emulation]"`.')
+        return EmulatorSimulationHelper(emulator_dir, dt, sim_time, solver_info,
+                                        pre_time=pre_time, bundle=emulator_bundle,
+                                        out_of_bounds=out_of_bounds)
+
     # Define valid solver types
     cellml_solvers = ['CVODE_opencor', 'CVODE_myokit']
     python_solvers = ['solve_ivp']
@@ -172,7 +200,8 @@ def get_simulation_helper_from_inp_data_dict(inp_data_dict):
     Convenience wrapper around
     [`get_simulation_helper`][solver_wrappers.get_simulation_helper] that reads
     ``model_path``, ``solver_info`` (and its ``solver``), ``model_type``, ``dt``,
-    ``sim_time`` and ``pre_time`` from the dict.
+    ``sim_time`` and ``pre_time`` from the dict -- and ``use_emulator`` plus
+    ``emulator_settings``, so a configured emulator is picked up here too.
 
     Args:
         inp_data_dict: Configuration dict (see
@@ -181,7 +210,15 @@ def get_simulation_helper_from_inp_data_dict(inp_data_dict):
     Returns:
         SimulationHelper: The backend instance for the configured solver.
     """
-    return get_simulation_helper(model_path=inp_data_dict["model_path"], solver=inp_data_dict["solver_info"]["solver"], model_type=inp_data_dict["model_type"], dt=inp_data_dict["dt"], sim_time=inp_data_dict["sim_time"], solver_info=inp_data_dict["solver_info"], pre_time=inp_data_dict["pre_time"])
+    emulator_settings = inp_data_dict.get("emulator_settings") or {}
+    use_emulator = bool(inp_data_dict.get("use_emulator", False))
+    emulator_dir = None
+    if use_emulator:
+        from emulators.emulator_trainer import resolve_emulator_dir
+        emulator_dir = resolve_emulator_dir(inp_data_dict)
+    return get_simulation_helper(model_path=inp_data_dict["model_path"], solver=inp_data_dict["solver_info"]["solver"], model_type=inp_data_dict["model_type"], dt=inp_data_dict["dt"], sim_time=inp_data_dict["sim_time"], solver_info=inp_data_dict["solver_info"], pre_time=inp_data_dict["pre_time"],
+                                 use_emulator=use_emulator, emulator_dir=emulator_dir,
+                                 out_of_bounds=emulator_settings.get("out_of_bounds", "error"))
 
 __all__ = [
     "get_simulation_helper",
@@ -189,4 +226,5 @@ __all__ = [
     "MyokitSimulationHelper",
     "OpenCORSimulationHelper",
     "CasADiPythonSimulationHelper",
+    "EmulatorSimulationHelper",
 ]

--- a/src/solver_wrappers/emulator_solver_helper.py
+++ b/src/solver_wrappers/emulator_solver_helper.py
@@ -1,0 +1,315 @@
+"""A `SimulationHelper` that answers from a trained emulator instead of integrating (issue #333).
+
+Everything downstream of a simulation -- the cost, Sobol sampling, MCMC, the Laplace Hessian --
+reaches the model through the helper interface, so putting the emulator behind that interface
+is what lets all of them use it without any of them knowing. The helper is constructed by the
+same factory as every other backend (``get_simulation_helper(..., use_emulator=True)``), so an
+emulator can be used wherever a solver is.
+
+What it emulates is the *scalar feature* of each obs_data data_item -- the value after the
+``operation`` reduction -- not the trace it was reduced from. That is why ``emulates_features``
+is True: the two places that would otherwise apply the operation read it and skip that step,
+because applying ``max_minus_min`` to an already-reduced scalar would quietly return zero.
+Anything that genuinely needs a trace (plotting, saving all outputs, prediction items) raises
+rather than inventing one.
+
+Time is still tracked exactly as the real backends track it. The protocol executor accumulates
+``tSim`` across sub-experiments whatever ran underneath, so the bookkeeping has to be right even
+though nothing is integrated.
+"""
+import numpy as np
+
+from emulators.emulator_bundle import EmulatorBundle
+from solver_wrappers.param_grouping import pair_names_with_values
+
+TRACE_REFUSAL = (
+    'needs the full simulated trace, which a feature emulator cannot produce -- it predicts '
+    'the scalar data_item features only. Re-run with use_emulator: false to plot or save '
+    'simulated outputs.')
+
+
+class SimulationHelper:
+    """Emulator-backed drop-in for the solver helpers.
+
+    Args:
+        emulator_dir: directory holding the trained bundle (``emulator_metadata.json`` etc).
+        dt: output sampling step, kept only so the time bookkeeping matches the real backends.
+        sim_time: logged duration.
+        solver_info: accepted and ignored; there is no integrator to configure.
+        pre_time: unlogged spin-up; absorbed into the emulator at training time.
+        bundle: an already-loaded bundle, used instead of reading ``emulator_dir`` (tests, and
+            callers that have validated one already).
+        out_of_bounds: 'error' | 'warn' | 'clip' -- what to do off the training box.
+    """
+
+    emulates_features = True
+
+    def __init__(self, emulator_dir, dt=0.01, sim_time=1.0, solver_info=None, pre_time=0.0,
+                 bundle=None, out_of_bounds='error'):
+        self.emulator_dir = emulator_dir
+        self.solver_info = solver_info or {}
+        self.out_of_bounds = out_of_bounds
+        # Loaded eagerly, on every rank. MCMC's worker ranks block inside the pool and never
+        # reach a lazy first call, so a rank-0-only load would leave them without an emulator.
+        self.bundle = bundle if bundle is not None else EmulatorBundle.load(emulator_dir)
+        _limit_torch_threads()
+
+        self.dt = dt
+        self.sim_time = sim_time
+        self.pre_time = pre_time
+        self.n_steps = 1
+        self.pre_steps = 0
+        self.stop_time = (pre_time or 0.0) + (sim_time or 0.0)
+        self.tSim = np.linspace(pre_time or 0.0, self.stop_time, 2)
+
+        self.param_names = self.bundle.meta.get('param_names') or []
+        self.param_defaults = self.bundle.meta.get('param_defaults') or {}
+        self.num_params = len(self.bundle.param_entry_labels)
+        self._has_modifiers = bool(self.bundle.meta.get('has_modifiers'))
+        self._theta = None
+        self._theta_is_authoritative = False
+        self._features = None
+        self._protocol_info = None
+        self._obs_map = None
+        self._num_obs = None
+
+    # ------------------------------------------------------------------ inputs
+
+    def set_theta(self, theta):
+        """Set the calibration vector directly, in ``params_for_id`` entry order.
+
+        This, not ``set_param_vals``, is the emulator's real input. A modifier entry occupies
+        one slot in theta but names several model parameters, and by the time the executor calls
+        ``set_param_vals`` those slots have already been expanded to per-parameter values --
+        which is the wrong thing to feed a surrogate trained on theta. CA's call sites set theta
+        here before the protocol runs, so no inversion is ever needed.
+        """
+        theta = np.asarray(theta, dtype=float).reshape(-1)
+        if theta.size != self.num_params:
+            raise ValueError(
+                f'the emulator was trained on {self.num_params} parameters '
+                f'({self.bundle.param_entry_labels}) but was given {theta.size} values.')
+        if self._theta is None or not np.array_equal(theta, self._theta):
+            self._features = None
+        self._theta = theta
+        # From here on the executor's set_param_vals for the calibrated set is redundant, and
+        # for a modifier entry it is actively wrong (it carries theta * baseline, not theta).
+        self._theta_is_authoritative = True
+
+    def set_param_vals(self, param_names, param_vals, change_states=True):
+        """Accept the executor's per-parameter values.
+
+        With no modifiers in play these are theta itself, entry for entry, so they are recorded
+        as such and the helper works for a caller that only knows the ordinary interface. With
+        modifiers they are the expanded per-target values, which theta cannot be recovered from
+        here -- ``set_theta`` must have been called, and this is then a consistency check.
+        """
+        names = list(param_names)
+        values = list(param_vals)
+        if len(names) != len(values):
+            raise ValueError(f'{len(names)} parameter name entries against {len(values)} values')
+
+        if self._is_theta_entry_list(names):
+            if self._theta_is_authoritative:
+                # theta came from set_theta for this evaluation; these are its expansion.
+                return
+            if self._has_modifiers:
+                raise RuntimeError(
+                    'this emulator has modifier parameters, whose theta cannot be recovered '
+                    'from expanded parameter values (a modifier slot expands to theta * '
+                    'baseline per target). Call set_theta(theta) first.')
+            theta = [_single_value(entry_names, value)
+                     for entry_names, value in zip(names, values)]
+            self.set_theta(theta)
+            self._theta_is_authoritative = False
+            return
+
+        # Not the calibrated set: the protocol's params_to_change. Those were fixed while the
+        # emulator was trained (the protocol fingerprint enforces it), so there is nothing to
+        # apply -- but a name that belongs to neither set means the caller thinks it is
+        # changing something the emulator cannot see, which must not pass silently.
+        known_protocol = set(map(str, ((self._protocol_info or {}).get('params_to_change') or {})))
+        unknown = [str(name)
+                   for entry, value in zip(names, values)
+                   for name, _ in pair_names_with_values(entry, value)
+                   if str(name) not in self.param_defaults and str(name) not in known_protocol]
+        if unknown:
+            raise ValueError(
+                f'the emulator cannot change {sorted(set(map(str, unknown)))}: it was trained '
+                f'over the params_for_id parameters only, with everything else held at the '
+                f'values it was trained with.')
+
+    def _is_theta_entry_list(self, names):
+        """True when ``names`` is the calibrated parameter set the emulator was trained on."""
+        return _jsonable_names(names) == self.param_names
+
+    # ------------------------------------------------------------------ running
+
+    def run(self):
+        """Predict the feature vector for the current theta. Returns success, like a solver."""
+        if self._theta is None:
+            raise RuntimeError('no parameters have been set on the emulator helper; call '
+                               'set_theta(theta) or set_param_vals(...) before run().')
+        if self._features is None:
+            self._features = self.bundle.predict(self._theta, out_of_bounds=self.out_of_bounds)
+        return True
+
+    def update_times(self, dt, start_time, sim_time, pre_time):
+        """Time bookkeeping only -- nothing is integrated, but ``tSim`` must still be right.
+
+        The protocol executor concatenates each sub-experiment's ``tSim`` onto a cumulative
+        time vector and drops the duplicated first sample, so a missing or single-point axis
+        would break the caller rather than the emulator. Mirrors the opencor backend.
+        """
+        self.dt = dt
+        self.pre_time = pre_time
+        self.sim_time = sim_time
+        self.pre_steps = int(pre_time / dt) if dt else 0
+        self.n_steps = max(int(sim_time / dt) if dt else 1, 1)
+        self.stop_time = start_time + pre_time + self.n_steps * dt
+        self.tSim = np.linspace(start_time + pre_time, self.stop_time, self.n_steps + 1)
+
+    def get_time(self, include_pre_time=False):
+        return self.tSim if include_pre_time else self.tSim - self.pre_time
+
+    # ------------------------------------------------------------------ outputs
+
+    def set_obs_map(self, const_idx_to_obs_idx, num_obs=None):
+        """Tell the helper which data_item each trained feature belongs to.
+
+        The emulator's outputs are ordered by ``obs_info['const_idx_to_obs_idx']`` while the
+        consumers index by data_item. Rather than assume the two coincide, the caller states
+        the mapping once at setup; without it they are taken to be the same, which is true
+        whenever every data_item is a scalar one -- the only case the emulator supports.
+        """
+        self._obs_map = [int(i) for i in const_idx_to_obs_idx]
+        self._num_obs = int(num_obs) if num_obs is not None else (max(self._obs_map) + 1)
+
+    def get_predicted_features(self):
+        """The predicted scalar feature per data_item, ``nan`` for any the emulator misses.
+
+        Indexed by data_item so both reduction sites can read it positionally.
+        """
+        if self._features is None:
+            self.run()
+        mapping = self._obs_map if self._obs_map is not None else list(range(len(self._features)))
+        n_items = self._num_obs if self._num_obs is not None else len(mapping)
+        by_item = np.full(max(n_items, len(mapping)), np.nan)
+        for k, obs_idx in enumerate(mapping):
+            by_item[obs_idx] = self._features[k]
+        return by_item
+
+    def get_results(self, variables_list_of_lists, flatten=False):
+        """The predicted features, in the shape the executor expects from a solver.
+
+        Each operand slot holds a length-1 array carrying its data_item's predicted feature.
+        The consumers that know about ``emulates_features`` read the value and skip the
+        operation; anything else applying ``mean``/``max``/``min`` to it gets the same number
+        back, which is the least surprising thing an unaware caller could receive.
+        """
+        if self._features is None:
+            self.run()
+        by_item = self.get_predicted_features()
+        if self._num_obs is not None and len(variables_list_of_lists) != self._num_obs:
+            # The only list the emulator can answer is the obs_data operands, one entry per
+            # data_item. A different length means something else was asked for -- prediction
+            # variables, most likely, which are traces the emulator does not have.
+            raise NotImplementedError(
+                f'the emulator can only return the {self._num_obs} obs_data data_item features '
+                f'it was trained on, but {len(variables_list_of_lists)} variables were '
+                f'requested. Prediction variables and other model outputs are traces, which '
+                f'{TRACE_REFUSAL}')
+        results = []
+        for item_idx, operands in enumerate(variables_list_of_lists):
+            operand_names = operands if isinstance(operands, (list, tuple)) else [operands]
+            value = by_item[item_idx] if item_idx < by_item.size else np.nan
+            results.append([np.array([value], dtype=float) for _ in operand_names])
+        if flatten:
+            return [array for item in results for array in item]
+        return results
+
+    def get_all_variable_names(self):
+        """The emulator's outputs, named as the observables they are."""
+        return list(self.bundle.feature_labels)
+
+    def get_init_param_vals(self, param_names):
+        """Parameter defaults, served from the snapshot taken when the emulator was trained.
+
+        The optimiser's x0 and ``resolve_modifier_baselines`` both read these before anything
+        is simulated. The emulator has no model to read them from, so training recorded them.
+        """
+        out = []
+        for entry in param_names:
+            names = entry if isinstance(entry, (list, tuple)) else [entry]
+            values = []
+            for name in names:
+                if str(name) not in self.param_defaults:
+                    raise ValueError(
+                        f'the emulator has no recorded default for {name!r}. It records the '
+                        f'params_for_id parameters and any modifier targets/inputs present when '
+                        f'it was trained; retrain it if those have changed.')
+                values.append(float(self.param_defaults[str(name)]))
+            out.append(values if len(values) > 1 else values[0])
+        return out
+
+    def get_default_param_vals(self, param_names):
+        """Same snapshot -- for an emulator the defaults never move, so the two coincide."""
+        return self.get_init_param_vals(param_names)
+
+    # ------------------------------------------------------------------ inert / refused
+
+    def set_protocol_info(self, protocol_info):
+        self._protocol_info = protocol_info
+
+    def reset_states(self):
+        return None
+
+    def reset_and_clear(self, only_one_exp=-1):
+        self._features = None
+        return None
+
+    def close_simulation(self):
+        return None
+
+    def run_offline_pre_and_set_default_state(self, t):
+        # The emulator absorbed every pre-pass at training time; there is no state to settle.
+        return None
+
+    def get_all_results(self, flatten=False):
+        raise NotImplementedError(f'get_all_results {TRACE_REFUSAL}')
+
+    def get_all_results_dict(self):
+        raise NotImplementedError(f'get_all_results_dict {TRACE_REFUSAL}')
+
+    def modify_params_and_run_and_get_results(self, *args, **kwargs):
+        raise NotImplementedError(f'modify_params_and_run_and_get_results {TRACE_REFUSAL}')
+
+
+def _single_value(entry_names, value):
+    """One theta value from an entry that may name several parameters sharing it."""
+    pairs = pair_names_with_values(entry_names, value, context='emulator set_param_vals')
+    values = [float(v) for _, v in pairs]
+    if len(set(values)) > 1:
+        raise ValueError(
+            f'the emulator was trained on one shared value for {entry_names}, but was given '
+            f'differing values {values}. Call set_theta(theta) instead.')
+    return values[0]
+
+
+def _jsonable_names(param_names):
+    return [[str(name) for name in (entry if isinstance(entry, (list, tuple)) else [entry])]
+            for entry in param_names]
+
+
+def _limit_torch_threads():
+    """One thread per rank.
+
+    Under mpiexec every rank holds its own copy of the emulator, and torch's default is to
+    take every core -- N ranks then oversubscribe the machine N-fold and each runs slower than
+    it would alone.
+    """
+    try:
+        import torch
+        torch.set_num_threads(1)
+    except Exception:                                   # pragma: no cover - torch is optional
+        pass

--- a/tests/test_emulator_settings.py
+++ b/tests/test_emulator_settings.py
@@ -167,6 +167,78 @@ def test_fingerprint_changes_with_bounds_observables_and_protocol():
     assert fingerprint(param_id_info, obs_info, protocol_info) == base
 
 
+def test_error_stats_carry_more_than_r2(tmp_path):
+    """R2 alone cannot rank features by how badly the emulator does on them.
+
+    A feature can score well and still read systematically high (bias), and RMSE
+    in one feature's units says nothing against another's (nrmse does). The table
+    an Analysis view draws needs all of them.
+    """
+    bundle = make_bundle()
+    bundle.meta.update({
+        'feature_mae': [0.02, 0.30],
+        'feature_bias': [0.00, -0.25],
+        'feature_max_abs_error': [0.05, 0.90],
+        'feature_nrmse': [0.01, 0.18],
+    })
+    rows = bundle.error_stats()
+    assert [r['label'] for r in rows] == bundle.feature_labels
+    assert rows[1]['bias'] == pytest.approx(-0.25)
+    assert rows[1]['nrmse'] == pytest.approx(0.18)
+    # Ranking by nrmse is what makes "which feature is worst" answerable across
+    # features measured in different units.
+    worst = max(rows, key=lambda r: r['nrmse'])
+    assert worst['label'] == bundle.feature_labels[1]
+
+
+def test_error_stats_report_a_missing_statistic_as_none(tmp_path):
+    """None, not nan: an older bundle has no value for a statistic added later,
+    which is a different thing from one that could not be computed."""
+    bundle = make_bundle()
+    rows = bundle.error_stats()
+    assert rows[0]['r2'] == pytest.approx(0.99)
+    assert rows[0]['bias'] is None
+
+
+def test_held_out_points_round_trip_and_carry_a_signed_residual(tmp_path):
+    """The points are the part statistics cannot replace.
+
+    A parity plot and a residual-against-parameter plot answer *where* the
+    emulator goes wrong, which is what decides whether the region a study cares
+    about is one of the good ones. A consumer cannot recompute them without the
+    emulator, the simulator and the split -- i.e. without being CA.
+    """
+    validation = {
+        'theta': np.array([[0.1, 0.2], [0.5, 0.6]]),
+        'y_true': np.array([[1.0, 2.0], [3.0, 4.0]]),
+        'y_pred': np.array([[1.1, 2.0], [2.7, 4.4]]),
+    }
+    bundle = make_bundle()
+    bundle.validation = validation
+    bundle.save(str(tmp_path))
+    assert os.path.isfile(tmp_path / 'emulator_validation.npz')
+
+    reloaded = EmulatorBundle.load(str(tmp_path))
+    points = reloaded.error_points()
+    assert points['theta'] == pytest.approx(validation['theta'])
+    assert points['y_true'] == pytest.approx(validation['y_true'])
+    # Sign convention fixed here so every consumer agrees: prediction minus truth,
+    # so a positive residual means the emulator reads high.
+    assert points['residual'][0][0] == pytest.approx(0.1)
+    assert points['residual'][1][0] == pytest.approx(-0.3)
+    # Labelled, so a plot can name its axes without re-deriving them.
+    assert points['feature_labels'] == reloaded.feature_labels
+    assert points['param_entry_labels'] == reloaded.param_entry_labels
+
+
+def test_a_bundle_without_held_out_points_says_so(tmp_path):
+    """An emulator trained before this existed is still a usable emulator."""
+    bundle = make_bundle()
+    bundle.save(str(tmp_path))
+    assert not os.path.isfile(tmp_path / 'emulator_validation.npz')
+    assert EmulatorBundle.load(str(tmp_path)).error_points() is None
+
+
 def test_bundle_round_trips_through_disk(tmp_path):
     bundle = make_bundle()
     bundle.x_train = np.array([[0.1, 0.2], [0.3, 0.4]])

--- a/tests/test_emulator_settings.py
+++ b/tests/test_emulator_settings.py
@@ -1,0 +1,194 @@
+"""The emulator artefact and its refusal rules (issue #333).
+
+An emulator that is merely inaccurate is not the danger -- it is an emulator that is
+inaccurate, out of its training range, or fitted against a different model, and answers anyway.
+Every test here is about one of those refusals firing, and firing with a message that names
+what is wrong. They use a stub predictor, so the whole seam is covered without autoemulate (and
+therefore without torch) being installed.
+"""
+import json
+import os
+
+import numpy as np
+import pytest
+
+from emulators.emulator_bundle import (EmulatorBoundsError, EmulatorBundle,
+                                       EmulatorQualityError, fingerprint)
+from parsers.PrimitiveParsers import ANALYSIS_OPTIONS, YamlFileParser, gradient_sources
+
+pytestmark = pytest.mark.unit
+
+
+class LinearStub:
+    """A trivial emulator: y = x @ w. Enough to exercise every path except the fit."""
+
+    def __init__(self, weights):
+        self.weights = np.asarray(weights, dtype=float)
+
+    def predict(self, x):
+        return np.asarray(x, dtype=float) @ self.weights
+
+
+def make_bundle(tmp_path=None, feature_r2=(0.99, 0.98), mins=(0.0, 0.0), maxs=(1.0, 1.0),
+                fingerprint_value='abc123', x_span=(1.0, 1.0), y_span=(1.0, 1.0)):
+    meta = {
+        'param_entry_labels': ['alpha', 'beta'],
+        'param_mins': list(mins),
+        'param_maxs': list(maxs),
+        'param_names': [['comp/alpha'], ['comp/beta']],
+        'param_defaults': {'comp/alpha': 0.5, 'comp/beta': 0.5},
+        'feature_labels': ['max (max comp/x)', 'mean (mean comp/y)'],
+        'feature_r2': list(feature_r2),
+        'feature_rmse': [0.01, 0.02],
+        'x_scale': {'shift': [0.0, 0.0], 'span': list(x_span)},
+        'y_scale': {'shift': [0.0, 0.0], 'span': list(y_span)},
+        'fingerprint': {'inputs_sha256': fingerprint_value},
+    }
+    model = LinearStub([[2.0, 0.0], [0.0, 3.0]])
+    return EmulatorBundle(model, meta)
+
+
+def test_predict_inverts_the_stored_scaling():
+    """The transforms live in the bundle, not in the fitting code.
+
+    CA parameters span orders of magnitude and autoemulate works in float32, so the scaling is
+    not optional -- and an emulator reloaded without it would predict in the wrong units while
+    looking entirely healthy.
+    """
+    bundle = make_bundle(mins=(0.0, 0.0), maxs=(10.0, 10.0),
+                         x_span=(2.0, 4.0), y_span=(10.0, 100.0))
+    # scale_x halves/quarters the input, the stub doubles/triples, unscale_y multiplies back
+    features = bundle.predict(np.array([2.0, 4.0]))
+    assert features == pytest.approx([2.0 / 2.0 * 2.0 * 10.0, 4.0 / 4.0 * 3.0 * 100.0])
+
+
+def test_a_low_r2_emulator_is_refused_by_name():
+    bundle = make_bundle(feature_r2=(0.99, 0.42))
+    bundle.check_quality(0.4)   # the threshold is the user's, so a lenient one still passes
+    with pytest.raises(EmulatorQualityError) as excinfo:
+        bundle.check_quality(0.9)
+    message = str(excinfo.value)
+    # Naming the feature is the point: "the emulator is bad" is not actionable.
+    assert 'mean (mean comp/y)' in message
+    assert '0.42' in message
+
+
+def test_nan_r2_counts_as_unusable():
+    """A feature that could not be scored is not a feature that scored well."""
+    bundle = make_bundle(feature_r2=(0.99, float('nan')))
+    with pytest.raises(EmulatorQualityError):
+        bundle.check_quality(0.9)
+
+
+def test_out_of_box_evaluation_is_refused_by_default():
+    bundle = make_bundle(mins=(0.0, 0.0), maxs=(1.0, 1.0))
+    with pytest.raises(EmulatorBoundsError) as excinfo:
+        bundle.predict(np.array([1.5, 0.5]))
+    message = str(excinfo.value)
+    assert 'alpha' in message and '1.5' in message
+    assert 'beta' not in message, 'only the offending parameter should be named'
+
+
+def test_out_of_box_policies_warn_and_clip():
+    bundle = make_bundle()
+    warned = bundle.predict(np.array([1.5, 0.5]), out_of_bounds='warn')
+    assert warned[0] == pytest.approx(3.0), 'warn must still extrapolate, not clip'
+    clipped = bundle.predict(np.array([1.5, 0.5]), out_of_bounds='clip')
+    assert clipped[0] == pytest.approx(2.0), 'clip must evaluate at the boundary'
+
+
+def test_a_stale_emulator_is_refused():
+    """Changed bounds, observables, protocol or model => a different theta -> features map.
+
+    Nothing about the emulator itself changes when those do, which is exactly why this has to
+    be checked rather than noticed.
+    """
+    bundle = make_bundle(fingerprint_value='abc123')
+    bundle.check_matches({'inputs_sha256': 'abc123'})
+    with pytest.raises(EmulatorQualityError, match='stale'):
+        bundle.check_matches({'inputs_sha256': 'deadbeef'})
+
+
+def test_changed_parameters_or_observables_are_refused():
+    bundle = make_bundle()
+    with pytest.raises(EmulatorQualityError, match='trained for parameters'):
+        bundle.check_matches({}, param_entry_labels=['alpha', 'gamma'])
+    with pytest.raises(EmulatorQualityError, match='trained for observables'):
+        bundle.check_matches({}, feature_labels=['something else'])
+
+
+def test_fingerprint_changes_with_bounds_observables_and_protocol():
+    param_id_info = {'param_names': [['comp/alpha']], 'param_mins': np.array([0.0]),
+                     'param_maxs': np.array([1.0])}
+    obs_info = {'operands': [['comp/x']], 'operations': ['max'], 'operation_kwargs': [None],
+                'data_types': ['constant'], 'experiment_idxs': [0], 'subexperiment_idxs': [0]}
+    protocol_info = {'pre_times': [0.0], 'sim_times': [[5]], 'params_to_change': {}}
+
+    base = fingerprint(param_id_info, obs_info, protocol_info)
+    widened = dict(param_id_info, param_maxs=np.array([2.0]))
+    assert fingerprint(widened, obs_info, protocol_info) != base
+    reoperated = dict(obs_info, operations=['min'])
+    assert fingerprint(param_id_info, reoperated, protocol_info) != base
+    relengthened = dict(protocol_info, sim_times=[[10]])
+    assert fingerprint(param_id_info, obs_info, relengthened) != base
+    # ... and is stable for an unchanged setup, or every run would look stale
+    assert fingerprint(param_id_info, obs_info, protocol_info) == base
+
+
+def test_bundle_round_trips_through_disk(tmp_path):
+    bundle = make_bundle()
+    bundle.x_train = np.array([[0.1, 0.2], [0.3, 0.4]])
+    bundle.y_train = np.array([[0.2, 0.6], [0.6, 1.2]])
+    bundle.save(str(tmp_path))
+
+    assert os.path.isfile(tmp_path / 'emulator_metadata.json')
+    reloaded = EmulatorBundle.load(str(tmp_path))
+    assert reloaded.feature_labels == bundle.feature_labels
+    assert reloaded.predict(np.array([0.5, 0.5])) == pytest.approx(bundle.predict([0.5, 0.5]))
+    # The design is kept so the emulator can be refitted or extended without re-simulating --
+    # the expensive half of training is the runs, not the fit.
+    assert reloaded.x_train == pytest.approx(bundle.x_train)
+
+
+def test_loading_from_an_empty_directory_says_how_to_train_one(tmp_path):
+    with pytest.raises(FileNotFoundError, match='run_emulator_training'):
+        EmulatorBundle.load(str(tmp_path))
+
+
+def test_metadata_missing_a_required_key_is_rejected():
+    with pytest.raises(ValueError, match='missing'):
+        EmulatorBundle(LinearStub([[1.0]]), {'param_entry_labels': ['a']})
+
+
+def test_user_inputs_defaults_match_the_schema(base_user_inputs, resources_dir):
+    """The parser's fill-ins and the advertised defaults are the same numbers.
+
+    A settings form shows the schema's default; the run uses the parser's. If they disagree,
+    the form tells the user something the run does not do.
+    """
+    config = base_user_inputs.copy()
+    config.update({'resources_dir': resources_dir})
+    config.pop('emulator_settings', None)
+    config.pop('do_emulation', None)
+    config.pop('use_emulator', None)
+    parsed = YamlFileParser().parse_user_inputs_file(
+        config, obs_path_needed=False, do_generation_with_fit_parameters=False)
+
+    assert parsed['do_emulation'] is False
+    assert parsed['use_emulator'] is False
+    for descriptor in ANALYSIS_OPTIONS['emulation']['options']:
+        assert parsed['emulator_settings'][descriptor['name']] == descriptor['default'], (
+            f"emulator_settings.{descriptor['name']} default disagrees with the schema")
+
+
+def test_gradient_menu_over_an_emulator_offers_finite_differences_only():
+    """The analytic arms differentiate the real model, which an emulator run is not evaluating.
+
+    Offering AD there would mean the optimiser descends a different function than the cost it
+    reports, so the menu a front-end builds must not contain it.
+    """
+    for model_type in ('cellml_only', 'casadi_python', 'aadc_python', 'python'):
+        values = [s['value'] for s in gradient_sources(model_type, use_emulator=True)]
+        assert values == ['FD'], f'{model_type} offered {values} over an emulator'
+    # ... and the ordinary menu is untouched
+    assert 'AD' in [s['value'] for s in gradient_sources('casadi_python')]

--- a/tests/test_emulator_settings.py
+++ b/tests/test_emulator_settings.py
@@ -62,6 +62,38 @@ def test_predict_inverts_the_stored_scaling():
     assert features == pytest.approx([2.0 / 2.0 * 2.0 * 10.0, 4.0 / 4.0 * 3.0 * 100.0])
 
 
+class DistributionStub:
+    """A probabilistic emulator: predict returns a distribution, not an array.
+
+    ``.mean`` is a property here, exactly as it is on a torch distribution -- as opposed to a
+    tensor or ndarray, where ``.mean`` is a method.
+    """
+
+    class _Gaussian:
+        def __init__(self, values):
+            self.mean = values
+
+    def __init__(self, weights):
+        self.weights = np.asarray(weights, dtype=float)
+
+    def predict(self, x):
+        return self._Gaussian(np.asarray(x, dtype=float) @ self.weights)
+
+
+def test_a_probabilistic_emulator_is_read_through_its_mean():
+    """Every Gaussian process -- autoemulate's default -- returns a distribution.
+
+    Taking ``.mean`` off it by truthiness would grab the *method* on a plain tensor and turn
+    every prediction into a bound method, so the distinction has to be by callability.
+    """
+    bundle = make_bundle()
+    bundle.model = DistributionStub([[2.0, 0.0], [0.0, 3.0]])
+    assert bundle.predict(np.array([0.5, 0.5])) == pytest.approx([1.0, 1.5])
+    # ... and the deterministic (array-returning) emulator still works
+    bundle.model = LinearStub([[2.0, 0.0], [0.0, 3.0]])
+    assert bundle.predict(np.array([0.5, 0.5])) == pytest.approx([1.0, 1.5])
+
+
 def test_a_low_r2_emulator_is_refused_by_name():
     bundle = make_bundle(feature_r2=(0.99, 0.42))
     bundle.check_quality(0.4)   # the threshold is the user's, so a lenient one still passes

--- a/tests/test_emulator_solver_helper.py
+++ b/tests/test_emulator_solver_helper.py
@@ -3,6 +3,10 @@
 These build a real ``CVS0DParamID`` over a stub emulator and no solver at all -- which is the
 point of putting the emulator behind the helper interface: nothing above it has to change, and
 nothing below it has to exist. autoemulate is not needed, so these run everywhere.
+
+The obs_data and params_for_id come from ``Simple_ODE_Benchmark`` (two parameters, two scalar
+features), matching test_emulator_training.py. Nothing is simulated here -- they are only a
+realistic shape for the parsers to produce.
 """
 import os
 
@@ -30,12 +34,14 @@ class LinearStub:
 def _config(base_user_inputs, resources_dir, tmp_path, **overrides):
     config = base_user_inputs.copy()
     config.update({
-        'file_prefix': 'Lotka_Volterra',
-        'input_param_file': 'Lotka_Volterra_parameters.csv',
+        'file_prefix': 'Simple_ODE_Benchmark',
+        'input_param_file': 'Simple_ODE_Benchmark_parameters.csv',
         'model_type': 'cellml_only',
         'resources_dir': resources_dir,
-        'param_id_obs_path': os.path.join(resources_dir, 'Lotka_Volterra_obs_data.json'),
-        'params_for_id_path': os.path.join(resources_dir, 'Lotka_Volterra_params_for_id.csv'),
+        'param_id_obs_path': os.path.join(resources_dir,
+                                          'Simple_ODE_Benchmark_obs_data.json'),
+        'params_for_id_path': os.path.join(resources_dir,
+                                           'Simple_ODE_Benchmark_params_for_id.csv'),
         'param_id_output_dir': str(tmp_path / 'param_id_output'),
         'param_id_method': 'genetic_algorithm',
         'DEBUG': True,
@@ -213,10 +219,11 @@ def test_cost_path_uses_the_predicted_features_and_skips_the_operation(
         base_user_inputs, resources_dir, tmp_path):
     """The whole point of the seam.
 
-    Both Lotka_Volterra observables are ``max`` of a trace. Re-applying an operation to an
-    already-reduced scalar is invisible for ``max`` -- but ``max_minus_min`` of one value is
-    zero, so this must be verified as "the operation did not run", not "the number looked
-    plausible". get_obs_output_dict returning exactly the emulator's vector is that check.
+    Both benchmark observables are ``steady_state_avg`` of a trace -- the mean of its second
+    half. Re-applying that to an already-reduced scalar is invisible (the mean of one value is
+    itself), and for an operation like ``max_minus_min`` it would silently be zero. So this has
+    to be verified as "the operation did not run", not "the number looked plausible", and
+    get_obs_output_dict returning exactly the emulator's vector is that check.
     """
     config = _config(base_user_inputs, resources_dir, tmp_path)
     bundle, _, _ = _write_bundle(config)

--- a/tests/test_emulator_solver_helper.py
+++ b/tests/test_emulator_solver_helper.py
@@ -1,0 +1,352 @@
+"""The emulator as a SimulationHelper, and the cost path that runs on it (issue #333).
+
+These build a real ``CVS0DParamID`` over a stub emulator and no solver at all -- which is the
+point of putting the emulator behind the helper interface: nothing above it has to change, and
+nothing below it has to exist. autoemulate is not needed, so these run everywhere.
+"""
+import os
+
+import numpy as np
+import pytest
+
+from emulators.emulator_bundle import EmulatorBundle, fingerprint
+from param_id.paramID import CVS0DParamID, emulated_feature_labels
+from parsers.PrimitiveParsers import (ObsAndParamDataParser, YamlFileParser,
+                                      param_entry_labels)
+
+pytestmark = pytest.mark.unit
+
+
+class LinearStub:
+    """features = x @ w, where x is the unit-box theta the bundle hands over."""
+
+    def __init__(self, weights):
+        self.weights = np.asarray(weights, dtype=float)
+
+    def predict(self, x):
+        return np.asarray(x, dtype=float) @ self.weights
+
+
+def _config(base_user_inputs, resources_dir, tmp_path, **overrides):
+    config = base_user_inputs.copy()
+    config.update({
+        'file_prefix': 'Lotka_Volterra',
+        'input_param_file': 'Lotka_Volterra_parameters.csv',
+        'model_type': 'cellml_only',
+        'resources_dir': resources_dir,
+        'param_id_obs_path': os.path.join(resources_dir, 'Lotka_Volterra_obs_data.json'),
+        'params_for_id_path': os.path.join(resources_dir, 'Lotka_Volterra_params_for_id.csv'),
+        'param_id_output_dir': str(tmp_path / 'param_id_output'),
+        'param_id_method': 'genetic_algorithm',
+        'DEBUG': True,
+        'use_emulator': True,
+        'emulator_settings': {'emulator_dir': str(tmp_path / 'emulator'), 'min_r2': 0.5},
+    })
+    config.update(overrides)
+    return YamlFileParser().parse_user_inputs_file(
+        config, obs_path_needed=True, do_generation_with_fit_parameters=False)
+
+
+def _parse_infos(config):
+    """obs_info / protocol_info / param_id_info, via the same parser CVS0DParamID uses."""
+    # process_obs_info writes the ground-truth npys, so it needs somewhere to write them.
+    scratch = os.path.join(config['emulator_settings']['emulator_dir'], '_parsed')
+    os.makedirs(scratch, exist_ok=True)
+    parser = ObsAndParamDataParser()
+    parsed = parser.parse_obs_data_json(
+        param_id_obs_path=config['param_id_obs_path'],
+        pre_time=config['pre_time'], sim_time=config['sim_time'],
+        model_type=config['model_type'], method=config['solver_info'].get('method'))
+    obs_info = parser.process_obs_info(gt_df=parsed['gt_df'], output_dir=scratch,
+                                       dt=config['dt'])
+    protocol_info = parser.process_protocol_and_weights(
+        gt_df=parsed['gt_df'], protocol_info=parsed['protocol_info'], dt=config['dt'])
+    param_id_info = parser.get_param_id_info(config['params_for_id_path'])
+    return obs_info, protocol_info, param_id_info
+
+
+def _write_bundle(config, weights=None, feature_r2=None, fingerprint_override=None,
+                  param_maxs=None):
+    """Write a stub bundle that matches this config, the way training would."""
+    obs_info, protocol_info, param_id_info = _parse_infos(config)
+    if param_maxs is not None:
+        param_id_info['param_maxs'] = np.asarray(param_maxs, dtype=float)
+    labels = emulated_feature_labels(obs_info)
+    num_params = len(param_id_info['param_names'])
+
+    if weights is None:
+        # Something varying in every parameter, so a finite-difference gradient is non-trivial.
+        weights = np.arange(1, num_params * len(labels) + 1, dtype=float).reshape(
+            num_params, len(labels))
+    digest = fingerprint(param_id_info, obs_info, protocol_info)
+    if fingerprint_override is not None:
+        digest = {'inputs_sha256': fingerprint_override}
+
+    meta = {
+        'param_entry_labels': param_entry_labels(param_id_info),
+        'param_mins': [float(v) for v in param_id_info['param_mins']],
+        'param_maxs': [float(v) for v in param_id_info['param_maxs']],
+        'param_names': [[str(n) for n in entry] for entry in param_id_info['param_names']],
+        'param_defaults': {str(name): 1.0
+                           for entry in param_id_info['param_names'] for name in entry},
+        'feature_labels': labels,
+        'feature_r2': list(feature_r2) if feature_r2 else [0.99] * len(labels),
+        'feature_rmse': [0.01] * len(labels),
+        'x_scale': {'shift': [float(v) for v in param_id_info['param_mins']],
+                    'span': [float(hi - lo) for lo, hi in zip(param_id_info['param_mins'],
+                                                              param_id_info['param_maxs'])]},
+        'y_scale': {'shift': [0.0] * len(labels), 'span': [1.0] * len(labels)},
+        'fingerprint': digest,
+    }
+    bundle = EmulatorBundle(LinearStub(weights), meta)
+    bundle.save(config['emulator_settings']['emulator_dir'])
+    return bundle, obs_info, param_id_info
+
+
+# --------------------------------------------------------------------------- the helper alone
+
+def test_helper_returns_one_predicted_feature_per_data_item(base_user_inputs, resources_dir,
+                                                            tmp_path):
+    from solver_wrappers import get_simulation_helper
+
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    bundle, obs_info, param_id_info = _write_bundle(config)
+
+    helper = get_simulation_helper(
+        solver='CVODE_myokit', model_type='cellml_only', model_path='not/used.cellml',
+        dt=0.01, sim_time=5.0, use_emulator=True,
+        emulator_dir=config['emulator_settings']['emulator_dir'])
+    assert helper.emulates_features is True
+
+    helper.set_obs_map(obs_info['const_idx_to_obs_idx'], num_obs=obs_info['num_obs'])
+    theta = np.asarray(param_id_info['param_mins'], dtype=float)
+    helper.set_theta(theta)
+    assert helper.run() is True
+
+    results = helper.get_results(obs_info['operands'])
+    assert len(results) == obs_info['num_obs']
+    expected = bundle.predict(theta)
+    for item_idx, operands in enumerate(obs_info['operands']):
+        assert len(results[item_idx]) == len(operands)
+        for operand_result in results[item_idx]:
+            # A length-1 array per operand: the shape a solver returns, holding the feature.
+            assert operand_result.shape == (1,)
+            assert operand_result[0] == pytest.approx(expected[item_idx])
+
+
+def test_helper_keeps_the_time_axis_the_executor_relies_on(base_user_inputs, resources_dir,
+                                                           tmp_path):
+    """Nothing is integrated, but the protocol executor still concatenates tSim per
+    sub-experiment and drops the duplicated first sample. A single-point axis would break it."""
+    from solver_wrappers import get_simulation_helper
+
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    _write_bundle(config)
+    helper = get_simulation_helper(
+        solver='CVODE_myokit', model_type='cellml_only', model_path='not/used.cellml',
+        dt=0.01, sim_time=5.0, use_emulator=True,
+        emulator_dir=config['emulator_settings']['emulator_dir'])
+
+    helper.update_times(0.01, 0.0, 2.0, 1.0)
+    assert len(helper.tSim) == 201
+    assert helper.tSim[0] == pytest.approx(1.0)
+    assert helper.get_time()[0] == pytest.approx(0.0)
+    # A sim_time shorter than dt must still leave something to concatenate.
+    helper.update_times(0.1, 0.0, 0.01, 0.0)
+    assert len(helper.tSim) >= 2
+
+
+def test_helper_refuses_to_invent_traces(base_user_inputs, resources_dir, tmp_path):
+    from solver_wrappers import get_simulation_helper
+
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    _write_bundle(config)
+    helper = get_simulation_helper(
+        solver='CVODE_myokit', model_type='cellml_only', model_path='not/used.cellml',
+        dt=0.01, sim_time=5.0, use_emulator=True,
+        emulator_dir=config['emulator_settings']['emulator_dir'])
+
+    with pytest.raises(NotImplementedError, match='trace'):
+        helper.get_all_results_dict()
+    with pytest.raises(NotImplementedError, match='trace'):
+        helper.get_all_results()
+
+
+def test_helper_refuses_a_parameter_it_cannot_see(base_user_inputs, resources_dir, tmp_path):
+    """Silently ignoring a set_param_vals it cannot honour would be a wrong answer, not an
+    approximation: the caller believes it changed something."""
+    from solver_wrappers import get_simulation_helper
+
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    _write_bundle(config)
+    helper = get_simulation_helper(
+        solver='CVODE_myokit', model_type='cellml_only', model_path='not/used.cellml',
+        dt=0.01, sim_time=5.0, use_emulator=True,
+        emulator_dir=config['emulator_settings']['emulator_dir'])
+
+    with pytest.raises(ValueError, match='cannot change'):
+        helper.set_param_vals([['some/other_param']], [3.0])
+
+
+def test_helper_serves_defaults_recorded_at_training_time(base_user_inputs, resources_dir,
+                                                          tmp_path):
+    """x0 and modifier baselines are read before anything simulates, and the emulator has no
+    model to read them from -- so training records them and the helper serves them."""
+    from solver_wrappers import get_simulation_helper
+
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    _, _, param_id_info = _write_bundle(config)
+    helper = get_simulation_helper(
+        solver='CVODE_myokit', model_type='cellml_only', model_path='not/used.cellml',
+        dt=0.01, sim_time=5.0, use_emulator=True,
+        emulator_dir=config['emulator_settings']['emulator_dir'])
+
+    values = helper.get_init_param_vals(param_id_info['param_names'])
+    assert values == [1.0] * len(param_id_info['param_names'])
+    with pytest.raises(ValueError, match='no recorded default'):
+        helper.get_init_param_vals([['never/trained']])
+
+
+# --------------------------------------------------------------- the cost path over an emulator
+
+def test_cost_path_uses_the_predicted_features_and_skips_the_operation(
+        base_user_inputs, resources_dir, tmp_path):
+    """The whole point of the seam.
+
+    Both Lotka_Volterra observables are ``max`` of a trace. Re-applying an operation to an
+    already-reduced scalar is invisible for ``max`` -- but ``max_minus_min`` of one value is
+    zero, so this must be verified as "the operation did not run", not "the number looked
+    plausible". get_obs_output_dict returning exactly the emulator's vector is that check.
+    """
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    bundle, _, _ = _write_bundle(config)
+
+    pid = CVS0DParamID.init_from_dict(config)
+    engine = pid.param_id
+    assert engine.emulates_features is True
+
+    theta = np.asarray(engine.param_id_info['param_mins'], dtype=float) * 1.5
+    cost, operands_list, _ = engine.get_cost_obs_and_pred_from_params(theta)
+    assert np.isfinite(cost)
+
+    obs_dict = engine.get_obs_output_dict(operands_list[0])
+    assert np.asarray(obs_dict['const']) == pytest.approx(bundle.predict(theta))
+
+
+def test_gradient_over_an_emulator_is_finite_differences(base_user_inputs, resources_dir,
+                                                         tmp_path):
+    """get_gradient must not raise here, because sp_minimize calls it unconditionally."""
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    _write_bundle(config)
+
+    engine = CVS0DParamID.init_from_dict(config).param_id
+    mins = np.asarray(engine.param_id_info['param_mins'], dtype=float)
+    maxs = np.asarray(engine.param_id_info['param_maxs'], dtype=float)
+    theta = 0.5 * (mins + maxs)
+
+    gradient = engine.get_gradient(theta)
+    assert gradient.shape == theta.shape
+    assert np.all(np.isfinite(gradient))
+    # The emulator is linear in theta and the cost is quadratic in the features, so the
+    # gradient is non-trivial -- a zero vector would mean the emulator never moved.
+    assert np.any(np.abs(gradient) > 0)
+
+
+def test_gradient_at_a_bound_stays_inside_the_training_box(base_user_inputs, resources_dir,
+                                                           tmp_path):
+    """An optimiser reaching a bound must not be refused mid-descent.
+
+    A central difference at the upper bound would step outside the box the emulator was
+    trained in -- which the emulator (rightly) refuses. The difference becomes one-sided
+    there instead, so the gradient stays exact for the function being minimised.
+    """
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    _write_bundle(config)
+    engine = CVS0DParamID.init_from_dict(config).param_id
+
+    at_max = np.asarray(engine.param_id_info['param_maxs'], dtype=float)
+    gradient = engine.get_gradient(at_max)
+    assert np.all(np.isfinite(gradient))
+
+    at_min = np.asarray(engine.param_id_info['param_mins'], dtype=float)
+    assert np.all(np.isfinite(engine.get_gradient(at_min)))
+
+
+def test_do_ad_is_turned_off_for_an_emulator(base_user_inputs, resources_dir, tmp_path):
+    config = _config(base_user_inputs, resources_dir, tmp_path, do_ad=True)
+    _write_bundle(config)
+    engine = CVS0DParamID.init_from_dict(config).param_id
+    # Left on, get_cost_from_operands would push emulator scalars through the CasADi-mode
+    # operation funcs, and reset would be suppressed across experiments.
+    assert engine.do_ad is False
+
+
+def test_a_stale_emulator_is_refused_at_setup(base_user_inputs, resources_dir, tmp_path):
+    """Refused when the engine is built, not on the thousandth cost evaluation."""
+    from emulators.emulator_bundle import EmulatorQualityError
+
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    _write_bundle(config, fingerprint_override='not-this-model')
+    with pytest.raises(EmulatorQualityError, match='stale'):
+        CVS0DParamID.init_from_dict(config)
+
+
+def test_a_poor_emulator_is_refused_at_setup(base_user_inputs, resources_dir, tmp_path):
+    from emulators.emulator_bundle import EmulatorQualityError
+
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    config['emulator_settings']['min_r2'] = 0.95
+    _write_bundle(config, feature_r2=[0.99, 0.30])
+    with pytest.raises(EmulatorQualityError, match='below the configured min_r2'):
+        CVS0DParamID.init_from_dict(config)
+
+
+def test_series_observables_are_refused_with_a_clear_message(base_user_inputs, resources_dir,
+                                                             tmp_path):
+    """Series emulation is the deferred follow-up, so it must say so rather than mis-answer."""
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    _write_bundle(config)
+
+    engine_config = dict(config)
+    pid = CVS0DParamID.init_from_dict(engine_config)
+    engine = pid.param_id
+    engine.obs_info['data_types'] = ['series'] + list(engine.obs_info['data_types'][1:])
+    with pytest.raises(ValueError, match='series'):
+        engine._configure_emulator()
+
+
+def test_sobol_sensitivity_runs_on_the_emulator(base_user_inputs, resources_dir, tmp_path):
+    """Sobol is the analysis an emulator most obviously pays for: num_samples*(2M+2)
+    evaluations, none of which now touch the solver.
+
+    The sampling manager reduces operands to features in its own loop, separate from the cost
+    path's, so it needs its own skip -- and this is what proves both were changed. With the stub
+    emulator no model is compiled at all, which is also the point.
+    """
+    from sensitivity_analysis.sensitivityAnalysis import SensitivityAnalysis
+
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    bundle, obs_info, param_id_info = _write_bundle(config)
+    config['sa_options'] = {
+        'method': 'sobol', 'num_samples': 8, 'sample_type': 'saltelli',
+        'output_dir': str(tmp_path / 'sa_out'),
+    }
+    config['model_path'] = 'not/used.cellml'
+
+    sa = SensitivityAnalysis.init_from_dict(config)
+    manager = sa.SA_manager
+    manager.set_sa_options(config['sa_options'])
+
+    samples = manager.generate_samples()
+    num_params = len(param_id_info['param_names'])
+    assert len(samples) == 8 * (2 * num_params + 2)
+
+    outputs = manager.generate_outputs_mpi(samples)
+    assert manager.sim_helper.emulates_features is True
+    assert outputs.shape == (len(samples), obs_info['num_obs'])
+    # Every row is the emulator's own prediction for that sample, not a re-reduced trace.
+    assert outputs[0] == pytest.approx(bundle.predict(samples[0]))
+
+    # ... and the indices come out of it, which is the analysis the user actually asked for.
+    S1, ST, S2 = manager.sobol_index(outputs)
+    assert len(S1) == obs_info['num_obs']

--- a/tests/test_emulator_solver_helper.py
+++ b/tests/test_emulator_solver_helper.py
@@ -259,6 +259,76 @@ def test_gradient_over_an_emulator_is_finite_differences(base_user_inputs, resou
     assert np.any(np.abs(gradient) > 0)
 
 
+def test_simulating_the_best_fit_degrades_instead_of_raising(
+        base_user_inputs, resources_dir, tmp_path):
+    """Callers pair this with plot_outputs() in one try block.
+
+    Raising here therefore cost the run its observable errors as well as its
+    traces -- the whole post-calibration report, for a run that had finished
+    perfectly well. There is simply nothing to re-simulate: the emulator's
+    features are the result.
+    """
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    _write_bundle(config)
+    pid = CVS0DParamID.init_from_dict(config)
+    pid.param_id.best_param_vals = np.asarray(
+        pid.param_id.param_id_info['param_mins'], dtype=float)
+
+    assert pid.simulate_with_best_param_vals() is None
+    assert pid.simulate_with_best_param_vals(return_series=True) == (None, None)
+    assert pid.best_output_calculated is True
+
+
+def test_a_calibration_on_an_emulator_still_writes_its_observable_errors(
+        base_user_inputs, resources_dir, tmp_path):
+    """A finished run must have something to show for itself.
+
+    An emulator has no traces, so the reconstruction plots cannot be drawn -- but
+    the observable *errors* are a comparison of feature against ground truth, and
+    that is exactly what an emulator has. Losing them along with the traces left a
+    completed calibration looking like it had produced nothing, because the error
+    vectors are what the outputs directory (and anything reading it) shows.
+    """
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    _write_bundle(config)
+
+    pid = CVS0DParamID.init_from_dict(config)
+    engine = pid.param_id
+    engine.best_param_vals = np.asarray(engine.param_id_info['param_mins'], dtype=float) * 1.2
+
+    from param_id.plot_outputs import ParamIDPlotOutputs
+
+    plotter = ParamIDPlotOutputs(pid)
+    percent, std = plotter.emulator_error_vectors()
+
+    assert percent.shape == (engine.obs_info['num_obs'],)
+    assert np.all(np.isfinite(percent))
+    assert np.all(np.isfinite(std))
+    # Not all zero: a zero vector is what "we never evaluated anything" looks
+    # like, and is indistinguishable from a perfect fit.
+    assert np.any(np.abs(percent) > 0)
+
+
+def test_all_series_degrades_rather_than_raising_on_an_emulator(
+        base_user_inputs, resources_dir, tmp_path):
+    """get_all_series asks for two things: the features and their traces.
+
+    Refusing outright cost the caller the features too, which is what stopped a
+    calibration writing its errors. The traces come back as None; the features
+    are the emulator's own.
+    """
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    bundle, _, _ = _write_bundle(config)
+    engine = CVS0DParamID.init_from_dict(config).param_id
+
+    theta = np.asarray(engine.param_id_info['param_mins'], dtype=float) * 1.1
+    _, operands_list, _ = engine.get_cost_obs_and_pred_from_params(theta)
+    obs_dict, all_series = engine.get_obs_output_dict(operands_list[0], get_all_series=True)
+
+    assert np.asarray(obs_dict['const']) == pytest.approx(bundle.predict(theta))
+    assert all(series is None for series in all_series)
+
+
 def test_gradient_at_a_bound_stays_inside_the_training_box(base_user_inputs, resources_dir,
                                                            tmp_path):
     """An optimiser reaching a bound must not be refused mid-descent.

--- a/tests/test_emulator_training.py
+++ b/tests/test_emulator_training.py
@@ -1,13 +1,21 @@
 """Training an emulator against the real solver, and then calibrating on it (issue #333).
 
-Two layers, because the two halves fail in different ways and only one of them needs a heavy
-optional dependency:
+The model is ``Simple_ODE_Benchmark``, CA's analytic benchmark: ``dx/dt = -x + p`` and
+``dy/dt = -3y + q``, observed as the steady-state averages of x and y. It is the right fixture
+for an emulator precisely because it is dull -- smooth and monotone, with no bifurcations or
+oscillations -- and because the answer is known in closed form: the features are ``p`` and
+``q/3`` to within the leftover transient, measured here at 0.03 and 1e-6 absolute. So the
+emulator can be checked against arithmetic rather than against another simulation, which is
+what makes a scaling or ordering bug impossible to mistake for a merely mediocre fit.
+
+Two layers, because the two halves fail in different ways and only one needs a heavy optional
+dependency:
 
 * the CA half -- design over the params_for_id box, simulate it (across MPI ranks), reduce each
   run to the same features the cost uses, and record the metadata a later run validates
   against. Tested with the fit stubbed out, so it runs everywhere.
-* the autoemulate half -- the fit itself, and whether an emulator trained this way actually
-  reproduces the simulator well enough to calibrate on. Skipped when autoemulate is absent.
+* the autoemulate half -- the fit itself, and whether the emulator recovers ``p`` and ``q/3``.
+  Skipped when autoemulate is absent.
 """
 import os
 
@@ -24,6 +32,12 @@ try:
     from mpi4py import MPI
 except ImportError:                                       # pragma: no cover - env dependent
     MPI = None
+
+
+def analytic_features(theta):
+    """The benchmark's steady states for theta = (p, q). See the module docstring."""
+    theta = np.asarray(theta, dtype=float)
+    return np.array([theta[0], theta[1] / 3.0])
 
 
 class _LinearFit:
@@ -44,21 +58,23 @@ def _config(base_user_inputs, resources_dir, temp_output_dir, temp_generated_mod
             **overrides):
     config = base_user_inputs.copy()
     config.update({
-        'file_prefix': 'Lotka_Volterra',
-        'input_param_file': 'Lotka_Volterra_parameters.csv',
+        'file_prefix': 'Simple_ODE_Benchmark',
+        'input_param_file': 'Simple_ODE_Benchmark_parameters.csv',
         'model_type': 'cellml_only',
         'solver': 'CVODE_myokit',
         'param_id_method': 'genetic_algorithm',
         'pre_time': 0.0,
-        'sim_time': 5.0,
-        'dt': 0.01,
+        'sim_time': 8.0,
+        'dt': 0.05,
         'DEBUG': True,
         'do_mcmc': False,
         'do_ia': False,
         'plot_predictions': False,
-        'solver_info': {'MaximumStep': 0.001, 'MaximumNumberOfSteps': 5000},
-        'param_id_obs_path': os.path.join(resources_dir, 'Lotka_Volterra_obs_data.json'),
-        'params_for_id_path': os.path.join(resources_dir, 'Lotka_Volterra_params_for_id.csv'),
+        'solver_info': {'MaximumStep': 0.01, 'MaximumNumberOfSteps': 5000},
+        'param_id_obs_path': os.path.join(resources_dir,
+                                          'Simple_ODE_Benchmark_obs_data.json'),
+        'params_for_id_path': os.path.join(resources_dir,
+                                           'Simple_ODE_Benchmark_params_for_id.csv'),
         'param_id_output_dir': temp_output_dir,
         'resources_dir': resources_dir,
         'generated_models_dir': temp_generated_models_dir,
@@ -73,7 +89,7 @@ def _config(base_user_inputs, resources_dir, temp_output_dir, temp_generated_mod
 
 def _generate_model(config, comm):
     if comm.Get_rank() == 0:
-        assert generate_with_new_architecture(False, config), 'Lotka_Volterra generation failed'
+        assert generate_with_new_architecture(False, config), 'benchmark generation failed'
     comm.Barrier()
 
 
@@ -165,29 +181,25 @@ def test_training_writes_a_checkable_artefact(base_user_inputs, resources_dir, t
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.mpi
-def test_a_trained_emulator_reports_its_accuracy_honestly(
+def test_a_trained_emulator_recovers_the_analytic_steady_states(
         base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
-    """End to end with the real library -- and the property that actually matters.
+    """End to end with the real library, against arithmetic.
 
-    This deliberately does *not* assert that the emulator is accurate. Lotka-Volterra's `max`
-    features over the full params_for_id box are a hard thing to emulate (alpha spans 0.1-7 and
-    the response spans 20-3900), and a small design genuinely produces a poor emulator: a
-    128-sample Gaussian process here scores R2 around 0.2 and 0.5. Pinning a threshold would
-    make this a test of how easy the fixture is.
+    The benchmark's features are ``p`` and ``q/3``, so "did the emulator work" has an answer
+    that does not depend on another simulation, on the emulator's own opinion of itself, or on
+    how forgiving a tolerance is chosen. A forgotten inverse transform, a permuted feature
+    order or a mixed-up parameter column all move the predictions off that line, and none of
+    them would show in the held-out score alone.
 
-    What must hold regardless is that the emulator's *self-report* is not optimistic. A
-    scaling bug -- forgetting to invert the y transform, say -- would leave the held-out score
-    looking healthy while predictions came out in the wrong units, and every refusal
-    downstream would pass. So the reported held-out R2 is checked against the R2 actually
-    achieved at fresh points evaluated on the simulator.
+    Measured on this fixture: 64 Sobol samples give held-out R2 of 0.99999 and 0.99997.
     """
     pytest.importorskip('autoemulate')
 
     config = _config(base_user_inputs, resources_dir, temp_output_dir,
                      temp_generated_models_dir,
                      emulator_settings={'num_train_samples': 64, 'sample_type': 'sobol',
-                                        'random_seed': 0, 'min_r2': -1e9, 'n_iter': 2,
-                                        'n_splits': 2, 'models': 'GaussianProcessRBF'})
+                                        'random_seed': 0, 'min_r2': 0.99, 'n_iter': 2,
+                                        'n_splits': 2})
     _generate_model(config, mpi_comm)
 
     trainer = EmulatorTrainer.init_from_dict(config, comm=mpi_comm)
@@ -198,37 +210,35 @@ def test_a_trained_emulator_reports_its_accuracy_honestly(
 
     assert bundle is not None
     reported = np.asarray(bundle.meta['feature_r2'], dtype=float)
-    assert np.all(np.isfinite(reported)), 'every feature must be scored, or none can be trusted'
-    assert len(bundle.feature_labels) == reported.size
+    assert np.all(np.isfinite(reported))
+    # A smooth, near-linear response is what an emulator is for; anything less than this on
+    # this fixture means something is wrong with the pipeline, not with the emulator.
+    assert np.all(reported > 0.99), f'held-out R2 {reported} on an almost linear response'
+    bundle.check_quality(0.99)
 
-    # Fresh points, evaluated on the simulator, never seen by the fit.
     mins = np.asarray(trainer.pid.param_id_info['param_mins'], dtype=float)
     maxs = np.asarray(trainer.pid.param_id_info['param_maxs'], dtype=float)
     rng = np.random.default_rng(12345)
-    truths, predictions = [], []
-    for _ in range(12):
+    for _ in range(8):
         theta = mins + rng.random(mins.size) * (maxs - mins)
-        _, operands_list, _ = trainer.pid.get_cost_obs_and_pred_from_params(theta)
-        truths.append(np.asarray(trainer.pid.get_obs_output_dict(operands_list[0])['const'],
-                                 dtype=float))
-        predictions.append(bundle.predict(theta))
-    truths, predictions = np.array(truths), np.array(predictions)
-    assert np.all(np.isfinite(predictions))
+        predicted = bundle.predict(theta)
+        expected = analytic_features(theta)
+        # Absolute, not relative: p is sampled down to ~0, where a relative tolerance says
+        # nothing. 0.1 is generous against a feature range of 6 and the simulator's own 0.03
+        # of leftover transient.
+        assert predicted == pytest.approx(expected, abs=0.1), (
+            f'at p={theta[0]:.4g}, q={theta[1]:.4g} the emulator predicts {predicted}, but '
+            f'the benchmark\'s steady states are {expected}')
 
-    for col, label in enumerate(bundle.feature_labels):
-        residual = float(np.sum((truths[:, col] - predictions[:, col]) ** 2))
-        total = float(np.sum((truths[:, col] - np.mean(truths[:, col])) ** 2))
-        actual_r2 = 1.0 - residual / total if total > 0 else float('nan')
-        assert actual_r2 > reported[col] - 1.0, (
-            f'{label}: the emulator reported held-out R2 {reported[col]:.3f} but achieves '
-            f'{actual_r2:.3f} against the simulator -- its self-report is not to be trusted')
+    # ... and the simulator agrees with the same arithmetic, so the line above is testing the
+    # emulator rather than a shared misunderstanding of what the features mean.
+    theta = 0.5 * (mins + maxs)
+    _, operands_list, _ = trainer.pid.get_cost_obs_and_pred_from_params(theta)
+    simulated = np.asarray(trainer.pid.get_obs_output_dict(operands_list[0])['const'],
+                           dtype=float)
+    assert simulated == pytest.approx(analytic_features(theta), abs=0.05)
 
-    # The refusal that all of this exists to support, against the score it really got.
-    from emulators.emulator_bundle import EmulatorQualityError
-    with pytest.raises(EmulatorQualityError, match='below the configured min_r2'):
-        bundle.check_quality(float(np.max(reported)) + 0.01)
-
-    # ... and the cost and gradient paths run on it, which is what the feature is for.
+    # ... and the cost and gradient paths run on the emulator, which is what it is for.
     emulator_config = dict(config)
     emulator_config['use_emulator'] = True
     emulator_config['do_emulation'] = False
@@ -237,6 +247,8 @@ def test_a_trained_emulator_reports_its_accuracy_honestly(
     emulator_config['one_rank'] = True
     engine = CVS0DParamID.init_from_dict(emulator_config).param_id
     assert engine.emulates_features is True
-    nominal = 0.5 * (mins + maxs)
-    assert np.isfinite(engine.get_cost_from_params(nominal))
-    assert np.all(np.isfinite(engine.get_gradient(nominal)))
+    assert np.isfinite(engine.get_cost_from_params(theta))
+    gradient = engine.get_gradient(theta)
+    assert np.all(np.isfinite(gradient))
+    # d(feature)/d(p) is 1 and d(feature)/d(q) is 1/3, so neither parameter can look inert.
+    assert np.all(np.abs(gradient) > 0)

--- a/tests/test_emulator_training.py
+++ b/tests/test_emulator_training.py
@@ -1,0 +1,218 @@
+"""Training an emulator against the real solver, and then calibrating on it (issue #333).
+
+Two layers, because the two halves fail in different ways and only one of them needs a heavy
+optional dependency:
+
+* the CA half -- design over the params_for_id box, simulate it (across MPI ranks), reduce each
+  run to the same features the cost uses, and record the metadata a later run validates
+  against. Tested with the fit stubbed out, so it runs everywhere.
+* the autoemulate half -- the fit itself, and whether an emulator trained this way actually
+  reproduces the simulator well enough to calibrate on. Skipped when autoemulate is absent.
+"""
+import os
+
+import numpy as np
+import pytest
+
+from emulators.emulator_bundle import EmulatorBundle
+from emulators.emulator_trainer import EmulatorTrainer, resolve_emulator_dir
+from param_id.paramID import CVS0DParamID
+from parsers.PrimitiveParsers import YamlFileParser
+from scripts.script_generate_with_new_architecture import generate_with_new_architecture
+
+try:
+    from mpi4py import MPI
+except ImportError:                                       # pragma: no cover - env dependent
+    MPI = None
+
+
+class _LinearFit:
+    """Stands in for a fitted emulator. Module level so joblib can pickle it."""
+
+    def predict(self, x):
+        return np.asarray(x, dtype=float)[:, :1] * np.ones((1, 2))
+
+
+@pytest.fixture
+def mpi_comm():
+    if MPI is None:
+        pytest.skip('mpi4py is required for the emulator training tests')
+    return MPI.COMM_WORLD
+
+
+def _config(base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir,
+            **overrides):
+    config = base_user_inputs.copy()
+    config.update({
+        'file_prefix': 'Lotka_Volterra',
+        'input_param_file': 'Lotka_Volterra_parameters.csv',
+        'model_type': 'cellml_only',
+        'solver': 'CVODE_myokit',
+        'param_id_method': 'genetic_algorithm',
+        'pre_time': 0.0,
+        'sim_time': 5.0,
+        'dt': 0.01,
+        'DEBUG': True,
+        'do_mcmc': False,
+        'do_ia': False,
+        'plot_predictions': False,
+        'solver_info': {'MaximumStep': 0.001, 'MaximumNumberOfSteps': 5000},
+        'param_id_obs_path': os.path.join(resources_dir, 'Lotka_Volterra_obs_data.json'),
+        'params_for_id_path': os.path.join(resources_dir, 'Lotka_Volterra_params_for_id.csv'),
+        'param_id_output_dir': temp_output_dir,
+        'resources_dir': resources_dir,
+        'generated_models_dir': temp_generated_models_dir,
+        'do_emulation': True,
+        'emulator_settings': {'num_train_samples': 24, 'sample_type': 'sobol',
+                              'random_seed': 0, 'min_r2': 0.5, 'n_iter': 2, 'n_splits': 2},
+    })
+    config.update(overrides)
+    return YamlFileParser().parse_user_inputs_file(
+        config, obs_path_needed=True, do_generation_with_fit_parameters=False)
+
+
+def _generate_model(config, comm):
+    if comm.Get_rank() == 0:
+        assert generate_with_new_architecture(False, config), 'Lotka_Volterra generation failed'
+    comm.Barrier()
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_training_set_targets_are_the_cost_features(base_user_inputs, resources_dir,
+                                                    temp_output_dir,
+                                                    temp_generated_models_dir, mpi_comm):
+    """The emulator is trained on exactly what the calibration is fitting.
+
+    If the training targets were computed a second way, the emulator could be a faithful
+    surrogate of something the cost does not use -- and every downstream number would be
+    self-consistently wrong. So the training target at a design point must equal the cost
+    path's own feature vector at that point, evaluated through the real solver.
+    """
+    config = _config(base_user_inputs, resources_dir, temp_output_dir,
+                     temp_generated_models_dir)
+    _generate_model(config, mpi_comm)
+
+    trainer = EmulatorTrainer.init_from_dict(config, comm=mpi_comm)
+    design = trainer.design()
+    assert design.shape == (24, len(trainer.pid.param_id_info['param_names']))
+    mins = np.asarray(trainer.pid.param_id_info['param_mins'], dtype=float)
+    maxs = np.asarray(trainer.pid.param_id_info['param_maxs'], dtype=float)
+    assert np.all(design >= mins) and np.all(design <= maxs), 'design left the training box'
+
+    x, y = trainer.evaluate(design)
+    if mpi_comm.Get_rank() != 0:
+        return
+    assert y.shape[1] == len(trainer.feature_labels)
+    assert np.all(np.isfinite(y))
+
+    # The check that matters: the same point, through the ordinary cost path.
+    _, operands_list, _ = trainer.pid.get_cost_obs_and_pred_from_params(x[0])
+    from_cost = np.asarray(trainer.pid.get_obs_output_dict(operands_list[0])['const'],
+                           dtype=float)
+    assert y[0] == pytest.approx(from_cost, rel=1e-9)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_training_writes_a_checkable_artefact(base_user_inputs, resources_dir, temp_output_dir,
+                                              temp_generated_models_dir, mpi_comm,
+                                              monkeypatch):
+    """Everything except the fit: the metadata a later run refuses on must all be there.
+
+    The fit is stubbed so this covers the CA half without autoemulate -- what is being checked
+    is the artefact, not the emulator inside it.
+    """
+    config = _config(base_user_inputs, resources_dir, temp_output_dir,
+                     temp_generated_models_dir)
+    _generate_model(config, mpi_comm)
+
+    trainer = EmulatorTrainer.init_from_dict(config, comm=mpi_comm)
+
+    def fake_fit(x, y):
+        x_scale = EmulatorBundle.make_scale(x)
+        y_scale = EmulatorBundle.make_scale(y)
+        return _LinearFit(), [0.97, 0.96], [0.01, 0.02], 'LinearStub', x_scale, y_scale
+
+    monkeypatch.setattr(trainer, 'fit', fake_fit)
+    monkeypatch.setattr('emulators.emulator_trainer.require_autoemulate', lambda: None)
+
+    bundle = trainer.train()
+    if mpi_comm.Get_rank() != 0:
+        assert bundle is None, 'only rank 0 writes the emulator'
+        return
+
+    saved = EmulatorBundle.load(resolve_emulator_dir(config))
+    assert saved.feature_labels == trainer.feature_labels
+    from parsers.PrimitiveParsers import param_entry_labels
+    assert saved.param_entry_labels == param_entry_labels(trainer.pid.param_id_info)
+    assert saved.meta['design']['num_train_samples'] == 24
+    assert saved.meta['design']['sample_type'] == 'sobol'
+    # The defaults the emulator will have to serve in place of a model.
+    for entry in trainer.pid.param_id_info['param_names']:
+        for name in entry:
+            assert str(name) in saved.meta['param_defaults']
+    # The training design is kept, so the emulator can be extended without re-simulating.
+    assert saved.x_train.shape[0] == saved.y_train.shape[0]
+    # ... and the artefact refuses a different problem, which is what it exists for.
+    from emulators.emulator_bundle import EmulatorQualityError
+    with pytest.raises(EmulatorQualityError):
+        saved.check_matches({'inputs_sha256': 'a-different-model'})
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_a_trained_emulator_reproduces_the_simulator_and_calibrates(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
+    """End to end, with the real library: train, then check it against the simulator.
+
+    The accuracy check is deliberately at points the emulator never saw, and against the
+    simulator rather than against the emulator's own held-out score -- the score is what the
+    emulator says about itself.
+    """
+    pytest.importorskip('autoemulate')
+
+    config = _config(base_user_inputs, resources_dir, temp_output_dir,
+                     temp_generated_models_dir,
+                     emulator_settings={'num_train_samples': 64, 'sample_type': 'sobol',
+                                        'random_seed': 0, 'min_r2': 0.0, 'n_iter': 2,
+                                        'n_splits': 2, 'models': 'RadialBasisFunctions'})
+    _generate_model(config, mpi_comm)
+
+    trainer = EmulatorTrainer.init_from_dict(config, comm=mpi_comm)
+    bundle = trainer.train()
+    mpi_comm.Barrier()
+
+    if mpi_comm.Get_rank() != 0:
+        return
+
+    assert bundle is not None
+    assert all(np.isfinite(bundle.meta['feature_r2']))
+
+    # Held-out accuracy, measured against the simulator at points not in the design.
+    mins = np.asarray(trainer.pid.param_id_info['param_mins'], dtype=float)
+    maxs = np.asarray(trainer.pid.param_id_info['param_maxs'], dtype=float)
+    rng = np.random.default_rng(12345)
+    for _ in range(3):
+        theta = mins + rng.random(mins.size) * (maxs - mins)
+        _, operands_list, _ = trainer.pid.get_cost_obs_and_pred_from_params(theta)
+        truth = np.asarray(trainer.pid.get_obs_output_dict(operands_list[0])['const'],
+                           dtype=float)
+        predicted = bundle.predict(theta)
+        scale = np.maximum(np.abs(truth), 1e-12)
+        assert np.all(np.abs(predicted - truth) / scale < 0.5), (
+            f'emulator prediction {predicted} is far from the simulator {truth}')
+
+    # ... and the cost path runs on it, which is what the whole feature is for.
+    emulator_config = dict(config)
+    emulator_config['use_emulator'] = True
+    emulator_config['do_emulation'] = False
+    emulator_config['one_rank'] = True
+    engine = CVS0DParamID.init_from_dict(emulator_config).param_id
+    assert engine.emulates_features is True
+    nominal = 0.5 * (mins + maxs)
+    assert np.isfinite(engine.get_cost_from_params(nominal))
+    assert np.all(np.isfinite(engine.get_gradient(nominal)))

--- a/tests/test_emulator_training.py
+++ b/tests/test_emulator_training.py
@@ -67,7 +67,7 @@ def _config(base_user_inputs, resources_dir, temp_output_dir, temp_generated_mod
         'sim_time': 8.0,
         'dt': 0.05,
         'DEBUG': True,
-        'do_mcmc': False,
+        'do_uq': False,
         'do_ia': False,
         'plot_predictions': False,
         'solver_info': {'MaximumStep': 0.01, 'MaximumNumberOfSteps': 5000},
@@ -150,7 +150,13 @@ def test_training_writes_a_checkable_artefact(base_user_inputs, resources_dir, t
     def fake_fit(x, y):
         x_scale = EmulatorBundle.make_scale(x)
         y_scale = EmulatorBundle.make_scale(y)
-        return _LinearFit(), [0.97, 0.96], [0.01, 0.02], 'LinearStub', x_scale, y_scale
+        validation = {
+            'r2': [0.97, 0.96], 'rmse': [0.01, 0.02], 'mae': [0.01, 0.02],
+            'bias': [0.0, 0.0], 'max_abs_error': [0.02, 0.04],
+            'nrmse': [0.01, 0.02],
+            'theta': x[:2], 'y_true': y[:2], 'y_pred': y[:2],
+        }
+        return _LinearFit(), validation, 'LinearStub', x_scale, y_scale
 
     monkeypatch.setattr(trainer, 'fit', fake_fit)
     monkeypatch.setattr('emulators.emulator_trainer.require_autoemulate', lambda: None)
@@ -176,6 +182,60 @@ def test_training_writes_a_checkable_artefact(base_user_inputs, resources_dir, t
     from emulators.emulator_bundle import EmulatorQualityError
     with pytest.raises(EmulatorQualityError):
         saved.check_matches({'inputs_sha256': 'a-different-model'})
+
+
+@pytest.mark.unit
+def test_the_validation_report_measures_error_in_real_units():
+    """The statistics and the points must be in the feature's own units.
+
+    The emulator is fitted in a scaled space; reporting its error there would give
+    a bias and an RMSE that mean nothing next to the observation they approximate,
+    and a parity plot whose axes are not the quantity being emulated.
+    """
+    from emulators.emulator_trainer import _validation_report
+
+    class DoublingStub:
+        """Predicts exactly 0.1 (scaled) above the truth, for a known bias."""
+
+        def predict(self, x):
+            return np.asarray(x, dtype=float) + 0.1
+
+    # y = x in the scaled space; real units are y*10 + 100, x*2 + 1.
+    x_test = np.array([[0.0], [0.5], [1.0]])
+    y_test = np.array([[0.0], [0.5], [1.0]])
+    x_scale = {'shift': [1.0], 'span': [2.0]}
+    y_scale = {'shift': [100.0], 'span': [10.0]}
+
+    report = _validation_report(DoublingStub(), x_test, y_test, x_scale, y_scale)
+
+    # A constant +0.1 scaled error is +1.0 in real units, on every point.
+    assert report['bias'][0] == pytest.approx(1.0)
+    assert report['mae'][0] == pytest.approx(1.0)
+    assert report['rmse'][0] == pytest.approx(1.0)
+    assert report['max_abs_error'][0] == pytest.approx(1.0)
+    # And the points come back as the parameters and features they really are.
+    assert report['theta'].flatten() == pytest.approx([1.0, 2.0, 3.0])
+    assert report['y_true'].flatten() == pytest.approx([100.0, 105.0, 110.0])
+    assert report['y_pred'].flatten() == pytest.approx([101.0, 106.0, 111.0])
+    # nrmse is against the feature's own spread (10 here), so features in
+    # different units can be compared.
+    assert report['nrmse'][0] == pytest.approx(0.1)
+
+
+@pytest.mark.unit
+def test_a_degenerate_test_column_scores_nan_not_a_perfect_fit():
+    from emulators.emulator_trainer import _validation_report
+
+    class ConstantStub:
+        def predict(self, x):
+            return np.zeros((len(x), 1))
+
+    report = _validation_report(
+        ConstantStub(), np.array([[0.0], [1.0]]), np.array([[0.0], [0.0]]),
+        {'shift': [0.0], 'span': [1.0]}, {'shift': [0.0], 'span': [1.0]},
+    )
+    assert np.isnan(report['r2'][0])
+    assert np.isnan(report['nrmse'][0])
 
 
 @pytest.mark.integration
@@ -209,6 +269,16 @@ def test_a_trained_emulator_recovers_the_analytic_steady_states(
         return
 
     assert bundle is not None
+    # The error data an Analysis view is drawn from, written beside the emulator.
+    saved = EmulatorBundle.load(resolve_emulator_dir(config))
+    points = saved.error_points()
+    assert points is not None, 'the held-out points must survive a save/load'
+    assert points['theta'].shape[1] == len(saved.param_entry_labels)
+    assert points['y_true'].shape == points['y_pred'].shape
+    stats = saved.error_stats()
+    assert len(stats) == len(saved.feature_labels)
+    assert all(row['bias'] is not None for row in stats)
+
     reported = np.asarray(bundle.meta['feature_r2'], dtype=float)
     assert np.all(np.isfinite(reported))
     # A smooth, near-linear response is what an emulator is for; anything less than this on

--- a/tests/test_emulator_training.py
+++ b/tests/test_emulator_training.py
@@ -165,51 +165,75 @@ def test_training_writes_a_checkable_artefact(base_user_inputs, resources_dir, t
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.mpi
-def test_a_trained_emulator_reproduces_the_simulator_and_calibrates(
+def test_a_trained_emulator_reports_its_accuracy_honestly(
         base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
-    """End to end, with the real library: train, then check it against the simulator.
+    """End to end with the real library -- and the property that actually matters.
 
-    The accuracy check is deliberately at points the emulator never saw, and against the
-    simulator rather than against the emulator's own held-out score -- the score is what the
-    emulator says about itself.
+    This deliberately does *not* assert that the emulator is accurate. Lotka-Volterra's `max`
+    features over the full params_for_id box are a hard thing to emulate (alpha spans 0.1-7 and
+    the response spans 20-3900), and a small design genuinely produces a poor emulator: a
+    128-sample Gaussian process here scores R2 around 0.2 and 0.5. Pinning a threshold would
+    make this a test of how easy the fixture is.
+
+    What must hold regardless is that the emulator's *self-report* is not optimistic. A
+    scaling bug -- forgetting to invert the y transform, say -- would leave the held-out score
+    looking healthy while predictions came out in the wrong units, and every refusal
+    downstream would pass. So the reported held-out R2 is checked against the R2 actually
+    achieved at fresh points evaluated on the simulator.
     """
     pytest.importorskip('autoemulate')
 
     config = _config(base_user_inputs, resources_dir, temp_output_dir,
                      temp_generated_models_dir,
                      emulator_settings={'num_train_samples': 64, 'sample_type': 'sobol',
-                                        'random_seed': 0, 'min_r2': 0.0, 'n_iter': 2,
-                                        'n_splits': 2, 'models': 'RadialBasisFunctions'})
+                                        'random_seed': 0, 'min_r2': -1e9, 'n_iter': 2,
+                                        'n_splits': 2, 'models': 'GaussianProcessRBF'})
     _generate_model(config, mpi_comm)
 
     trainer = EmulatorTrainer.init_from_dict(config, comm=mpi_comm)
     bundle = trainer.train()
     mpi_comm.Barrier()
-
     if mpi_comm.Get_rank() != 0:
         return
 
     assert bundle is not None
-    assert all(np.isfinite(bundle.meta['feature_r2']))
+    reported = np.asarray(bundle.meta['feature_r2'], dtype=float)
+    assert np.all(np.isfinite(reported)), 'every feature must be scored, or none can be trusted'
+    assert len(bundle.feature_labels) == reported.size
 
-    # Held-out accuracy, measured against the simulator at points not in the design.
+    # Fresh points, evaluated on the simulator, never seen by the fit.
     mins = np.asarray(trainer.pid.param_id_info['param_mins'], dtype=float)
     maxs = np.asarray(trainer.pid.param_id_info['param_maxs'], dtype=float)
     rng = np.random.default_rng(12345)
-    for _ in range(3):
+    truths, predictions = [], []
+    for _ in range(12):
         theta = mins + rng.random(mins.size) * (maxs - mins)
         _, operands_list, _ = trainer.pid.get_cost_obs_and_pred_from_params(theta)
-        truth = np.asarray(trainer.pid.get_obs_output_dict(operands_list[0])['const'],
-                           dtype=float)
-        predicted = bundle.predict(theta)
-        scale = np.maximum(np.abs(truth), 1e-12)
-        assert np.all(np.abs(predicted - truth) / scale < 0.5), (
-            f'emulator prediction {predicted} is far from the simulator {truth}')
+        truths.append(np.asarray(trainer.pid.get_obs_output_dict(operands_list[0])['const'],
+                                 dtype=float))
+        predictions.append(bundle.predict(theta))
+    truths, predictions = np.array(truths), np.array(predictions)
+    assert np.all(np.isfinite(predictions))
 
-    # ... and the cost path runs on it, which is what the whole feature is for.
+    for col, label in enumerate(bundle.feature_labels):
+        residual = float(np.sum((truths[:, col] - predictions[:, col]) ** 2))
+        total = float(np.sum((truths[:, col] - np.mean(truths[:, col])) ** 2))
+        actual_r2 = 1.0 - residual / total if total > 0 else float('nan')
+        assert actual_r2 > reported[col] - 1.0, (
+            f'{label}: the emulator reported held-out R2 {reported[col]:.3f} but achieves '
+            f'{actual_r2:.3f} against the simulator -- its self-report is not to be trusted')
+
+    # The refusal that all of this exists to support, against the score it really got.
+    from emulators.emulator_bundle import EmulatorQualityError
+    with pytest.raises(EmulatorQualityError, match='below the configured min_r2'):
+        bundle.check_quality(float(np.max(reported)) + 0.01)
+
+    # ... and the cost and gradient paths run on it, which is what the feature is for.
     emulator_config = dict(config)
     emulator_config['use_emulator'] = True
     emulator_config['do_emulation'] = False
+    emulator_config['emulator_settings'] = dict(config['emulator_settings'])
+    emulator_config['emulator_settings']['emulator_dir'] = resolve_emulator_dir(config)
     emulator_config['one_rank'] = True
     engine = CVS0DParamID.init_from_dict(emulator_config).param_id
     assert engine.emulates_features is True

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -472,7 +472,8 @@ def run(solver_info):
 def test_analysis_options_schema_well_formed():
     """The non-calibration analysis modes (sensitivity, UQ, identifiability) expose their option
     blocks the same way, so a tool can auto-populate their settings forms too."""
-    assert set(ANALYSIS_OPTIONS) == {'sensitivity_analysis', 'uq', 'identifiability_analysis'}
+    assert set(ANALYSIS_OPTIONS) == {'sensitivity_analysis', 'uq', 'identifiability_analysis',
+                                     'emulation'}
     for mode, meta in ANALYSIS_OPTIONS.items():
         assert meta.get('label') and meta.get('enable_flag') and meta.get('options_key')
         _assert_descriptors_well_formed(mode, meta.get('options'))
@@ -487,10 +488,18 @@ def test_analysis_options_schema_well_formed():
     assert names('uq') == {'method', 'library', 'num_steps', 'num_walkers', 'burn_in'}
     assert ANALYSIS_OPTIONS['uq']['options_key'] == 'UQ_options'
     assert names('identifiability_analysis') == {'method', 'gradient_source', 'sub_method'}
+    assert names('emulation') == {
+        'emulator_dir', 'models', 'num_train_samples', 'sample_type', 'log_scale_params',
+        'random_seed', 'test_fraction', 'n_splits', 'n_iter', 'min_r2', 'out_of_bounds',
+        'fd_rel_step'}
     assert analysis_options('not_a_mode') == []
     # the enabling flags match the documented user_inputs feature flags
     assert {m['enable_flag'] for m in ANALYSIS_OPTIONS.values()} == {
-        'do_sensitivity', 'do_uq', 'do_ia'}
+        'do_sensitivity', 'do_uq', 'do_ia', 'do_emulation'}
+    # Emulation alone carries a second flag, because it has a train step and a use step:
+    # do_emulation fits the surrogate, use_emulator makes the analyses evaluate it (#333).
+    assert ANALYSIS_OPTIONS['emulation']['use_flag'] == 'use_emulator'
+    assert {m.get('use_flag') for m in ANALYSIS_OPTIONS.values()} == {None, 'use_emulator'}
 
 
 def _option(mode, name):
@@ -526,6 +535,11 @@ def test_closed_set_analysis_options_are_enums_with_choices():
         # surrogate methods and the pyMC backend land.
         ('uq', 'method'): ['mcmc'],
         ('uq', 'library'): ['emcee'],
+        # -> EmulatorTrainer.design (raises ValueError otherwise)
+        ('emulation', 'sample_type'): ['sobol', 'latin_hypercube', 'random'],
+        # -> EmulatorBundle.check_bounds. 'error' is the default deliberately: outside its
+        # training box an emulator extrapolates with no error estimate at all.
+        ('emulation', 'out_of_bounds'): ['error', 'warn', 'clip'],
     }
     for (mode, name), choices in expected.items():
         opt = _option(mode, name)

--- a/tutorial/docs/api/emulators.md
+++ b/tutorial/docs/api/emulators.md
@@ -1,0 +1,47 @@
+# Emulators (surrogate models)
+
+`EmulatorTrainer` fits a surrogate of the model's scalar observable features, and
+`EmulatorBundle` is the saved artefact plus the checks that decide whether it may be
+used. See [Emulators](../emulators.md) for the workflow.
+
+::: emulators.emulator_trainer.EmulatorTrainer
+    options:
+      members:
+        - init_from_dict
+        - design
+        - evaluate
+        - fit
+        - train
+        - feature_labels
+
+::: emulators.emulator_trainer.emulator_model_names
+
+::: emulators.emulator_trainer.resolve_emulator_dir
+
+::: emulators.emulator_bundle.EmulatorBundle
+    options:
+      members:
+        - predict
+        - check_quality
+        - check_bounds
+        - check_matches
+        - save
+        - load
+        - make_scale
+
+::: emulators.emulator_bundle.fingerprint
+
+The emulator is used through the ordinary simulation-helper interface, so every analysis
+reaches it the same way it reaches a solver.
+
+::: solver_wrappers.emulator_solver_helper.SimulationHelper
+    options:
+      members:
+        - set_theta
+        - set_param_vals
+        - run
+        - get_results
+        - get_predicted_features
+        - set_obs_map
+        - update_times
+        - get_init_param_vals

--- a/tutorial/docs/emulators.md
+++ b/tutorial/docs/emulators.md
@@ -104,6 +104,20 @@ saves the emulator. The script prints the held-out R² per observable:
 **Read those numbers before using it.** They are the only thing standing between you and a set
 of Sobol indices for a model you did not simulate.
 
+!!! warning "How good an emulator you can get depends on the parameter box"
+    Difficulty grows with the width of the `params_for_id` ranges, the number of parameters and
+    how rough the feature is. A worked example from this repo: emulating `max` of the two
+    Lotka-Volterra states over their *full* declared ranges (`alpha` 0.1–7, `gamma` 0.1–10,
+    where the response spans 20–3900) gives held-out R² of only about **0.2 and 0.5** from a
+    128-sample Gaussian process — and 256 samples does not reliably improve it, because `max` of
+    an oscillation whose period changes sharply with the parameters is close to discontinuous.
+
+    If your R² is poor, the useful moves are, in order: narrow the parameter ranges to the
+    region you actually care about; add samples; set `log_scale_params: true` when a bound
+    spans decades; try `models: all`; and consider whether the feature itself is a smooth
+    function of the parameters at all. What you should *not* do is lower `min_r2` to make the
+    run proceed.
+
 The saved directory contains:
 
 | File | What it is |

--- a/tutorial/docs/emulators.md
+++ b/tutorial/docs/emulators.md
@@ -96,9 +96,10 @@ The design points are spread across MPI ranks, each runs the real solver, and ra
 saves the emulator. The script prints the held-out R² per observable:
 
 ```
-[emulator] saved to .../emulators/Lotka_Volterra_Lotka_Volterra_obs_data
-    held-out R2   0.9986   x_max (max Lotka_Volterra/x)
-    held-out R2   0.9791   y_max (max Lotka_Volterra/y)
+[emulator] training on 64 samples across 8 rank(s)
+[emulator] saved to .../emulators/Simple_ODE_Benchmark_Simple_ODE_Benchmark_obs_data
+    held-out R2   1.0000   x_{SS} (steady_state_avg benchmark/x)
+    held-out R2   1.0000   y_{SS} (steady_state_avg benchmark/y)
 ```
 
 **Read those numbers before using it.** They are the only thing standing between you and a set
@@ -106,17 +107,20 @@ of Sobol indices for a model you did not simulate.
 
 !!! warning "How good an emulator you can get depends on the parameter box"
     Difficulty grows with the width of the `params_for_id` ranges, the number of parameters and
-    how rough the feature is. A worked example from this repo: emulating `max` of the two
-    Lotka-Volterra states over their *full* declared ranges (`alpha` 0.1–7, `gamma` 0.1–10,
-    where the response spans 20–3900) gives held-out R² of only about **0.2 and 0.5** from a
-    128-sample Gaussian process — and 256 samples does not reliably improve it, because `max` of
-    an oscillation whose period changes sharply with the parameters is close to discontinuous.
+    how rough the feature is. Two worked examples from this repo, at opposite ends:
+
+    * **`Simple_ODE_Benchmark`** — steady states of `dx/dt = -x + p`, `dy/dt = -3y + q`, i.e. a
+      smooth monotone response. 64 Sobol samples give held-out R² of **0.99999** and **0.99997**.
+      This is what a well-posed emulation problem looks like.
+    * **`Lotka_Volterra`** — `max` of each state over the *full* declared ranges (`alpha` 0.1–7,
+      `gamma` 0.1–10, the response spanning 20–3900). A 128-sample Gaussian process manages only
+      about **0.2 and 0.5**, and 256 samples does not reliably improve it: `max` of an
+      oscillation whose period shifts sharply with the parameters is close to discontinuous.
 
     If your R² is poor, the useful moves are, in order: narrow the parameter ranges to the
-    region you actually care about; add samples; set `log_scale_params: true` when a bound
-    spans decades; try `models: all`; and consider whether the feature itself is a smooth
-    function of the parameters at all. What you should *not* do is lower `min_r2` to make the
-    run proceed.
+    region you actually care about; add samples; set `log_scale_params: true` when a bound spans
+    decades; try `models: all`; and consider whether the feature is a smooth function of the
+    parameters at all. What you should *not* do is lower `min_r2` to make the run proceed.
 
 The saved directory contains:
 

--- a/tutorial/docs/emulators.md
+++ b/tutorial/docs/emulators.md
@@ -1,0 +1,170 @@
+# Emulators (Surrogate Models)
+
+An **emulator** (or surrogate) is a fast statistical stand-in for your model. Circulatory Autogen
+fits one that maps the parameters in your `params_for_id.csv` to the **scalar features** of your
+`obs_data.json` data items — the same numbers the cost function is computed from. Once it is
+trained, calibration, sensitivity analysis, UQ/MCMC and identifiability analysis can all evaluate
+the emulator instead of running the solver.
+
+!!! warning "The training runs are paid up front"
+    Training costs `num_train_samples` simulations. That is only worth it when the downstream use
+    is much larger:
+
+    * **Sobol sensitivity analysis** — `num_samples × (2M + 2)` model evaluations. Worth it.
+    * **MCMC / UQ** — tens of thousands of evaluations. Worth it.
+    * **Identifiability analysis** — a Hessian's worth per parameter pair. Usually worth it.
+    * **A single genetic-algorithm calibration** — often *cheaper run directly*. Not worth it.
+
+!!! note "Scope: scalar features, not waveforms"
+    The emulator predicts each data item's value **after** its `operation` (`max`, `mean`,
+    `max_minus_min`, …). It does not produce simulated traces, so `data_type: series` and
+    `frequency` observables, prediction variables and output plots are not available in emulator
+    mode — CA refuses them explicitly rather than returning something that looks plausible.
+    Emulating full time series is a planned follow-up.
+
+## Installation
+
+The emulator backend is [autoemulate](https://pypi.org/project/autoemulate/), an optional
+dependency (it pulls in torch, gpytorch and lightgbm, and needs Python ≥3.10, <3.13):
+
+```bash
+pip install "circulatory_autogen[emulation]"
+```
+
+Everything else in CA works without it; only `do_emulation` / `use_emulator` need it.
+
+## Configuration
+
+Two independent flags, because emulation has two steps:
+
+```yaml
+do_emulation: false   # train an emulator against the solver named by `solver`
+use_emulator: false   # make the analyses evaluate the trained emulator
+```
+
+`solver:` keeps meaning the **truth solver** — the one the emulator is trained against, and the
+one you compare it with. That is deliberate: switching to an emulator should not lose track of
+what it is approximating.
+
+```yaml
+emulator_settings:
+  # emulator_dir:            # default <param_id_output_dir>/emulators/<file_prefix>_<obs_prefix>
+  models: default            # 'default', 'all', or a comma-separated list of emulator names
+  num_train_samples: 128     # simulations run to build the training set
+  sample_type: sobol         # sobol | latin_hypercube | random
+  log_scale_params: false    # space the design logarithmically (needs every min > 0)
+  random_seed: 0
+  test_fraction: 0.2         # held out and never trained on -- what R2/RMSE are measured on
+  n_splits: 5                # autoemulate cross-validation folds
+  n_iter: 10                 # hyper-parameter settings sampled per emulator
+  min_r2: 0.9                # refuse to USE an emulator worse than this
+  out_of_bounds: error       # error | warn | clip
+  fd_rel_step: 1.0e-3        # step for the finite-difference gradient over the emulator
+```
+
+The available `models` names come from the installed autoemulate and are discoverable in code:
+
+```python
+from emulators.emulator_trainer import emulator_model_names
+print(emulator_model_names())   # GaussianProcessRBF, RadialBasisFunctions, LightGBM, ...
+```
+
+## Training
+
+```bash
+cd user_run_files
+./run_emulator_training.sh 8      # 8 MPI processes
+```
+
+The design points are spread across MPI ranks, each runs the real solver, and rank 0 fits and
+saves the emulator. The script prints the held-out R² per observable:
+
+```
+[emulator] saved to .../emulators/Lotka_Volterra_Lotka_Volterra_obs_data
+    held-out R2   0.9986   x_max (max Lotka_Volterra/x)
+    held-out R2   0.9791   y_max (max Lotka_Volterra/y)
+```
+
+**Read those numbers before using it.** They are the only thing standing between you and a set
+of Sobol indices for a model you did not simulate.
+
+The saved directory contains:
+
+| File | What it is |
+|---|---|
+| `emulator.joblib` | the fitted emulator |
+| `emulator_metadata.json` | R²/RMSE per feature, the training box, the design, provenance |
+| `training_data.npz` | the design and its simulated targets, so it can be refitted or extended without re-simulating |
+
+## Using it
+
+Set `use_emulator: true` and run any of the usual scripts unchanged:
+
+```bash
+./run_param_id.sh 4
+./run_sensitivity_analysis.sh 4
+./run_identifiability_analysis.sh
+```
+
+Nothing else in the configuration changes. To sanity-check a result, run the same analysis with
+`use_emulator: false` and compare — that is what keeping `solver:` meaningful is for.
+
+## When CA refuses
+
+An unvalidated emulator does not fail loudly; it returns plausible wrong numbers, and every
+downstream index, cost and posterior inherits the error with nothing to show for it. So CA
+refuses rather than proceeding quietly:
+
+| Situation | What happens |
+|---|---|
+| Worst held-out R² below `min_r2` | refused at setup, naming the observable and its R² |
+| A parameter outside the training box | refused (or warns/clips, per `out_of_bounds`) |
+| Parameter bounds, observables, operations, protocol or the model file changed since training | refused as **stale** — retrain |
+| A `series` or `frequency` data item | refused: the emulator predicts scalars only |
+| `autoemulate` not installed | refused, naming the install command |
+
+An emulator is an interpolant. Outside the box it was trained in it is an extrapolation with no
+error estimate at all, which is why `out_of_bounds: error` is the default.
+
+## Gradients
+
+Over an emulator the only gradient source is **finite differences on the emulator itself**. The
+analytic arms (CasADi AD, Myokit CVODES FSA, AADC) all differentiate the *real* model, which is
+not the function an emulator run is evaluating — using one would mean the optimiser descends a
+different function than the cost it reports.
+
+This costs `2M` emulator evaluations per gradient, which is a matrix multiply apiece rather than
+`2M` simulations, so gradient-based calibration (`sp_minimize`, `multi_start_sp_minimize`) and
+the Laplace identifiability analysis work normally. `do_ad` is turned off automatically, with a
+message, when `use_emulator` is set.
+
+## From Python
+
+```python
+from emulators.emulator_trainer import EmulatorTrainer
+from param_id.paramID import CVS0DParamID
+
+inp["do_emulation"] = True
+inp["emulator_settings"] = {"num_train_samples": 200, "models": "GaussianProcessRBF"}
+bundle = EmulatorTrainer.init_from_dict(inp).train()
+print(dict(zip(bundle.feature_labels, bundle.meta["feature_r2"])))
+
+inp["use_emulator"] = True
+pid = CVS0DParamID.init_from_dict(inp)   # calibrates against the emulator
+```
+
+`EmulatorTrainer.init_from_dict` always builds its engine with `use_emulator` forced off, so
+training runs the real solver even when the config asks for an emulator elsewhere.
+
+## Notes
+
+* The training targets are computed through the **same code path as the cost**
+  (`param_id.fd_backend.observable_features`), so the emulator approximates exactly what your
+  calibration is fitting rather than a second implementation of it.
+* Parameters are mapped to the unit box and features are standardised before fitting. CA
+  parameters routinely span a compliance near `1e-9` and a resistance near `1e8`, and autoemulate
+  works in float32; the transforms are stored in the bundle and inverted on prediction.
+* Modifier and grouped parameters are supported: the emulator is trained on θ — one value per
+  `params_for_id` entry — not on the expanded per-parameter values.
+* `params_to_change` from your protocol are held at the values they had during training. Change
+  the protocol and the emulator is refused as stale.

--- a/tutorial/docs/emulators.md
+++ b/tutorial/docs/emulators.md
@@ -127,8 +127,40 @@ The saved directory contains:
 | File | What it is |
 |---|---|
 | `emulator.joblib` | the fitted emulator |
-| `emulator_metadata.json` | R²/RMSE per feature, the training box, the design, provenance |
+| `emulator_metadata.json` | per-feature R², RMSE, MAE, bias, max abs error and nRMSE; the training box; the design; provenance |
 | `training_data.npz` | the design and its simulated targets, so it can be refitted or extended without re-simulating |
+| `emulator_validation.npz` | the held-out points: `theta`, the simulator's `y_true` and the emulator's `y_pred`, in real units |
+
+### Analysing the error
+
+The statistics say how wrong the emulator is on average; the held-out points say
+**where**, which is what decides whether the region you care about is one of the good
+ones. Both are read through the bundle:
+
+```python
+from emulators.emulator_bundle import EmulatorBundle
+bundle = EmulatorBundle.load(emulator_dir)
+
+for row in bundle.error_stats():
+    print(row['label'], row['r2'], row['bias'], row['nrmse'])
+
+points = bundle.error_points()      # None if the bundle predates this
+# points['y_pred'] vs points['y_true']  -> parity plot
+# points['residual'] vs points['theta'] -> where in the space it goes wrong
+```
+
+`residual` is **prediction minus truth**, fixed here so every consumer agrees on
+the sign: positive means the emulator reads high. Why more than R²:
+
+* **`bias`** — a feature can score a good R² and still read systematically high,
+  which shifts every downstream cost rather than just adding noise to it.
+* **`nrmse`** — RMSE in one feature's units says nothing against another's, so it
+  is the only one of these that can rank features against each other.
+* **`max_abs_error`** — an emulator that is good almost everywhere still misleads
+  a calibration that walks through the one place it is not.
+
+These points are free: training already paid to simulate them and then deliberately
+did not fit to them.
 
 ## Using it
 

--- a/tutorial/docs/emulators.md
+++ b/tutorial/docs/emulators.md
@@ -31,7 +31,23 @@ dependency (it pulls in torch, gpytorch and lightgbm, and needs Python ≥3.10, 
 pip install "circulatory_autogen[emulation]"
 ```
 
-Everything else in CA works without it; only `do_emulation` / `use_emulator` need it.
+Everything else in CA works without it; only `do_emulation` / `use_emulator` need it. CA never
+imports autoemulate unless one of those flags is set — it checks whether the package exists
+without loading it, so a normal run does not pay torch's import time.
+
+!!! tip "Two installation gotchas"
+    **Pin a CPU torch.** Left alone, pip installs the CUDA build and its ~2.5 GB of `nvidia-*`
+    wheels. On a machine without a GPU:
+
+    ```bash
+    pip install torch==2.12.1+cpu --index-url https://download.pytorch.org/whl/cpu
+    pip install "autoemulate>=2.1,<3" --extra-index-url https://download.pytorch.org/whl/cpu
+    ```
+
+    **autoemulate 2.1.2 cannot sit alongside torch ≥ 2.13.** Its `harmonic` dependency pins
+    `setuptools==68.0.0` while torch 2.13 requires `setuptools>=77.0.3`, so pip reports
+    `ResolutionImpossible`. Pinning torch to 2.12.x (as above) resolves it. Without a pin, pip
+    silently backtracks through several 500 MB torch wheels looking for a combination that works.
 
 ## Configuration
 

--- a/tutorial/mkdocs.yml
+++ b/tutorial/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - Parameter Identification: parameter-identification.md
   - Sensitivity Analysis: sensitivity-analysis.md
   - Identifiability Analysis: identifiability-analysis.md
+  - Emulators (Surrogate Models): emulators.md
   - "Example: 3Compartment Model": example-3compartment-model.md
   - Running on the HPC: running-on-hpc.md
   - Other Useful Features: other-features.md
@@ -44,6 +45,7 @@ nav:
       - Parameter identification: api/param-id.md
       - Sensitivity analysis: api/sensitivity.md
       - Identifiability analysis: api/identifiability.md
+      - Emulators: api/emulators.md
       - Protocols: api/protocols.md
       - Observation data &amp; utilities: api/utilities.md
       - Parsers &amp; generators (internal): api/internals.md

--- a/user_run_files/run_emulator_training.sh
+++ b/user_run_files/run_emulator_training.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+if [[ $# -eq 0 ]] ; then
+    echo 'usage is ./run_emulator_training.sh num_processors'
+    exit 1
+fi
+
+# Source the path
+source python_path.sh
+
+echo "Training an emulator with $1 processors"
+
+# Make sure the model the emulator is trained against is up to date
+./run_autogeneration.sh
+
+# Check the exit status of the previous command
+if [ $? -eq 0 ]; then
+  echo "Autogeneration completed successfully."
+
+  # If successful, proceed with the mpirun command
+  mpiexec -n "$1" "${python_path}" ../src/scripts/train_emulator_run_script.py
+
+else
+  echo "Error: Autogeneration failed. Aborting."
+  exit 1
+fi

--- a/user_run_files/user_inputs.yaml
+++ b/user_run_files/user_inputs.yaml
@@ -149,4 +149,44 @@ do_ia: false
 ia_options:
   method: Laplace # profile_likelihood
 
+#______ emulator (surrogate model) inputs ___________
+# An emulator maps the params_for_id parameters to the scalar features of your obs_data.json
+# data items -- the same numbers the cost is computed from. Train it once, and calibration,
+# sensitivity analysis, MCMC/UQ and identifiability analysis can all evaluate it instead of the
+# solver. The N training simulations are paid up front, so this wins for Sobol SA
+# (num_samples*(2M+2) runs), MCMC and identifiability, and does NOT win for a single GA run.
+#
+# The two flags are independent:
+#   do_emulation  - train an emulator (./run_emulator_training.sh <num_processors>)
+#   use_emulator  - make the analyses evaluate the trained emulator
+# `solver` above keeps naming the solver used to TRAIN, and to compare the emulator against.
+# Needs the optional dependency: pip install "circulatory_autogen[emulation]"
+do_emulation: false
+use_emulator: false
+emulator_settings:
+  # Where the trained emulator lives.
+  # Default: <param_id_output_dir>/emulators/<file_prefix>_<obs_prefix>
+  # emulator_dir:
+  # 'default' (autoemulate's default set), 'all', or a comma-separated list of emulator names
+  models: default
+  # Number of simulations run to build the training set
+  num_train_samples: 128
+  # Design over the params_for_id box: sobol, latin_hypercube or random
+  sample_type: sobol
+  # Space the design logarithmically (worth it when a bound spans decades; needs min > 0)
+  log_scale_params: false
+  random_seed: 0
+  # Held out and never trained on -- this is what the reported R2/RMSE are measured against
+  test_fraction: 0.2
+  n_splits: 5
+  n_iter: 10
+  # Refuse to USE an emulator whose worst held-out per-feature R2 is below this. An emulator
+  # below it does not fail loudly; it returns plausible wrong numbers.
+  min_r2: 0.9
+  # Outside its training box an emulator is extrapolating with no error estimate:
+  # error (default), warn, or clip
+  out_of_bounds: error
+  # Relative step for the finite-difference gradient over the emulator
+  fd_rel_step: 1.0e-3
+
 plot_predictions: true


### PR DESCRIPTION
Closes #333.

Fit a surrogate of the forward model once, then let the expensive analyses evaluate it instead of the simulator. Sobol SA costs `num_samples·(2M+2)` runs, MCMC tens of thousands, identifiability a Hessian's worth — and all three reach the model through one narrow mapping: **theta in, scalar observable features out**. This trains a surrogate of exactly that mapping and puts it behind the `SimulationHelper` interface, so calibration, SA, UQ and IA all gain it without any of them knowing.

## Scope

**What is emulated:** theta (the `params_for_id` vector, one slot per entry) → each `obs_data.json` data item's feature *after* its `operation`. That is what the cost, the Sobol driver and the Fisher information all consume. Emulating traces instead needs dimension reduction and only buys surrogate plots; it is left as a follow-up and **refused clearly** in the meantime rather than approximated.

**Two flags**, because emulation has a train step and a use step:

```yaml
do_emulation: false   # train an emulator against the solver named by `solver`
use_emulator: false   # make calibration/SA/UQ/IA evaluate it
```

`solver:` deliberately keeps meaning the *truth* solver — the one an emulator is trained against and compared with — so it is not repurposed as an emulator selector.

**Backend:** [autoemulate](https://pypi.org/project/autoemulate/) 2.1.2, as an optional extra (`pip install ".[emulation]"`). CA checks whether the package exists *without importing it*, so a run that is not emulating never pays torch's import time.

## Validation is the load-bearing part

An unvalidated emulator does not fail loudly. It returns plausible wrong numbers, and every Sobol index, cost and posterior downstream inherits the error with nothing to show for it. So the artefact carries held-out R²/RMSE **per feature**, the parameter box it was trained in, and a fingerprint of the model file, bounds, observables, operations and protocol — and CA refuses to use one that is:

| | |
|---|---|
| below `min_r2` (default 0.9) | refused at setup, naming the observable and its R² |
| evaluated outside its training box | refused (or warns/clips, per `out_of_bounds`) |
| stale — bounds, observables, operations, protocol or the model file changed | refused, naming what changed |
| asked for a `series`/`frequency` observable, a prediction trace, or output plots | refused, not approximated |
| missing autoemulate | refused, naming the install command |

## Design notes

- **Training targets come from `fd_backend.observable_features`** — the same function the cost is computed from. A second implementation of "reduce a run to its features" would let the emulator be faithful to something the calibration is not fitting.
- **`emulates_features`** on the helper tells the two places that reduce operands to features to skip that step. This is not cosmetic: re-applying `max` to an already-reduced scalar is invisible, but `max_minus_min` of one value is **zero**, and the cost would then be fitting zeros with nothing looking wrong.
- **`get_cost`/`get_gradient` branch on the emulator first.** A `casadi_python` model would otherwise evaluate its real symbolic graph here and quietly ignore the emulator. The gradient is finite differences on the emulator's own cost — the analytic arms all differentiate the real model — clipped to the training box, so a descent reaching a bound is not refused mid-run.
- **Parameters are mapped to the unit box and features standardised before fitting**, with the transforms stored in the bundle. CA parameters span a compliance near 1e-9 next to a resistance near 1e8, and autoemulate works in float32.
- **Modifier and grouped parameters** work: theta is handed to the helper directly, before the expansion that turns a modifier's single slot into `theta * baseline` per target.

## Discoverable schema

`ANALYSIS_OPTIONS['emulation']` (12 options) — the only entry carrying a `use_flag` as well as an `enable_flag`. `gradient_sources(..., use_emulator=True)` collapses to FD alone. Emulator model names are a runtime registry like the cost funcs: `emulators.emulator_trainer.emulator_model_names()`. `tests/test_solver_info_validation.py` is updated for all of it.

## Files

| | |
|---|---|
| `src/emulators/` | `EmulatorTrainer` (design → simulate across MPI ranks → fit → validate → persist) and `EmulatorBundle` (the artefact and every refusal rule) |
| `src/solver_wrappers/emulator_solver_helper.py` | the helper, built by the same factory as every other backend |
| `src/scripts/train_emulator_run_script.py`, `user_run_files/run_emulator_training.sh` | `./run_emulator_training.sh <num_processors>` |
| `tutorial/docs/emulators.md`, `api/emulators.md` | workflow, refusal rules, and the up-front-cost caveat |

## Testing

The fixture is **`Simple_ODE_Benchmark`**, CA's analytic benchmark — `dx/dt = -x + p`, `dy/dt = -3y + q`, observed as steady-state averages. It is the right model for this because it is dull: smooth, monotone, no bifurcations or oscillations — and because its answer is known in closed form. The features are `p` and `q/3` to within the leftover transient (measured at 0.03 and 1e-6 absolute), so "did the emulator work" becomes arithmetic rather than a comparison against another simulation or against the emulator's own opinion of itself. Measured: 64 Sobol samples give held-out R² of **0.99999** and **0.99997**, and the test asserts R² > 0.99 plus predictions landing on `p` and `q/3` at points never sampled. A forgotten inverse transform, a permuted feature order or a mixed-up parameter column all move predictions off that line, and none would show in the held-out score alone. The simulator is checked against the same arithmetic too, so the assertion cannot pass on a shared misunderstanding of what the features mean.

- `test_emulator_settings.py`, `test_emulator_solver_helper.py` (`unit`, no autoemulate): the artefact, every refusal, the helper contract, the cost-path seam and **Sobol over an emulator** — all with a stub predictor and no solver compiled at all.
- `test_emulator_training.py` (`integration`, `slow`, `mpi`): training end-to-end against the real model, with the autoemulate fit `importorskip`'d.
- 311 unit tests pass; full `-m "not slow"` run: 621 passed, 1 failure — the pre-existing `SN_simple` + PythonGenerator ODE-analyser limitation already documented in CLAUDE.md.
- A **3-rank training run reproduces the serial design and targets element-wise**.
- Against the real library (autoemulate 2.1.2, CPU torch 2.12.1) the full train → validate → persist → calibrate path runs; all 30 emulator tests plus the schema tests pass.

## Analysing the emulator's error

Held-out R² is enough to *refuse* a bad emulator; it is not enough to analyse one, and that is what a user does next. A single score is one number about the whole design, while a calibration walks through one part of the space. So training also keeps:

- **The held-out points** — `emulator_validation.npz`: the parameters, the simulator's answer at each and the emulator's, in real units. This is what a parity plot and a residual-against-parameter plot are drawn from, and a consumer cannot recompute them without the emulator, the simulator *and* the split — i.e. without being CA. They cost nothing: training already paid to simulate them and then deliberately did not fit to them.
- **More per-feature statistics** — MAE, signed bias, max absolute error and nRMSE beside R² and RMSE. Each answers something R² cannot: a feature can score well and still read systematically high (bias), which shifts every downstream cost rather than adding noise to it; RMSE in one feature's units says nothing against another's, while nRMSE can rank them; and an emulator that is good almost everywhere still misleads a calibration that walks through the one place it is not.

Read through `EmulatorBundle.error_stats()` and `error_points()`. The residual's sign is fixed there — **prediction minus truth** — so every consumer agrees that a positive residual means the emulator reads high. [CUFLynx #239](https://github.com/physiomelinks/CUFLynx/pull/239) plots them.

Two defects this exposed, both of which made a *finished* emulator calibration look like it had produced nothing:

- `simulate_with_best_param_vals` raised. Callers pair it with `plot_outputs()` in one try block, so raising cost the run its observable errors as well as its traces. There is nothing to re-simulate — the emulator's features are the result — so it now says so and returns.
- `plot_outputs` then died inside `get_obs_output_dict(get_all_series=True)`, which refused outright. Refusing the *traces* was right; refusing the *features* with them was not, since the errors are a comparison of feature against ground truth and that is exactly what an emulator has. The series come back as `None`, and `save_emulator_outputs` writes the same `percent_error_vec` / `error_vec_names` files an ordinary run writes — so every consumer of an outputs directory is unchanged — skipping only the reconstruction pages.

## Two things worth knowing

**A real bug the live fit caught.** Every Gaussian process — autoemulate's default — returns a *distribution*, and taking `.mean` by truthiness grabs the *method* on a plain tensor, so deterministic emulators would have predicted a bound method. Fixed, with a regression test.

**Installing autoemulate is awkward and the error does not say why.** `harmonic` pins `setuptools==68.0.0` while torch ≥2.13 requires ≥77.0.3, so an unpinned install ends in `ResolutionImpossible` — after backtracking through several 500 MB CUDA wheels. Pin `torch==2.12.1+cpu`. Both traps are documented.

## What users should expect

Emulation difficulty depends on the width of the parameter box, not just on CA. The docs give both ends of the range measured here: R² of **1.0000** on `Simple_ODE_Benchmark`, and only **0.2 and 0.5** for `max` of the Lotka-Volterra states over their full declared ranges, where the response spans 20–3900 and `max` of an oscillation with a parameter-dependent period is close to discontinuous. In that second case the emulator reported its poor scores accurately and the default `min_r2` refuses it — the machinery working, not failing.

And the caveat from the issue: the N training runs are paid up front. The win is real for Sobol, MCMC and identifiability, and **not** for a single GA calibration, which may well be cheaper run directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
