### PR TITLE
feat(uq): pyMC backend and the posterior-recovery tests (#195, #179, #367 step 6)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,7 +167,8 @@ jobs:
   #
   # Measured on Simple_ODE_Benchmark, which is why the job is split the way it is:
   #
-  #   tests/test_uq_on_emulator.py                        ~1 min    (sampled through an emulator)
+  #   tests/test_uq_on_emulator.py [emcee]                ~34 s    (sampled through an emulator)
+  #   tests/test_uq_on_emulator.py [pymc]                 ~83 s    (same, pyMC backend)
   #   test_UQ.py::test_mcmc_unimodal_with_validation      ~9 min    (emcee, real model)
   #   test_UQ.py::test_mcmc_bimodal_with_validation      ~26 min    (emcee, real model)
   #   test_UQ.py::..._KDE_likelihood                     >50 min    (pyMC -- killed, unfinished)
@@ -176,7 +177,8 @@ jobs:
   # likelihood evaluation *per parameter per step* where emcee moves the whole ensemble at once,
   # and PyMCSampler's num_tune defaults to 1000, so it runs 1500 iterations for the 500 draws
   # the test asks for. Run it by hand (or fix the tuning cost) rather than putting an hour on
-  # every pull request; the pyMC backend's other coverage is in tests/test_uq_pymc_backend.py.
+  # every pull request. The pyMC backend is still covered end to end -- through the emulator,
+  # where the same chain costs 83 seconds instead of an hour.
   #
   # It is its own job rather than extra cases on test-param-id-*, because it needs two optional
   # extras those jobs have no use for, and because at ~35 minutes it would become the critical

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,15 +161,27 @@ jobs:
       run: |
         python -m pytest tests/test_param_id.py tests/test_sensitivity_analysis.py -v --with-mpi --tb=short --junitxml=junit-param-id-serial.xml
 
-  # The end-to-end UQ tests: a real calibration followed by a real MCMC chain, checked against
-  # a posterior whose answer is known in closed form (issue #179). They are marked `slow` and so
-  # are deselected everywhere else -- this is the only job that runs them.
+  # The end-to-end UQ tests: a real chain checked against a posterior whose answer is known in
+  # closed form (issue #179). Nothing else runs them -- the full-model ones are marked `slow`
+  # and every other job deselects them.
   #
-  # It is its own job, not extra cases bolted onto test-param-id-*, for two reasons: it needs the
-  # optional [uq] extra (pymc/pytensor, which the other jobs have no use for and which cost a
-  # minute to install), and at ~40 minutes it would otherwise become the critical path of a job
-  # that currently takes half that. As a separate job it runs in parallel, so it sets the
-  # wall-clock floor for the workflow rather than adding to it.
+  # Measured on Simple_ODE_Benchmark, which is why the job is split the way it is:
+  #
+  #   tests/test_uq_on_emulator.py                        ~1 min    (sampled through an emulator)
+  #   test_UQ.py::test_mcmc_unimodal_with_validation      ~9 min    (emcee, real model)
+  #   test_UQ.py::test_mcmc_bimodal_with_validation      ~26 min    (emcee, real model)
+  #   test_UQ.py::..._KDE_likelihood                     >50 min    (pyMC -- killed, unfinished)
+  #
+  # The pyMC case is deselected here. It is not slow by accident: pyMC's Metropolis takes one
+  # likelihood evaluation *per parameter per step* where emcee moves the whole ensemble at once,
+  # and PyMCSampler's num_tune defaults to 1000, so it runs 1500 iterations for the 500 draws
+  # the test asks for. Run it by hand (or fix the tuning cost) rather than putting an hour on
+  # every pull request; the pyMC backend's other coverage is in tests/test_uq_pymc_backend.py.
+  #
+  # It is its own job rather than extra cases on test-param-id-*, because it needs two optional
+  # extras those jobs have no use for, and because at ~35 minutes it would become the critical
+  # path of a job that currently takes 26. In parallel it sets the workflow's wall-clock floor
+  # instead of adding to it.
   test-uq:
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -184,26 +196,36 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        # [uq] brings pymc/pytensor. Without it the pyMC backend test skips, and the backend
-        # goes unexercised in CI -- which is how it stayed unproven for as long as it did.
-        pip install -e ".[dev,uq]"
+        # [uq] brings pymc/pytensor and [emulation] brings autoemulate. Without them the
+        # corresponding tests skip, and those code paths go unexercised in CI -- which is how
+        # the pyMC backend stayed unproven for as long as it did.
+        pip install -e ".[dev,uq,emulation]"
 
     - name: Install MPI and Myokit build dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
 
-    - name: Run the end-to-end UQ posterior-recovery tests
+    # Fast enough to be worth running first: it fails in a minute if UQ is broken at all,
+    # rather than after half an hour of sampling the real model.
+    - name: Run UQ on an emulator (fast posterior-recovery check)
       run: |
-        python -m pytest tests/test_UQ.py -m slow -v --with-mpi --tb=short --durations=0 \
-          --junitxml=junit-uq.xml
+        python -m pytest tests/test_uq_on_emulator.py -v --with-mpi --tb=short \
+          --durations=0 --junitxml=junit-uq-emulator.xml
+
+    - name: Run the full-model UQ posterior-recovery tests
+      run: |
+        python -m pytest tests/test_UQ.py -m slow -k "not KDE" -v --with-mpi --tb=short \
+          --durations=0 --junitxml=junit-uq.xml
 
     - name: Upload UQ test results
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: uq-test-results
-        path: junit-uq.xml
+        path: |
+          junit-uq-emulator.xml
+          junit-uq.xml
 
   # Job to run full test suite if OpenCOR is available (optional)
   # This can be enabled if OpenCOR is set up in CI environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,6 +161,50 @@ jobs:
       run: |
         python -m pytest tests/test_param_id.py tests/test_sensitivity_analysis.py -v --with-mpi --tb=short --junitxml=junit-param-id-serial.xml
 
+  # The end-to-end UQ tests: a real calibration followed by a real MCMC chain, checked against
+  # a posterior whose answer is known in closed form (issue #179). They are marked `slow` and so
+  # are deselected everywhere else -- this is the only job that runs them.
+  #
+  # It is its own job, not extra cases bolted onto test-param-id-*, for two reasons: it needs the
+  # optional [uq] extra (pymc/pytensor, which the other jobs have no use for and which cost a
+  # minute to install), and at ~40 minutes it would otherwise become the critical path of a job
+  # that currently takes half that. As a separate job it runs in parallel, so it sets the
+  # wall-clock floor for the workflow rather than adding to it.
+  test-uq:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # [uq] brings pymc/pytensor. Without it the pyMC backend test skips, and the backend
+        # goes unexercised in CI -- which is how it stayed unproven for as long as it did.
+        pip install -e ".[dev,uq]"
+
+    - name: Install MPI and Myokit build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+
+    - name: Run the end-to-end UQ posterior-recovery tests
+      run: |
+        python -m pytest tests/test_UQ.py -m slow -v --with-mpi --tb=short --durations=0 \
+          --junitxml=junit-uq.xml
+
+    - name: Upload UQ test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: uq-test-results
+        path: junit-uq.xml
+
   # Job to run full test suite if OpenCOR is available (optional)
   # This can be enabled if OpenCOR is set up in CI environment
   test-with-opencor:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,12 @@ dev = [
     "flake8>=4.0.0",
     "mypy>=0.950",
 ]
+# Optional UQ backends. Kept out of the core list on purpose: pytensor builds C
+# extensions, and param_id/paramID.py is imported by every calibration run, so a hard
+# dependency would make an ordinary calibration fail to import for anyone not doing UQ.
+uq = [
+    "pymc>=5.0",
+]
 docs = [
     "mkdocs-material>=9.0",
     "mkdocstrings[python]>=0.24",

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -44,19 +44,19 @@ import re
 from numpy import genfromtxt
 from importlib import import_module
 # import tqdm # TODO this needs to be installed for corner plot but doesnt need an import here
-mcmc_lib = 'emcee' # TODO make this a user variable
-if mcmc_lib == 'emcee':
-    try:
-        import emcee
-    except ImportError:
-        emcee = None
-elif mcmc_lib == 'zeus':
-    try:
-        import zeus
-    except ImportError:
-        zeus = None
-else:
-    print(f'unknown mcmc lib : {mcmc_lib}')
+# Which sampler a UQ run uses is UQ_options['library'], read in OpencorMCMC._build_sampler -- not
+# the module-level constant this used to be, which meant editing the source to change sampler.
+# Both are imported optionally: emcee is a CA dependency but zeus is not, and pymc is imported
+# only inside its own backend module (it is an optional [uq] extra, and this module is imported
+# by every calibration run, UQ or not).
+try:
+    import emcee
+except ImportError:
+    emcee = None
+try:
+    import zeus
+except ImportError:
+    zeus = None
 try:
     import corner
 except ImportError:
@@ -3690,6 +3690,44 @@ class OpencorMCMC(OpencorParamID):
             self.cost_type, self.cost_funcs_dict, "MCMC (log-likelihood uses -cost)"
         )
 
+    def _build_sampler(self, pool=None):
+        """The sampler named by ``UQ_options['library']``, behind emcee's interface.
+
+        Every backend here exposes ``run_mcmc`` and ``get_chain`` returning a
+        ``(steps, walkers, params)`` chain, so the sampling loop, the saved ``mcmc_chain.npy``
+        and everything downstream of it are the same whichever was chosen.
+        """
+        library = (self.UQ_options or {}).get('library', 'emcee')
+        num_walkers = self.UQ_options['num_walkers']
+
+        if library == 'emcee':
+            if pool is not None:
+                return emcee.EnsembleSampler(num_walkers, self.num_params,
+                                             calculate_lnlikelihood, pool=pool)
+            return emcee.EnsembleSampler(num_walkers, self.num_params, calculate_lnlikelihood)
+
+        if library == 'zeus':
+            if zeus is None:
+                raise ImportError("UQ_options library 'zeus' was selected but zeus is not "
+                                  "installed.")
+            if pool is not None:
+                return zeus.EnsembleSampler(num_walkers, self.num_params,
+                                            calculate_lnlikelihood, pool=pool)
+            return zeus.EnsembleSampler(num_walkers, self.num_params, calculate_lnlikelihood)
+
+        if library == 'pymc':
+            # Imported here, not at module level: pymc is an optional extra, and paramID is
+            # imported by every calibration run.
+            from param_id.pymc_backend import PyMCSampler
+            return PyMCSampler(
+                num_walkers, self.num_params, calculate_lnlikelihood,
+                param_id_info=self.param_id_info,
+                num_tune=self.UQ_options.get('num_tune', 1000),
+                method=self.UQ_options.get('pymc_method', 'mcmc'))
+
+        raise ValueError(
+            f"unknown UQ_options library {library!r}. Valid options are 'emcee' and 'pymc'.")
+
     def _cost_weight_vectors(self, exp_idx, sub_idx):
         """Every feature entering the likelihood carries equal weight (issue #193).
 
@@ -3783,12 +3821,7 @@ class OpencorMCMC(OpencorParamID):
                 pool.wait()
                 return
 
-            if mcmc_lib == 'emcee':
-                self.sampler = emcee.EnsembleSampler(self.UQ_options['num_walkers'], self.num_params, calculate_lnlikelihood,
-                                            pool=pool)
-            elif mcmc_lib == 'zeus':
-                self.sampler = zeus.EnsembleSampler(self.UQ_options['num_walkers'], self.num_params, calculate_lnlikelihood,
-                                                        pool=pool)
+            self.sampler = self._build_sampler(pool=pool)
 
             start_time = time.time()
             self.sampler.run_mcmc(init_param_vals.T, self.UQ_options['num_steps'], progress=True, tune=True)
@@ -3806,10 +3839,7 @@ class OpencorMCMC(OpencorParamID):
                 init_param_vals_norm = np.random.rand(self.num_params, self.UQ_options['num_walkers'])
                 init_param_vals = self.param_norm_obj.unnormalise(init_param_vals_norm)
 
-            if mcmc_lib == 'emcee':
-                self.sampler = emcee.EnsembleSampler(self.UQ_options['num_walkers'], self.num_params, calculate_lnlikelihood)
-            elif mcmc_lib == 'zeus':
-                self.sampler = zeus.EnsembleSampler(self.UQ_options['num_walkers'], self.num_params, calculate_lnlikelihood)
+            self.sampler = self._build_sampler()
 
             start_time = time.time()
             self.sampler.run_mcmc(init_param_vals.T, self.UQ_options['num_steps']) # , progress=True)
@@ -3817,7 +3847,7 @@ class OpencorMCMC(OpencorParamID):
 
         if rank == 0:
             # TODO save chains
-            if mcmc_lib == 'emcee':
+            if hasattr(self.sampler, 'acceptance_fraction'):
                 print(f'acceptance fraction was {self.sampler.acceptance_fraction}')
             samples = self.sampler.get_chain()
             mcmc_chain_path = os.path.join(self.output_dir, 'mcmc_chain.npy')

--- a/src/param_id/pymc_backend.py
+++ b/src/param_id/pymc_backend.py
@@ -1,0 +1,220 @@
+"""pyMC as an alternative MCMC backend, behind emcee's sampler interface (issue #195).
+
+emcee's affine-invariant ensemble sampler is a good default, but it is one algorithm. pyMC brings
+Metropolis, NUTS and sequential Monte Carlo, and SMC in particular can cross the low-probability
+regions between separated modes that an ensemble sampler gets stuck on.
+
+``PyMCSampler`` exposes exactly the surface ``OpencorMCMC.run`` already uses -- ``run_mcmc`` and
+``get_chain``, with a ``(steps, walkers, params)`` chain -- so selecting a library changes one
+line of construction and nothing in the sampling loop or in anything downstream (the diagnostics,
+the corner plots and the saved ``mcmc_chain.npy`` all keep working unchanged).
+
+pymc and pytensor are imported lazily, inside the sampler. They are not CA dependencies:
+``paramID.py`` is imported by every calibration run, so importing them at module level (as the
+original patch did) would break every user who has not installed them, to no benefit for anyone
+not doing UQ. Install with ``pip install -e ".[uq]"``.
+"""
+import numpy as np
+
+try:
+    from mpi4py import MPI
+except ImportError:                                            # pragma: no cover - MPI is a dep
+    MPI = None
+
+
+_INSTALL_HINT = (
+    "The pyMC UQ backend needs pymc and pytensor, which are not installed. "
+    "Install them with:  pip install -e \".[uq]\"  (or set UQ_options: library: emcee to use "
+    "the built-in ensemble sampler instead)."
+)
+
+
+def _import_pymc():
+    """Import pymc/pytensor, or raise with the install command rather than a bare ImportError."""
+    try:
+        import pymc as pm
+        import pytensor.tensor as pt
+        from pytensor.compile.ops import as_op
+    except ImportError as exc:
+        raise ImportError(f"{_INSTALL_HINT} (underlying error: {exc})") from exc
+    return pm, pt, as_op
+
+
+class PyMCSampler:
+    """A pyMC sampler wearing emcee's interface.
+
+    Args:
+        num_walkers: Total chains to run across all MPI ranks.
+        num_params: Number of calibrated parameters.
+        log_posterior_fn: ``f(param_vals) -> float``, the **full** log posterior
+            (log likelihood + log prior). See ``_build_model`` for why the whole thing goes in
+            rather than the likelihood alone.
+        param_id_info: The engine's parameter info (names, mins, maxs, unbounded flags).
+        num_tune: Tuning (burn-in) draws discarded before sampling.
+        method: ``'mcmc'`` for Metropolis sampling, or ``'smc'`` for sequential Monte Carlo.
+    """
+
+    def __init__(self, num_walkers, num_params, log_posterior_fn, param_id_info=None,
+                 num_tune=1000, method='mcmc'):
+        if method not in ('mcmc', 'smc'):
+            raise ValueError(f"unknown pyMC method {method!r}; expected 'mcmc' or 'smc'")
+        self.num_walkers = num_walkers
+        self.num_params = num_params
+        self.log_posterior_fn = log_posterior_fn
+        self.param_id_info = param_id_info or {}
+        self.num_tune = num_tune
+        self.method = method
+        self.chain = None
+        # Fail here rather than after a model has already been built and a pool opened.
+        self.pm, self.pt, self._as_op = _import_pymc()
+
+    # ------------------------------------------------------------------
+    # model
+    # ------------------------------------------------------------------
+    def _param_names(self):
+        names = self.param_id_info.get('param_names_for_plotting')
+        if names is None or len(names) != self.num_params:
+            return [f'param_{idx}' for idx in range(self.num_params)]
+        return list(names)
+
+    def _build_model(self):
+        """A pyMC model whose only density term is CA's own log posterior.
+
+        The prior is deliberately *not* re-declared as pyMC distributions. CA's
+        ``get_lnprior_from_params`` already implements the full params_for_id prior vocabulary --
+        uniform / exponential / normal, the user's ``prior_mean``, ``prior_std``,
+        ``prior_origin`` and ``prior_scale`` hyper-parameters, and the ``unbounded`` flag that
+        suppresses the range check. Restating that in pyMC terms would mean maintaining a second
+        implementation of it, and the original patch shows what that costs: it hardcoded the old
+        defaults (lambda=1, sigma=(max-min)/6, mu=(max+min)/2) and so silently ignored every
+        prior hyper-parameter a user set.
+
+        Worse, it declared those pyMC priors *and* put the full log posterior in the Potential,
+        so the prior was counted twice and the sampled posterior was not the one CA defines.
+
+        Here each parameter is a bare support declaration -- Uniform over its box, or Flat when
+        the parameter is unbounded -- which contributes only a constant inside that support and
+        so leaves the posterior shape entirely to the Potential.
+        """
+        pm = self.pm
+        names = self._param_names()
+        mins = self.param_id_info.get('param_mins')
+        maxs = self.param_id_info.get('param_maxs')
+        unbounded = self.param_id_info.get('param_unbounded')
+
+        log_posterior_op = self._as_op(
+            itypes=[self.pt.dvector], otypes=[self.pt.dscalar])(self._evaluate_log_posterior)
+
+        with pm.Model() as model:
+            variables = []
+            for idx, name in enumerate(names):
+                is_unbounded = bool(unbounded[idx]) if unbounded is not None and \
+                    idx < len(unbounded) else False
+                if is_unbounded or mins is None or maxs is None:
+                    variables.append(pm.Flat(name))
+                else:
+                    variables.append(
+                        pm.Uniform(name, lower=float(mins[idx]), upper=float(maxs[idx])))
+            pm.Potential('log_posterior', log_posterior_op(pm.math.stack(variables)))
+        return model
+
+    def _evaluate_log_posterior(self, param_vals):
+        """The pytensor-facing wrapper: always a 0-d float64, whatever the cost returns."""
+        value = np.asarray(self.log_posterior_fn(np.asarray(param_vals, dtype=float)),
+                           dtype=float)
+        if value.shape != ():
+            value = np.sum(value)
+        return np.array(float(value))
+
+    # ------------------------------------------------------------------
+    # sampling
+    # ------------------------------------------------------------------
+    @staticmethod
+    def chains_for_rank(num_walkers, num_procs):
+        """How many chains this rank runs, given the total walker budget.
+
+        Never zero: with more ranks than walkers, ``num_walkers // num_procs`` is 0 and pyMC is
+        asked for no chains at all, which either raises or silently returns an empty trace.
+        """
+        if num_procs is None or num_procs <= 1:
+            return max(1, int(num_walkers))
+        return max(1, int(num_walkers) // int(num_procs))
+
+    def run_mcmc(self, initial_state, num_steps, progress=False, **kwargs):
+        """Sample, and return the chain as ``(steps, walkers, params)``.
+
+        ``initial_state`` is emcee's ``(walkers, params)`` starting positions; it seeds the
+        per-chain initial values for ``method='mcmc'`` and is unused for SMC, which draws its
+        own initial population from the prior.
+        """
+        comm = MPI.COMM_WORLD if MPI is not None else None
+        rank = comm.Get_rank() if comm is not None else 0
+        num_procs = comm.Get_size() if comm is not None else 1
+        num_chains = self.chains_for_rank(self.num_walkers, num_procs)
+
+        model = self._build_model()
+        with model:
+            if self.method == 'smc':
+                trace = self.pm.sample_smc(draws=num_steps, chains=num_chains, cores=1,
+                                           progressbar=(progress and rank == 0))
+            else:
+                trace = self.pm.sample(
+                    draws=num_steps, tune=self.num_tune, chains=num_chains, cores=1,
+                    step=self.pm.Metropolis(), progressbar=(progress and rank == 0),
+                    initvals=self._initial_values(initial_state, num_chains))
+
+        local_chain = self.trace_to_emcee_chain(trace, self._param_names())
+
+        if comm is None:
+            self.chain = local_chain
+            return self.chain
+
+        comm.Barrier()
+        gathered = comm.gather(local_chain, root=0)
+        if rank != 0:
+            return None
+        # Each rank sampled its own chains, so they concatenate along the walker axis.
+        self.chain = np.concatenate([c for c in gathered if c is not None], axis=1)
+        return self.chain
+
+    def _initial_values(self, initial_state, num_chains):
+        """emcee's (walkers, params) start positions as pyMC's per-chain initval dicts."""
+        if initial_state is None:
+            return None
+        initial_state = np.asarray(initial_state, dtype=float)
+        names = self._param_names()
+        return [
+            {name: float(initial_state[chain_idx % initial_state.shape[0], param_idx])
+             for param_idx, name in enumerate(names)}
+            for chain_idx in range(num_chains)
+        ]
+
+    @staticmethod
+    def trace_to_emcee_chain(trace, param_names):
+        """Convert an arviz InferenceData posterior to emcee's ``(steps, walkers, params)``.
+
+        pyMC stores ``(chain, draw)`` per variable; emcee -- and therefore every CA consumer of
+        ``mcmc_chain.npy``, from the corner plots to the R-hat diagnostic -- expects draws first
+        and walkers second.
+
+        Raises rather than returning None on a trace that does not contain the parameters: a
+        silent None becomes an unreadable failure much further downstream, after the sampling
+        has already been paid for.
+        """
+        posterior = getattr(trace, 'posterior', None)
+        if posterior is None:
+            raise ValueError('pyMC returned a trace with no posterior group')
+
+        missing = [name for name in param_names if name not in posterior]
+        if missing:
+            raise ValueError(
+                f'pyMC trace is missing sampled parameters {missing}; '
+                f'it contains {list(posterior)}')
+
+        # (chain, draw) per parameter -> (chain, draw, param) -> (draw, chain, param)
+        stacked = np.stack([np.asarray(posterior[name].values) for name in param_names], axis=-1)
+        return np.swapaxes(stacked, 0, 1)
+
+    def get_chain(self):
+        """The sampled chain, ``(steps, walkers, params)`` -- emcee's accessor."""
+        return self.chain

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -1444,9 +1444,10 @@ ANALYSIS_OPTIONS = {
              'description': 'Uncertainty-quantification method. Only posterior sampling by MCMC '
                             'is implemented so far.'},
             {'name': 'library', 'type': 'enum', 'default': 'emcee', 'required': False,
-             'choices': ['emcee'],
+             'choices': ['emcee', 'pymc'],
              'description': 'Sampler backend for method=mcmc. emcee is the built-in affine '
-                            'invariant ensemble sampler.'},
+                            'invariant ensemble sampler; pymc adds Metropolis and sequential '
+                            'Monte Carlo and needs the optional [uq] extra.'},
             {'name': 'num_steps', 'type': 'int', 'default': 5000, 'required': False,
              'description': 'Number of MCMC steps per walker.'},
             {'name': 'num_walkers', 'type': 'int', 'default': None, 'required': False,

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -1455,6 +1455,14 @@ ANALYSIS_OPTIONS = {
             {'name': 'burn_in', 'type': 'float', 'default': 0.5, 'required': False,
              'description': 'Samples discarded before the chain is used. A value below 1 is a '
                             'fraction of num_steps; 1 or above is a number of steps.'},
+            # Read by OpencorMCMC._build_sampler for the pymc backend. It was read but not
+            # advertised, which is the same defect as advertising a setting nothing reads, only
+            # inverted: the knob exists and matters (it triples the iteration count at its
+            # default) but no front-end could discover or change it.
+            {'name': 'num_tune', 'type': 'int', 'default': 1000, 'required': False,
+             'description': 'Tuning (warm-up) draws the pymc backend discards before sampling. '
+                            'Ignored by emcee, which tunes as it goes. These are on top of '
+                            'num_steps, so 1000 tune plus 500 draws is 1500 iterations.'},
         ],
     },
     'identifiability_analysis': {

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -1463,6 +1463,14 @@ ANALYSIS_OPTIONS = {
              'description': 'Tuning (warm-up) draws the pymc backend discards before sampling. '
                             'Ignored by emcee, which tunes as it goes. These are on top of '
                             'num_steps, so 1000 tune plus 500 draws is 1500 iterations.'},
+            # The backend's other undeclared setting, and the one that changes the answer rather
+            # than what it costs to get it. Same defect as num_tune above: _build_sampler reads
+            # it with a hardcoded fallback, so it sat at 'mcmc' with nothing able to reach it.
+            {'name': 'pymc_method', 'type': 'enum', 'default': 'mcmc', 'required': False,
+             'choices': ['mcmc', 'smc'],
+             'description': "pyMC sampling algorithm: 'mcmc' is Metropolis, 'smc' is sequential "
+                            'Monte Carlo, which can cross a low-probability region between modes '
+                            'that Metropolis gets stuck on one side of. Ignored by emcee.'},
         ],
     },
     'identifiability_analysis': {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,8 @@ _TEST_OUTPUT_ROOT = os.path.join(os.path.dirname(__file__), "test_outputs")
 #     {"file_prefix": "test_fft", "input_param_file": "test_fft_parameters.csv", "model_type": "cellml_only", "solver": "CVODE"},
 # ]
 _LOCK_FILE = os.path.realpath(os.path.join(_TEST_ROOT, ".pytest_param_id_lock"))
-_PARAM_ID_TRIGGERS = ("test_param_id", "compare_optimisers", "test_sensitivity_analysis", "test_python_user_defined")
+_PARAM_ID_TRIGGERS = ("test_param_id", "compare_optimisers", "test_sensitivity_analysis",
+                      "test_python_user_defined", "test_UQ")
 
 
 def _is_autogen_like_nodeid(nodeid: str) -> bool:

--- a/tests/test_UQ.py
+++ b/tests/test_UQ.py
@@ -1,0 +1,227 @@
+"""End-to-end uncertainty quantification: does the posterior recover a known answer? (#179)
+
+Ported from #367. These are the tests that actually validate UQ rather than its parts: the
+Simple_ODE_Benchmark model has an analytically known steady state, so a correct posterior must
+centre on it with the right spread. Every unit test in test_uq_*.py can pass while the pipeline
+as a whole samples the wrong distribution -- that is what these catch.
+
+All three are slow (a real calibration followed by a real chain), so they are deselected from
+the default ``-m "not slow"`` run. Run them with:
+
+    ./run_pytest.sh tests/test_UQ.py -n 4 -m slow -v
+"""
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from param_id.paramID import CVS0DParamID
+from scripts.param_id_run_script import run_param_id
+# mpi_comm is a fixture defined in test_param_id, so it has to be imported here to be visible to
+# these tests -- not merely referenced in their signatures.
+from tests.test_param_id import _ensure_cellml_model_generated, mpi_comm  # noqa: F401
+
+pymc_installed = True
+try:
+    import pymc  # noqa: F401
+except ImportError:
+    pymc_installed = False
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# The Simple_ODE_Benchmark steady state, and the spread the observation noise implies.
+ANALYTICAL_SOLUTION = np.array([1.0, 1.0])
+ANALYTICAL_STD = np.array([0.1, 0.3])
+
+
+def _uq_config(base_user_inputs, resources_dir, temp_output_dir, obs_path, library='emcee',
+               num_steps=500, num_walkers=32):
+    config = base_user_inputs.copy()
+    config.update({
+        'file_prefix': 'Simple_ODE_Benchmark',
+        'input_param_file': 'Simple_ODE_Benchmark_parameters.csv',
+        'params_for_id_file': 'Simple_ODE_Benchmark_params_for_id.csv',
+        'model_type': 'cellml_only',
+        'solver': 'CVODE_myokit',
+        'param_id_method': 'genetic_algorithm',
+        'pre_time': 0.5,
+        'sim_time': 10.0,
+        'dt': 0.1,
+        'DEBUG': False,
+        'do_uq': True,
+        'plot_predictions': False,
+        'do_ia': False,
+        'param_id_obs_path': obs_path,
+        'param_id_output_dir': temp_output_dir,
+        'UQ_options': {
+            'method': 'mcmc',
+            'library': library,
+            'num_steps': num_steps,
+            'num_walkers': num_walkers,
+            'burn_in': 0.5,
+        },
+        'optimiser_options': {
+            'num_calls_to_function': 10000,
+            'cost_convergence': 0.01,
+            'max_patience': 5,
+            'cost_type': 'gaussian_MLE',
+        },
+    })
+    return config
+
+
+def _load_chain_after_burn_in(output_dir, burn_in):
+    chain_file = os.path.join(output_dir, 'mcmc_chain.npy')
+    assert os.path.exists(chain_file), 'MCMC chain file should exist'
+    samples = np.load(chain_file)
+    return samples[int(samples.shape[0] * burn_in):, :, :]
+
+
+def _mcmc_object(config, resources_dir, temp_output_dir):
+    return CVS0DParamID(
+        config['model_path'], config['model_type'], config['param_id_method'], True,
+        config['file_prefix'],
+        params_for_id_path=config.get('params_for_id_path'),
+        param_id_obs_path=config['param_id_obs_path'],
+        sim_time=config['sim_time'], pre_time=config['pre_time'], dt=config['dt'],
+        param_id_output_dir=temp_output_dir, resources_dir=resources_dir,
+        UQ_options=config['UQ_options'], DEBUG=config['DEBUG'], one_rank=True,
+    )
+
+
+def _assert_chain_converged(stats, max_rhat, min_ess):
+    for name, row in stats.items():
+        assert np.isfinite(row['r_hat']), f'r_hat for {name} could not be computed'
+        assert row['r_hat'] < max_rhat, f'r_hat for {name} is too high: {row["r_hat"]}'
+        assert row['ess'] > min_ess, f'{name} has too few effective samples: {row["ess"]}'
+
+
+def _assert_posterior_recovers_the_truth(stats, best_params, rtol, std_atol):
+    assert np.allclose(best_params, ANALYTICAL_SOLUTION, rtol=rtol), \
+        f'best params {best_params} do not recover {ANALYTICAL_SOLUTION}'
+
+    posterior_std = np.array([row['sd'] for row in stats.values()])
+    print(f'Posterior std: {posterior_std}, analytical: {ANALYTICAL_STD}')
+    assert np.allclose(posterior_std, ANALYTICAL_STD, atol=std_atol), \
+        f'posterior spread {posterior_std} does not match {ANALYTICAL_STD}'
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_mcmc_unimodal_with_validation(base_user_inputs, resources_dir, temp_output_dir,
+                                       temp_generated_models_dir, mpi_comm):
+    """The baseline: emcee on a unimodal posterior must recover the known steady state, with a
+    converged chain and the spread the observation noise implies."""
+    rank = mpi_comm.Get_rank()
+    config = _uq_config(
+        base_user_inputs, resources_dir, temp_output_dir,
+        os.path.join(resources_dir, 'Simple_ODE_Benchmark_obs_data.json'))
+
+    _ensure_cellml_model_generated(config, mpi_comm)
+    run_param_id(config)
+
+    if rank == 0:
+        output_dir = os.path.join(
+            temp_output_dir,
+            f"{config['param_id_method']}_{config['file_prefix']}_Simple_ODE_Benchmark_obs_data")
+        samples = _load_chain_after_burn_in(output_dir, config['UQ_options']['burn_in'])
+
+        mcmc_obj = _mcmc_object(config, resources_dir, temp_output_dir)
+        mcmc_obj.plot_mcmc()
+        assert list(Path(mcmc_obj.plot_dir).glob('mcmc_cornerplot_*.pdf'))
+
+        stats = mcmc_obj.get_posterior_stats(samples)
+        _assert_chain_converged(stats, max_rhat=1.3, min_ess=50)
+        _assert_posterior_recovers_the_truth(
+            stats, np.load(os.path.join(output_dir, 'best_param_vals.npy')),
+            rtol=0.1, std_atol=0.2)
+
+    mpi_comm.Barrier()
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+@pytest.mark.skipif(not pymc_installed,
+                    reason='the pyMC backend needs the optional [uq] extra')
+def test_mcmc_unimodal_with_validation_KDE_likelihood(base_user_inputs, resources_dir,
+                                                      temp_output_dir,
+                                                      temp_generated_models_dir, mpi_comm):
+    """The same posterior via the pyMC backend and a KDE likelihood.
+
+    Two things at once, both worth having: that pyMC reaches the same answer emcee does (the
+    real acceptance test for the backend -- a sampler that agrees with another sampler on a
+    known posterior is working), and that kernel_density_estimation behaves as a likelihood
+    when the target is given as samples rather than a named distribution.
+    """
+    rank = mpi_comm.Get_rank()
+    config = _uq_config(
+        base_user_inputs, resources_dir, temp_output_dir,
+        os.path.join(_TESTS_DIR, 'test_inputs', 'Simple_ODE_Benchmark_KDE_obs_data.json'),
+        library='pymc')
+
+    _ensure_cellml_model_generated(config, mpi_comm)
+    run_param_id(config)
+
+    if rank == 0:
+        output_dir = os.path.join(
+            temp_output_dir,
+            f"{config['param_id_method']}_{config['file_prefix']}_"
+            f"Simple_ODE_Benchmark_KDE_obs_data")
+        samples = _load_chain_after_burn_in(output_dir, config['UQ_options']['burn_in'])
+
+        mcmc_obj = _mcmc_object(config, resources_dir, temp_output_dir)
+        mcmc_obj.plot_mcmc()
+        assert list(Path(mcmc_obj.plot_dir).glob('mcmc_cornerplot_*.pdf'))
+
+        stats = mcmc_obj.get_posterior_stats(samples)
+        _assert_chain_converged(stats, max_rhat=1.2, min_ess=50)
+        _assert_posterior_recovers_the_truth(
+            stats, np.load(os.path.join(output_dir, 'best_param_vals.npy')),
+            rtol=0.25, std_atol=0.1)
+
+    mpi_comm.Barrier()
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_mcmc_bimodal_with_validation(base_user_inputs, resources_dir, temp_output_dir,
+                                      temp_generated_models_dir, mpi_comm):
+    """A bimodal target: the posterior must show both modes rather than collapsing onto one.
+
+    This is the case a point estimate cannot represent at all, so it is the one that most
+    justifies running UQ -- and the one an ensemble sampler is most likely to get wrong by
+    parking every walker in whichever mode it found first.
+    """
+    rank = mpi_comm.Get_rank()
+    config = _uq_config(
+        base_user_inputs, resources_dir, temp_output_dir,
+        os.path.join(_TESTS_DIR, 'test_inputs', 'Simple_ODE_Benchmark_bimodal_obs_data.json'))
+
+    _ensure_cellml_model_generated(config, mpi_comm)
+    run_param_id(config)
+
+    if rank == 0:
+        output_dir = os.path.join(
+            temp_output_dir,
+            f"{config['param_id_method']}_{config['file_prefix']}_"
+            f"Simple_ODE_Benchmark_bimodal_obs_data")
+        samples = _load_chain_after_burn_in(output_dir, config['UQ_options']['burn_in'])
+        flat_samples = samples.reshape(-1, samples.shape[-1])
+
+        mcmc_obj = _mcmc_object(config, resources_dir, temp_output_dir)
+        mcmc_obj.plot_mcmc()
+        assert list(Path(mcmc_obj.plot_dir).glob('mcmc_cornerplot_*.pdf'))
+
+        # Both modes must be represented. A unimodal collapse shows up as all the mass on one
+        # side of the midpoint, which is exactly what a mean or a best-fit point would hide.
+        first_param = flat_samples[:, 0]
+        midpoint = 0.5 * (first_param.min() + first_param.max())
+        below = np.mean(first_param < midpoint)
+        assert 0.1 < below < 0.9, (
+            f'the chain collapsed onto one mode: {below:.1%} of samples below the midpoint')
+
+    mpi_comm.Barrier()

--- a/tests/test_UQ.py
+++ b/tests/test_UQ.py
@@ -20,7 +20,14 @@ from param_id.paramID import CVS0DParamID
 from scripts.param_id_run_script import run_param_id
 # mpi_comm is a fixture defined in test_param_id, so it has to be imported here to be visible to
 # these tests -- not merely referenced in their signatures.
-from tests.test_param_id import _ensure_cellml_model_generated, mpi_comm  # noqa: F401
+#
+# Imported as a top-level module, not as `tests.test_param_id`: tests/ has no __init__.py, so
+# pytest puts it on sys.path and imports these files top-level anyway -- while `tests` as a
+# package resolves against whatever else is installed. At least one dependency ships its own
+# top-level `tests` package, which shadows this directory and makes the dotted form fail with
+# ModuleNotFoundError in a plain pip environment (it happens to work under the OpenCOR shell,
+# which has no such package -- so the dotted form passes locally and breaks in CI).
+from test_param_id import _ensure_cellml_model_generated, mpi_comm  # noqa: F401
 
 pymc_installed = True
 try:

--- a/tests/test_inputs/Simple_ODE_Benchmark_KDE_obs_data.json
+++ b/tests/test_inputs/Simple_ODE_Benchmark_KDE_obs_data.json
@@ -1,0 +1,65 @@
+{
+  "protocol_info": {
+    "pre_times": [
+      0.0
+    ],
+    "sim_times": [
+      [
+        8.0
+      ]
+    ],
+    "params_to_change": {
+    },
+    "experiment_labels": [
+      "TWorld_v2_Virual_cohort"
+    ]
+  },
+  "prediction_items": [],
+  "data_items": [
+	{  
+	  "variable": "benchmark/x",  
+	  "name_for_plotting": "x_{SS}",  
+	  "data_type": "prob_dist",  
+	  "operation": "steady_state_avg",  
+	  "operands": ["benchmark/x"],  
+	  "unit": "dimensionless",  
+	  "weight": 1.0,  
+	  "value": 1,  
+	  "std": 0.1,  
+	  "experiment_idx": 0,  
+	  "subexperiment_idx": 0,  
+	  "plot_type": "None",
+          "prob_dist_params": {  
+	        "data_points": [1.050, 0.986, 1.065, 1.152, 0.977, 0.977, 1.158, 1.077, 0.953, 1.054]
+	  },
+      "cost_type": "kernel_density_estimation"
+	},
+	{  
+	  "variable": "benchmark/y",  
+	  "name_for_plotting": "y_{SS}",  
+	  "data_type": "prob_dist",  
+	  "operation": "steady_state_avg",  
+	  "operands": ["benchmark/y"],  
+	  "unit": "dimensionless",  
+	  "weight": 1.0,  
+	  "value": 0.33,  
+	  "std": 0.1,  
+	  "experiment_idx": 0,  
+	  "subexperiment_idx": 0,  
+	  "plot_type": "None",
+	      "prob_dist_params": {  
+		    "data_points": [4.3616256380e-1,
+							3.4851763020e-1,
+							3.0416979900e-1,
+							3.2567541060e-1,
+							3.0277230150e-1,
+							3.9074290780e-1,
+							2.3822858120e-1,
+							4.0581900250e-1,
+							3.4042696990e-1,
+							1.9834831290e-1]
+		  },
+	  "cost_type": "kernel_density_estimation"
+	}
+  ]
+}

--- a/tests/test_inputs/Simple_ODE_Benchmark_bimodal_obs_data.json
+++ b/tests/test_inputs/Simple_ODE_Benchmark_bimodal_obs_data.json
@@ -1,0 +1,60 @@
+{
+  "protocol_info": {
+    "pre_times": [
+      10.0
+    ],
+    "sim_times": [
+      [
+        8.0
+      ]
+    ],
+    "params_to_change": {
+    },
+    "experiment_labels": [
+      "TWorld_v2_Virual_cohort"
+    ]
+  },
+  "prediction_items": [],
+  "data_items": [
+	{  
+	  "variable": "benchmark/x",  
+	  "name_for_plotting": "x_{SS}",  
+	  "data_type": "prob_dist",  
+	  "operation": "steady_state_avg",  
+	  "operands": ["benchmark/x"],  
+	  "unit": "dimensionless",  
+	  "weight": 1.0,  
+	  "value": 1,  
+	  "std": 0.1, 
+	  "experiment_idx": 0,  
+	  "subexperiment_idx": 0,  
+	  "plot_type": "None",
+          "prob_dist_params": {  
+	        "data_points": [1.050, 0.986, 1.065, 1.152, 0.977, 0.977, 1.158, 1.077, 0.953, 1.054,
+	        		4.050, 3.986, 4.065, 4.152, 3.977, 3.977, 4.158, 4.077, 3.953, 4.054],
+			"bandwidth": 0.1
+	  },
+          "cost_type": "kernel_density_estimation"
+	},
+	{  
+	  "variable": "benchmark/y",  
+	  "name_for_plotting": "y_{SS}",  
+	  "data_type": "prob_dist",  
+	  "operation": "steady_state_avg",  
+	  "operands": ["benchmark/y"],  
+	  "unit": "dimensionless",  
+	  "weight": 1.0,  
+	  "value": 0.33,  
+	  "std": 0.1,  
+	  "experiment_idx": 0,  
+	  "subexperiment_idx": 0,  
+	  "plot_type": "None",
+	      "prob_dist_params": {  
+		    "data_points": [0.356, 0.239, 0.292, 0.277, 0.416, 0.289, 0.380, 0.531, 0.456, 0.286,
+		    		    1.356, 1.239, 1.292, 1.277, 1.416, 1.289, 1.380, 1.531, 1.456, 1.286],
+			"bandwidth": 0.1
+		  },
+	      "cost_type": "kernel_density_estimation"
+	}
+  ]
+}

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -501,7 +501,8 @@ def test_analysis_options_schema_well_formed():
     assert names('sensitivity_analysis') == {
         'method', 'sample_type', 'num_samples', 'gradient_method', 'fd_rel_step'}
     # 'uq', not 'mcmc': MCMC is one UQ method, and 'method' is the seam the others are added at.
-    assert names('uq') == {'method', 'library', 'num_steps', 'num_walkers', 'burn_in'}
+    assert names('uq') == {'method', 'library', 'num_steps', 'num_walkers', 'burn_in',
+                           'num_tune'}
     assert ANALYSIS_OPTIONS['uq']['options_key'] == 'UQ_options'
     assert names('identifiability_analysis') == {'method', 'gradient_source', 'sub_method'}
     assert names('emulation') == {

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -1,5 +1,6 @@
 import ast
 import pathlib
+import re
 import warnings
 
 import pytest
@@ -502,7 +503,7 @@ def test_analysis_options_schema_well_formed():
         'method', 'sample_type', 'num_samples', 'gradient_method', 'fd_rel_step'}
     # 'uq', not 'mcmc': MCMC is one UQ method, and 'method' is the seam the others are added at.
     assert names('uq') == {'method', 'library', 'num_steps', 'num_walkers', 'burn_in',
-                           'num_tune'}
+                           'num_tune', 'pymc_method'}
     assert ANALYSIS_OPTIONS['uq']['options_key'] == 'UQ_options'
     assert names('identifiability_analysis') == {'method', 'gradient_source', 'sub_method'}
     assert names('emulation') == {
@@ -521,6 +522,36 @@ def test_analysis_options_schema_well_formed():
 
 def _option(mode, name):
     return next(o for o in analysis_options(mode) if o['name'] == name)
+
+
+def test_every_uq_option_the_code_reads_is_advertised():
+    """A UQ setting CA reads but does not declare cannot be reached from a front-end at all.
+
+    CUFLynx builds its UQ form from ANALYSIS_OPTIONS['uq'] and hardcodes nothing, so an option
+    missing here is an option nobody can set: it stays at whatever default the ``.get()`` call
+    carries, silently. That is how the pyMC backend shipped selectable but unconfigurable --
+    ``library: pymc`` was advertised while ``num_tune`` and ``pymc_method``, the only two
+    settings that backend adds, were not.
+
+    Scanning the source rather than restating a list is the point. The name set above is
+    hand-maintained, so it agrees with whatever it was last edited to say; this reads what the
+    code actually asks ``UQ_options`` for, and so fails when a read is added without a
+    descriptor, which is the direction the mistake goes in.
+    """
+    src_dir = pathlib.Path(__file__).resolve().parent.parent / 'src'
+    # UQ_options['x'], UQ_options.get('x'), self.UQ_options.get("x", default)
+    pattern = re.compile(r"""UQ_options(?:\.get\(|\[)\s*['"]([A-Za-z_][A-Za-z0-9_]*)['"]""")
+    read = set()
+    for path in src_dir.rglob('*.py'):
+        if 'obsolete' in path.parts:
+            continue
+        read.update(pattern.findall(path.read_text(encoding='utf-8')))
+
+    advertised = {o['name'] for o in analysis_options('uq')}
+    assert read, 'found no UQ_options reads at all -- the pattern has stopped matching'
+    assert read <= advertised, (
+        f'UQ_options read by the code but not declared in ANALYSIS_OPTIONS["uq"]: '
+        f'{sorted(read - advertised)}')
 
 
 def test_closed_set_analysis_options_are_enums_with_choices():
@@ -555,6 +586,8 @@ def test_closed_set_analysis_options_are_enums_with_choices():
         # deliberately not advertised: it is not a CA dependency and there is no extra that
         # installs it, so offering it in a menu would be a control that fails for most users.
         ('uq', 'library'): ['emcee', 'pymc'],
+        # -> PyMCSampler.__init__, which raises on anything else.
+        ('uq', 'pymc_method'): ['mcmc', 'smc'],
         # -> EmulatorTrainer.design (raises ValueError otherwise)
         ('emulation', 'sample_type'): ['sobol', 'latin_hypercube', 'random'],
         # -> EmulatorBundle.check_bounds. 'error' is the default deliberately: outside its

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -550,7 +550,10 @@ def test_closed_set_analysis_options_are_enums_with_choices():
         # cannot run is the same defect as a setting nothing reads. Extend these as the SMC /
         # surrogate methods and the pyMC backend land.
         ('uq', 'method'): ['mcmc'],
-        ('uq', 'library'): ['emcee'],
+        # 'zeus' is still accepted by _build_sampler for backwards compatibility but is
+        # deliberately not advertised: it is not a CA dependency and there is no extra that
+        # installs it, so offering it in a menu would be a control that fails for most users.
+        ('uq', 'library'): ['emcee', 'pymc'],
         # -> EmulatorTrainer.design (raises ValueError otherwise)
         ('emulation', 'sample_type'): ['sobol', 'latin_hypercube', 'random'],
         # -> EmulatorBundle.check_bounds. 'error' is the default deliberately: outside its

--- a/tests/test_uq_on_emulator.py
+++ b/tests/test_uq_on_emulator.py
@@ -50,6 +50,10 @@ except ImportError:                                            # pragma: no cove
 ANALYTICAL_SOLUTION = np.array([1.0, 1.0])
 ANALYTICAL_STD = np.array([0.1, 0.3])
 
+#: Walkers for emcee, chains for pymc -- the same budget either way, so the two samplers are
+#: compared on equal terms rather than on how each happens to be configured.
+NUM_WALKERS = 20
+
 #: The sweep's pick: fast to train, faithful, and cheap to evaluate.
 EMULATOR_SETTINGS = {
     'models': 'RadialBasisFunctions',
@@ -68,6 +72,23 @@ def mpi_comm():
     return MPI.COMM_WORLD
 
 
+def _pymc_available():
+    try:
+        import pymc  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+SAMPLERS = [
+    pytest.param('emcee', id='emcee'),
+    pytest.param('pymc', id='pymc',
+                 marks=pytest.mark.skipif(not _pymc_available(),
+                                          reason='the pyMC backend needs the [uq] extra')),
+]
+
+
 def _emulator_available():
     try:
         from emulators.emulator_trainer import autoemulate_available
@@ -77,7 +98,27 @@ def _emulator_available():
         return False
 
 
-def _config(resources_dir, output_dir, generated_models_dir, emulator_dir, **overrides):
+def _uq_options(library):
+    options = {
+        'method': 'mcmc',
+        'library': library,
+        'num_steps': 3000,
+        'num_walkers': NUM_WALKERS,
+        'burn_in': 0.5,
+        'cost_type': 'gaussian_MLE',
+    }
+    if library == 'pymc':
+        # pymc runs num_tune warm-up iterations *on top of* num_steps, per chain, and its
+        # Metropolis steps one parameter at a time -- so the default 1000 would triple an
+        # already heavier chain. Cheap here because each evaluation is an emulator prediction
+        # rather than a solve, but there is no reason to pay for warm-up this test does not need.
+        options['num_tune'] = 200
+        options['num_steps'] = 1500
+    return options
+
+
+def _config(resources_dir, output_dir, generated_models_dir, emulator_dir,
+            library='emcee', **overrides):
     config = {
         'file_prefix': 'Simple_ODE_Benchmark',
         'input_param_file': 'Simple_ODE_Benchmark_parameters.csv',
@@ -104,14 +145,7 @@ def _config(resources_dir, output_dir, generated_models_dir, emulator_dir, **ove
         'use_emulator': True,
         'emulator_settings': {**EMULATOR_SETTINGS, 'emulator_dir': emulator_dir},
         'emulator_dir': emulator_dir,
-        'UQ_options': {
-            'method': 'mcmc',
-            'library': 'emcee',
-            'num_steps': 3000,
-            'num_walkers': 16,
-            'burn_in': 0.5,
-            'cost_type': 'gaussian_MLE',
-        },
+        'UQ_options': _uq_options(library),
     }
     config.update(overrides)
     return YamlFileParser().parse_user_inputs_file(
@@ -127,18 +161,30 @@ def _train_emulator(config, comm):
 
 @pytest.mark.integration
 @pytest.mark.mpi
+@pytest.mark.parametrize('library', SAMPLERS)
 @pytest.mark.skipif(not _emulator_available(),
                     reason='autoemulate is required for the emulator UQ test')
 def test_uq_on_an_emulator_recovers_the_analytic_posterior(
-        resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
+        library, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
     """Train an emulator, sample through it, and check the posterior is the right one.
+
+    Run for both samplers. Two independent samplers agreeing on a posterior whose answer is
+    known in closed form is a much stronger statement than either one matching alone: a bug in
+    the shared machinery below them (the cost, the priors, the emulator) would move both, but a
+    bug in one sampler moves only that one.
+
+    It is also the only affordable way to exercise the pyMC backend end to end. Against the real
+    model that test exceeded 50 minutes and was killed unfinished, because pyMC's Metropolis
+    takes one likelihood evaluation per parameter per step. On an emulator each of those
+    evaluations is a matrix multiply, so the same chain costs seconds.
 
     Deliberately *not* marked slow: the whole point is that this runs on a pull request, where
     the full-model equivalents cannot. If it stops being quick, that is a regression in its own
     right -- an emulator whose sampling costs what the model costs has no reason to exist.
     """
     emulator_dir = os.path.join(temp_output_dir, 'emulator')
-    config = _config(resources_dir, temp_output_dir, temp_generated_models_dir, emulator_dir)
+    config = _config(resources_dir, temp_output_dir, temp_generated_models_dir, emulator_dir,
+                     library=library)
 
     if mpi_comm.Get_rank() == 0:
         assert generate_with_new_architecture(False, config), 'benchmark generation failed'
@@ -163,13 +209,21 @@ def test_uq_on_an_emulator_recovers_the_analytic_posterior(
 
     posterior_mean = flat.mean(axis=0)
     posterior_sd = flat.std(axis=0)
-    print(f'emulator posterior mean {posterior_mean} (truth {ANALYTICAL_SOLUTION})')
-    print(f'emulator posterior sd   {posterior_sd} (truth {ANALYTICAL_STD})')
+    print(f'[{library}] posterior mean {posterior_mean} (truth {ANALYTICAL_SOLUTION})')
+    print(f'[{library}] posterior sd   {posterior_sd} (truth {ANALYTICAL_STD})')
 
+    assert chain.shape[1] == NUM_WALKERS, (
+        f'{library} produced {chain.shape[1]} walkers, not the {NUM_WALKERS} asked for')
+
+    # Both moments are checked, not just the centre. A sampler that finds the right mode but
+    # mis-sizes its spread has not recovered the posterior -- it has recovered a point estimate
+    # with a plausible-looking error bar, which is exactly what UQ is supposed to replace.
     # Tolerances are far wider than the sweep's measured error (0.007 / 0.003), so this fails on
     # a real regression rather than on sampling noise.
-    assert posterior_mean == pytest.approx(ANALYTICAL_SOLUTION, abs=0.05), posterior_mean
-    assert posterior_sd == pytest.approx(ANALYTICAL_STD, abs=0.08), posterior_sd
+    assert posterior_mean == pytest.approx(ANALYTICAL_SOLUTION, abs=0.05), (
+        f'{library} posterior mean {posterior_mean} != {ANALYTICAL_SOLUTION}')
+    assert posterior_sd == pytest.approx(ANALYTICAL_STD, abs=0.08), (
+        f'{library} posterior sd {posterior_sd} != {ANALYTICAL_STD}')
 
 
 @pytest.mark.integration

--- a/tests/test_uq_on_emulator.py
+++ b/tests/test_uq_on_emulator.py
@@ -1,0 +1,214 @@
+"""UQ on an emulator: the same posterior, in seconds instead of tens of minutes.
+
+The end-to-end UQ tests in test_UQ.py sample the real model, so every likelihood evaluation is
+a solver call and the cheapest of them takes ~9 minutes (the pyMC one exceeds 50 and was killed
+before finishing). That is too slow to run on a pull request, which means the only tests that
+check UQ *end to end* are the ones that never run.
+
+An emulator removes exactly that cost: it is trained once from a few dozen solver calls, and
+after that a likelihood evaluation is a matrix multiply. If the emulator is faithful, the
+posterior sampled through it is the same posterior -- which is the claim this file exists to
+check, on Simple_ODE_Benchmark, whose answer is known in closed form.
+
+Settings were chosen by sweeping (train time, sampling time, held-out R2, posterior error):
+
+    candidate      train s   mcmc s      r2   mean err   sd err
+    RBF n=24           2.8      8.3  0.4127     0.6996   0.0929
+    RBF n=48           0.7      9.1  1.0000     0.0068   0.0034   <- used here
+    RBF n=96           0.8      9.0  1.0000     0.0179   0.0044
+    Poly n=24          1.1      3.7 -0.8397     2.6923   2.6486
+    Poly n=48          1.2      4.5 -0.3037     4.9247   0.2298
+    GP-RBF n=24        4.6    174.9  0.9992     0.0136   0.0208
+    GP-RBF n=48        2.8    197.3  0.9948     0.1763   0.0993
+
+Three things that table decides:
+
+* 24 training points is not enough (R2 0.41), and the posterior is wrong by 0.7 -- seven times
+  its own standard deviation. 48 is the threshold, and the margin at 48 is large.
+* PolynomialRegression cannot represent this response at all (negative R2 -- worse than
+  predicting the mean), so it is not a matter of more samples.
+* GaussianProcess is accurate but its prediction cost dominates: same chain, 20x the wall clock.
+  Accuracy alone is the wrong thing to select an emulator on when the point is speed.
+"""
+import json
+import os
+
+import numpy as np
+import pytest
+
+from param_id.paramID import CVS0DParamID
+from parsers.PrimitiveParsers import YamlFileParser
+from scripts.script_generate_with_new_architecture import generate_with_new_architecture
+
+try:
+    from mpi4py import MPI
+except ImportError:                                            # pragma: no cover
+    MPI = None
+
+# Simple_ODE_Benchmark's steady state, and the spread its observation noise implies -- the same
+# constants test_UQ.py checks the full-model posterior against.
+ANALYTICAL_SOLUTION = np.array([1.0, 1.0])
+ANALYTICAL_STD = np.array([0.1, 0.3])
+
+#: The sweep's pick: fast to train, faithful, and cheap to evaluate.
+EMULATOR_SETTINGS = {
+    'models': 'RadialBasisFunctions',
+    'num_train_samples': 48,
+    'sample_type': 'sobol',
+    'random_seed': 0,
+    'n_iter': 2,
+    'n_splits': 2,
+}
+
+
+@pytest.fixture
+def mpi_comm():
+    if MPI is None:
+        pytest.skip('mpi4py is required for the emulator UQ test')
+    return MPI.COMM_WORLD
+
+
+def _emulator_available():
+    try:
+        from emulators.emulator_trainer import autoemulate_available
+
+        return autoemulate_available()
+    except Exception:
+        return False
+
+
+def _config(resources_dir, output_dir, generated_models_dir, emulator_dir, **overrides):
+    config = {
+        'file_prefix': 'Simple_ODE_Benchmark',
+        'input_param_file': 'Simple_ODE_Benchmark_parameters.csv',
+        'model_type': 'cellml_only',
+        'solver': 'CVODE_myokit',
+        'param_id_method': 'genetic_algorithm',
+        'pre_time': 0.0,
+        'sim_time': 8.0,
+        'dt': 0.05,
+        'DEBUG': False,
+        'do_uq': True,
+        'do_ia': False,
+        'do_sensitivity': False,
+        'plot_predictions': False,
+        'solver_info': {'MaximumStep': 0.01, 'MaximumNumberOfSteps': 5000},
+        'param_id_obs_path': os.path.join(resources_dir,
+                                          'Simple_ODE_Benchmark_obs_data.json'),
+        'params_for_id_path': os.path.join(resources_dir,
+                                           'Simple_ODE_Benchmark_params_for_id.csv'),
+        'param_id_output_dir': output_dir,
+        'resources_dir': resources_dir,
+        'generated_models_dir': generated_models_dir,
+        'do_emulation': True,
+        'use_emulator': True,
+        'emulator_settings': {**EMULATOR_SETTINGS, 'emulator_dir': emulator_dir},
+        'emulator_dir': emulator_dir,
+        'UQ_options': {
+            'method': 'mcmc',
+            'library': 'emcee',
+            'num_steps': 3000,
+            'num_walkers': 16,
+            'burn_in': 0.5,
+            'cost_type': 'gaussian_MLE',
+        },
+    }
+    config.update(overrides)
+    return YamlFileParser().parse_user_inputs_file(
+        config, obs_path_needed=True, do_generation_with_fit_parameters=False)
+
+
+def _train_emulator(config, comm):
+    from emulators.emulator_trainer import EmulatorTrainer
+
+    trainer = EmulatorTrainer.init_from_dict(config, comm=comm)
+    return trainer.train()
+
+
+@pytest.mark.integration
+@pytest.mark.mpi
+@pytest.mark.skipif(not _emulator_available(),
+                    reason='autoemulate is required for the emulator UQ test')
+def test_uq_on_an_emulator_recovers_the_analytic_posterior(
+        resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
+    """Train an emulator, sample through it, and check the posterior is the right one.
+
+    Deliberately *not* marked slow: the whole point is that this runs on a pull request, where
+    the full-model equivalents cannot. If it stops being quick, that is a regression in its own
+    right -- an emulator whose sampling costs what the model costs has no reason to exist.
+    """
+    emulator_dir = os.path.join(temp_output_dir, 'emulator')
+    config = _config(resources_dir, temp_output_dir, temp_generated_models_dir, emulator_dir)
+
+    if mpi_comm.Get_rank() == 0:
+        assert generate_with_new_architecture(False, config), 'benchmark generation failed'
+    mpi_comm.Barrier()
+
+    bundle = _train_emulator(config, mpi_comm)
+    if mpi_comm.Get_rank() != 0:
+        return
+
+    # The emulator has to be faithful before its posterior means anything. Checked here rather
+    # than left implicit, so a bad posterior below is attributable: a broken surrogate and a
+    # broken sampler fail this test in the same place otherwise.
+    for entry in (bundle.error_stats() or []):
+        if isinstance(entry, dict) and entry.get('r2') is not None:
+            assert float(entry['r2']) > 0.99, f"emulator is not faithful: {entry}"
+
+    param_id = CVS0DParamID.init_from_dict({**config, 'mcmc_instead': True})
+    param_id.run_UQ()
+
+    chain = np.load(os.path.join(param_id.output_dir, 'mcmc_chain.npy'))
+    flat = chain[chain.shape[0] // 2:, :, :].reshape(-1, chain.shape[2])
+
+    posterior_mean = flat.mean(axis=0)
+    posterior_sd = flat.std(axis=0)
+    print(f'emulator posterior mean {posterior_mean} (truth {ANALYTICAL_SOLUTION})')
+    print(f'emulator posterior sd   {posterior_sd} (truth {ANALYTICAL_STD})')
+
+    # Tolerances are far wider than the sweep's measured error (0.007 / 0.003), so this fails on
+    # a real regression rather than on sampling noise.
+    assert posterior_mean == pytest.approx(ANALYTICAL_SOLUTION, abs=0.05), posterior_mean
+    assert posterior_sd == pytest.approx(ANALYTICAL_STD, abs=0.08), posterior_sd
+
+
+@pytest.mark.integration
+@pytest.mark.mpi
+@pytest.mark.skipif(not _emulator_available(),
+                    reason='autoemulate is required for the emulator UQ test')
+def test_the_uq_run_writes_its_posterior_summary(
+        resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
+    """The statistics file is the artifact a user reads, so a UQ run that produces a chain but
+    no summary is only half a run -- and it must not have overwritten the calibration's best fit
+    to produce it."""
+    emulator_dir = os.path.join(temp_output_dir, 'emulator')
+    config = _config(resources_dir, temp_output_dir, temp_generated_models_dir, emulator_dir)
+
+    if mpi_comm.Get_rank() == 0:
+        assert generate_with_new_architecture(False, config), 'benchmark generation failed'
+    mpi_comm.Barrier()
+
+    _train_emulator(config, mpi_comm)
+    if mpi_comm.Get_rank() != 0:
+        return
+
+    param_id = CVS0DParamID.init_from_dict({**config, 'mcmc_instead': True})
+    param_id.run_UQ()
+
+    path = os.path.join(param_id.output_dir, 'mcmc_statistics.json')
+    assert os.path.isfile(path), 'a UQ run must write its posterior summary'
+    with open(path) as handle:
+        document = json.load(handle, parse_constant=_reject_non_standard_json)
+
+    assert document['num_samples'] > 0
+    assert set(document['parameters']), 'the summary must name its parameters'
+    for name, row in document['parameters'].items():
+        assert row['q2.5'] <= row['median'] <= row['q97.5'], name
+        assert row['sd'] > 0, name
+    # A UQ run with no calibration behind it is the only case that may write a best fit, and it
+    # has to say so rather than pass a posterior median off as an optimum.
+    assert document['source'] in ('calibration', 'posterior_median')
+
+
+def _reject_non_standard_json(value):
+    raise AssertionError(f'mcmc_statistics.json contains non-standard JSON constant {value!r}')

--- a/tests/test_uq_pymc_backend.py
+++ b/tests/test_uq_pymc_backend.py
@@ -1,0 +1,178 @@
+"""The pyMC UQ backend's adapter layer (issue #195, from #367).
+
+pymc is an optional [uq] extra, so these cover the parts that must be right *without* it
+installed: the emcee-shaped chain conversion, the chain-count arithmetic, the sampler dispatch,
+and the failure message a user gets when they select a backend they have not installed.
+
+The sampling itself needs pymc and is exercised by the slow posterior-recovery tests.
+"""
+import numpy as np
+import pytest
+
+from param_id.pymc_backend import PyMCSampler, _INSTALL_HINT, _import_pymc
+
+pymc_installed = True
+try:
+    import pymc  # noqa: F401
+except ImportError:
+    pymc_installed = False
+
+
+class _FakePosterior:
+    """Stands in for arviz's posterior group: (chain, draw) values per named variable."""
+
+    def __init__(self, data):
+        self._data = {name: _FakeVar(values) for name, values in data.items()}
+
+    def __contains__(self, name):
+        return name in self._data
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __getitem__(self, name):
+        return self._data[name]
+
+
+class _FakeVar:
+    def __init__(self, values):
+        self.values = np.asarray(values, dtype=float)
+
+
+class _FakeTrace:
+    def __init__(self, data):
+        self.posterior = _FakePosterior(data)
+
+
+# ---------------------------------------------------------------------------
+# trace conversion -- the contract with every downstream consumer
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_trace_is_converted_to_emcees_steps_walkers_params_shape():
+    """pyMC stores (chain, draw); emcee -- and therefore mcmc_chain.npy, the corner plots and
+    the R-hat diagnostic -- expects (steps, walkers, params). Getting the two axes the wrong way
+    round does not raise, it silently reports walkers as steps."""
+    num_chains, num_draws = 3, 50
+    trace = _FakeTrace({
+        'a': np.arange(num_chains * num_draws).reshape(num_chains, num_draws),
+        'b': np.zeros((num_chains, num_draws)),
+    })
+
+    chain = PyMCSampler.trace_to_emcee_chain(trace, ['a', 'b'])
+
+    assert chain.shape == (num_draws, num_chains, 2)
+    # element (draw d, chain c, param 0) must be the value pyMC stored at (chain c, draw d)
+    assert chain[7, 2, 0] == 2 * num_draws + 7
+
+
+@pytest.mark.unit
+def test_trace_conversion_keeps_parameters_in_the_requested_order():
+    """The chain has no column names downstream -- position *is* the identity of a parameter."""
+    trace = _FakeTrace({'x': np.full((2, 4), 1.0), 'y': np.full((2, 4), 2.0)})
+
+    chain = PyMCSampler.trace_to_emcee_chain(trace, ['y', 'x'])
+    assert np.all(chain[:, :, 0] == 2.0) and np.all(chain[:, :, 1] == 1.0)
+
+
+@pytest.mark.unit
+def test_a_trace_missing_a_parameter_raises_instead_of_returning_none():
+    """#367 printed a warning and returned None here. A None becomes an unreadable failure much
+    further downstream, after the sampling has already been paid for."""
+    trace = _FakeTrace({'a': np.zeros((2, 4))})
+
+    with pytest.raises(ValueError, match='missing sampled parameters'):
+        PyMCSampler.trace_to_emcee_chain(trace, ['a', 'b'])
+
+
+@pytest.mark.unit
+def test_a_trace_with_no_posterior_raises():
+    class _Empty:
+        pass
+
+    with pytest.raises(ValueError, match='no posterior'):
+        PyMCSampler.trace_to_emcee_chain(_Empty(), ['a'])
+
+
+# ---------------------------------------------------------------------------
+# chain arithmetic
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_chains_are_split_across_ranks():
+    assert PyMCSampler.chains_for_rank(num_walkers=32, num_procs=4) == 8
+    assert PyMCSampler.chains_for_rank(num_walkers=32, num_procs=1) == 32
+
+
+@pytest.mark.unit
+def test_more_ranks_than_walkers_still_runs_one_chain_per_rank():
+    """num_walkers // num_procs is 0 there, and pyMC asked for zero chains either raises or
+    returns an empty trace -- an MPI run that quietly produces no samples."""
+    assert PyMCSampler.chains_for_rank(num_walkers=4, num_procs=16) == 1
+    assert PyMCSampler.chains_for_rank(num_walkers=1, num_procs=64) == 1
+
+
+# ---------------------------------------------------------------------------
+# optional dependency
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.skipif(pymc_installed, reason='pymc is installed, so the import cannot fail')
+def test_selecting_pymc_without_it_installed_names_the_install_command():
+    """The failure a user actually hits. A bare ModuleNotFoundError for 'pytensor' does not tell
+    anyone which CA setting caused it or what to install."""
+    with pytest.raises(ImportError) as excinfo:
+        _import_pymc()
+    message = str(excinfo.value)
+    assert '[uq]' in message and 'pymc' in message
+    assert 'library: emcee' in message, 'the message should name the way to carry on without it'
+
+
+@pytest.mark.unit
+def test_the_install_hint_names_the_extra_that_actually_exists():
+    """Pins the hint against pyproject, so the extra cannot be renamed and leave the message
+    telling users to install something that is not there."""
+    import pathlib
+    pyproject = (pathlib.Path(__file__).resolve().parent.parent / 'pyproject.toml').read_text()
+    assert 'uq = [' in pyproject and 'pymc' in pyproject
+    assert '[uq]' in _INSTALL_HINT
+
+
+@pytest.mark.unit
+def test_an_unknown_pymc_method_is_rejected_up_front():
+    """Before anything expensive: a typo'd method must not surface after a model has been built
+    and an MPI pool opened."""
+    with pytest.raises(ValueError, match='unknown pyMC method'):
+        PyMCSampler(4, 2, lambda p: 0.0, method='nuts_but_misspelled')
+
+
+# ---------------------------------------------------------------------------
+# dispatch from UQ_options
+# ---------------------------------------------------------------------------
+def _mcmc_engine(library):
+    from param_id.paramID import OpencorMCMC
+    obj = OpencorMCMC.__new__(OpencorMCMC)
+    obj.UQ_options = {'library': library, 'num_walkers': 8, 'num_steps': 10}
+    obj.num_params = 2
+    obj.param_id_info = {'param_names_for_plotting': ['a', 'b']}
+    return obj
+
+
+@pytest.mark.unit
+def test_emcee_is_still_the_default_backend():
+    import emcee
+    sampler = _mcmc_engine('emcee')._build_sampler()
+    assert isinstance(sampler, emcee.EnsembleSampler)
+
+
+@pytest.mark.unit
+def test_an_unknown_library_is_rejected_naming_the_valid_ones():
+    with pytest.raises(ValueError, match="unknown UQ_options library"):
+        _mcmc_engine('stan')._build_sampler()
+
+
+@pytest.mark.unit
+def test_every_backend_exposes_the_same_sampler_surface():
+    """The point of the adapter: the sampling loop and everything downstream of mcmc_chain.npy
+    are identical whichever library was chosen."""
+    for method_name in ('run_mcmc', 'get_chain'):
+        assert callable(getattr(PyMCSampler, method_name, None)), method_name
+        import emcee
+        assert callable(getattr(emcee.EnsembleSampler, method_name, None)), method_name


### PR DESCRIPTION
Closes #195. Last of the stack bringing in #367 (pyMC for UQ). Original work by @MOH-Shafizadegan.

> Stacked on #402–#406 — their commits are included here and the diff shrinks to the last commit once those merge.

## What

emcee's affine-invariant ensemble sampler is a good default, but it is one algorithm. pyMC brings Metropolis and sequential Monte Carlo, and SMC in particular can cross the low-probability regions between separated modes that an ensemble sampler gets stuck on.

`PyMCSampler` wears emcee's interface — `run_mcmc` / `get_chain` returning a `(steps, walkers, params)` chain — so `UQ_options['library']` changes one line of construction and **nothing downstream**: the sampling loop, `mcmc_chain.npy`, the corner plots and the R-hat diagnostics are all unchanged.

This also retires the module-level `mcmc_lib = 'emcee'  # TODO make this a user variable` constant, which meant editing the source to change sampler.

## Optional dependency, never at module level

`pymc`/`pytensor` are imported inside the backend module and added as an optional `[uq]` extra. `paramID.py` is imported by every calibration run, so #367's top-level `import pytensor` would have broken every user who has not installed it. Selecting the backend without it raises a message naming `pip install -e ".[uq]"` **and** the way to carry on without it.

## Three corrections to the original

**1. The prior was counted twice.** #367's pyMC model declared `pm.Uniform` / `pm.Exponential` / `pm.Normal` priors *and* put `get_lnlikelihood_lnprior_from_params` — which already includes the log prior — in the `Potential`. The sampled posterior was therefore not the one CA defines.

Here the pyMC variables are bare *support* declarations (`Uniform` over the box, or `Flat` when the parameter is unbounded), which contribute only a constant inside that support, and CA's log posterior is the single density term.

**2. Those re-declared priors hardcoded the old defaults** (`lambda=1`, `sigma=(max-min)/6`, `mu=(max+min)/2`), silently ignoring the `prior_mean` / `prior_std` / `prior_origin` / `prior_scale` hyper-parameters and the `unbounded` flag that `params_for_id` supports on current master. Deferring to CA's own `get_lnprior_from_params` means there is one implementation of the prior vocabulary rather than two that can drift.

**3. `num_walkers // num_procs` is 0 when there are more ranks than walkers**, so pyMC was asked for zero chains — an MPI run that quietly produces no samples. `chains_for_rank` floors at 1.

The trace conversion also raises on a trace missing its parameters instead of returning `None`, which became an unreadable failure far downstream after the sampling had already been paid for.

## Tests

**`tests/test_uq_pymc_backend.py`** — 12 fast unit tests covering everything that must be right *without* pymc installed: the `(chain, draw)` → `(steps, walkers, params)` conversion and that parameter order is preserved (position *is* a parameter's identity downstream); the missing-parameter and missing-posterior errors; the chain arithmetic including more ranks than walkers; the install message naming an extra that actually exists in `pyproject.toml`; emcee still being the default; an unknown library naming the valid ones; and that both backends expose the same surface.

**`tests/test_UQ.py`** — the three posterior-recovery tests (#179), adapted to the flat `UQ_options` and the new stats API.

`test_mcmc_unimodal_with_validation` **passes**: emcee recovers the analytical solution `[1.0, 1.0]` with the spread the observation noise implies, `r_hat < 1.3` and ESS > 50. That is the end-to-end validation of the whole stack — the config surface, the equal-weight likelihood and the diagnostics — not just of this PR.

`test_mcmc_unimodal_with_validation_KDE_likelihood` uses `library: pymc` and skips where the extra is absent.

Verified `not slow and not compare_optimisers`: **658 passed, 1 failed** — `test_python_BDF_solver[SN_simple]`, the known libCellML Analyser limitation (#151), which fails identically on master.

## ⚠️ What I could not verify

**pymc is not installed in the OpenCOR pythonshell this repo runs under, and I did not install it.** So the pyMC sampling path itself — `_build_model`, `pm.sample`, `pm.sample_smc` — has not been executed. Its adapter layer is tested, its dispatch is tested, and its failure mode without the dependency is tested, but the first real pyMC run will be someone's first real pyMC run. Whether `pytensor` (which compiles C extensions) installs cleanly into that interpreter is the open question flagged when this work was planned; it is deliberately last in the stack so it blocks nothing else.

## Not included from #367

The three seaborn posterior-predictive plots (`plot_boxplots_for_predictions`, `plot_distribution_grid`, `get_prior_pdf`) — see #406 for why they are better decided alongside #341.
