### PR TITLE
Name flattened CellML per input model instead of a new tempfile per run

### DIFF
--- a/src/solver_wrappers/myokit_helper.py
+++ b/src/solver_wrappers/myokit_helper.py
@@ -14,8 +14,61 @@ from solver_wrappers.name_resolver import VariableNameResolver
 from utilities.protocol_shapes import materialise_shapes, validate_trace_references
 import xml.etree.ElementTree as ET
 import tempfile
+import hashlib
 import re
 import os
+
+
+# Where flattened CellML goes. A flattened model is a pure function of its input file, so
+# it is written under one stable name per input and overwritten on each run. It used to be
+# a fresh ``NamedTemporaryFile(delete=False)`` per simulation -- nothing ever deleted them,
+# and a calibration run flattens once per helper, so /tmp accumulated one ~100 kB file per
+# simulation forever (7,655 of them, 719 MB, on one dev machine).
+FLATTENED_CELLML_DIRNAME = 'circulatory_autogen_flattened'
+
+
+def flattened_cellml_path(path):
+    """The stable path the flattened form of *path* is written to.
+
+    The digest of the absolute input path keeps two models that share a basename in
+    different resources dirs from overwriting each other: silently simulating the wrong
+    model is a far worse failure than the disk use this naming fixes.
+    """
+    resolved = os.path.abspath(path)
+    digest = hashlib.sha1(resolved.encode('utf-8')).hexdigest()[:8]
+    stem = os.path.splitext(os.path.basename(resolved))[0]
+    cache_dir = os.path.join(tempfile.gettempdir(), FLATTENED_CELLML_DIRNAME)
+    os.makedirs(cache_dir, exist_ok=True)
+    return os.path.join(cache_dir, f'{stem}_{digest}_flat.cellml')
+
+
+def write_flattened_cellml(prepared_path, model_string):
+    """Write *model_string* to *prepared_path*, atomically.
+
+    Under ``mpiexec`` every rank flattens the same model to the same path, so a plain
+    open-and-write lets one rank parse what another is still writing. Staging in the same
+    directory and calling os.replace makes the swap atomic, and readers see either the old
+    complete file or the new one.
+    """
+    os.makedirs(os.path.dirname(prepared_path), exist_ok=True)
+    fd, staging_path = tempfile.mkstemp(
+        prefix=f'.{os.path.basename(prepared_path)}.',
+        suffix='.tmp',
+        dir=os.path.dirname(prepared_path),
+        text=True,
+    )
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as wf:
+            wf.write(model_string)
+            wf.flush()
+            os.fsync(wf.fileno())
+        os.replace(staging_path, prepared_path)
+    except Exception:
+        try:
+            os.remove(staging_path)
+        except OSError:
+            pass
+        raise
 
 
 # CA's default CVODES tolerances for the Myokit backend, mirrored by the CVODE_myokit schema
@@ -327,11 +380,9 @@ class SimulationHelper:
             # Print the flattened model to string
             model_string = cellml.print_model(flat_model)
 
-            # Create temp file with the flattened model
-            with tempfile.NamedTemporaryFile(mode='w+', suffix='.cellml', delete=False) as f:
-                prepared_path = f.name
-            with open(prepared_path, 'w') as f:
-                f.write(model_string)
+            # One file per input model, overwritten, not a new tempfile per run.
+            prepared_path = flattened_cellml_path(path)
+            write_flattened_cellml(prepared_path, model_string)
 
             return prepared_path
 

--- a/tests/test_flattened_cellml_naming.py
+++ b/tests/test_flattened_cellml_naming.py
@@ -1,0 +1,91 @@
+"""The flattened-CellML cache is named per input model, not per run.
+
+Regression tests for the /tmp leak: `_prepare_cellml_for_myokit_libcellml` used a
+`NamedTemporaryFile(delete=False)` per call and nothing ever deleted the results, so a
+machine accumulated one ~100 kB flattened model per simulation indefinitely.
+"""
+
+import os
+import sys
+
+import pytest
+
+# Add src to path
+_TEST_ROOT = os.path.join(os.path.dirname(__file__), '..')
+_SRC_DIR = os.path.join(_TEST_ROOT, 'src')
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+from solver_wrappers.myokit_helper import (
+    flattened_cellml_path,
+    write_flattened_cellml,
+)
+
+
+@pytest.mark.unit
+def test_the_same_input_always_gets_the_same_path(tmp_path):
+    model = tmp_path / 'heart.cellml'
+    model.write_text('<model/>')
+
+    assert flattened_cellml_path(str(model)) == flattened_cellml_path(str(model))
+
+
+@pytest.mark.unit
+def test_a_relative_and_absolute_path_agree(tmp_path, monkeypatch):
+    model = tmp_path / 'heart.cellml'
+    model.write_text('<model/>')
+
+    monkeypatch.chdir(tmp_path)
+    assert flattened_cellml_path('heart.cellml') == flattened_cellml_path(str(model))
+
+
+@pytest.mark.unit
+def test_the_name_carries_the_input_stem(tmp_path):
+    model = tmp_path / 'simple_physiological.cellml'
+    model.write_text('<model/>')
+
+    assert os.path.basename(flattened_cellml_path(str(model))).startswith(
+        'simple_physiological_'
+    )
+
+
+@pytest.mark.unit
+def test_two_models_sharing_a_basename_do_not_collide(tmp_path):
+    # The whole reason the name is not just the stem: overwriting here would mean
+    # silently simulating the wrong model.
+    first = tmp_path / 'a' / 'heart.cellml'
+    second = tmp_path / 'b' / 'heart.cellml'
+    for path in (first, second):
+        path.parent.mkdir(parents=True)
+        path.write_text('<model/>')
+
+    assert flattened_cellml_path(str(first)) != flattened_cellml_path(str(second))
+
+
+@pytest.mark.unit
+def test_rewriting_overwrites_rather_than_accumulating(tmp_path):
+    target = tmp_path / 'cache' / 'heart_deadbeef_flat.cellml'
+
+    for text in ('<model>one</model>', '<model>two</model>', '<model>three</model>'):
+        write_flattened_cellml(str(target), text)
+
+    assert target.read_text() == '<model>three</model>'
+    # One file, and no staging files left behind by the atomic swap.
+    assert sorted(p.name for p in target.parent.iterdir()) == [target.name]
+
+
+@pytest.mark.unit
+def test_a_failed_write_leaves_no_staging_file(tmp_path):
+    target = tmp_path / 'cache' / 'heart_deadbeef_flat.cellml'
+    write_flattened_cellml(str(target), '<model>good</model>')
+
+    class Unwritable:
+        def __str__(self):
+            raise RuntimeError('boom')
+
+    with pytest.raises(Exception):
+        write_flattened_cellml(str(target), Unwritable())
+
+    # The previous complete file survives, and nothing partial is left beside it.
+    assert target.read_text() == '<model>good</model>'
+    assert sorted(p.name for p in target.parent.iterdir()) == [target.name]


### PR DESCRIPTION
## Problem

`_prepare_cellml_for_myokit_libcellml` wrote its flattened model to a `NamedTemporaryFile(suffix='.cellml', delete=False)`, and nothing ever deleted the result. A helper flattens once per construction, so a calibration run leaves one ~100 kB file in `/tmp` per simulation, permanently.

On one dev machine that was **7,655 files / 719 MB**, going back weeks, on a root filesystem that had reached 99% full. Ubuntu only clears `/tmp` at boot (`/usr/lib/tmpfiles.d/tmp.conf` is `D /tmp`, with no age argument), so nothing reclaimed them.

## Change

A flattened model is a pure function of its input file, so it now goes to **one stable path per input model, overwritten each run**, under `/tmp/circulatory_autogen_flattened/` instead of scattered through `/tmp`.

Two details beyond the obvious rename:

**The name carries an 8-char digest of the absolute input path, not just the stem.** Keying on the stem alone would let two models both called `heart.cellml` in different resources dirs overwrite each other — silently simulating the wrong model is a far worse failure than the disk use this fixes.

**The write is atomic.** Under `mpiexec` every rank flattens the same model to the same path, so a plain open-and-write lets one rank parse what another is still writing. Staging in the same directory and calling `os.replace` means a reader sees either the old complete file or the new one. This mirrors the existing `CVSCellMLGenerator._write_text_file_atomic`.

There is no skip-if-exists caching: the model is still flattened on every call exactly as before, only the destination path changed.

## Known limitation

The digest keys on the absolute path, so a model generated into a per-run temp directory (as the tests do) is genuinely a different input each run and still produces a new cache entry. For normal runs, where models live at stable paths under `resources/` or `generated_models/`, the file is overwritten as intended. The residual growth is bounded to one tidy directory that can be cleared wholesale, rather than thousands of files spread across `/tmp`.

## Tests

New `tests/test_flattened_cellml_naming.py` (6 tests, `unit` marker): stable naming for the same input, relative and absolute paths agreeing, the stem appearing in the name, two models sharing a basename not colliding, repeated writes overwriting rather than accumulating, and a failed write leaving neither a staging file nor a corrupted target.

End-to-end check: `tests/test_solvers.py -k myokit` — **8 passed**, with the stray `/tmp/tmp*.cellml` count unchanged across the run (zero new files) and 7 correctly-named cache entries created.

Full `./run_pytest.sh -m "not slow"`: **631 passed, 8 failed**. All 8 failures reproduce identically on a clean tree at `master` — 7 in `tests/test_mpi_utils.py` (`subprocess.run([sys.executable, ...])` with an empty `sys.executable` under the OpenCOR pythonshell) and `test_python_BDF_solver[SN_simple]`, the `PythonGenerator`/SN limitation already documented in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
