### PR TITLE
fix(solvers): say why a backend is unavailable instead of "not available"

### DIFF
--- a/src/solver_wrappers/__init__.py
+++ b/src/solver_wrappers/__init__.py
@@ -4,26 +4,58 @@ Solver wrapper factory.
 Provides access to OpenCOR, Myokit, and SciPy-based solvers through a common API.
 """
 import os
+import traceback
+
 from solver_wrappers.python_solver_helper import SimulationHelper as PythonSimulationHelper
+
+#: Why each optional backend failed to import, keyed by backend name. A backend is optional
+#: because it may genuinely not be installed -- but the import can also fail for reasons that
+#: have nothing to do with installation, and those used to be indistinguishable: every failure
+#: became a bare `None` and then the same "X is not available" message, whatever went wrong.
+#: A real example is a fresh CI runner where two MPI ranks import myokit at once and race on
+#: creating ~/.config/myokit/myokit.ini; the message said myokit was not installed, when it was.
+#: Keeping the reason turns that into something a user can act on (see _unavailable_message).
+BACKEND_IMPORT_ERRORS = {}
+
+
+def _record_import_error(name, exc):
+    BACKEND_IMPORT_ERRORS[name] = ''.join(
+        traceback.format_exception_only(type(exc), exc)).strip()
+
+
+def _unavailable_message(backend, solver):
+    """The error for a solver whose backend did not import, naming the underlying cause."""
+    reason = BACKEND_IMPORT_ERRORS.get(backend)
+    if not reason:
+        return f"{backend} solver requested but {backend} is not available"
+    return (f"{solver} solver requested but the {backend} backend failed to import: {reason}. "
+            f"If {backend} is installed, this is not an installation problem -- the import "
+            f"itself raised, and that error is the one to fix.")
+
+
 try:
     from solver_wrappers.myokit_helper import SimulationHelper as MyokitSimulationHelper
-except:
+except Exception as _exc:                                # noqa: BLE001 - reason is recorded
     MyokitSimulationHelper = None
+    _record_import_error('Myokit', _exc)
 
 try:
     from solver_wrappers.opencor_helper import SimulationHelper as OpenCORSimulationHelper
-except Exception:
+except Exception as _exc:
     OpenCORSimulationHelper = None
+    _record_import_error('OpenCOR', _exc)
 
 try:
     from solver_wrappers.casadi_python_solver_helper import SimulationHelper as CasADiPythonSimulationHelper
-except Exception:
+except Exception as _exc:
     CasADiPythonSimulationHelper = None
+    _record_import_error('CasADi', _exc)
 
 try:
     from solver_wrappers.aadc_python_solver_helper import SimulationHelper as AadcPythonSimulationHelper
-except Exception:
+except Exception as _exc:
     AadcPythonSimulationHelper = None
+    _record_import_error('AADC', _exc)
 
 # Not `from mpi4py import MPI`. This module picks a solver; it has no collectives
 # to run. That import initialised MPI and registered an atexit MPI_Finalize for
@@ -89,14 +121,14 @@ def get_simulation_helper(model_path: str = None, solver: str = None,
         if OpenCORSimulationHelper is not None:
             return OpenCORSimulationHelper(model_path, dt, sim_time, solver_info, pre_time=pre_time)
         else:
-            raise RuntimeError("OpenCOR solver requested but OpenCOR is not available")
+            raise RuntimeError(_unavailable_message('OpenCOR', 'CVODE_opencor'))
     elif solver == 'CVODE_myokit':
         if is_python_model:
             raise ValueError("CVODE_myokit solver cannot be used with Python models. Use a solve_ivp method instead.")
         if MyokitSimulationHelper is not None:
             return MyokitSimulationHelper(model_path, dt, sim_time, solver_info, pre_time=pre_time)
         else:
-            raise RuntimeError("Myokit solver requested but Myokit is not available")
+            raise RuntimeError(_unavailable_message('Myokit', 'CVODE_myokit'))
     elif solver in python_solvers:
         if not is_python_model:
             raise ValueError(f"solve_ivp method {solver} can only be used with Python models. Use CVODE_opencor (or legacy CVODE) or CVODE_myokit for CellML models.")
@@ -109,7 +141,7 @@ def get_simulation_helper(model_path: str = None, solver: str = None,
         if CasADiPythonSimulationHelper is not None:
             return CasADiPythonSimulationHelper(model_path, dt, sim_time, solver_info, pre_time=pre_time)
         else:
-            raise RuntimeError("CasADi solver requested but CasADi is not available")
+            raise RuntimeError(_unavailable_message('CasADi', solver))
     elif solver in aadc_solvers:
         if not is_aadc_python_model:
             raise ValueError(f"Solver {solver} can only be used for AADC Python models (model_type='aadc_python').")

--- a/tests/test_backend_import_errors.py
+++ b/tests/test_backend_import_errors.py
@@ -1,0 +1,87 @@
+"""An unavailable solver backend must say *why* it is unavailable.
+
+Every optional backend is imported under a try/except so a missing package does not break an
+install that never uses it. The cost was that a genuinely-broken import looked exactly like a
+missing one: both became ``None``, and both produced "X is not available".
+
+That is not a cosmetic difference. A fresh CI runner where two MPI ranks import myokit at once
+can race on creating ``~/.config/myokit/myokit.ini``, and the resulting message told us myokit
+was not installed -- when it was, and the real error had already been discarded.
+"""
+import pytest
+
+from solver_wrappers import (
+    BACKEND_IMPORT_ERRORS, _record_import_error, _unavailable_message, get_simulation_helper)
+
+
+@pytest.mark.unit
+def test_the_reason_an_import_failed_is_kept():
+    try:
+        raise ValueError('myokit.ini is missing a section header')
+    except ValueError as exc:
+        _record_import_error('FakeBackend', exc)
+
+    try:
+        assert 'myokit.ini is missing a section header' in BACKEND_IMPORT_ERRORS['FakeBackend']
+        assert 'ValueError' in BACKEND_IMPORT_ERRORS['FakeBackend']
+    finally:
+        BACKEND_IMPORT_ERRORS.pop('FakeBackend', None)
+
+
+@pytest.mark.unit
+def test_the_message_names_the_underlying_error_when_there_is_one():
+    try:
+        raise RuntimeError('libsundials_cvodes.so: cannot open shared object file')
+    except RuntimeError as exc:
+        _record_import_error('FakeBackend', exc)
+
+    try:
+        message = _unavailable_message('FakeBackend', 'fake_solver')
+        assert 'cannot open shared object file' in message
+        assert 'fake_solver' in message
+        # and it must say plainly that installing the package is not the fix
+        assert 'not an installation problem' in message
+    finally:
+        BACKEND_IMPORT_ERRORS.pop('FakeBackend', None)
+
+
+@pytest.mark.unit
+def test_a_genuinely_absent_backend_still_reads_as_absent():
+    """No recorded reason means the import never ran or the package really is missing; the
+    message must not imply a hidden error that does not exist."""
+    BACKEND_IMPORT_ERRORS.pop('NeverImported', None)
+    message = _unavailable_message('NeverImported', 'some_solver')
+    assert 'not available' in message
+    assert 'failed to import' not in message
+
+
+@pytest.mark.unit
+def test_requesting_a_backend_that_failed_to_import_surfaces_the_reason(monkeypatch):
+    """End to end through the factory: the RuntimeError a caller sees carries the cause."""
+    import solver_wrappers
+
+    monkeypatch.setattr(solver_wrappers, 'MyokitSimulationHelper', None)
+    monkeypatch.setitem(solver_wrappers.BACKEND_IMPORT_ERRORS, 'Myokit',
+                        "ImportError: no module named 'configparser'")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        get_simulation_helper(model_path='m.cellml', solver='CVODE_myokit',
+                              model_type='cellml_only', dt=0.01, sim_time=1.0)
+
+    message = str(excinfo.value)
+    assert "no module named 'configparser'" in message
+    assert 'CVODE_myokit' in message
+
+
+@pytest.mark.unit
+def test_every_optional_backend_records_its_failures():
+    """A backend added later must be wired into the same reporting, or it reintroduces the
+    silent-None behaviour this replaces."""
+    import inspect
+
+    import solver_wrappers
+
+    source = inspect.getsource(solver_wrappers)
+    # Each optional import is a try/except that records, rather than swallowing.
+    assert source.count('_record_import_error(') >= 4
+    assert 'except:' not in source, 'a bare except would discard the reason again'


### PR DESCRIPTION
## The failure that prompted this

PR #403's `test-param-id-mpi` job failed with:

```
RuntimeError: Myokit solver requested but Myokit is not available
```

on a runner whose own pip log a minute earlier says:

```
Successfully installed ... myokit-1.39.2 ...
```

The message pointed squarely at installation, which was fine. **Re-running the identical commit passed** (23m38s, no code change), so the failure was transient — plausibly the two MPI ranks racing to create `~/.config/myokit/myokit.ini`, which myokit writes on first import. Whatever it was, the real exception had already been thrown away, and the message actively pointed away from it.

## Why it was thrown away

Each optional backend is imported under a try/except so a missing package does not break an install that never uses it. That is right. What was wrong is that the reason went nowhere:

```python
try:
    from solver_wrappers.myokit_helper import SimulationHelper as MyokitSimulationHelper
except:                      # bare -- also swallows KeyboardInterrupt / SystemExit
    MyokitSimulationHelper = None
```

A genuinely-broken import and a genuinely-missing package both became `None`, and both produced the same "X is not available".

## The change

The reason is recorded per backend in `BACKEND_IMPORT_ERRORS` and included in the error:

```
RuntimeError: CVODE_myokit solver requested but the Myokit backend failed to import:
configparser.MissingSectionHeaderError: File contains no section headers. If Myokit is
installed, this is not an installation problem -- the import itself raised, and that
error is the one to fix.
```

A backend with **no** recorded reason still reads as simply absent, so a genuinely missing package is not dressed up as a hidden failure.

No behaviour change beyond the message: the same backends are optional, and the same calls raise.

## Tests

New `tests/test_backend_import_errors.py`, 5 fast unit tests: the reason is kept; the message names it and says installing is not the fix; an absent backend still reads as absent; the reason reaches the caller end-to-end through `get_simulation_helper`; and a guard that every optional backend records its failure and that no bare `except:` returns — otherwise a backend added later silently reintroduces the behaviour this replaces.

## Verification

Local `not slow and not compare_optimisers`: **8 failures before this change and 8 after**, i.e. none added. For the record those 8 are all pre-existing on master in this environment — `test_python_BDF_solver[SN_simple]` (#151) plus 7 in `test_mpi_utils.py` that fail under the OpenCOR pythonshell because `sys.executable` is empty there (`PermissionError: [Errno 13] Permission denied: ''`). Those 7 pass in CI; they may be worth a skip-guard for OpenCOR-shell runs, but that is #401's area rather than this PR's.
