### PR TITLE
feat(uq): write mcmc_statistics.json instead of overwriting the calibration best fit

### DIFF
--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -3040,44 +3040,176 @@ class OpencorMCMC(OpencorParamID):
             print('mcmc complete')
             print(f'mcmc chain saved in {mcmc_chain_path}')
 
-            # save best param vals and best cost from mcmc mean
-            samples = samples[samples.shape[0]//2:, :, :]
-            # thin = 10
-            # samples = samples[::thin, :, :]
-            flat_samples = samples.reshape(-1, self.num_params)
-            means = np.zeros((self.num_params))
-            medians = np.zeros((self.num_params))
-            for param_idx in range(self.num_params):
-                means[param_idx] = np.mean(flat_samples[:, param_idx])
-                medians[param_idx] = np.median(flat_samples[:, param_idx])
+            flat_samples = samples[self.burn_in_index(samples.shape[0]):, :, :].reshape(
+                -1, self.num_params)
+            self.save_mcmc_statistics(flat_samples)
 
-            # rerun with original and mcmc optimal param vals
-            mcmc_best_param_vals = medians  # means
-            # TODO change the below to get_cost_from_params when inheriting
-            mcmc_best_cost, _ = self.get_cost_and_obs_from_params(mcmc_best_param_vals, reset=True)
-            if self.best_param_vals is None:
-                self.best_param_vals = mcmc_best_param_vals
-                self.best_cost = mcmc_best_cost
-                print('cost from mcmc median param vals is {}'.format(self.best_cost))
-                print('saving best_param_vals and best_cost from mcmc medians')
+    def burn_in_index(self, num_steps):
+        """The first step to keep, from ``UQ_options['burn_in']``.
 
-                np.save(os.path.join(self.output_dir, 'best_cost'), self.best_cost)
-                np.save(os.path.join(self.output_dir, 'best_param_vals'), self.best_param_vals)
+        A value below 1 is a fraction of the chain; 1 or above is a number of steps. Defaults to
+        half the chain, which is what this used to hardcode. Always leaves at least one step, so
+        a burn_in longer than the run degrades to "keep the last sample" rather than producing an
+        empty array and a stack of nan statistics.
+        """
+        burn_in = (self.UQ_options or {}).get('burn_in', 0.5)
+        try:
+            burn_in = float(burn_in)
+        except (TypeError, ValueError):
+            print(f"WARNING: UQ_options burn_in {burn_in!r} is not a number; using half the chain.")
+            burn_in = 0.5
+
+        index = int(num_steps * burn_in) if burn_in < 1 else int(burn_in)
+        if index >= num_steps:
+            print(f'WARNING: burn_in discards all {num_steps} steps of the chain; '
+                  f'keeping the last one. Run more steps, or lower burn_in.')
+            index = num_steps - 1
+        return max(0, index)
+
+    def flat_param_names(self):
+        """One name per calibrated parameter, for labelling the statistics.
+
+        A grouped row calibrates one value shared across several model variables, so it is one
+        parameter with several names; the first stands for the group, as it does elsewhere.
+        """
+        # len(), never truthiness: param_id_info holds these as numpy arrays, and `not array`
+        # raises rather than answering.
+        info = self.param_id_info or {}
+        names = info.get('param_names_for_plotting')
+        if names is None or len(names) != self.num_params:
+            names = info.get('param_names')
+        if names is None:
+            names = []
+        flat = []
+        for idx in range(self.num_params):
+            if idx < len(names):
+                entry = names[idx]
+                flat.append(str(entry[0] if isinstance(entry, (list, tuple)) else entry))
             else:
-                original_best_cost, _ = self.get_cost_and_obs_from_params(self.best_param_vals, reset=True)
-                if mcmc_best_cost < original_best_cost:
-                    self.best_param_vals = mcmc_best_param_vals
-                    self.best_cost = mcmc_best_cost
-                    print('cost from mcmc median param vals is {}'.format(self.best_cost))
-                    print('resaving best_param_vals and best_cost from mcmc medians')
+                flat.append(f'param_{idx}')
+        return flat
 
-                    np.save(os.path.join(self.output_dir, 'best_cost'), self.best_cost)
-                    np.save(os.path.join(self.output_dir, 'best_param_vals'), self.best_param_vals)
-                else:
-                    self.best_cost = original_best_cost
-                    # leave the original best fit param val as the best fit value, mcmc just gives distributions
-                    print('cost from mcmc median param vals is {}'.format(mcmc_best_cost))
-                    print('Keeping the genetic algorithm best fit as it is lower, ({})'.format(self.best_cost))
+    def posterior_statistics(self, flat_samples):
+        """Per-parameter summary of the posterior, plus the cost at its point summaries.
+
+        A posterior is a distribution, and the honest summary of one is a spread rather than a
+        single number -- so mean *and* median *and* the quartiles and the 95% interval, not a
+        winner. The costs are reported for comparison with the calibration's best, deliberately
+        without acting on that comparison: see save_mcmc_statistics.
+        """
+        flat_samples = np.asarray(flat_samples, dtype=float)
+        names = self.flat_param_names()
+
+        means = flat_samples.mean(axis=0)
+        medians = np.median(flat_samples, axis=0)
+
+        stats = {}
+        for idx, name in enumerate(names):
+            column = flat_samples[:, idx]
+            stats[name] = {
+                'mean': float(means[idx]),
+                'median': float(medians[idx]),
+                'sd': float(np.std(column, ddof=1)) if column.size > 1 else float('nan'),
+                'q2.5': float(np.percentile(column, 2.5)),
+                'q25': float(np.percentile(column, 25)),
+                'q75': float(np.percentile(column, 75)),
+                'q97.5': float(np.percentile(column, 97.5)),
+                'min': float(np.min(column)),
+                'max': float(np.max(column)),
+            }
+        return stats, means, medians
+
+    def calibration_best_cost(self):
+        """The calibration's best cost as a finite float, or None if there isn't one.
+
+        Prefers the value on disk: a UQ run is often handed the calibration's *parameters*
+        (set_best_param_vals) without its cost, leaving the in-memory best_cost at inf. Reporting
+        inf would put a JSON Infinity in the file -- which strict JSON parsers reject -- and make
+        every posterior median look like it had beaten the calibration.
+        """
+        candidates = [self.best_cost]
+        path = os.path.join(self.output_dir, 'best_cost.npy')
+        if os.path.isfile(path):
+            try:
+                candidates.append(np.load(path))
+            except Exception:
+                pass
+        for candidate in candidates:
+            if candidate is None:
+                continue
+            try:
+                value = float(np.ravel(candidate)[0])
+            except (TypeError, ValueError, IndexError):
+                continue
+            if np.isfinite(value):
+                return value
+        return None
+
+    def save_mcmc_statistics(self, flat_samples):
+        """Write ``mcmc_statistics.json``, and leave the calibration's best fit alone.
+
+        This used to overwrite best_param_vals.npy and best_cost.npy with the posterior median
+        whenever that median scored a lower cost. Two different estimators were being conflated:
+        a posterior median summarises a distribution, a calibration best is an argmin, and they
+        answer different questions. Silently replacing one with the other meant a UQ run mutated
+        the calibration's answer -- and the file gave no clue which estimator it held.
+
+        The comparison is still reported, because it is genuinely informative (a median that
+        beats the optimum usually means the calibration stopped early, or that the posterior is
+        skewed), but nothing is decided on it. Choosing between the two is the user's call, and
+        both are now on disk to choose from.
+
+        The one exception is a UQ run with no calibration behind it at all: nothing else has
+        written a best fit, so the median is the only estimate there is, and the rest of the
+        pipeline (plotting, predictions) needs one. That is recorded in the file's `source`.
+        """
+        stats, means, medians = self.posterior_statistics(flat_samples)
+
+        median_cost = float(np.ravel(
+            self.get_cost_and_obs_from_params(medians, reset=True)[0])[0])
+        mean_cost = float(np.ravel(
+            self.get_cost_and_obs_from_params(means, reset=True)[0])[0])
+
+        document = {
+            'parameters': stats,
+            'num_samples': int(np.asarray(flat_samples).shape[0]),
+            'cost_at_posterior_median': median_cost,
+            'cost_at_posterior_mean': mean_cost,
+            'calibration_best_cost': self.calibration_best_cost(),
+        }
+
+        if self.best_param_vals is None:
+            # No calibration behind this run, so this is not an overwrite: it is the only
+            # estimate available, and downstream plotting/prediction needs one.
+            self.best_param_vals = medians
+            self.best_cost = median_cost
+            document['source'] = 'posterior_median'
+            document['calibration_best_cost'] = None
+            np.save(os.path.join(self.output_dir, 'best_cost'), self.best_cost)
+            np.save(os.path.join(self.output_dir, 'best_param_vals'), self.best_param_vals)
+            print('No calibration best fit existed, so best_param_vals and best_cost were '
+                  'written from the posterior median.')
+        else:
+            document['source'] = 'calibration'
+            calibration_cost = document['calibration_best_cost']
+            reported = 'unknown' if calibration_cost is None else calibration_cost
+            print(f'cost at the posterior median is {median_cost}, at the posterior mean is '
+                  f'{mean_cost}; the calibration best fit ({reported}) is left unchanged '
+                  f'(a posterior median is not an optimum -- see mcmc_statistics.json for the '
+                  f'full posterior summary).')
+            # Only when there is a real number to beat. The engine's in-memory best_cost is inf
+            # on a UQ run that adopted a calibration's parameters without its cost, and
+            # "lower than inf" is true of everything.
+            if calibration_cost is not None and median_cost < calibration_cost:
+                print('NOTE: the posterior median scores a lower cost than the calibration best '
+                      'fit. That usually means the calibration stopped early or the posterior '
+                      'is skewed. Both are on disk; choosing between them is yours to make.')
+
+        path = os.path.join(self.output_dir, 'mcmc_statistics.json')
+        with open(path, 'w') as write_file:
+            json.dump(document, write_file, indent=2)
+        print(f'mcmc statistics saved in {path}')
+        return document
 
     def calculate_pred_from_posterior_samples(self, flat_samples, n_sims=100):
         # idxs of output are [exp_idx][sim_idx, pred_idx, time_idx]

--- a/tests/test_mcmc_statistics.py
+++ b/tests/test_mcmc_statistics.py
@@ -1,0 +1,262 @@
+"""A UQ run summarises the posterior; it does not replace the calibration's best fit.
+
+``OpencorMCMC.run`` used to overwrite ``best_param_vals.npy`` / ``best_cost.npy`` with the
+posterior median whenever that median happened to score a lower cost. Two different estimators
+were being conflated -- a median summarises a distribution, a calibration best is an argmin --
+so a UQ run silently mutated the calibration's answer, and the file gave no clue which estimator
+it held. It now writes ``mcmc_statistics.json`` alongside instead.
+"""
+import json
+import os
+
+import numpy as np
+import pytest
+
+from param_id.paramID import OpencorMCMC
+
+
+class _StubMCMC:
+    """An OpencorMCMC with only what the statistics path touches."""
+
+    def __new__(cls, *args, **kwargs):
+        return OpencorMCMC.__new__(OpencorMCMC)
+
+
+def _engine(tmp_path, num_params=2, best_param_vals=None, best_cost=None,
+            costs=(0.5, 0.7), UQ_options=None, names=None):
+    obj = OpencorMCMC.__new__(OpencorMCMC)
+    obj.output_dir = str(tmp_path)
+    obj.num_params = num_params
+    obj.best_param_vals = best_param_vals
+    obj.best_cost = best_cost
+    obj.UQ_options = UQ_options if UQ_options is not None else {}
+    obj.param_id_info = {'param_names_for_plotting': names
+                         or [f'p_{i}' for i in range(num_params)]}
+    obj._costs = list(costs)
+    obj.get_cost_and_obs_from_params = lambda vals, reset=True: (obj._costs.pop(0), None)
+    return obj
+
+
+def _read(tmp_path):
+    with open(os.path.join(tmp_path, 'mcmc_statistics.json')) as handle:
+        return json.load(handle)
+
+
+# ---------------------------------------------------------------------------
+# the calibration's best fit is left alone
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_a_uq_run_does_not_overwrite_the_calibration_best_fit(tmp_path):
+    """Even when the posterior median scores lower -- which is exactly when the old code
+    replaced it."""
+    calibration_best = np.array([1.0, 2.0])
+    engine = _engine(tmp_path, best_param_vals=calibration_best, best_cost=0.9,
+                     costs=(0.1, 0.2))          # median cost 0.1, far below the calibration's
+
+    engine.save_mcmc_statistics(np.random.default_rng(0).normal(size=(200, 2)))
+
+    assert np.array_equal(engine.best_param_vals, calibration_best)
+    assert engine.best_cost == 0.9
+    assert not os.path.exists(os.path.join(tmp_path, 'best_param_vals.npy'))
+    assert not os.path.exists(os.path.join(tmp_path, 'best_cost.npy'))
+    assert _read(tmp_path)['source'] == 'calibration'
+
+
+@pytest.mark.unit
+def test_the_comparison_is_still_reported_just_not_acted_on(capsys, tmp_path):
+    """A median that beats the optimum is informative -- it usually means the calibration
+    stopped early, or the posterior is skewed. Worth saying; not worth deciding on."""
+    engine = _engine(tmp_path, best_param_vals=np.array([1.0, 2.0]), best_cost=0.9,
+                     costs=(0.1, 0.2))
+    engine.save_mcmc_statistics(np.random.default_rng(0).normal(size=(100, 2)))
+
+    printed = capsys.readouterr().out
+    assert 'left' in printed and 'unchanged' in printed
+    assert 'lower cost than the calibration' in printed
+
+    document = _read(tmp_path)
+    assert document['cost_at_posterior_median'] == 0.1
+    assert document['cost_at_posterior_mean'] == 0.2
+    assert document['calibration_best_cost'] == 0.9
+
+
+@pytest.mark.unit
+def test_a_uq_only_run_still_writes_a_best_fit(tmp_path):
+    """Not an overwrite: nothing else has written one, the median is the only estimate there is,
+    and the rest of the pipeline needs it. The file records where it came from."""
+    engine = _engine(tmp_path, best_param_vals=None, best_cost=None, costs=(0.3, 0.4))
+    samples = np.random.default_rng(1).normal(loc=[5.0, -2.0], size=(300, 2))
+
+    engine.save_mcmc_statistics(samples)
+
+    assert engine.best_param_vals is not None
+    assert os.path.isfile(os.path.join(tmp_path, 'best_param_vals.npy'))
+    saved = np.load(os.path.join(tmp_path, 'best_param_vals.npy'))
+    assert saved == pytest.approx(np.median(samples, axis=0))
+
+    document = _read(tmp_path)
+    assert document['source'] == 'posterior_median'
+    assert document['calibration_best_cost'] is None
+
+
+# ---------------------------------------------------------------------------
+# the statistics themselves
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_the_summary_reports_a_spread_not_a_winner(tmp_path):
+    """A posterior is a distribution; summarising it as one number is what caused the
+    conflation in the first place."""
+    rng = np.random.default_rng(2)
+    samples = rng.normal(loc=[3.0, 10.0], scale=[1.0, 2.0], size=(20000, 2))
+    engine = _engine(tmp_path, costs=(0.1, 0.2), best_param_vals=np.zeros(2), best_cost=1.0)
+
+    stats, _, _ = engine.posterior_statistics(samples)
+
+    assert set(stats) == {'p_0', 'p_1'}
+    assert set(stats['p_0']) == {'mean', 'median', 'sd', 'q2.5', 'q25', 'q75', 'q97.5',
+                                 'min', 'max'}
+    assert stats['p_0']['mean'] == pytest.approx(3.0, abs=0.05)
+    assert stats['p_0']['median'] == pytest.approx(3.0, abs=0.05)
+    assert stats['p_1']['sd'] == pytest.approx(2.0, abs=0.05)
+    # a 95% interval on a normal is about +-1.96 sigma
+    assert stats['p_1']['q2.5'] == pytest.approx(10.0 - 1.96 * 2.0, abs=0.15)
+    assert stats['p_1']['q97.5'] == pytest.approx(10.0 + 1.96 * 2.0, abs=0.15)
+    assert stats['p_0']['q25'] < stats['p_0']['median'] < stats['p_0']['q75']
+
+
+@pytest.mark.unit
+def test_the_statistics_are_written_as_readable_json(tmp_path):
+    engine = _engine(tmp_path, best_param_vals=np.array([1.0, 2.0]), best_cost=0.5,
+                     costs=(0.6, 0.7))
+    engine.save_mcmc_statistics(np.random.default_rng(3).normal(size=(150, 2)))
+
+    document = _read(tmp_path)
+    assert document['num_samples'] == 150
+    assert set(document['parameters']) == {'p_0', 'p_1'}
+    # every value must be a plain float, not a numpy scalar, or json.dump would have failed
+    assert isinstance(document['parameters']['p_0']['median'], float)
+
+
+# ---------------------------------------------------------------------------
+# burn_in -- a setting the schema advertised but nothing read
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_burn_in_below_one_is_a_fraction_of_the_chain(tmp_path):
+    engine = _engine(tmp_path, UQ_options={'burn_in': 0.25})
+    assert engine.burn_in_index(400) == 100
+
+
+@pytest.mark.unit
+def test_burn_in_of_one_or_more_is_a_number_of_steps(tmp_path):
+    engine = _engine(tmp_path, UQ_options={'burn_in': 120})
+    assert engine.burn_in_index(400) == 120
+
+
+@pytest.mark.unit
+def test_burn_in_defaults_to_half_the_chain(tmp_path):
+    """What this used to hardcode as samples[shape[0]//2:]."""
+    assert _engine(tmp_path, UQ_options={}).burn_in_index(400) == 200
+
+
+@pytest.mark.unit
+def test_a_burn_in_longer_than_the_run_keeps_the_last_sample(capsys, tmp_path):
+    """An empty array would give a stack of nan statistics and no indication why."""
+    engine = _engine(tmp_path, UQ_options={'burn_in': 5000})
+    assert engine.burn_in_index(400) == 399
+    assert 'discards all' in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_a_nonsense_burn_in_falls_back_with_a_warning(capsys, tmp_path):
+    engine = _engine(tmp_path, UQ_options={'burn_in': 'half'})
+    assert engine.burn_in_index(400) == 200
+    assert 'not a number' in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# parameter naming
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_a_grouped_parameter_is_labelled_by_its_first_member(tmp_path):
+    """A grouped row calibrates one value shared across several model variables: one parameter,
+    several names."""
+    engine = _engine(tmp_path, num_params=2,
+                     names=[['heart/C', 'aorta/C'], 'heart/R'])
+    assert engine.flat_param_names() == ['heart/C', 'heart/R']
+
+
+@pytest.mark.unit
+def test_missing_names_fall_back_to_indices(tmp_path):
+    engine = _engine(tmp_path, num_params=3, names=['only_one'])
+    engine.param_id_info = {}
+    assert engine.flat_param_names() == ['param_0', 'param_1', 'param_2']
+
+
+@pytest.mark.unit
+def test_names_held_as_a_numpy_array_are_handled(tmp_path):
+    """param_id_info holds these as numpy arrays in a real run, and `not array` raises rather
+    than answering -- which is exactly how this broke the first time."""
+    engine = _engine(tmp_path, num_params=2)
+    engine.param_id_info = {
+        'param_names_for_plotting': np.array(['q_{sbv}', 'C_{ao}']),
+        'param_names': np.array(['a', 'b']),
+    }
+    assert engine.flat_param_names() == ['q_{sbv}', 'C_{ao}']
+
+
+@pytest.mark.unit
+def test_a_best_cost_stored_as_an_array_is_compared_as_a_number(tmp_path):
+    """best_cost comes back off disk as a numpy array, and comparing one with `<` inside an
+    `if` is ambiguous the moment it is not 0-d."""
+    engine = _engine(tmp_path, best_param_vals=np.array([1.0, 2.0]),
+                     best_cost=np.array([0.9]), costs=(0.1, 0.2))
+
+    engine.save_mcmc_statistics(np.random.default_rng(4).normal(size=(100, 2)))
+
+    document = _read(tmp_path)
+    assert document['calibration_best_cost'] == pytest.approx(0.9)
+    assert document['source'] == 'calibration'
+
+
+# ---------------------------------------------------------------------------
+# an unknown calibration cost
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_an_infinite_best_cost_is_reported_as_unknown_not_as_infinity(capsys, tmp_path):
+    """A UQ run is often handed the calibration's *parameters* without its cost, leaving the
+    in-memory best_cost at inf. Writing that gives the file a JSON Infinity -- which strict
+    parsers reject -- and makes every posterior median look like it beat the calibration,
+    because everything is lower than inf."""
+    engine = _engine(tmp_path, best_param_vals=np.array([1.0, 2.0]), best_cost=np.inf,
+                     costs=(2.1, 2.0))
+
+    engine.save_mcmc_statistics(np.random.default_rng(5).normal(size=(100, 2)))
+
+    document = _read(tmp_path)
+    assert document['calibration_best_cost'] is None
+    printed = capsys.readouterr().out
+    assert 'unknown' in printed
+    assert 'lower cost than the calibration' not in printed, \
+        'there was no number to beat, so nothing should claim it was beaten'
+
+    # and the file must be strict JSON -- Infinity is not
+    with open(os.path.join(tmp_path, 'mcmc_statistics.json')) as handle:
+        json.loads(handle.read(), parse_constant=_reject_constant)
+
+
+def _reject_constant(value):
+    raise AssertionError(f'mcmc_statistics.json contains non-standard JSON constant {value!r}')
+
+
+@pytest.mark.unit
+def test_the_calibration_cost_is_read_from_disk_when_memory_has_none(tmp_path):
+    """best_cost.npy is what the calibration actually wrote; the in-memory value may never have
+    been set on this object."""
+    np.save(os.path.join(tmp_path, 'best_cost'), np.array(0.42))
+    engine = _engine(tmp_path, best_param_vals=np.array([1.0, 2.0]), best_cost=np.inf,
+                     costs=(0.9, 1.0))
+
+    assert engine.calibration_best_cost() == pytest.approx(0.42)
+
+    engine.save_mcmc_statistics(np.random.default_rng(6).normal(size=(80, 2)))
+    assert _read(tmp_path)['calibration_best_cost'] == pytest.approx(0.42)


### PR DESCRIPTION
Branched from current `master` (`2e0354c`), independent of the open UQ stack.

## Why

A UQ run overwrote `best_param_vals.npy` and `best_cost.npy` with the posterior median whenever that median happened to score a lower cost:

```python
if mcmc_best_cost < original_best_cost:
    np.save(os.path.join(self.output_dir, 'best_cost'), self.best_cost)
    np.save(os.path.join(self.output_dir, 'best_param_vals'), self.best_param_vals)
```

Two different estimators were being conflated. **A posterior median summarises a distribution; a calibration best is an argmin.** They answer different questions, and neither is a substitute for the other. The consequence was that running UQ silently mutated the calibration's answer — and the file gave no indication which estimator it then held, so a later run, plot or benchmark could not tell whether `best_param_vals` came from an optimiser or from a chain.

## What now happens

The posterior is summarised properly, in **`mcmc_statistics.json`**:

```json
{
  "parameters": {
    "q_{sbv}": {
      "mean": 0.0006727039858072163,
      "median": 0.0006708264765799087,
      "sd": 3.360897175051176e-05,
      "q2.5": 0.000592644840390434,
      "q25": 0.0006540019330240691,
      "q75": 0.0006916554362856165,
      "q97.5": 0.0007406598614217347,
      "min": 0.000558914382170334,
      "max": 0.0007409146244677607
    }
  },
  "num_samples": 100,
  "cost_at_posterior_median": 2.1096479561121004,
  "cost_at_posterior_mean": 1.9582864112536809,
  "calibration_best_cost": 2.4206897497201307,
  "source": "calibration"
}
```

A posterior is a distribution, so the honest summary is a spread rather than a single winner — mean *and* median *and* the quartiles and the 95% interval.

**The comparison is still reported, just not acted on.** A median that beats the optimum is genuinely informative — it usually means the calibration stopped early, or the posterior is skewed:

```
cost at the posterior median is 2.1096, at the posterior mean is 1.9583; the calibration
best fit (2.4207) is left unchanged (a posterior median is not an optimum -- see
mcmc_statistics.json for the full posterior summary).
NOTE: the posterior median scores a lower cost than the calibration best fit. That usually
means the calibration stopped early or the posterior is skewed. Both are on disk; choosing
between them is yours to make.
```

**One case still writes `best_param_vals`:** a UQ run with no calibration behind it. That is not an overwrite — nothing else has written one, the median is the only estimate there is, and plotting and prediction need one. The file records that in its `source` field (`"posterior_median"` rather than `"calibration"`).

## Three things fixed along the way

- **`burn_in` is finally read.** #402 added it to `ANALYSIS_OPTIONS` and nothing consumed it, so it was a control a user could set with no effect — the exact defect the discoverable schema exists to prevent, and one I introduced. Below 1 it is a fraction of the chain, 1 or above a number of steps, defaulting to the half this used to hardcode. A `burn_in` longer than the run keeps the last sample and says so, rather than producing an empty array and a stack of `nan` statistics.
- **The calibration cost is read from `best_cost.npy` when the in-memory value is not finite.** A UQ run is often handed the calibration's *parameters* (`set_best_param_vals`) without its cost, leaving `best_cost` at `inf`. Reporting that wrote a JSON `Infinity` — which strict parsers reject — and made *every* posterior median look like it had beaten the calibration, because everything is lower than `inf`. This actually happened on the first end-to-end run.
- **Parameter names are read by length, not truthiness.** `param_id_info` holds them as numpy arrays, and `not array` raises rather than answering. That broke the first integration run and is now covered by a test using an ndarray, which my original stub had not.

## Tests

New `tests/test_mcmc_statistics.py`, 16 fast unit tests: the calibration best fit survives a UQ run *even when the median scores lower* (the case the old code replaced); the comparison is still printed; a UQ-only run still writes a best fit and records its source; the summary recovers known mean/median/sd/quantiles from a large sample; the JSON is readable and contains plain floats; all five `burn_in` behaviours; grouped and ndarray parameter names; and an infinite/absent calibration cost reported as `null` rather than `Infinity`, verified by re-parsing the file with `parse_constant` set to reject non-standard constants.

Verified end to end on `test_param_id_3compartment_succeeds` and `test_param_id_3compartment_extra_ops_succeeds`, both of which run real UQ.

Full `not slow and not compare_optimisers`: **656 passed, 8 failed** — the same 8 that fail on unmodified `master` in this environment (`test_python_BDF_solver[SN_simple]`, #151, plus 7 in `test_mpi_utils.py` that fail under the OpenCOR pythonshell because `sys.executable` is empty there). None added.

## Interaction with the open UQ stack

This lands on `master`, so #404/#405/#406/#408 will need a rebase. Worth knowing: **#405's fix becomes largely redundant** once this merges. That PR wrapped the best-cost computation in `calibration_weighting()` because the flattened likelihood weights were leaking into `best_cost.npy` — and this change stops UQ writing that file at all in the normal case. The wrapping is still correct for the cost reported *inside* `mcmc_statistics.json` (it should be comparable with the calibration's), so the two compose, but the CI failure it was fixing can no longer occur.
