### PR TITLE
fix(cpp): carry MaximumStep onto dt_solver instead of dropping it

### DIFF
--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -2366,16 +2366,30 @@ def migrate_legacy_solver_info_keys(solver_name, solver_info):
             )
             solver_info.pop('MaximumNumberOfSteps', None)
     elif solver_name in _CPP_SOLVERS:
-        # Nothing to migrate onto: the generated C++ takes its step from the framework key
-        # 'dt_solver'. Dropping loudly beats rejecting, so a config written for a CVODE backend
-        # still runs -- it just says what stopped applying. rtol/atol are NOT dropped here: the
-        # generator emits them into the solver since #398.
+        # The generated C++ integrates at a fixed step, taken from the framework key
+        # 'dt_solver'. rtol/atol are NOT touched here: the generator emits them since #398.
         if 'MaximumStep' in solver_info:
-            _warn_dropped_solver_info_key(
-                solver_name, 'MaximumStep',
-                'The generated C++ integrates at a fixed step; use the framework key '
-                "'dt_solver' to set it.",
-            )
+            if 'dt_solver' in solver_info:
+                # Both given: dt_solver is the one the generated code reads, so MaximumStep
+                # stops applying and says so. Not an error -- a config written for a CVODE
+                # backend has to keep running.
+                _warn_dropped_solver_info_key(
+                    solver_name, 'MaximumStep',
+                    'The generated C++ integrates at the fixed step in '
+                    "'dt_solver', which is already set.",
+                )
+            else:
+                # Carried across rather than discarded. Dropping it lost the only step the
+                # user had given -- and this runs *before* the parser's own
+                # MaximumStep -> dt_solver fallback, so there was nothing left for that to
+                # find and generation died with KeyError: 'dt_solver' on every cpp config
+                # that had not already been rewritten to the new key.
+                #
+                # A maximum adaptive step and a fixed step are not the same quantity, but
+                # reading the former as the latter is conservative, and is exactly what that
+                # fallback already did.
+                solver_info['dt_solver'] = solver_info['MaximumStep']
+                _warn_renamed_solver_info_key(solver_name, 'MaximumStep', 'dt_solver')
             solver_info.pop('MaximumStep', None)
 
     return solver_info

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -777,6 +777,49 @@ def test_cpp_maximum_step_is_migrated_with_a_warning_not_rejected(solver, capsys
         assert kept not in warned, kept + ' is wired up and must not warn'
 
 
+@pytest.mark.parametrize('solver', ['CVODE', 'RK4', 'PETSC'])
+def test_cpp_maximum_step_alone_becomes_the_solver_step(solver, capsys):
+    """MaximumStep on its own is the only step the user gave, so it has to survive.
+
+    It used to be dropped here, and the parser's own MaximumStep -> dt_solver fallback runs
+    *after* this -- so nothing was left for it to find and generation died with
+    ``KeyError: 'dt_solver'`` on every cpp config that had not already been rewritten to the new
+    key, including the cpp autogeneration test.
+    """
+    migrated = migrate_legacy_solver_info_keys(solver, {
+        'solver': solver,
+        'MaximumStep': 0.001,
+    })
+    assert migrated == {'solver': solver, 'dt_solver': 0.001}
+    validate_solver_info(solver, migrated)
+
+    warned = capsys.readouterr().out
+    assert 'MaximumStep' in warned and 'dt_solver' in warned, (
+        'a renamed setting must name what it became'
+    )
+
+
+def test_a_cpp_config_with_only_maximum_step_still_generates():
+    """The end the bug was actually felt at: the value has to reach the generator.
+
+    ``script_generate_with_new_architecture`` reads ``solver_info['dt_solver']`` directly, so a
+    config that names the step the old way must arrive with that key present rather than raising
+    KeyError part-way through generation.
+    """
+    parsed = YamlFileParser().parse_user_inputs_file(
+        {
+            'file_prefix': '3compartment',
+            'input_param_file': '3compartment_parameters.csv',
+            'model_type': 'cpp',
+            'solver': 'RK4',
+            'solver_info': {'MaximumStep': 0.001},
+        },
+        obs_path_needed=False,
+        do_generation_with_fit_parameters=False,
+    )
+    assert parsed['solver_info']['dt_solver'] == 0.001
+
+
 def test_solve_ivp_rejects_maximum_step_keys():
     with pytest.raises(ValueError, match="MaximumStep"):
         validate_solver_info('solve_ivp', {


### PR DESCRIPTION
`test_generate_cpp_model_succeeds` fails on **master itself**, and on every open branch, with:

```
KeyError: 'dt_solver'
```

It has been failing since #330 changed how cpp solver_info is migrated.

## What happens

The generated C++ integrates at the fixed step named by the framework key `dt_solver`, so `migrate_legacy_solver_info_keys` dropped `MaximumStep` for the cpp solvers, warning that `dt_solver` is the setting to use instead.

Two things are wrong with that.

**It discards the only step the user gave.** The advice in the warning is right, but a rename that throws the value away is not a migration — and every other backend in that function migrates rather than drops (`solve_ivp` onto `max_step`, `casadi_integrator` onto `max_step_size`), for exactly this reason.

**It runs too early.** `parse_user_inputs_file` has its own `MaximumStep → dt_solver` fallback thirty lines further down, which would have covered this — but the drop happens first, so by the time the fallback looks there is nothing left to find. Generation then reaches `script_generate_with_new_architecture`, which reads `solver_info['dt_solver']` directly, and raises.

So any cpp config that had not already been rewritten to the new key could not generate at all — which is every config written for a CVODE backend, and the cpp autogeneration test.

## The fix

`MaximumStep` is carried onto `dt_solver` when `dt_solver` is absent, and dropped loudly (exactly as before) when both are set, since `dt_solver` is the one the generated code reads. Setting both is not made an error: an existing test documents that a config written for a CVODE backend must keep running and merely say which of its settings stopped applying, and that behaviour is preserved.

A maximum adaptive step and a fixed step are not the same quantity, but reading the former as the latter is the conservative choice — and is exactly what the pre-existing fallback already did with the same value.

## Testing

- `test_cpp_maximum_step_alone_becomes_the_solver_step` — the migration, for all three cpp solvers, including that the warning names what the setting became.
- `test_a_cpp_config_with_only_maximum_step_still_generates` — the end the bug was actually felt at: the value has to reach the generator with `dt_solver` present.
- The existing cpp migration tests are unchanged and still pass, including the both-keys-set case.
- 76 solver-info validation tests and `test_generate_cpp_model_succeeds` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
