### PR TITLE
feat(uq): write the MCMC chain as it is sampled, not only at the end

### DIFF
--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -3628,7 +3628,57 @@ def calculate_lnlikelihood(param_vals):
     """
     return mcmc_object.get_lnlikelihood_lnprior_from_params(param_vals)
 
-class OpencorMCMC(OpencorParamID): 
+
+def save_chain_atomically(path, samples):
+    """Write ``samples`` to ``path`` so a concurrent reader never sees half an array.
+
+    The chain is written *while* it is being sampled, so something else is expected to be
+    polling this file -- a front-end drawing the run, or a user with a notebook open. Writing in
+    place would leave a window in which the file is a truncated array, and ``np.load`` on that
+    raises rather than returning fewer steps. Writing beside it and renaming closes the window:
+    ``os.replace`` is atomic, so a reader sees either the previous chain or the new one.
+
+    ``np.save`` appends ``.npy`` to any path that lacks it, which would turn the temporary name
+    into ``...npy.tmp.npy`` and leave it behind; handing it an open file avoids that.
+    """
+    tmp_path = f'{path}.tmp'
+    with open(tmp_path, 'wb') as tmp_file:
+        np.save(tmp_file, samples)
+    os.replace(tmp_path, path)
+
+
+def sample_with_checkpoints(sampler, initial_state, num_steps, save_chain, save_every,
+                            **sample_kwargs):
+    """Run ``sampler`` for ``num_steps``, saving the chain so far every ``save_every`` steps.
+
+    ``run_mcmc`` is one blocking call that returns only when sampling is done, which is why the
+    chain used to reach disk once, hours in. ``sample()`` is the same loop as a generator, so
+    checkpointing is just doing something on the way round.
+
+    Falls back to ``run_mcmc`` when ``save_every`` is non-positive (checkpointing off) or the
+    sampler has no ``sample`` -- zeus is driven through the same code path here, and a backend
+    that only offers ``run_mcmc`` should keep working rather than raise.
+
+    Returns the number of checkpoints written, which is what a test can assert on without
+    reaching into the filesystem.
+    """
+    sample = getattr(sampler, 'sample', None)
+    if save_every <= 0 or sample is None:
+        sampler.run_mcmc(initial_state, num_steps, **sample_kwargs)
+        return 0
+
+    checkpoints = 0
+    for step, _state in enumerate(sample(initial_state, iterations=num_steps, **sample_kwargs),
+                                  start=1):
+        # Not on the last step: the caller saves the finished chain either way, and saving the
+        # same array twice in a row is pure I/O on the largest it will ever be.
+        if step % save_every == 0 and step < num_steps:
+            save_chain(sampler.get_chain())
+            checkpoints += 1
+    return checkpoints
+
+
+class OpencorMCMC(OpencorParamID):
     """
     Class for doing mcmc on opencor models
     
@@ -3834,7 +3884,7 @@ class OpencorMCMC(OpencorParamID):
             self.sampler = self._build_sampler(pool=pool)
 
             start_time = time.time()
-            self.sampler.run_mcmc(init_param_vals.T, self.UQ_options['num_steps'], progress=True, tune=True)
+            self._sample(init_param_vals.T, progress=True, tune=True)
             print(f'mcmc time = {time.time() - start_time}')
             pool.close()
 
@@ -3852,22 +3902,39 @@ class OpencorMCMC(OpencorParamID):
             self.sampler = self._build_sampler()
 
             start_time = time.time()
-            self.sampler.run_mcmc(init_param_vals.T, self.UQ_options['num_steps']) # , progress=True)
+            self._sample(init_param_vals.T) # , progress=True)
             print(f'mcmc time = {time.time()-start_time}')
 
         if rank == 0:
-            # TODO save chains
             if hasattr(self.sampler, 'acceptance_fraction'):
                 print(f'acceptance fraction was {self.sampler.acceptance_fraction}')
             samples = self.sampler.get_chain()
-            mcmc_chain_path = os.path.join(self.output_dir, 'mcmc_chain.npy')
-            np.save(mcmc_chain_path, samples)
+            mcmc_chain_path = self.mcmc_chain_path()
+            save_chain_atomically(mcmc_chain_path, samples)
             print('mcmc complete')
             print(f'mcmc chain saved in {mcmc_chain_path}')
 
             flat_samples = samples[self.burn_in_index(samples.shape[0]):, :, :].reshape(
                 -1, self.num_params)
             self.save_mcmc_statistics(flat_samples)
+
+    def mcmc_chain_path(self):
+        """Where the chain is written -- the same path during the run as at the end of it.
+
+        Deliberately one file rather than a partial one that is renamed at the end: everything
+        that reads a chain (``load_mcmc_chain``, the plotters, a front-end) then needs no notion
+        of "the run has finished", and a run that is cancelled or killed leaves its chain exactly
+        where the tooling already looks for it.
+        """
+        return os.path.join(self.output_dir, 'mcmc_chain.npy')
+
+    def _sample(self, initial_state, **sample_kwargs):
+        """Sample, leaving a readable chain behind on the way rather than only at the end."""
+        return sample_with_checkpoints(
+            self.sampler, initial_state, self.UQ_options['num_steps'],
+            lambda samples: save_chain_atomically(self.mcmc_chain_path(), samples),
+            self.UQ_options.get('chain_save_every', 50),
+            **sample_kwargs)
 
     def burn_in_index(self, num_steps):
         """The first step to keep, from ``UQ_options['burn_in']``.

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -1471,6 +1471,11 @@ ANALYSIS_OPTIONS = {
              'description': "pyMC sampling algorithm: 'mcmc' is Metropolis, 'smc' is sequential "
                             'Monte Carlo, which can cross a low-probability region between modes '
                             'that Metropolis gets stuck on one side of. Ignored by emcee.'},
+            {'name': 'chain_save_every', 'type': 'int', 'default': 50, 'required': False,
+             'description': 'Steps between writes of the partial chain to mcmc_chain.npy, so a '
+                            'running chain can be watched and a cancelled one is not lost. 0 '
+                            'saves only at the end, which a very wide chain on a slow shared '
+                            'filesystem may prefer. Ignored by a backend that cannot be stepped.'},
         ],
     },
     'identifiability_analysis': {

--- a/tests/test_mcmc_chain_checkpoints.py
+++ b/tests/test_mcmc_chain_checkpoints.py
@@ -1,0 +1,207 @@
+"""The MCMC chain has to be on disk *during* the run, not only after it (issue #417).
+
+``run_mcmc`` is one blocking call, so the chain used to appear once, hours in. That makes a long
+run unobservable -- there is no way to see whether the walkers are mixing or stuck until it is
+too late to stop it -- and makes a cancelled or killed run a total loss, when a partial chain is
+a perfectly good chain with fewer steps.
+
+What is asserted here is what a reader polling the file actually needs: that it appears early,
+that it grows, that it is always loadable, and that the finished chain is not changed by any of
+it.
+"""
+
+import os
+import threading
+
+import numpy as np
+import pytest
+
+from param_id.paramID import sample_with_checkpoints, save_chain_atomically
+
+pytestmark = pytest.mark.unit
+
+NUM_WALKERS = 4
+NUM_PARAMS = 2
+
+
+class _StubSampler:
+    """A sampler with emcee's two relevant surfaces: ``sample()`` and ``get_chain()``.
+
+    emcee's ``sample`` is a generator that yields once per step and accumulates the chain as it
+    goes, which is the property the checkpointing relies on.
+    """
+
+    def __init__(self, seed=0):
+        self.steps = []
+        self.run_mcmc_calls = 0
+        self.sample_kwargs = None
+        self._rng = np.random.default_rng(seed)
+
+    def sample(self, initial_state, iterations, **kwargs):
+        self.sample_kwargs = kwargs
+        for _ in range(iterations):
+            self.steps.append(self._rng.normal(size=(NUM_WALKERS, NUM_PARAMS)))
+            yield 'state'
+
+    def get_chain(self):
+        return np.array(self.steps)
+
+    def run_mcmc(self, initial_state, num_steps, **kwargs):
+        self.run_mcmc_calls += 1
+        for _ in self.sample(initial_state, num_steps, **kwargs):
+            pass
+
+
+class _RunMcmcOnlySampler:
+    """A backend that cannot be stepped -- it only offers the blocking call."""
+
+    def __init__(self):
+        self.run_mcmc_calls = 0
+
+    def get_chain(self):
+        return np.zeros((1, NUM_WALKERS, NUM_PARAMS))
+
+    def run_mcmc(self, initial_state, num_steps, **kwargs):
+        self.run_mcmc_calls += 1
+
+
+def _saver(path, seen):
+    """Record the shape of every chain written, and write it, so both can be asserted."""
+    def save(samples):
+        save_chain_atomically(path, samples)
+        seen.append(np.load(path).shape)
+    return save
+
+
+def test_the_chain_appears_and_grows_while_sampling(tmp_path):
+    """The point of the change: a reader polling this file sees the run progress."""
+    path = str(tmp_path / 'mcmc_chain.npy')
+    sampler = _StubSampler()
+    shapes = []
+
+    written = sample_with_checkpoints(sampler, 'x0', 20, _saver(path, shapes), save_every=5)
+
+    # Steps 5, 10, 15 -- not 20, which the caller saves as the finished chain.
+    assert written == 3
+    assert [s[0] for s in shapes] == [5, 10, 15]
+    assert all(s[1:] == (NUM_WALKERS, NUM_PARAMS) for s in shapes)
+
+
+def test_each_checkpoint_is_the_chain_so_far_not_a_placeholder(tmp_path):
+    """A file that exists but holds the wrong steps is worse than no file: it would plot."""
+    path = str(tmp_path / 'mcmc_chain.npy')
+    sampler = _StubSampler()
+
+    sample_with_checkpoints(sampler, 'x0', 9, lambda s: save_chain_atomically(path, s),
+                            save_every=3)
+
+    on_disk = np.load(path)
+    # The last checkpoint is step 6 (9 is the final step, left to the caller).
+    np.testing.assert_allclose(on_disk, sampler.get_chain()[:6])
+
+
+def test_the_finished_chain_is_exactly_what_it_was_before(tmp_path):
+    """Checkpointing must not change the answer -- it writes what sampling already produced."""
+    path = str(tmp_path / 'mcmc_chain.npy')
+
+    checkpointed = _StubSampler(seed=7)
+    sample_with_checkpoints(checkpointed, 'x0', 12, lambda s: save_chain_atomically(path, s),
+                            save_every=4)
+
+    straight_through = _StubSampler(seed=7)
+    sample_with_checkpoints(straight_through, 'x0', 12, lambda s: None, save_every=0)
+
+    np.testing.assert_allclose(checkpointed.get_chain(), straight_through.get_chain())
+
+
+def test_checkpointing_off_falls_back_to_the_blocking_call(tmp_path):
+    """0 is 'save only at the end' -- the behaviour before this change, still reachable."""
+    sampler = _StubSampler()
+    saves = []
+
+    written = sample_with_checkpoints(sampler, 'x0', 10, saves.append, save_every=0)
+
+    assert written == 0
+    assert saves == []
+    assert sampler.run_mcmc_calls == 1
+    assert sampler.get_chain().shape[0] == 10
+
+
+def test_a_backend_that_cannot_be_stepped_still_runs():
+    """zeus goes through this path too, and a backend offering only run_mcmc must not raise."""
+    sampler = _RunMcmcOnlySampler()
+    saves = []
+
+    written = sample_with_checkpoints(sampler, 'x0', 10, saves.append, save_every=5)
+
+    assert written == 0
+    assert sampler.run_mcmc_calls == 1
+
+
+def test_sampler_kwargs_are_passed_through():
+    """The MPI path asks for progress and tuning; routing through sample() must not drop them."""
+    sampler = _StubSampler()
+
+    sample_with_checkpoints(sampler, 'x0', 4, lambda s: None, save_every=2,
+                            progress=True, tune=True)
+
+    assert sampler.sample_kwargs == {'progress': True, 'tune': True}
+
+
+def test_a_partial_write_is_never_visible(tmp_path):
+    """Written beside the file and renamed, so a poller never loads a truncated array.
+
+    Checked by overwriting a large chain with a small one while reading in a loop: an in-place
+    write leaves a window where the file is half of each, and np.load raises on it.
+    """
+    path = str(tmp_path / 'mcmc_chain.npy')
+    save_chain_atomically(path, np.ones((400, NUM_WALKERS, NUM_PARAMS)))
+
+    for _ in range(25):
+        save_chain_atomically(path, np.zeros((400, NUM_WALKERS, NUM_PARAMS)))
+        loaded = np.load(path)          # raises if it ever catches a partial file
+        assert loaded.shape == (400, NUM_WALKERS, NUM_PARAMS)
+
+    # and nothing is left lying beside it
+    assert os.listdir(tmp_path) == ['mcmc_chain.npy']
+
+
+def test_a_concurrent_reader_never_sees_a_broken_chain(tmp_path):
+    """The real arrangement: CA writes the chain while something else polls it, uncoordinated.
+
+    A writer runs alongside a reader with no lock between them. np.save releases the GIL while
+    it writes, so an in-place write genuinely loses this race -- the reader catches a truncated
+    array and np.load raises, or the halves of two different chains and the values disagree.
+    Both are asserted, because a file that loads but holds half of each would plot.
+
+    A thread rather than a process on purpose: the suite runs under mpiexec, where forking is
+    unwise and OpenCOR's embedded interpreter leaves sys.executable empty so spawn cannot start
+    a child at all.
+    """
+    path = str(tmp_path / 'mcmc_chain.npy')
+    save_chain_atomically(path, np.zeros((300, NUM_WALKERS, NUM_PARAMS)))
+    stop = threading.Event()
+    failures = []
+
+    def write_until_stopped():
+        step = 0
+        while not stop.is_set():
+            step += 1
+            try:
+                save_chain_atomically(path, np.full((300, NUM_WALKERS, NUM_PARAMS), float(step)))
+            except Exception as exc:  # noqa: BLE001 - surfaced through `failures`
+                failures.append(exc)
+                return
+
+    writer = threading.Thread(target=write_until_stopped)
+    writer.start()
+    try:
+        for _ in range(80):
+            samples = np.load(path)     # the assertion is that this does not raise
+            assert samples.shape == (300, NUM_WALKERS, NUM_PARAMS)
+            # every element comes from one write, never half of two
+            assert len(np.unique(samples)) == 1
+    finally:
+        stop.set()
+        writer.join(timeout=30)
+    assert not failures, f'the writer failed: {failures[0]!r}'

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -503,7 +503,7 @@ def test_analysis_options_schema_well_formed():
         'method', 'sample_type', 'num_samples', 'gradient_method', 'fd_rel_step'}
     # 'uq', not 'mcmc': MCMC is one UQ method, and 'method' is the seam the others are added at.
     assert names('uq') == {'method', 'library', 'num_steps', 'num_walkers', 'burn_in',
-                           'num_tune', 'pymc_method'}
+                           'num_tune', 'pymc_method', 'chain_save_every'}
     assert ANALYSIS_OPTIONS['uq']['options_key'] == 'UQ_options'
     assert names('identifiability_analysis') == {'method', 'gradient_source', 'sub_method'}
     assert names('emulation') == {


### PR DESCRIPTION
Closes #417. Unblocks CUFLynx #244.

## The problem

`run_mcmc` is one blocking call, so `mcmc_chain.npy` appeared once, hours in. Nothing was written between start and finish — there was even a `# TODO save chains` sitting at the save.

Three things followed:

- **A long run was unobservable.** The only live signal is emcee's tqdm bar, and only on the MPI path; the serial branch has `progress=True` commented out. No way to see walkers stuck or still in burn-in until it was too late to act.
- **A cancelled or killed run lost everything** — a wall-clock limit on an HPC queue, a lost node, a cancel button. A partial chain is a perfectly good chain with fewer steps.
- **CUFLynx #244 could not be built.** Its live progress polls files the CA runner writes as it goes; for MCMC there were none, at any refresh rate.

## The change

`sample_with_checkpoints` drives `emcee.EnsembleSampler.sample()` — the same loop as a generator — saving every `chain_save_every` steps. It falls back to `run_mcmc` when checkpointing is off or the sampler has no `sample`, so **zeus**, which goes through this path too, is unaffected.

`save_chain_atomically` writes beside the file and `os.replace`s it in. Something is expected to be reading this file while it is written, and an in-place `np.save` leaves a window in which it is a truncated array — `np.load` raises on that rather than returning fewer steps.

### One design choice worth flagging

It stays **one file**, `mcmc_chain.npy`, from the first checkpoint to the last — not a partial file renamed at the end. A rename would mean every reader (`load_mcmc_chain`, the plotters, a front-end) needed a notion of "has the run finished", and a killed run would leave its chain somewhere the tooling does not look.

`chain_save_every` (default 50; `0` restores the old save-once behaviour) is declared in `ANALYSIS_OPTIONS['uq']`, so a front-end can reach it without hardcoding.

## Scope

pyMC is untouched: `pm.sample()` is also blocking with no generator equivalent and needs its own `callback` hook. #417 records it as a follow-up rather than a blocker — emcee is the default backend and gets the benefit now.

## Tests

Eight in `tests/test_mcmc_chain_checkpoints.py`, asserting what a polling reader actually needs: the file appears early and grows; each checkpoint holds *the chain so far*, not a placeholder; the finished chain is identical to one sampled without checkpointing; `0` falls back to the blocking call; a `run_mcmc`-only backend still runs; `progress`/`tune` survive the reroute.

The load-bearing one is the concurrent-reader test — a writer thread rewriting the chain while the test reads it in a loop, asserting both that `np.load` never raises *and* that the values never come from two different writes. Verified it catches the bug it is written for: reverting to an in-place `np.save` fails it with `EOFError: No data left in file`. It uses a thread rather than a process deliberately — the suite runs under `mpiexec` where forking is unwise, and OpenCOR's embedded interpreter leaves `sys.executable` empty so `spawn` cannot start a child at all.

Full `-m "not slow"`: 733 passed, with the same 8 pre-existing failures as `master` (the `mpi_utils` no-MPI-at-import tests and `test_python_BDF_solver`, which fail under `mpiexec` regardless of this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)