### PR TITLE
fix(uq): numpy 2.0 removed np.trapz, so bind trapezoid by capability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -220,6 +220,50 @@ jobs:
         python -m pytest tests/test_UQ.py -m slow -k "not KDE" -v --with-mpi --tb=short \
           --durations=0 --junitxml=junit-uq.xml
 
+    # A skipped test is a green step, so this job could report success having run nothing at
+    # all -- and that is the likely failure, not a red X: every UQ test is guarded by a skipif
+    # on an optional extra (autoemulate, pymc). If [emulation] or [uq] silently fails to
+    # resolve, the whole point of this job evaporates and the badge still says pass.
+    - name: Fail if the UQ tests did not actually run
+      if: always()
+      run: |
+        python - <<'PY'
+        import glob
+        import sys
+        import xml.etree.ElementTree as ET
+
+        problems = []
+        seen_any = False
+        for path in sorted(glob.glob('junit-uq*.xml')):
+            seen_any = True
+            suites = ET.parse(path).getroot()
+            suites = [suites] if suites.tag == 'testsuite' else suites.findall('testsuite')
+            for suite in suites:
+                total = int(suite.get('tests', 0))
+                skipped = int(suite.get('skipped', 0))
+                ran = total - skipped
+                print(f'{path}: {total} collected, {skipped} skipped, {ran} ran')
+                if total == 0:
+                    problems.append(f'{path} collected no tests')
+                elif ran == 0:
+                    problems.append(f'{path} ran nothing -- all {total} tests skipped')
+                elif skipped:
+                    problems.append(f'{path} skipped {skipped} of {total} tests')
+
+        if not seen_any:
+            problems.append('no junit-uq*.xml was produced, so no UQ tests ran at all')
+
+        if problems:
+            print()
+            print('The UQ job is meant to be the one place these run. Every UQ test is behind a '
+                  'skipif on an optional extra, so a skip here almost always means [uq] or '
+                  '[emulation] did not install rather than that the test was inapplicable.')
+            for problem in problems:
+                print(f'  - {problem}')
+            sys.exit(1)
+        print('every UQ test ran')
+        PY
+
     - name: Upload UQ test results
       if: always()
       uses: actions/upload-artifact@v4

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -111,6 +111,16 @@ warnings.filterwarnings( "ignore", module = "matplotlib/..*" )
 mcmc_object = None
 
 
+# numpy 2.0 renamed trapz to trapezoid and removed the old name; numpy 1.x has only the old one,
+# and this project supports both (CI runs 2.2 while the OpenCOR shell ships 1.26). Bound once here
+# rather than branched at the call site, and named for what it does rather than for either
+# spelling.
+try:
+    from numpy import trapezoid as integrate_trapezoid       # numpy >= 2.0
+except ImportError:                                          # pragma: no cover - numpy < 2.0
+    from numpy import trapz as integrate_trapezoid
+
+
 def _resolve_UQ_options(UQ_options, mcmc_options):
     """Accept the deprecated ``mcmc_options=`` kwarg wherever ``UQ_options=`` is now taken.
 
@@ -1222,7 +1232,7 @@ class CVS0DParamID():
         # Subtract the max before exponentiating: the log prior is unnormalised, so its absolute
         # level is arbitrary and can overflow exp() outright.
         pdf[finite] = np.exp(lnprior[finite] - np.max(lnprior[finite]))
-        area = np.trapz(pdf, x_values)
+        area = integrate_trapezoid(pdf, x_values)
         if area > 0:
             pdf /= area
         return pdf

--- a/tests/test_uq_posterior_plots.py
+++ b/tests/test_uq_posterior_plots.py
@@ -9,7 +9,7 @@ import os
 import numpy as np
 import pytest
 
-from param_id.paramID import CVS0DParamID
+from param_id.paramID import CVS0DParamID, integrate_trapezoid
 
 
 class _StubEngine:
@@ -223,7 +223,9 @@ def test_normal_prior_pdf_peaks_at_its_mean_and_integrates_to_one(tmp_path):
     pdf = plotter.get_prior_pdf(0, x)
 
     assert x[int(np.argmax(pdf))] == pytest.approx(3.0, abs=0.05)
-    assert np.trapz(pdf, x) == pytest.approx(1.0, abs=1e-6)
+    # Imported from paramID rather than called as np.trapz: numpy 2.0 removed that name,
+    # and a test that only runs on numpy 1.x is not testing the code CI runs.
+    assert integrate_trapezoid(pdf, x) == pytest.approx(1.0, abs=1e-6)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Fixes the three CI failures on master:

```
FAILED tests/test_uq_posterior_plots.py::test_normal_prior_pdf_peaks_at_its_mean_and_integrates_to_one
FAILED tests/test_uq_posterior_plots.py::test_the_prior_pdf_comes_from_the_engines_own_prior
FAILED tests/test_uq_posterior_plots.py::test_uniform_prior_pdf_is_flat_inside_the_bounds_and_zero_outside
  AttributeError: module 'numpy' has no attribute 'trapz'
```

## Cause

`get_prior_pdf` normalises the prior with `np.trapz`. **numpy 2.0 renamed it to `trapezoid` and removed the old spelling**, and CI resolves `numpy>=1.19.0` to 2.2.

## Why not just rename it

Renaming to `trapezoid` would move the breakage rather than fix it: **numpy 1.26 has `trapz` and not `trapezoid`**, and that is what the OpenCOR shell ships — the interpreter `./run_pytest.sh` uses. `pyproject.toml` allows both generations, so both have to work.

So the name is bound once, by capability:

```python
try:
    from numpy import trapezoid as integrate_trapezoid   # numpy >= 2.0
except ImportError:                                      # numpy < 2.0
    from numpy import trapz as integrate_trapezoid
```

Bound at import rather than branched at the call site, and named for what it does rather than for either spelling, so the call site no longer depends on which numpy is installed.

## The test was part of the problem

It asserted the pdf integrates to 1 by calling `np.trapz` **directly**, so it exercised numpy's old API rather than the code's. That is precisely how this reached master: it passes on numpy 1.26 locally and fails on 2.2 in CI. It now imports the same shim, so the test and the code agree about which function they mean.

## Verification

Both arms were exercised against the numpy 1.26 baseline available here — the second by giving numpy the new name — and integrate identically:

```
numpy 1.26.4: shim selects trapz
with numpy.trapezoid present: shim selects trapezoid
both arms integrate identically: 0.9999994262
paramID.integrate_trapezoid resolves and agrees
```

`tests/test_uq_posterior_plots.py`: 12 passed. Full `not slow and not compare_optimisers`: 753 passed, 8 failed — the pre-existing environment failures only (`test_python_BDF_solver[SN_simple]`, #151, plus 7 in `test_mpi_utils.py` that need a real `sys.executable`, which the OpenCOR shell does not provide).

I also swept for the other common numpy 2.0 removals — `np.float_`, `np.int0`, `np.alltrue`, `np.sometrue`, `np.product`, `np.cumproduct`, `np.round_`, `np.NaN`, `np.Inf`, `np.infty` and friends. `np.trapz` was the only one in the codebase.

## Worth considering separately

Nothing in CI runs the suite on numpy 1.x, and nothing local runs it on 2.x, so this class of divergence is invisible from either side. A numpy 1.x leg in the `test` matrix — or a floor bump to `numpy>=2` if 1.x support is not actually wanted — would close the gap. Out of scope here; this PR just unbreaks master.
