### PR TITLE
feat(uq): the pyMC backend writes its chain as it samples, not only at the end (#417)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -208,6 +208,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
 
+    # Seconds, and the only place the pyMC-sampling half of these runs: without [uq] they skip,
+    # which is exactly how the backend's live-chain checkpointing could regress unnoticed.
+    - name: Run the pyMC live-chain tests
+      run: |
+        python -m pytest tests/test_uq_pymc_live_chain.py -v --tb=short \
+          --junitxml=junit-uq-pymc-live.xml
+
     # Fast enough to be worth running first: it fails in a minute if UQ is broken at all,
     # rather than after half an hour of sampling the real model.
     - name: Run UQ on an emulator (fast posterior-recovery check)
@@ -271,6 +278,7 @@ jobs:
         name: uq-test-results
         path: |
           junit-uq-emulator.xml
+          junit-uq-pymc-live.xml
           junit-uq.xml
 
   # Job to run full test suite if OpenCOR is available (optional)

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -3655,14 +3655,35 @@ def sample_with_checkpoints(sampler, initial_state, num_steps, save_chain, save_
     chain used to reach disk once, hours in. ``sample()`` is the same loop as a generator, so
     checkpointing is just doing something on the way round.
 
+    A backend with no generator form can still checkpoint, if it has some hook of its own to do
+    it from: one that sets ``saves_own_checkpoints`` is handed ``save_chain`` and ``save_every``
+    and is trusted to call the hook itself. pyMC is that case -- ``pm.sample`` cannot be stepped
+    but does take a per-draw callback -- and without this it took the fallback below, so a pyMC
+    run's chain appeared only at the end however ``chain_save_every`` was set.
+
     Falls back to ``run_mcmc`` when ``save_every`` is non-positive (checkpointing off) or the
-    sampler has no ``sample`` -- zeus is driven through the same code path here, and a backend
-    that only offers ``run_mcmc`` should keep working rather than raise.
+    sampler has neither ``sample`` nor its own checkpointing -- zeus is driven through the same
+    code path here, and a backend that only offers ``run_mcmc`` should keep working rather than
+    raise.
 
     Returns the number of checkpoints written, which is what a test can assert on without
     reaching into the filesystem.
     """
     sample = getattr(sampler, 'sample', None)
+    if save_every > 0 and getattr(sampler, 'saves_own_checkpoints', False):
+        # Counted here rather than trusted to the backend, so "how many were written" means the
+        # same thing -- calls to this hook -- whichever route produced them.
+        checkpoints = 0
+
+        def counted_save(samples):
+            nonlocal checkpoints
+            checkpoints += 1
+            save_chain(samples)
+
+        sampler.run_mcmc(initial_state, num_steps, save_chain=counted_save,
+                         save_every=save_every, **sample_kwargs)
+        return checkpoints
+
     if save_every <= 0 or sample is None:
         sampler.run_mcmc(initial_state, num_steps, **sample_kwargs)
         return 0

--- a/src/param_id/pymc_backend.py
+++ b/src/param_id/pymc_backend.py
@@ -13,7 +13,17 @@ pymc and pytensor are imported lazily, inside the sampler. They are not CA depen
 ``paramID.py`` is imported by every calibration run, so importing them at module level (as the
 original patch did) would break every user who has not installed them, to no benefit for anyone
 not doing UQ. Install with ``pip install -e ".[uq]"``.
+
+The one place the two backends are not interchangeable is *how* the chain reaches disk while it
+is being sampled (#417). emcee's ``sample()`` is a generator, so the caller checkpoints between
+steps; ``pm.sample`` is a single blocking call with no generator equivalent, and a pyMC run
+therefore wrote nothing until it finished -- a live progress plot of it stayed empty for the
+whole run. ``pm.sample`` does take a per-draw ``callback``, so this module does its own
+checkpointing through that and declares ``saves_own_checkpoints`` so the shared loop hands it
+the same ``save_chain`` hook rather than falling back to the blocking call.
 """
+import sys
+
 import numpy as np
 
 try:
@@ -40,6 +50,92 @@ def _import_pymc():
     return pm, pt, as_op
 
 
+def _progressbar_wanted(progress, rank):
+    """Whether to let pyMC draw its progress bar.
+
+    Only rank 0 has anything to draw, and only when the caller asked for progress at all -- but
+    also only onto a terminal. pyMC's bar is a rich table that repaints, so redirected into a
+    log file it becomes thousands of lines of ANSI escapes wrapped around a redrawn table
+    (measured: ~8 kB for a 1000-draw run, growing with the run), interleaved with whatever else
+    is writing to that log. That is the run log a user is left reading when a run goes wrong,
+    and the bar is worth nothing in it: nobody watches a progress bar in a file. A terminal
+    still gets it.
+    """
+    return bool(progress) and rank == 0 and bool(getattr(sys.stdout, 'isatty', lambda: False)())
+
+
+class _LiveChainWriter:
+    """pyMC's per-draw callback, writing the draws so far the way #417 writes emcee's.
+
+    pyMC hands a callback ``(trace, draw)`` after every recorded draw, where ``trace`` is the
+    per-chain backend it is filling and ``draw`` carries the chain index and whether the draw is
+    a tuning one. That is enough to write the same growing ``mcmc_chain.npy`` an emcee run
+    writes, without pretending ``pm.sample`` can be stepped.
+
+    **The live file is the draws in the order pyMC produced them, as a single walker.** With
+    ``cores=1`` -- which is what CA asks for, because the parallelism is MPI ranks, not pyMC
+    processes -- chains are sampled one after another, not advanced together. So there is no
+    honest ``(steps, walkers, params)`` rectangle covering all of them until the last one
+    finishes: chain 2 has one draw while chain 1 has five thousand, and squaring that off means
+    either throwing away chain 1's draws or inventing chain 2's. Concatenating them instead is
+    exactly what happened, in the order it happened, and it grows monotonically for the whole
+    run -- which is what a progress view needs. The finished chain, written by the caller once
+    sampling returns, is the real ``(steps, chains, params)`` from every rank.
+
+    Tuning draws are dropped, because pyMC drops them: they are recorded in the same trace but
+    do not appear in the posterior, and a live view that included them would disagree with the
+    chain that lands at the end.
+
+    Nothing in here may raise. A callback that throws takes the whole ``pm.sample`` call down
+    with it, and losing hours of sampling because a progress nicety could not write a file is a
+    far worse failure than not having the file. A first failure is reported and turns the
+    checkpointing off for the rest of the run.
+    """
+
+    def __init__(self, save_chain, save_every, param_names, num_tune):
+        self.save_chain = save_chain
+        self.save_every = save_every
+        self.param_names = list(param_names)
+        self.num_tune = int(num_tune)
+        # chain index -> pyMC's trace for it, in the order sampling reached them; the traces are
+        # the same objects for the life of the run, so a finished chain stays readable here.
+        self.traces = {}
+        self.num_draws = 0
+        self.disabled = False
+
+    def __call__(self, trace, draw):
+        self.traces[draw.chain] = trace
+        if self.disabled or draw.tuning:
+            return
+        self.num_draws += 1
+        if self.num_draws % self.save_every:
+            return
+        try:
+            samples = self.chain_so_far()
+            if samples is not None:
+                self.save_chain(samples)
+        except Exception as exc:                       # noqa: BLE001 - see the class docstring
+            self.disabled = True
+            print(f'WARNING: could not write the partial MCMC chain ({exc}); sampling continues '
+                  'and the chain will be saved at the end of the run.')
+
+    def chain_so_far(self):
+        """The post-tuning draws so far, ``(draws, 1, params)``, or None before there are any."""
+        parts = []
+        for trace in self.traces.values():
+            recorded = len(trace)
+            if recorded <= self.num_tune:
+                continue
+            # A trace still being filled is preallocated to its full length, so it has to be cut
+            # to what has actually been recorded -- the tail is zeros, not draws.
+            parts.append(np.stack(
+                [np.asarray(trace.get_values(name))[self.num_tune:recorded]
+                 for name in self.param_names], axis=-1))
+        if not parts:
+            return None
+        return np.concatenate(parts, axis=0)[:, np.newaxis, :]
+
+
 class PyMCSampler:
     """A pyMC sampler wearing emcee's interface.
 
@@ -53,6 +149,12 @@ class PyMCSampler:
         num_tune: Tuning (burn-in) draws discarded before sampling.
         method: ``'mcmc'`` for Metropolis sampling, or ``'smc'`` for sequential Monte Carlo.
     """
+
+    #: Read by ``paramID.sample_with_checkpoints``. ``pm.sample`` is one blocking call with no
+    #: generator form, so this backend cannot be driven a step at a time -- but it does not have
+    #: to fall back to writing the chain only at the end either: it checkpoints itself from
+    #: pyMC's per-draw callback, given the same ``save_chain`` hook.
+    saves_own_checkpoints = True
 
     def __init__(self, num_walkers, num_params, log_posterior_fn, param_id_info=None,
                  num_tune=1000, method='mcmc'):
@@ -140,27 +242,36 @@ class PyMCSampler:
             return max(1, int(num_walkers))
         return max(1, int(num_walkers) // int(num_procs))
 
-    def run_mcmc(self, initial_state, num_steps, progress=False, **kwargs):
+    def run_mcmc(self, initial_state, num_steps, progress=False, save_chain=None, save_every=0,
+                 **kwargs):
         """Sample, and return the chain as ``(steps, walkers, params)``.
 
         ``initial_state`` is emcee's ``(walkers, params)`` starting positions; it seeds the
         per-chain initial values for ``method='mcmc'`` and is unused for SMC, which draws its
         own initial population from the prior.
+
+        ``save_chain``/``save_every`` are the checkpoint hook from
+        ``paramID.sample_with_checkpoints`` (issue #417): call ``save_chain(samples)`` every
+        ``save_every`` draws so the run can be watched and a cancelled one is not lost. Routed
+        into ``pm.sample``'s per-draw callback -- see ``_LiveChainWriter`` for what the partial
+        chain contains and why.
         """
         comm = MPI.COMM_WORLD if MPI is not None else None
         rank = comm.Get_rank() if comm is not None else 0
         num_procs = comm.Get_size() if comm is not None else 1
         num_chains = self.chains_for_rank(self.num_walkers, num_procs)
+        checkpointer = self._make_checkpointer(save_chain, save_every, rank)
 
         model = self._build_model()
         with model:
             if self.method == 'smc':
                 trace = self.pm.sample_smc(draws=num_steps, chains=num_chains, cores=1,
-                                           progressbar=(progress and rank == 0))
+                                           progressbar=_progressbar_wanted(progress, rank))
             else:
                 trace = self.pm.sample(
                     draws=num_steps, tune=self.num_tune, chains=num_chains, cores=1,
-                    step=self.pm.Metropolis(), progressbar=(progress and rank == 0),
+                    step=self.pm.Metropolis(), progressbar=_progressbar_wanted(progress, rank),
+                    callback=checkpointer,
                     initvals=self._initial_values(initial_state, num_chains))
 
         local_chain = self.trace_to_emcee_chain(trace, self._param_names())
@@ -176,6 +287,29 @@ class PyMCSampler:
         # Each rank sampled its own chains, so they concatenate along the walker axis.
         self.chain = np.concatenate([c for c in gathered if c is not None], axis=1)
         return self.chain
+
+    def _make_checkpointer(self, save_chain, save_every, rank):
+        """The per-draw callback that writes the partial chain, or None if nothing should.
+
+        Nothing should when checkpointing is off, when this is not rank 0, or under SMC:
+
+        * **Not rank 0.** Every rank samples its own chains into the same output directory, and
+          the chain file is one path. Ranks all writing it would each overwrite the others with
+          a chain that is only their own -- so the file would flicker between ranks rather than
+          grow. Only rank 0 writes, which means the live file shows rank 0's chains; the other
+          ranks' are gathered into the finished chain at the end, as they always were.
+        * **SMC.** ``pm.sample_smc`` takes no callback -- it advances a whole population per
+          stage rather than drawing one sample at a time, so there is no per-draw hook to hang
+          this on. Rather than leave that looking broken, say it: the chain arrives at the end.
+        """
+        if save_chain is None or save_every <= 0 or rank != 0:
+            return None
+        if self.method == 'smc':
+            print("NOTE: pyMC's sequential Monte Carlo (pymc_method 'smc') has no per-draw hook, "
+                  'so the chain is written once, when sampling finishes. UQ_options '
+                  "chain_save_every takes effect for pymc_method 'mcmc' only.")
+            return None
+        return _LiveChainWriter(save_chain, save_every, self._param_names(), self.num_tune)
 
     def _initial_values(self, initial_state, num_chains):
         """emcee's (walkers, params) start positions as pyMC's per-chain initval dicts."""

--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -1475,7 +1475,10 @@ ANALYSIS_OPTIONS = {
              'description': 'Steps between writes of the partial chain to mcmc_chain.npy, so a '
                             'running chain can be watched and a cancelled one is not lost. 0 '
                             'saves only at the end, which a very wide chain on a slow shared '
-                            'filesystem may prefer. Ignored by a backend that cannot be stepped.'},
+                            'filesystem may prefer. Under pymc it counts post-tuning draws and '
+                            "the partial chain holds rank 0's draws so far as a single walker; "
+                            "pymc_method 'smc' has no per-draw hook, so it saves only at the "
+                            'end whatever this is set to.'},
         ],
     },
     'identifiability_analysis': {

--- a/tests/test_mcmc_chain_checkpoints.py
+++ b/tests/test_mcmc_chain_checkpoints.py
@@ -65,6 +65,28 @@ class _RunMcmcOnlySampler:
         self.run_mcmc_calls += 1
 
 
+class _SelfCheckpointingSampler:
+    """A backend that cannot be stepped but checkpoints itself -- pyMC's shape.
+
+    ``pm.sample`` is one blocking call with no generator form, but it does take a per-draw
+    callback, so the backend can write the partial chain from inside its own run_mcmc.
+    """
+
+    saves_own_checkpoints = True
+
+    def __init__(self):
+        self.run_mcmc_kwargs = None
+
+    def get_chain(self):
+        return np.zeros((1, NUM_WALKERS, NUM_PARAMS))
+
+    def run_mcmc(self, initial_state, num_steps, save_chain=None, save_every=0, **kwargs):
+        self.run_mcmc_kwargs = kwargs
+        for step in range(1, num_steps + 1):
+            if save_every and step % save_every == 0:
+                save_chain(np.zeros((step, 1, NUM_PARAMS)))
+
+
 def _saver(path, seen):
     """Record the shape of every chain written, and write it, so both can be asserted."""
     def save(samples):
@@ -136,6 +158,41 @@ def test_a_backend_that_cannot_be_stepped_still_runs():
 
     assert written == 0
     assert sampler.run_mcmc_calls == 1
+
+
+def test_a_backend_that_checkpoints_itself_is_given_the_hook(tmp_path):
+    """The pyMC case (#417 follow-up). Before this it matched 'cannot be stepped' and took the
+    blocking fallback, so its chain appeared only at the end however chain_save_every was set --
+    the file a live progress view polls stayed absent for the whole run."""
+    path = str(tmp_path / 'mcmc_chain.npy')
+    sampler = _SelfCheckpointingSampler()
+    shapes = []
+
+    written = sample_with_checkpoints(sampler, 'x0', 20, _saver(path, shapes), save_every=5)
+
+    assert written == 4, 'the count is the calls to the hook, whichever route made them'
+    assert [s[0] for s in shapes] == [5, 10, 15, 20]
+    assert np.load(path).shape == (20, 1, NUM_PARAMS)
+
+
+def test_a_self_checkpointing_backend_still_honours_checkpointing_off():
+    """save_every 0 means 'only at the end' for every backend, so the hook must not be handed
+    over -- a backend given save_every=0 would write nothing anyway, but it must not be asked."""
+    sampler = _SelfCheckpointingSampler()
+    saves = []
+
+    written = sample_with_checkpoints(sampler, 'x0', 10, saves.append, save_every=0)
+
+    assert written == 0 and saves == []
+
+
+def test_self_checkpointing_backends_get_the_sampler_kwargs_too():
+    sampler = _SelfCheckpointingSampler()
+
+    sample_with_checkpoints(sampler, 'x0', 4, lambda s: None, save_every=2,
+                            progress=True, tune=True)
+
+    assert sampler.run_mcmc_kwargs == {'progress': True, 'tune': True}
 
 
 def test_sampler_kwargs_are_passed_through():

--- a/tests/test_uq_pymc_live_chain.py
+++ b/tests/test_uq_pymc_live_chain.py
@@ -1,0 +1,299 @@
+"""The pyMC backend writes its chain while it samples, not only at the end (issue #417).
+
+#418 gave emcee a growing ``mcmc_chain.npy`` by stepping its generator. pyMC has no generator:
+``pm.sample`` is one blocking call, so it matched "a backend that cannot be stepped" and took
+the fallback -- its chain appeared once, at the end, whatever ``chain_save_every`` said, and a
+live progress view of a pyMC run stayed empty for the whole run. It does take a per-draw
+callback, which is what the backend now checkpoints from.
+
+The part worth testing hardest is the one that looks right and is not: **draw ordering across
+chains**. pyMC with ``cores=1`` samples chain 0 to completion, then chain 1, and reports draws
+through a callback that carries the chain index and a tuning flag. A partial chain that mixed
+those up, or that included the tuning draws pyMC discards, would still load and still plot --
+it would just be showing something other than the posterior being sampled.
+
+The fake-trace tests run everywhere; the ones that actually sample are guarded on the optional
+[uq] extra and are the reason this file is in the UQ CI job.
+"""
+import os
+import sys
+from collections import namedtuple
+
+import numpy as np
+import pytest
+
+from param_id.paramID import sample_with_checkpoints, save_chain_atomically
+from param_id.pymc_backend import PyMCSampler, _LiveChainWriter, _progressbar_wanted
+
+pymc_installed = True
+try:
+    import pymc  # noqa: F401
+except ImportError:
+    pymc_installed = False
+
+PARAM_NAMES = ['a', 'b']
+
+
+# ---------------------------------------------------------------------------
+# a stand-in for pyMC's per-chain trace and its callback
+# ---------------------------------------------------------------------------
+#: pyMC's ``Draw``, in field order (pymc.sampling.parallel.Draw).
+Draw = namedtuple('Draw', 'chain is_last draw_idx tuning stats point')
+
+
+class _FakeTrace:
+    """pyMC's NDArray chain backend, in the two respects the writer touches.
+
+    The preallocation matters and is the reason this is not just a list: pyMC sizes the arrays
+    to the whole run up front and fills them as it goes, so ``get_values`` on a chain that is
+    still sampling returns real draws followed by zeros. A writer that did not cut it to
+    ``len(trace)`` would publish a chain padded with zeros -- values no sampler produced.
+    """
+
+    def __init__(self, total_draws):
+        self.samples = {name: np.zeros(total_draws) for name in PARAM_NAMES}
+        self.recorded = 0
+
+    def record(self, values):
+        for name, value in zip(PARAM_NAMES, values):
+            self.samples[name][self.recorded] = value
+        self.recorded += 1
+
+    def __len__(self):
+        return self.recorded
+
+    def get_values(self, varname):
+        return self.samples[varname]
+
+
+def _replay_pymc(writer, draws_per_chain, num_tune, num_chains, start=0.0):
+    """Drive ``writer`` with the callback sequence pyMC produces at ``cores=1``.
+
+    Chain by chain, tuning draws first, one callback per recorded draw. Returns the draws that
+    should end up in the chain -- every chain's post-tuning draws, concatenated in the order
+    they were sampled.
+    """
+    total = num_tune + draws_per_chain
+    expected = []
+    value = start
+    for chain in range(num_chains):
+        trace = _FakeTrace(total)
+        for idx in range(total):
+            value += 1.0
+            point = [value, -value]
+            trace.record(point)
+            if idx >= num_tune:
+                expected.append(point)
+            writer(trace=trace, draw=Draw(chain, False, idx, idx < num_tune, {}, {}))
+    return np.asarray(expected)
+
+
+# ---------------------------------------------------------------------------
+# what lands in the partial chain
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_the_chain_is_written_every_save_every_draws_and_grows():
+    """The point of the change: a reader polling the file sees the run progress."""
+    written = []
+    writer = _LiveChainWriter(written.append, save_every=5, param_names=PARAM_NAMES, num_tune=2)
+
+    _replay_pymc(writer, draws_per_chain=20, num_tune=2, num_chains=1)
+
+    assert [chunk.shape for chunk in written] == [(5, 1, 2), (10, 1, 2), (15, 1, 2), (20, 1, 2)]
+
+
+@pytest.mark.unit
+def test_the_partial_chain_is_the_draws_so_far_in_the_order_they_were_sampled():
+    """The ordering assertion. Chain 0's draws, then chain 1's -- which is what happened, and is
+    the only arrangement of sequentially sampled chains that is all real draws and never
+    shrinks."""
+    written = []
+    writer = _LiveChainWriter(written.append, save_every=4, param_names=PARAM_NAMES, num_tune=3)
+
+    expected = _replay_pymc(writer, draws_per_chain=8, num_tune=3, num_chains=2)
+
+    assert len(expected) == 16
+    np.testing.assert_allclose(written[-1], expected[:, np.newaxis, :])
+    # and every checkpoint on the way is a prefix of it, never a re-truncated view
+    for chunk in written:
+        np.testing.assert_allclose(chunk, expected[:chunk.shape[0], np.newaxis, :])
+
+
+@pytest.mark.unit
+def test_tuning_draws_are_left_out_because_pymc_leaves_them_out():
+    """They are recorded in the same trace but are not in the posterior. A live view holding
+    them would disagree with the chain that lands at the end -- and the tuning draws are the
+    least converged ones there are, so it would disagree in the direction that looks worst."""
+    written = []
+    writer = _LiveChainWriter(written.append, save_every=2, param_names=PARAM_NAMES, num_tune=6)
+
+    expected = _replay_pymc(writer, draws_per_chain=4, num_tune=6, num_chains=1)
+
+    assert written[-1].shape[0] == 4, 'four post-tuning draws, not ten recorded ones'
+    np.testing.assert_allclose(written[-1], expected[:, np.newaxis, :])
+
+
+@pytest.mark.unit
+def test_the_preallocated_tail_of_a_running_trace_is_never_published():
+    """pyMC sizes a chain's arrays to the whole run up front. Publishing the array as-is would
+    pad the chain with zeros, which plot as a walker that has collapsed onto zero."""
+    written = []
+    writer = _LiveChainWriter(written.append, save_every=3, param_names=PARAM_NAMES, num_tune=1)
+
+    _replay_pymc(writer, draws_per_chain=9, num_tune=1, num_chains=1)
+
+    assert not np.any(written[0] == 0.0), 'the unfilled tail leaked into the chain'
+    assert written[0].shape[0] == 3
+
+
+@pytest.mark.unit
+def test_nothing_is_written_before_there_is_a_post_tuning_draw():
+    """A file that exists but holds no draws is worse than no file: it would plot."""
+    written = []
+    writer = _LiveChainWriter(written.append, save_every=1, param_names=PARAM_NAMES, num_tune=4)
+
+    _replay_pymc(writer, draws_per_chain=0, num_tune=4, num_chains=2)
+
+    assert written == []
+
+
+@pytest.mark.unit
+def test_a_checkpoint_that_cannot_be_written_does_not_kill_the_run(capsys):
+    """A callback that raises takes pm.sample down with it. Losing hours of sampling because a
+    progress nicety could not write a file is far worse than not having the file, so the first
+    failure is reported and turns checkpointing off for the rest of the run."""
+    calls = []
+
+    def exploding_save(samples):
+        calls.append(samples)
+        raise OSError('no space left on device')
+
+    writer = _LiveChainWriter(exploding_save, save_every=2, param_names=PARAM_NAMES, num_tune=0)
+
+    _replay_pymc(writer, draws_per_chain=10, num_tune=0, num_chains=1)   # must not raise
+
+    assert len(calls) == 1, 'it should stop trying after the first failure'
+    output = capsys.readouterr().out
+    assert 'no space left on device' in output and 'sampling continues' in output
+
+
+# ---------------------------------------------------------------------------
+# when checkpointing applies at all
+# ---------------------------------------------------------------------------
+def _sampler(method='mcmc', num_tune=5):
+    """A PyMCSampler without pymc installed -- these paths are decided before any of it runs."""
+    sampler = PyMCSampler.__new__(PyMCSampler)
+    sampler.method = method
+    sampler.num_tune = num_tune
+    sampler.num_params = len(PARAM_NAMES)
+    sampler.param_id_info = {'param_names_for_plotting': PARAM_NAMES}
+    return sampler
+
+
+@pytest.mark.unit
+def test_only_rank_zero_writes_the_partial_chain():
+    """Every rank samples its own chains into the same output directory, and the chain file is
+    one path. Ranks all writing it would each overwrite the others with a chain that is only
+    their own, so the file would flicker between ranks instead of growing."""
+    assert _sampler()._make_checkpointer(lambda s: None, 10, rank=0) is not None
+    assert _sampler()._make_checkpointer(lambda s: None, 10, rank=1) is None
+    assert _sampler()._make_checkpointer(lambda s: None, 10, rank=7) is None
+
+
+@pytest.mark.unit
+def test_checkpointing_off_means_no_callback():
+    assert _sampler()._make_checkpointer(lambda s: None, 0, rank=0) is None
+    assert _sampler()._make_checkpointer(None, 50, rank=0) is None
+
+
+@pytest.mark.unit
+def test_smc_says_it_saves_only_at_the_end_rather_than_looking_broken(capsys):
+    """sample_smc advances a whole population per stage and takes no callback, so there is no
+    per-draw hook to write from. Silence there would look identical to the bug this fixes."""
+    assert _sampler(method='smc')._make_checkpointer(lambda s: None, 10, rank=0) is None
+
+    output = capsys.readouterr().out
+    assert 'chain_save_every' in output and 'smc' in output
+
+
+@pytest.mark.unit
+def test_the_backend_declares_that_it_checkpoints_itself():
+    """The flag sample_with_checkpoints dispatches on. Without it the backend matches 'cannot be
+    stepped' and silently goes back to writing the chain once, at the end."""
+    assert PyMCSampler.saves_own_checkpoints is True
+
+
+@pytest.mark.unit
+def test_the_progress_bar_is_kept_out_of_a_redirected_log():
+    """pyMC's bar is a rich table that repaints; in a log file that is thousands of lines of
+    ANSI escapes around a redrawn table, interleaved with the run's own output."""
+    assert _progressbar_wanted(True, rank=0) == bool(
+        getattr(sys.stdout, 'isatty', lambda: False)())
+    assert _progressbar_wanted(False, rank=0) is False
+    assert _progressbar_wanted(True, rank=3) is False
+
+
+# ---------------------------------------------------------------------------
+# the real thing
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.skipif(not pymc_installed, reason='needs the optional [uq] extra')
+def test_a_real_pymc_run_writes_a_growing_chain_that_matches_what_it_returns(tmp_path):
+    """End to end against pyMC itself: the fakes above encode what pyMC's callback does, and
+    this is what proves that encoding right -- the draws pooled from the callback are exactly
+    the chains pm.sample went on to return, in order.
+    """
+    num_steps, num_chains, num_tune = 6, 2, 3
+    path = str(tmp_path / 'mcmc_chain.npy')
+    shapes = []
+
+    def save(samples):
+        save_chain_atomically(path, samples)
+        shapes.append(np.load(path).shape)      # loadable at every checkpoint, or this raises
+
+    sampler = PyMCSampler(
+        num_walkers=num_chains, num_params=2,
+        log_posterior_fn=lambda params: -0.5 * float(np.sum(np.asarray(params) ** 2)),
+        param_id_info={'param_names_for_plotting': PARAM_NAMES,
+                       'param_mins': [-5.0, -5.0], 'param_maxs': [5.0, 5.0]},
+        num_tune=num_tune)
+
+    initial_state = np.array([[0.1, -0.1], [0.2, -0.2]])
+    checkpoints = sample_with_checkpoints(sampler, initial_state, num_steps, save, save_every=2)
+    chain = sampler.get_chain()
+
+    # the finished chain is the shape everything downstream expects, and is not disturbed by any
+    # of the checkpointing
+    assert chain.shape == (num_steps, num_chains, 2)
+
+    # a checkpoint every 2 post-tuning draws over 2 chains x 6 draws, and never the tuning ones
+    assert checkpoints == 6
+    assert [s[0] for s in shapes] == [2, 4, 6, 8, 10, 12]
+    assert all(s[1:] == (1, 2) for s in shapes)
+
+    # ...and the draws are the chains pyMC returned, chain 0 then chain 1
+    pooled = np.concatenate([chain[:, c, :] for c in range(num_chains)], axis=0)
+    np.testing.assert_allclose(np.load(path)[:, 0, :], pooled)
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(not pymc_installed, reason='needs the optional [uq] extra')
+def test_a_real_pymc_run_with_checkpointing_off_writes_nothing_until_the_end(tmp_path):
+    """0 still means "only at the end" -- the behaviour before this change, still reachable for
+    a very wide chain on a slow shared filesystem."""
+    path = str(tmp_path / 'mcmc_chain.npy')
+
+    sampler = PyMCSampler(
+        num_walkers=1, num_params=2,
+        log_posterior_fn=lambda params: -0.5 * float(np.sum(np.asarray(params) ** 2)),
+        param_id_info={'param_names_for_plotting': PARAM_NAMES,
+                       'param_mins': [-5.0, -5.0], 'param_maxs': [5.0, 5.0]},
+        num_tune=2)
+
+    checkpoints = sample_with_checkpoints(
+        sampler, np.array([[0.1, -0.1]]), 5,
+        lambda samples: save_chain_atomically(path, samples), save_every=0)
+
+    assert checkpoints == 0
+    assert not os.path.exists(path)
+    assert sampler.get_chain().shape == (5, 1, 2)


### PR DESCRIPTION
Follow-up to #418, closing the pyMC half of the scope note on #417.

## The problem

#418 made `mcmc_chain.npy` grow during an emcee run by stepping `sample()`, which is what CUFLynx's live MCMC progress plot reads. pyMC has no generator — `pm.sample` is one blocking call — so `PyMCSampler` matched `sample_with_checkpoints`' documented "cannot be stepped" fallback and its chain still appeared only at the end, whatever `chain_save_every` was set to. So a pyMC run's Progress tab stayed empty for the whole run, and a cancelled one still lost everything: exactly the two failures #417 set out to fix, for one of the two backends.

## The fix

`pm.sample` takes a per-draw `callback`, so the backend checkpoints from that and declares `saves_own_checkpoints`; `sample_with_checkpoints` hands a declaring backend the same `save_chain` hook rather than falling back to the blocking call. Both backends write the same file, so **CUFLynx needs no change**.

What the partial chain holds, and why:

- **The draws in the order pyMC produced them, as a single walker.** At `cores=1` — what CA asks for, since the parallelism is MPI ranks — chains are sampled one after another, so there is no honest `(steps, walkers, params)` rectangle over all of them until the last one finishes: chain 2 has one draw while chain 1 has five thousand, and squaring that off means either discarding chain 1's draws or inventing chain 2's. Concatenating is what actually happened, in the order it happened, and it grows monotonically for the whole run. The **finished** chain is untouched: the real `(steps, walkers, params)`, gathered from every rank.
- **Tuning draws excluded**, because pyMC excludes them from the posterior — a live view holding them would disagree with the chain that lands at the end, and disagree in the least-converged direction.
- **Rank 0 only.** Every rank samples its own chains into one output directory and the chain file is one path, so ranks all writing it would overwrite each other and the file would flicker between ranks instead of growing.
- **`pymc_method: 'smc'`** has no per-draw hook (`sample_smc` advances a whole population per stage), so it still saves once at the end — and now prints that it will, rather than looking broken.
- **A checkpoint that cannot be written is reported and switched off, never raised.** A callback that throws takes the whole `pm.sample` call down with it, and losing hours of sampling because a progress nicety could not write a file is a far worse failure than not having the file.

Also stops pyMC's progress bar when stdout is not a terminal — the other half of the pyMC complaint on #417. It is a rich table that repaints, so in a redirected run log it is thousands of lines of ANSI escapes around a redrawn table (~8 kB for a 1000-draw run, growing with the run), interleaved with the runner's own DONE/FAIL markers. A terminal still gets the bar.

`ANALYSIS_OPTIONS`' `chain_save_every` description is updated to say what it now means under pymc, so a front-end reading the schema is not describing behaviour that no longer holds.

## Testing

`tests/test_uq_pymc_live_chain.py` — the ordering across chains is the part that looks right and isn't, so it is checked twice: against a stand-in for pyMC's trace (ordering, tuning draws, the preallocated tail that would otherwise publish zeros as draws, a write that fails), and then against pyMC itself — the draws pooled from the callback are exactly the chains `pm.sample` went on to return, in order. Routing tests for the new dispatch are in `tests/test_mcmc_chain_checkpoints.py`.

The pyMC half only runs with the `[uq]` extra, so the file is added to the UQ CI job, which is the one place it is installed.

Verified end to end on `Simple_ODE_Benchmark` through `run_param_id` with `library: pymc` (2 chains × 8 draws, `chain_save_every: 2`): partial chains written at 2, 4, … 16 pooled draws, then the finished `(8, 2, 2)`. Locally, `./run_pytest.sh -m "not slow"` is 787 passed with the same 8 pre-existing failures as the base commit (7 subprocess-spawning `test_mpi_utils` cases, and the documented SN_simple python-codegen one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
