### PR TITLE
fix(uq): a multi-rank pyMC run deadlocks, because it is given emcee's worker pool

### DIFF
--- a/.github/scripts/fail_if_tests_skipped.py
+++ b/.github/scripts/fail_if_tests_skipped.py
@@ -1,0 +1,60 @@
+"""Fail a CI job whose tests were collected but skipped.
+
+Every UQ test is guarded by a ``skipif`` on an optional extra -- ``[uq]`` for pymc, ``[emulation]``
+for autoemulate. So if one of those fails to install, the job that exists to run them skips every
+one of them and reports success: a green badge over a job that ran nothing. That is the likely
+failure mode here, not a red X.
+
+Usage::
+
+    python .github/scripts/fail_if_tests_skipped.py junit-uq*.xml
+
+Exits non-zero if any named file collected nothing, ran nothing, or skipped any test. Globs are
+expanded here rather than by the shell, so a pattern that matches no file is reported as "no
+results were produced" instead of being passed through literally and read as a missing file.
+"""
+import glob
+import sys
+import xml.etree.ElementTree as ET
+
+
+def main(patterns):
+    problems = []
+    seen_any = False
+
+    for pattern in patterns:
+        for path in sorted(glob.glob(pattern)):
+            seen_any = True
+            suites = ET.parse(path).getroot()
+            suites = [suites] if suites.tag == 'testsuite' else suites.findall('testsuite')
+            for suite in suites:
+                total = int(suite.get('tests', 0))
+                skipped = int(suite.get('skipped', 0))
+                ran = total - skipped
+                print(f'{path}: {total} collected, {skipped} skipped, {ran} ran')
+                if total == 0:
+                    problems.append(f'{path} collected no tests')
+                elif ran == 0:
+                    problems.append(f'{path} ran nothing -- all {total} tests skipped')
+                elif skipped:
+                    problems.append(f'{path} skipped {skipped} of {total} tests')
+
+    if not seen_any:
+        problems.append(f'no results were produced for {" ".join(patterns)}, '
+                        'so no tests ran at all')
+
+    if problems:
+        print()
+        print('This job is meant to be the one place these run. Every test here is behind a '
+              'skipif on an optional extra, so a skip almost always means [uq] or [emulation] '
+              'did not install rather than that the test was inapplicable.')
+        for problem in problems:
+            print(f'  - {problem}')
+        return 1
+
+    print('every test ran')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:] or ['junit-*.xml']))

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -215,6 +215,16 @@ jobs:
         python -m pytest tests/test_uq_pymc_live_chain.py -v --tb=short \
           --junitxml=junit-uq-pymc-live.xml
 
+    # Launches its own `mpiexec -n 2`, so it needs no MPI harness of its own -- but it is the
+    # only multi-rank UQ coverage anywhere in CI, for either backend. Both arrangements (pyMC
+    # sampling per rank, emcee farming likelihoods to a pool) hang rather than fail when they
+    # are wrong, so the test carries a deadline and the step carries one too.
+    - name: Run the multi-rank UQ tests
+      timeout-minutes: 15
+      run: |
+        python -m pytest tests/test_uq_pymc_mpi.py -v --tb=short \
+          --junitxml=junit-uq-mpi.xml
+
     # Fast enough to be worth running first: it fails in a minute if UQ is broken at all,
     # rather than after half an hour of sampling the real model.
     - name: Run UQ on an emulator (fast posterior-recovery check)
@@ -278,6 +288,7 @@ jobs:
         name: uq-test-results
         path: |
           junit-uq-emulator.xml
+          junit-uq-mpi.xml
           junit-uq-pymc-live.xml
           junit-uq.xml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -223,7 +223,7 @@ jobs:
       timeout-minutes: 15
       run: |
         python -m pytest tests/test_uq_pymc_mpi.py -v --tb=short \
-          --junitxml=junit-uq-mpi.xml
+          --junitxml=junit-uq-pymc-mpi.xml
 
     # Fast enough to be worth running first: it fails in a minute if UQ is broken at all,
     # rather than after half an hour of sampling the real model.
@@ -243,43 +243,7 @@ jobs:
     # resolve, the whole point of this job evaporates and the badge still says pass.
     - name: Fail if the UQ tests did not actually run
       if: always()
-      run: |
-        python - <<'PY'
-        import glob
-        import sys
-        import xml.etree.ElementTree as ET
-
-        problems = []
-        seen_any = False
-        for path in sorted(glob.glob('junit-uq*.xml')):
-            seen_any = True
-            suites = ET.parse(path).getroot()
-            suites = [suites] if suites.tag == 'testsuite' else suites.findall('testsuite')
-            for suite in suites:
-                total = int(suite.get('tests', 0))
-                skipped = int(suite.get('skipped', 0))
-                ran = total - skipped
-                print(f'{path}: {total} collected, {skipped} skipped, {ran} ran')
-                if total == 0:
-                    problems.append(f'{path} collected no tests')
-                elif ran == 0:
-                    problems.append(f'{path} ran nothing -- all {total} tests skipped')
-                elif skipped:
-                    problems.append(f'{path} skipped {skipped} of {total} tests')
-
-        if not seen_any:
-            problems.append('no junit-uq*.xml was produced, so no UQ tests ran at all')
-
-        if problems:
-            print()
-            print('The UQ job is meant to be the one place these run. Every UQ test is behind a '
-                  'skipif on an optional extra, so a skip here almost always means [uq] or '
-                  '[emulation] did not install rather than that the test was inapplicable.')
-            for problem in problems:
-                print(f'  - {problem}')
-            sys.exit(1)
-        print('every UQ test ran')
-        PY
+      run: python .github/scripts/fail_if_tests_skipped.py "junit-uq*.xml"
 
     - name: Upload UQ test results
       if: always()
@@ -288,9 +252,64 @@ jobs:
         name: uq-test-results
         path: |
           junit-uq-emulator.xml
-          junit-uq-mpi.xml
+          junit-uq-pymc-mpi.xml
           junit-uq-pymc-live.xml
           junit-uq.xml
+
+  # UQ with more than one rank -- the way a real UQ run is launched (`run_param_id.sh` takes a
+  # processor count), and, until this job, the way nothing was ever tested. Every other UQ job
+  # runs pytest directly, on one rank, where the multi-rank branches are not taken at all: that
+  # is how a deadlock in the pyMC arm survived from #408 until #424.
+  #
+  # It runs the emulator UQ tests because they are the only end-to-end UQ that is affordable on
+  # a pull request -- both samplers, a posterior with a closed-form answer, minutes not hours --
+  # and they cover the two arrangements that can deadlock: emcee farming likelihoods to an
+  # MPIPool, and pyMC sampling its own chains per rank.
+  #
+  # Each rank writes its own junit file, since both ranks run the whole file and a shared path
+  # would have them overwrite each other. The quoting matters: OMPI_COMM_WORLD_RANK must be
+  # expanded by each rank's own shell, not by the shell that launches mpiexec.
+  test-uq-mpi:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev,uq,emulation]"
+
+    - name: Install MPI and Myokit build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+
+    - name: Run the emulator UQ tests on two ranks
+      timeout-minutes: 30
+      run: |
+        mpiexec -n 2 bash -c 'python -m pytest tests/test_uq_on_emulator.py -v --with-mpi \
+          --tb=short --durations=0 --junitxml=junit-uq-2rank-$OMPI_COMM_WORLD_RANK.xml'
+
+    # Same reasoning as the serial UQ job: these are all behind skipif on an optional extra, so
+    # a job that installed neither would pass having run nothing. Rank 0's results are the ones
+    # checked -- both ranks run the same tests.
+    - name: Fail if the multi-rank UQ tests did not actually run
+      if: always()
+      run: python .github/scripts/fail_if_tests_skipped.py "junit-uq-2rank-0.xml"
+
+    - name: Upload multi-rank UQ test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: uq-mpi-test-results
+        path: |
+          junit-uq-2rank-*.xml
 
   # Job to run full test suite if OpenCOR is available (optional)
   # This can be enabled if OpenCOR is set up in CI environment

--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -110,6 +110,11 @@ warnings.filterwarnings( "ignore", module = "matplotlib/..*" )
 # can't be pickled because they are pyqt.
 mcmc_object = None
 
+#: The UQ backends that parallelise across MPI ranks by farming likelihood evaluations out to a
+#: worker pool, rather than by giving each rank chains of its own. See
+#: ``OpencorMCMC.sampler_needs_a_worker_pool`` for why the two arrangements cannot be mixed.
+_POOL_BACKED_UQ_LIBRARIES = ('emcee', 'zeus')
+
 
 # numpy 2.0 renamed trapz to trapezoid and removed the old name; numpy 1.x has only the old one,
 # and this project supports both (CI runs 2.2 while the OpenCOR shell ships 1.26). Bound once here
@@ -3876,22 +3881,13 @@ class OpencorMCMC(OpencorParamID):
             print('Running mcmc')
 
 
-        if num_procs > 1:
+        if num_procs > 1 and self.sampler_needs_a_worker_pool():
             # from pathos import multiprocessing
             # from pathos.multiprocessing import ProcessPool
             from schwimmbad import MPIPool
 
             if rank == 0:
-                if self.best_param_vals is not None:
-                    best_param_vals_norm = self.param_norm_obj.normalise(self.best_param_vals)
-                    # create initial params in gaussian ball around best_param_vals estimate
-                    init_param_vals_norm = (np.ones((self.UQ_options['num_walkers'], self.num_params))*best_param_vals_norm).T + \
-                                       0.1*np.random.randn(self.num_params, self.UQ_options['num_walkers'])
-                    init_param_vals_norm = np.clip(init_param_vals_norm, 0.001, 0.999)
-                    init_param_vals = self.param_norm_obj.unnormalise(init_param_vals_norm)
-                else:
-                    init_param_vals_norm = np.random.rand(self.num_params, self.UQ_options['num_walkers'])
-                    init_param_vals = self.param_norm_obj.unnormalise(init_param_vals_norm)
+                init_param_vals = self._initial_walker_positions(ball_scale=0.1)
 
             try:
                 pool = MPIPool() # workers dont get past this line in this try, they wait for work to do
@@ -3905,25 +3901,38 @@ class OpencorMCMC(OpencorParamID):
             self.sampler = self._build_sampler(pool=pool)
 
             start_time = time.time()
-            self._sample(init_param_vals.T, progress=True, tune=True)
+            self._sample(init_param_vals, progress=True, tune=True)
             print(f'mcmc time = {time.time() - start_time}')
             pool.close()
 
-        else:
-            if self.best_param_vals is not None:
-                best_param_vals_norm = self.param_norm_obj.normalise(self.best_param_vals)
-                init_param_vals_norm = (np.ones((self.UQ_options['num_walkers'], self.num_params))*best_param_vals_norm).T + \
-                                   0.01*np.random.randn(self.num_params, self.UQ_options['num_walkers'])
-                init_param_vals_norm = np.clip(init_param_vals_norm, 0.001, 0.999)
-                init_param_vals = self.param_norm_obj.unnormalise(init_param_vals_norm)
-            else:
-                init_param_vals_norm = np.random.rand(self.num_params, self.UQ_options['num_walkers'])
-                init_param_vals = self.param_norm_obj.unnormalise(init_param_vals_norm)
+        elif num_procs > 1:
+            # Every rank samples its own chains and they are gathered at the end, so no rank is
+            # a worker and no pool is opened. See sampler_needs_a_worker_pool.
+            #
+            # The starting ensemble is drawn once and broadcast rather than drawn per rank: the
+            # ranks must agree on it (best_param_vals is only guaranteed on rank 0, so drawing
+            # locally would put some ranks in a ball around the calibrated fit and others on a
+            # uniform draw over the whole prior box), and each rank then takes the slice of
+            # walkers it is responsible for so the gathered chain covers the ensemble asked for
+            # rather than repeating its first few walkers on every rank.
+            init_param_vals = self._initial_walker_positions(ball_scale=0.1) if rank == 0 else None
+            init_param_vals = comm.bcast(init_param_vals, root=0)
 
             self.sampler = self._build_sampler()
 
             start_time = time.time()
-            self._sample(init_param_vals.T) # , progress=True)
+            self._sample(self._walkers_for_rank(init_param_vals, rank, num_procs),
+                         progress=True, tune=True)
+            if rank == 0:
+                print(f'mcmc time = {time.time() - start_time}')
+
+        else:
+            init_param_vals = self._initial_walker_positions(ball_scale=0.01)
+
+            self.sampler = self._build_sampler()
+
+            start_time = time.time()
+            self._sample(init_param_vals) # , progress=True)
             print(f'mcmc time = {time.time()-start_time}')
 
         if rank == 0:
@@ -3938,6 +3947,65 @@ class OpencorMCMC(OpencorParamID):
             flat_samples = samples[self.burn_in_index(samples.shape[0]):, :, :].reshape(
                 -1, self.num_params)
             self.save_mcmc_statistics(flat_samples)
+
+    def sampler_needs_a_worker_pool(self):
+        """Whether this backend parallelises across ranks by farming out the likelihood.
+
+        The two backends parallelise in opposite directions, and running one arrangement under
+        the other hangs:
+
+        * **emcee and zeus** advance one ensemble in one process. The parallelism is the
+          likelihood: the sampler is handed a ``schwimmbad.MPIPool``, and every other rank sits
+          in ``pool.wait()`` serving evaluations until the master closes the pool.
+        * **pyMC** has no such hook. ``PyMCSampler`` instead gives each rank
+          ``chains_for_rank(...)`` chains of its own and gathers them along the walker axis at
+          the end -- which means every rank must reach ``run_mcmc``, and its ``comm.Barrier()``
+          and ``comm.gather`` are collectives over COMM_WORLD.
+
+        Opening a pool for pyMC therefore deadlocked every ``mpiexec -n >1`` UQ run with
+        ``library: pymc``: the workers were parked inside ``pool.wait()``, blocked in a receive
+        that only the master's ``pool.close()`` ends, so they could never join the master's
+        barrier -- and the master waits on that barrier forever, holding the pool open. Neither
+        side can move, and the run hangs after sampling with no error and no chain written. It
+        was never seen because nothing exercised it: the pyMC tests run on one rank, where this
+        branch is not taken at all.
+        """
+        return (self.UQ_options or {}).get('library', 'emcee') in _POOL_BACKED_UQ_LIBRARIES
+
+    def _initial_walker_positions(self, ball_scale):
+        """Starting positions for the ensemble, ``(num_walkers, num_params)``.
+
+        A gaussian ball of relative width ``ball_scale`` around the calibrated fit, in
+        normalised space, or a uniform draw over the prior box when there is no fit to start
+        from. Was written out twice, once per branch of ``run``, with the two copies differing
+        only in ``ball_scale`` -- a third branch is not worth a third copy.
+        """
+        num_walkers = self.UQ_options['num_walkers']
+        if self.best_param_vals is not None:
+            best_param_vals_norm = self.param_norm_obj.normalise(self.best_param_vals)
+            # create initial params in gaussian ball around best_param_vals estimate
+            init_param_vals_norm = (np.ones((num_walkers, self.num_params))*best_param_vals_norm).T + \
+                               ball_scale*np.random.randn(self.num_params, num_walkers)
+            init_param_vals_norm = np.clip(init_param_vals_norm, 0.001, 0.999)
+        else:
+            init_param_vals_norm = np.random.rand(self.num_params, num_walkers)
+        return self.param_norm_obj.unnormalise(init_param_vals_norm).T
+
+    @staticmethod
+    def _walkers_for_rank(init_param_vals, rank, num_procs):
+        """The slice of the starting ensemble this rank is responsible for.
+
+        Mirrors ``PyMCSampler.chains_for_rank``, which decides how many chains the rank runs
+        from the same two numbers -- if these two disagree, a rank either starts chains from
+        another rank's positions or is handed positions it never uses.
+
+        Indices wrap, because ``chains_for_rank`` never returns zero: with more ranks than
+        walkers every rank still runs one chain, and the ranks past the end of the ensemble
+        start over at its beginning rather than being handed nothing.
+        """
+        num_walkers = len(init_param_vals)
+        per_rank = max(1, num_walkers // num_procs)
+        return init_param_vals[(rank*per_rank + np.arange(per_rank)) % num_walkers]
 
     def mcmc_chain_path(self):
         """Where the chain is written -- the same path during the run as at the end of it.

--- a/tests/test_uq_on_emulator.py
+++ b/tests/test_uq_on_emulator.py
@@ -89,6 +89,19 @@ SAMPLERS = [
 ]
 
 
+def _agree(mpi_comm, problem):
+    """Fail on every rank, or on none -- given rank 0's verdict.
+
+    A rank that fails an assertion on its own walks out of the test while the others are still
+    heading for a collective, and the run then hangs rather than reporting the failure. So the
+    checks that come *before* a collective are decided on rank 0 and broadcast, and every rank
+    raises on the same answer. The broadcast also orders the ranks, so it stands in for the
+    barrier that used to follow the check.
+    """
+    problem = mpi_comm.bcast(problem, root=0)
+    assert not problem, problem
+
+
 def _emulator_available():
     try:
         from emulators.emulator_trainer import autoemulate_available
@@ -186,23 +199,30 @@ def test_uq_on_an_emulator_recovers_the_analytic_posterior(
     config = _config(resources_dir, temp_output_dir, temp_generated_models_dir, emulator_dir,
                      library=library)
 
-    if mpi_comm.Get_rank() == 0:
-        assert generate_with_new_architecture(False, config), 'benchmark generation failed'
-    mpi_comm.Barrier()
+    _agree(mpi_comm, None if mpi_comm.Get_rank() != 0 or
+           generate_with_new_architecture(False, config) else 'benchmark generation failed')
 
     bundle = _train_emulator(config, mpi_comm)
-    if mpi_comm.Get_rank() != 0:
-        return
 
     # The emulator has to be faithful before its posterior means anything. Checked here rather
     # than left implicit, so a bad posterior below is attributable: a broken surrogate and a
     # broken sampler fail this test in the same place otherwise.
-    for entry in (bundle.error_stats() or []):
-        if isinstance(entry, dict) and entry.get('r2') is not None:
-            assert float(entry['r2']) > 0.99, f"emulator is not faithful: {entry}"
+    unfaithful = None
+    if mpi_comm.Get_rank() == 0:
+        for entry in (bundle.error_stats() or []):
+            if isinstance(entry, dict) and entry.get('r2') is not None and \
+                    float(entry['r2']) <= 0.99:
+                unfaithful = f'emulator is not faithful: {entry}'
+    _agree(mpi_comm, unfaithful)
 
+    # Every rank samples: UQ is a parallel run, and which ranks do what is the sampler's
+    # business (emcee farms likelihoods to a pool, pyMC gives each rank its own chains). A rank
+    # that skipped this would strand the others inside the sampler's collectives -- which is
+    # what used to happen here, so this file could only ever be run on one rank.
     param_id = CVS0DParamID.init_from_dict({**config, 'mcmc_instead': True})
     param_id.run_UQ()
+    if mpi_comm.Get_rank() != 0:
+        return
 
     chain = np.load(os.path.join(param_id.output_dir, 'mcmc_chain.npy'))
     flat = chain[chain.shape[0] // 2:, :, :].reshape(-1, chain.shape[2])
@@ -238,16 +258,16 @@ def test_the_uq_run_writes_its_posterior_summary(
     emulator_dir = os.path.join(temp_output_dir, 'emulator')
     config = _config(resources_dir, temp_output_dir, temp_generated_models_dir, emulator_dir)
 
-    if mpi_comm.Get_rank() == 0:
-        assert generate_with_new_architecture(False, config), 'benchmark generation failed'
-    mpi_comm.Barrier()
+    _agree(mpi_comm, None if mpi_comm.Get_rank() != 0 or
+           generate_with_new_architecture(False, config) else 'benchmark generation failed')
 
     _train_emulator(config, mpi_comm)
-    if mpi_comm.Get_rank() != 0:
-        return
 
+    # Every rank samples -- see the note in the test above.
     param_id = CVS0DParamID.init_from_dict({**config, 'mcmc_instead': True})
     param_id.run_UQ()
+    if mpi_comm.Get_rank() != 0:
+        return
 
     path = os.path.join(param_id.output_dir, 'mcmc_statistics.json')
     assert os.path.isfile(path), 'a UQ run must write its posterior summary'

--- a/tests/test_uq_pymc_mpi.py
+++ b/tests/test_uq_pymc_mpi.py
@@ -1,0 +1,334 @@
+"""A multi-rank UQ run with ``library: pymc`` used to hang forever.
+
+The two backends parallelise in opposite directions. emcee and zeus advance one ensemble in one
+process and farm the likelihood out to a ``schwimmbad.MPIPool``, where every other rank sits in
+``pool.wait()`` until the master closes the pool. pyMC has no such hook: ``PyMCSampler`` gives
+each rank chains of its own and gathers them at the end, so every rank has to reach
+``run_mcmc`` and its ``comm.Barrier()``/``comm.gather`` are collectives over COMM_WORLD.
+
+``OpencorMCMC.run`` opened the pool for both. So under ``mpiexec -n >1`` with pymc, the workers
+were parked in a receive that only the master's ``pool.close()`` ends, and the master waited on
+a barrier they could never reach: the run hung after sampling, with no error and no chain. It
+went unnoticed because nothing exercised it -- the pyMC tests all run on one rank, where the
+pool branch is not taken.
+
+The dispatch tests below run everywhere. The last one actually launches ``mpiexec -n 2`` and is
+the regression test proper: before the fix it times out, which is what a hang looks like when
+something is watching it.
+"""
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+
+import numpy as np
+import pytest
+
+from param_id.paramID import OpencorMCMC
+from utilities.mpi_utils import LAUNCHER_ENV_VARS
+
+pymc_installed = True
+try:
+    import pymc  # noqa: F401
+except ImportError:
+    pymc_installed = False
+
+pytestmark = pytest.mark.unit
+
+NUM_PARAMS = 2
+
+
+class _StubNorm:
+    """param_norm_obj, which only has to round-trip here."""
+
+    @staticmethod
+    def normalise(vals):
+        return np.asarray(vals, dtype=float)
+
+    @staticmethod
+    def unnormalise(vals):
+        return np.asarray(vals, dtype=float)
+
+
+def _engine(library='emcee', num_walkers=8, best_param_vals=None):
+    engine = OpencorMCMC.__new__(OpencorMCMC)
+    engine.UQ_options = {'library': library, 'num_walkers': num_walkers, 'num_steps': 10}
+    engine.num_params = NUM_PARAMS
+    engine.param_norm_obj = _StubNorm()
+    engine.best_param_vals = best_param_vals
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# which arrangement each backend gets
+# ---------------------------------------------------------------------------
+def test_emcee_and_zeus_want_the_worker_pool():
+    """They drive one ensemble from one process; the ranks are there to evaluate likelihoods."""
+    assert _engine('emcee').sampler_needs_a_worker_pool() is True
+    assert _engine('zeus').sampler_needs_a_worker_pool() is True
+
+
+def test_the_default_backend_still_wants_the_worker_pool():
+    """UQ_options with no library at all is emcee -- the MPI behaviour must not change for it."""
+    engine = _engine()
+    del engine.UQ_options['library']
+    assert engine.sampler_needs_a_worker_pool() is True
+
+
+def test_pymc_does_not_want_a_worker_pool():
+    """The fix. A pool for pyMC parks the ranks where they can never reach its collectives."""
+    assert _engine('pymc').sampler_needs_a_worker_pool() is False
+
+
+# ---------------------------------------------------------------------------
+# splitting the ensemble across ranks
+# ---------------------------------------------------------------------------
+def test_each_rank_gets_its_own_walkers():
+    """Every rank taking the same first few walkers would sample the same starts repeatedly and
+    report them as an ensemble of independent chains."""
+    positions = np.arange(8 * NUM_PARAMS, dtype=float).reshape(8, NUM_PARAMS)
+
+    slices = [OpencorMCMC._walkers_for_rank(positions, rank, 4) for rank in range(4)]
+
+    assert [s.shape for s in slices] == [(2, NUM_PARAMS)] * 4
+    np.testing.assert_allclose(np.concatenate(slices), positions, err_msg='the ensemble should '
+                               'be covered exactly once across the ranks')
+
+
+def test_the_split_matches_the_number_of_chains_the_backend_will_run():
+    """_walkers_for_rank and PyMCSampler.chains_for_rank decide from the same two numbers; if
+    they disagree a rank starts chains from another rank's positions."""
+    from param_id.pymc_backend import PyMCSampler
+
+    positions = np.zeros((32, NUM_PARAMS))
+    for num_procs in (1, 2, 4, 5, 64):
+        for rank in range(num_procs):
+            assert len(OpencorMCMC._walkers_for_rank(positions, rank, num_procs)) == \
+                PyMCSampler.chains_for_rank(32, num_procs), (num_procs, rank)
+
+
+def test_more_ranks_than_walkers_wraps_rather_than_starving_a_rank():
+    """chains_for_rank never returns zero, so every rank runs a chain and needs a start."""
+    positions = np.arange(3 * NUM_PARAMS, dtype=float).reshape(3, NUM_PARAMS)
+
+    slices = [OpencorMCMC._walkers_for_rank(positions, rank, 6) for rank in range(6)]
+
+    assert all(s.shape == (1, NUM_PARAMS) for s in slices)
+    np.testing.assert_allclose(slices[3][0], positions[0], err_msg='rank 3 should wrap to the '
+                               'start of the ensemble rather than run off the end')
+
+
+# ---------------------------------------------------------------------------
+# the starting ensemble
+# ---------------------------------------------------------------------------
+def test_walker_positions_are_walkers_by_params():
+    """The orientation the samplers take. Transposed, it is a chain of the wrong length in the
+    wrong number of parameters, which does not raise -- it samples something else."""
+    assert _engine(num_walkers=8)._initial_walker_positions(0.1).shape == (8, NUM_PARAMS)
+
+
+def test_positions_cluster_around_the_calibrated_fit_when_there_is_one():
+    best = np.array([0.5, 0.25])
+    positions = _engine(num_walkers=200, best_param_vals=best)._initial_walker_positions(0.01)
+
+    np.testing.assert_allclose(positions.mean(axis=0), best, atol=0.01)
+    assert positions.std(axis=0).max() < 0.05, 'a tight ball, not a draw over the whole box'
+
+
+def test_positions_spread_over_the_prior_box_when_there_is_no_fit():
+    positions = _engine(num_walkers=400)._initial_walker_positions(0.01)
+
+    assert positions.min() >= 0.0 and positions.max() <= 1.0
+    assert positions.std(axis=0).min() > 0.2, 'should cover the box, not sit in a ball'
+
+
+# ---------------------------------------------------------------------------
+# what run() actually does with more than one rank
+# ---------------------------------------------------------------------------
+class _FakeComm:
+    def __init__(self, rank, size, broadcast=None):
+        self._rank, self._size, self._broadcast = rank, size, broadcast
+
+    def Get_rank(self):
+        return self._rank
+
+    def Get_size(self):
+        return self._size
+
+    def bcast(self, obj, root=0):
+        return obj if self._rank == root else self._broadcast
+
+
+class _FakeMPI:
+    def __init__(self, comm):
+        self.COMM_WORLD = comm
+
+
+class _StubSampler:
+    def get_chain(self):
+        return np.zeros((10, 2, NUM_PARAMS))
+
+
+def _run_with(monkeypatch, engine, rank, size, broadcast=None, tmp_path=None):
+    """Drive OpencorMCMC.run with a fake COMM_WORLD, recording what it chose to do.
+
+    The pool is faked rather than forbidden outright: ``run`` wraps ``MPIPool()`` in a bare
+    ``except: return``, so a fake that raised would be swallowed and read as "no pool opened" --
+    the very thing under test.
+    """
+    import schwimmbad
+
+    import param_id.paramID as paramID
+
+    pools = []
+
+    class _FakePool:
+        def __init__(self, *args, **kwargs):
+            pools.append(self)
+
+        def is_master(self):
+            return True
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(paramID, 'MPI', _FakeMPI(_FakeComm(rank, size, broadcast)))
+    monkeypatch.setattr(schwimmbad, 'MPIPool', _FakePool)
+
+    sampled = {'pools': pools}
+    engine.sampler = None
+    engine.output_dir = str(tmp_path) if tmp_path is not None else None
+    engine.save_mcmc_statistics = lambda flat_samples: sampled.update(stats=flat_samples.shape)
+
+    def build(pool=None):
+        sampled['pool'] = pool
+        engine.sampler = _StubSampler()
+        return engine.sampler
+
+    engine._build_sampler = build
+    engine._sample = lambda positions, **kwargs: sampled.update(positions=np.asarray(positions),
+                                                                kwargs=kwargs)
+    engine.run()
+    return sampled
+
+
+def test_a_multi_rank_pymc_run_opens_no_pool_and_samples_on_every_rank(monkeypatch, tmp_path):
+    """The regression, at the point the decision is made. Opening the pool here is what parked
+    the workers where the sampler's collectives could not reach them."""
+    positions = np.zeros((8, NUM_PARAMS))
+
+    for rank in range(4):
+        sampled = _run_with(monkeypatch, _engine('pymc'), rank, 4, broadcast=positions,
+                            tmp_path=tmp_path)
+        assert sampled['pools'] == [], 'no worker pool may be opened for pyMC'
+        assert sampled['pool'] is None, 'the sampler must not be given a pool'
+        assert sampled['positions'].shape == (2, NUM_PARAMS), "this rank's own walkers"
+
+
+def test_a_multi_rank_emcee_run_still_opens_the_pool(monkeypatch, tmp_path):
+    """The fix must not change how the default backend runs under MPI."""
+    sampled = _run_with(monkeypatch, _engine('emcee'), 0, 4, tmp_path=tmp_path)
+
+    assert len(sampled['pools']) == 1, 'emcee still parallelises through a worker pool'
+    assert sampled['pool'] is sampled['pools'][0], 'and the sampler is given it'
+    assert sampled['positions'].shape == (8, NUM_PARAMS), 'the master drives the whole ensemble'
+
+
+def test_a_single_rank_run_opens_no_pool_whichever_backend(monkeypatch, tmp_path):
+    for library in ('emcee', 'pymc'):
+        sampled = _run_with(monkeypatch, _engine(library), 0, 1, tmp_path=tmp_path)
+        assert sampled['pools'] == [] and sampled['pool'] is None
+        assert sampled['positions'].shape == (8, NUM_PARAMS), 'one rank runs every walker'
+
+
+# ---------------------------------------------------------------------------
+# the real thing: two ranks, no model, and a clock on it
+# ---------------------------------------------------------------------------
+#: Runs OpencorMCMC.run on an analytic posterior, so the MPI arrangement is exercised without a
+#: CellML model. Before the fix this hangs at the barrier inside PyMCSampler.run_mcmc; the test
+#: gives it a deadline so a hang is reported as a failure rather than by never finishing.
+_TWO_RANK_RUN = '''
+import sys
+sys.path.insert(0, {src!r})
+LIBRARY, NUM_WALKERS, NUM_STEPS = {library!r}, {num_walkers}, 6
+
+import numpy as np
+import param_id.paramID as paramID
+from param_id.paramID import OpencorMCMC
+
+
+class Norm:
+    def normalise(self, vals):
+        return np.asarray(vals, dtype=float)
+
+    def unnormalise(self, vals):
+        return np.asarray(vals, dtype=float)
+
+
+class Engine(OpencorMCMC):
+    def __init__(self):
+        self.UQ_options = {{'library': LIBRARY, 'num_walkers': NUM_WALKERS,
+                           'num_steps': NUM_STEPS,
+                           'num_tune': 2, 'chain_save_every': 2, 'burn_in': 0.5}}
+        self.num_params = 2
+        self.param_norm_obj = Norm()
+        self.best_param_vals = None
+        self.param_id_info = {{'param_names_for_plotting': ['a', 'b'],
+                              'param_mins': [-5.0, -5.0], 'param_maxs': [5.0, 5.0]}}
+        self.output_dir = {output_dir!r}
+        self.saved = None
+
+    def get_lnlikelihood_lnprior_from_params(self, param_vals):
+        return -0.5 * float(np.sum(np.asarray(param_vals) ** 2))
+
+    def save_mcmc_statistics(self, flat_samples):
+        self.saved = flat_samples.shape
+
+
+engine = Engine()
+paramID.mcmc_object = engine
+engine.run()
+
+from mpi4py import MPI
+if MPI.COMM_WORLD.Get_rank() == 0:
+    chain = np.load(engine.mcmc_chain_path())
+    assert chain.shape == (NUM_STEPS, NUM_WALKERS, 2), chain.shape
+    assert engine.saved is not None, 'rank 0 never reached the end of run()'
+    print('OK', chain.shape)
+'''
+
+
+@pytest.mark.parametrize('library, num_walkers', [
+    pytest.param('pymc', 2, marks=pytest.mark.skipif(not pymc_installed,
+                                                     reason='needs the optional [uq] extra')),
+    ('emcee', 4),
+])
+@pytest.mark.skipif(not sys.executable, reason='no interpreter to launch (OpenCOR pythonshell)')
+@pytest.mark.skipif(shutil.which('mpiexec') is None, reason='no mpiexec')
+def test_two_ranks_finish_instead_of_hanging(tmp_path, library, num_walkers):
+    """The bug itself: two ranks and a run that has to end.
+
+    ``pymc`` is the regression -- before the fix this hangs, and the deadline below is what turns
+    a hang into a failure. ``emcee`` is here because nothing else covers it: the pool branch only
+    runs with more than one rank, and every UQ test in CI runs on one, so the branch this change
+    refactors would otherwise be exercised by nothing at all.
+
+    Deliberately not run under the suite's own ranks -- a nested launch inherits the parent job's
+    launcher variables and confuses the child. The environment is cleaned the way
+    tests/test_mpi_utils.py cleans it.
+    """
+    src = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src')
+    code = textwrap.dedent(_TWO_RANK_RUN).format(src=src, output_dir=str(tmp_path),
+                                                 library=library, num_walkers=num_walkers)
+    env = {key: value for key, value in os.environ.items() if key not in LAUNCHER_ENV_VARS}
+
+    try:
+        proc = subprocess.run(['mpiexec', '-n', '2', sys.executable, '-c', code],
+                              capture_output=True, text=True, timeout=600, env=env)
+    except subprocess.TimeoutExpired:
+        pytest.fail('a two-rank pyMC UQ run did not finish: the ranks are deadlocked, which is '
+                    'the bug this test exists for')
+
+    assert proc.returncode == 0, f'stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}'
+    assert 'OK' in proc.stdout, proc.stdout


### PR DESCRIPTION
## The bug

`mpiexec -n >1` with `UQ_options: library: pymc` hangs forever. Not slowly — permanently, after sampling has finished, with no error, no chain written, and nothing in the log to suggest what went wrong.

The two backends parallelise in opposite directions:

- **emcee / zeus** advance one ensemble in one process. The parallelism is the *likelihood*: the sampler is handed a `schwimmbad.MPIPool`, and every other rank sits in `pool.wait()` serving evaluations until the master calls `pool.close()`.
- **pyMC** has no such hook. `PyMCSampler` instead gives each rank `chains_for_rank(...)` chains of its own and gathers them along the walker axis — so every rank must reach `run_mcmc`, and its `comm.Barrier()` / `comm.gather` are collectives over `COMM_WORLD`.

`OpencorMCMC.run` opened the pool for both. The workers were therefore parked inside `pool.wait()`, blocked in a receive that only the master's `pool.close()` ends, so they could never join the master's barrier — and the master waits on that barrier forever, holding the pool open. Neither side can move.

It has been there since the backend landed in #408, because nothing exercises it: every pyMC test in CI runs on a single rank, where the pool branch isn't taken at all.

## The fix

`run()` now picks the arrangement the backend actually wants, via `sampler_needs_a_worker_pool()`. With pyMC on more than one rank it opens no pool and every rank samples — which is what `PyMCSampler` was written for all along. **emcee and zeus are untouched.**

Two supporting changes, both consequences of ranks now doing their own sampling:

- **The starting ensemble is drawn once on rank 0 and broadcast**, rather than drawn per rank. `best_param_vals` is only guaranteed on rank 0, so drawing locally would start some ranks in a tight ball around the calibrated fit and others on a uniform draw over the whole prior box — a difference that would show up as a wildly heterogeneous "ensemble".
- **Each rank then takes its own slice of the walkers** (`_walkers_for_rank`, mirroring `chains_for_rank`), so the gathered chain covers the ensemble that was asked for instead of repeating its first few walkers on every rank.

The duplicated starting-position block (previously written out once per branch of `run`, the two copies differing only in the ball width) is now one method, since a third branch wasn't worth a third copy.

## Testing

`tests/test_uq_pymc_mpi.py`.

The regression test **launches a real `mpiexec -n 2` UQ run** over an analytic posterior — no CellML model needed, a few seconds — and puts a deadline on it, because a deadlock does not fail, it waits. Verified both ways against this branch:

- unfixed source: hangs, killed at 90 s
- fixed source: finishes in ~5 s, chain shape `(6, 2, 2)`

The same test also runs **emcee on two ranks**, because the pool branch is refactored here and every UQ test in CI runs on one rank — so without it, the branch this PR touches would be covered by nothing at all. It passes, exercising a real `MPIPool` with real workers.

The dispatch decision, the ensemble split (including the wrap when there are more ranks than walkers) and the starting positions are covered by plain unit tests needing neither MPI nor pymc.

The file is added to the UQ CI job, the only place pymc is installed, with a 15-minute step timeout so a regression is reported rather than left to sit until the job's own limit.

Locally: `./run_pytest.sh -m "not slow"` shows the same 8 pre-existing failures as the base commit (7 subprocess-spawning `test_mpi_utils` cases under the OpenCOR shell, plus the documented SN_simple python-codegen one) and no new ones.

Independent of #422 (merged), though it builds on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
