### PR TITLE
ci: split the param_id jobs in half, because one test was half of each

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,8 +113,50 @@ jobs:
           echo "> CI runs the Myokit-first suite and fails on real test failures." >> $GITHUB_STEP_SUMMARY
         fi
 
+  # The param_id suite is split in two, serial and MPI alike, because one test was half of it.
+  # Measured on the run that prompted the split (per-test, from the job logs):
+  #
+  #   test_param_id_simple_physiological_succeeds     705 s serial / 621 s MPI
+  #   everything else in both files, together         801 s serial / 600 s MPI
+  #
+  # That one test calibrates a whole-circulation model where every other test uses a small one
+  # (3compartment, lotka_volterra, fitzhugh_nagumo), so the split is by model scale rather than
+  # an arbitrary halving: `full_scale_model` marks it, and the two halves select on the marker.
+  # A new full-scale test joins the first half by wearing the marker; anything else lands in the
+  # second half by default. Splitting on a marker rather than on `-k <test name>` means renaming
+  # the test cannot silently put 12 minutes back into one job.
+  #
+  # Each half is ~10-13 minutes and they run in parallel, so the wall clock is halved rather
+  # than the work reduced.
+  test-param-id-mpi-full-scale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+
+    - name: Install MPI and Myokit build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+
+    - name: Run the full-scale model calibration with MPI
+      run: |
+        mpiexec -n 2 python -m pytest tests/test_param_id.py -m full_scale_model -v --with-mpi \
+          --tb=short --durations=0 --junitxml=junit-param-id-full-scale.xml
+
   test-param-id-mpi:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
     - uses: actions/checkout@v4
 
@@ -135,10 +177,40 @@ jobs:
 
     - name: Run param_id and sensitivity analysis tests with MPI
       run: |
-        mpiexec -n 2 python -m pytest tests/test_param_id.py tests/test_sensitivity_analysis.py -v --with-mpi --tb=short --junitxml=junit-param-id.xml
+        mpiexec -n 2 python -m pytest tests/test_param_id.py tests/test_sensitivity_analysis.py \
+          -m "not full_scale_model" -v --with-mpi --tb=short --durations=0 \
+          --junitxml=junit-param-id.xml
+
+  # Split on the same marker as the MPI pair above, for the same reason -- see the note there.
+  test-param-id-serial-full-scale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+
+    - name: Install MPI and Myokit build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+
+    - name: Run the full-scale model calibration in serial mode
+      run: |
+        python -m pytest tests/test_param_id.py -m full_scale_model -v --with-mpi --tb=short \
+          --durations=0 --junitxml=junit-param-id-serial-full-scale.xml
 
   test-param-id-serial:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
     - uses: actions/checkout@v4
 
@@ -159,7 +231,9 @@ jobs:
 
     - name: Run param_id and sensitivity analysis tests in serial mode
       run: |
-        python -m pytest tests/test_param_id.py tests/test_sensitivity_analysis.py -v --with-mpi --tb=short --junitxml=junit-param-id-serial.xml
+        python -m pytest tests/test_param_id.py tests/test_sensitivity_analysis.py \
+          -m "not full_scale_model" -v --with-mpi --tb=short --durations=0 \
+          --junitxml=junit-param-id-serial.xml
 
   # The end-to-end UQ tests: a real chain checked against a posterior whose answer is known in
   # closed form (issue #179). Nothing else runs them -- the full-model ones are marked `slow`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ markers = [
     "autogen_rank(idx): autogeneration test assigned rank index",
     "solver_task: marks a solver test that signals completion",
     "compare_optimisers: marks compare_optimisers tests",
+    "full_scale_model: calibrates a whole-circulation model rather than a small one, so it takes minutes rather than seconds; CI splits the param_id jobs on this marker to halve their wall clock",
     "xdist_group(name): group marker used by pytest-xdist to serialize groups",
 ]
 # Coverage options

--- a/tests/test_param_id.py
+++ b/tests/test_param_id.py
@@ -1116,6 +1116,7 @@ def test_param_id_SN_simple_CVODE_myokit_ga_smoke(
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.mpi
+@pytest.mark.full_scale_model
 def test_param_id_simple_physiological_succeeds(base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
     """
     Test that parameter identification succeeds for simple_physiological model.


### PR DESCRIPTION
`test-param-id-serial` and `test-param-id-mpi` each ran the whole calibration + sensitivity suite — about **25 and 20 minutes** — and **one test was roughly half of each**. Per-test timings, reconstructed from the timestamps in a recent green run's job logs:

| | serial | MPI |
|---|---|---|
| `test_param_id_simple_physiological_succeeds` | 705 s | 621 s |
| everything else in both files, together | 801 s | 600 s |

## The split

Not an arbitrary halving: that test calibrates a **whole-circulation model**, where every other test in the suite uses a small one (3compartment, lotka_volterra, fitzhugh_nagumo, nke_pump). Splitting by model scale gives two halves that are already balanced *and* says something true about the suite, rather than encoding a number that drifts.

| job | selection | measured |
|---|---|---|
| `test-param-id-serial-full-scale` / `test-param-id-mpi-full-scale` | `-m full_scale_model` | 8m05s (MPI, local) |
| `test-param-id-serial` / `test-param-id-mpi` | `-m "not full_scale_model"` | 10m58s (MPI, local) |

They run in parallel, so the wall clock halves rather than the work reducing.

**Why a marker and not `-k <test name>`:** renaming the test would silently put twelve minutes back into one job and leave the other running nothing, and neither job would fail to say so. `full_scale_model` is registered in pyproject and carried by the test; a future full-scale test joins the first half by wearing the marker, and anything else lands in the second half by default.

## Verification

- Both halves run with `mpiexec -n 2`: the full-scale half is **1 passed in 8m05s**, the rest is **75 passed, 8 skipped, 0 failed in 10m58s** (the 8 skips are the pre-existing AADC ones, unrelated to the split).
- Collection confirms the halves partition the suite exactly: **1 + 83 = 84**, the number collected unsplit.

The MPI halves were worth checking rather than assuming — the suite coordinates ranks through markers, so deselecting tests could have disturbed that. It doesn't.

Also adds `--durations=0` to all four jobs, so the next time this needs splitting the numbers are in the log rather than reconstructed from log timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
