### PR TITLE
feat(schema): say which sampler reads each UQ option, so a form can follow the choice

### DIFF
--- a/src/parsers/PrimitiveParsers.py
+++ b/src/parsers/PrimitiveParsers.py
@@ -1281,6 +1281,32 @@ def param_id_method_options(param_id_method):
     return []
 
 
+def uq_options(library=None):
+    """The `UQ_options` settings a given sampler `library` reads, for tools that auto-populate
+    the UQ settings form.
+
+    The samplers do not take the same settings: `num_tune` and `pymc_method` are pyMC's alone,
+    and `_build_sampler` passes them to no other backend. Until now that was said only in each
+    description ("Ignored by emcee"), which a form cannot act on -- so an emcee user was offered
+    a tuning count that nothing would read and a pyMC algorithm that would not run, and had no
+    way to tell those apart from the settings that do apply.
+
+    A descriptor carrying `libraries` applies to those backends only; one without it applies to
+    every backend, which is the common case and keeps the annotation to the exceptions. Returns
+    every option when `library` is None, so a caller wanting the whole schema (or a tool that
+    has not chosen a backend yet) still gets it.
+
+    Unknown library names return the library-agnostic options rather than nothing: a front-end
+    on a newer CA than its schema knows should degrade to the settings that are certainly
+    right, not to an empty form.
+    """
+    options = ANALYSIS_OPTIONS['uq']['options']
+    if library is None:
+        return list(options)
+    return [opt for opt in options
+            if 'libraries' not in opt or library in opt['libraries']]
+
+
 def solver_info_fields(solver):
     """The `solver_info` settings a given solver accepts (see SOLVER_INFO_FIELDS), for tools that
     auto-populate the solver settings form. Empty list for an unknown solver."""
@@ -1461,6 +1487,7 @@ ANALYSIS_OPTIONS = {
             # inverted: the knob exists and matters (it triples the iteration count at its
             # default) but no front-end could discover or change it.
             {'name': 'num_tune', 'type': 'int', 'default': 1000, 'required': False,
+             'libraries': ['pymc'],
              'description': 'Tuning (warm-up) draws the pymc backend discards before sampling. '
                             'Ignored by emcee, which tunes as it goes. These are on top of '
                             'num_steps, so 1000 tune plus 500 draws is 1500 iterations.'},
@@ -1469,6 +1496,7 @@ ANALYSIS_OPTIONS = {
             # it with a hardcoded fallback, so it sat at 'mcmc' with nothing able to reach it.
             {'name': 'pymc_method', 'type': 'enum', 'default': 'mcmc', 'required': False,
              'choices': ['mcmc', 'smc'],
+             'libraries': ['pymc'],
              'description': "pyMC sampling algorithm: 'mcmc' is Metropolis, 'smc' is sequential "
                             'Monte Carlo, which can cross a low-probability region between modes '
                             'that Metropolis gets stuck on one side of. Ignored by emcee.'},

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -19,6 +19,7 @@ from parsers.PrimitiveParsers import (
     gradient_sources,
     ANALYSIS_OPTIONS,
     analysis_options,
+    uq_options,
     _SOLVER_INTEGRATOR_KEYS,
     _CASADI_ADJOINT_METHODS,
 )
@@ -552,6 +553,59 @@ def test_every_uq_option_the_code_reads_is_advertised():
     assert read <= advertised, (
         f'UQ_options read by the code but not declared in ANALYSIS_OPTIONS["uq"]: '
         f'{sorted(read - advertised)}')
+
+
+def test_uq_options_are_filtered_by_sampler_library():
+    """A settings form should offer what the chosen sampler actually reads, and nothing else.
+
+    ``num_tune`` and ``pymc_method`` are pyMC's alone. Offering them under emcee is not a
+    cosmetic wart: the user sets a tuning count that nothing reads and an algorithm that will
+    not run, and has no way to tell those from the settings that do apply.
+    """
+    everything = {o['name'] for o in analysis_options('uq')}
+    pymc_only = {'num_tune', 'pymc_method'}
+
+    assert {o['name'] for o in uq_options('pymc')} == everything
+    assert {o['name'] for o in uq_options('emcee')} == everything - pymc_only
+    # No library named at all is "show me the schema", not "show me nothing".
+    assert {o['name'] for o in uq_options()} == everything
+
+
+def test_an_unknown_sampler_library_still_gets_the_shared_options():
+    """A front-end newer than the CA it is pointed at (or older) must degrade to the settings
+    that are certainly right, rather than to an empty form with no way to configure a run."""
+    assert {o['name'] for o in uq_options('zeus')} == \
+        {o['name'] for o in analysis_options('uq')} - {'num_tune', 'pymc_method'}
+
+
+def test_library_specific_uq_options_are_read_only_in_that_librarys_arm():
+    """The annotation has to match the dispatch, or the form hides a setting that matters.
+
+    Restating "num_tune and pymc_method are pyMC's" in the test would only agree with itself.
+    This reads ``_build_sampler``, which is where the choice is actually made, and requires that
+    an option marked for one library is read inside that library's branch and not before it --
+    so moving a read out of the pyMC arm without dropping the annotation fails here.
+    """
+    import inspect
+
+    from param_id.paramID import OpencorMCMC
+
+    source = inspect.getsource(OpencorMCMC._build_sampler)
+    before_pymc, marker, pymc_arm = source.partition("if library == 'pymc'")
+    assert marker, "_build_sampler no longer dispatches on library == 'pymc'"
+
+    annotated = [o for o in analysis_options('uq') if o.get('libraries')]
+    assert annotated, 'no UQ option is annotated with the libraries that read it'
+    for opt in annotated:
+        assert opt['libraries'] == ['pymc'], (
+            f"{opt['name']}: this test only knows how to check the pyMC arm; extend it "
+            'alongside a new library-specific option')
+        assert opt['name'] in pymc_arm, (
+            f"{opt['name']} is advertised as pyMC-only but _build_sampler's pyMC arm never "
+            'reads it')
+        assert opt['name'] not in before_pymc, (
+            f"{opt['name']} is advertised as pyMC-only but is read before the pyMC arm, so "
+            'another backend reads it too and the form must offer it there')
 
 
 def test_closed_set_analysis_options_are_enums_with_choices():


### PR DESCRIPTION
## The problem

The UQ settings form offers every `UQ_options` setting whatever sampler is selected — including the two that only pyMC reads. An emcee user is asked for a **tuning count nothing will read** (`num_tune`) and a **pyMC algorithm that will not run** (`pymc_method`), with nothing to distinguish those from the settings that do apply.

CUFLynx builds that form from `ANALYSIS_OPTIONS['uq']` and hardcodes nothing — deliberately — so it cannot fix this at its end without duplicating knowledge that lives here.

The applicability was already documented, but only in prose:

```python
'description': '... Ignored by emcee, which tunes as it goes. ...'
```

A form cannot act on that.

## The change

It becomes machine-readable. A descriptor may carry `libraries`, and a new accessor returns what a given sampler reads:

```python
uq_options('emcee')  # -> method, library, num_steps, num_walkers, burn_in, chain_save_every
uq_options('pymc')   # -> ... plus num_tune, pymc_method
uq_options()         # -> the whole schema
```

Three decisions worth naming:

- **Annotate the exceptions, not everything.** Most UQ settings are library-agnostic; a `libraries` key on each would be noise that goes stale. Absent means "every backend".
- **No library named returns everything**, so a caller that hasn't chosen a backend yet still gets a schema.
- **An unknown library returns the library-agnostic options**, not nothing — a front-end paired with a CA whose schema it doesn't recognise should degrade to the settings that are certainly right, not to an empty form with no way to configure a run.

`chain_save_every` is deliberately *not* annotated: both backends honour it (emcee through `sample_with_checkpoints`, pyMC through its per-draw callback since #422).

## Tests

Three, in `test_solver_info_validation.py` alongside the existing UQ schema checks:

- the filtering itself, against `analysis_options('uq')` rather than a restated list
- the unknown-library degradation
- **a correspondence check** that reads `_build_sampler` and requires an option annotated for pyMC to be read *inside* the pyMC arm and not before it. Restating "num_tune and pymc_method are pyMC's" in a test would only agree with itself; this fails if a read moves out of that arm and the annotation stays behind — which is the direction the mistake goes in, and the same principle as the existing `test_every_uq_option_the_code_reads_is_advertised`.

Verified in both directions: with the annotation dropped and the accessor kept, all three fail (`no UQ option is annotated with the libraries that read it`, and the two set comparisons). Full non-slow suite: no new failures — only the pre-existing `test_mpi_utils` subprocess cases under the OpenCOR shell.

The CUFLynx side (filtering the panel on this key, with a fallback to today's behaviour for an older CA) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
