### PR TITLE
chore: bump the package version to 0.3.0, matching the release tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "circulatory-autogen"
-version = "0.1.0"
+# Keep in step with the release tag: every release is accompanied by a chore PR bumping this.
+# It had drifted to 0.1.0 while the published release was Version_0_2, so anything built from
+# the tree reported a version lower than the one already out.
+version = "0.3.0"
 description = "Generation and calibration of CellML circulatory system models from module/vessel arrays"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
`pyproject.toml` said `version = "0.1.0"` while the published release was `Version_0_2` — so anything built from the tree reported a version *lower* than the one already out, and now lower than the [v0.3.0](https://github.com/physiomelinks/circulatory_autogen/releases/tag/v0.3.0) tag.

Nothing consumes that number today, which is why it drifted unnoticed. It stops being cosmetic with #428: the packaging epic publishes this metadata to PyPI, where the version *is* the identity of the artifact and cannot be corrected after upload — a wrong number has to be yanked and re-released.

From here this is a per-release chore: tag, then bump.

## Optional follow-up

If you want the chore enforced rather than remembered, a CI job on tag pushes can assert the two agree:

```yaml
- name: Tag matches the package version
  run: |
    tag="${GITHUB_REF_NAME#v}"
    pkg=$(python -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
    [ "$tag" = "$pkg" ] || { echo "tag $tag != pyproject $pkg"; exit 1; }
```

That turns "we forgot to bump" from something discovered on PyPI into a red X on the tag. Happy to add it in a separate PR if you want it — left out here to keep this one a single line of intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
