### PR TITLE
docs: point the Tests badge at physiomelinks master, not the fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Overview
 
-[![Tests](https://github.com/FinbarArgus/circulatory_autogen/workflows/Tests/badge.svg)](https://github.com/FinbarArgus/circulatory_autogen/actions/workflows/tests.yml)
+[![Tests](https://github.com/physiomelinks/circulatory_autogen/actions/workflows/tests.yml/badge.svg?branch=master&event=push)](https://github.com/physiomelinks/circulatory_autogen/actions/workflows/tests.yml)
 
 This project allows the generation and calibration of cellml (and soon to be more) circulatory system models from an array of module/vessel names and connections.
 
-> **Note:** Test results and pass percentage are displayed in the [GitHub Actions workflow summary](https://github.com/FinbarArgus/circulatory_autogen/actions/workflows/tests.yml). The badge above shows the overall test status (passing/failing). 
+> **Note:** Test results and pass percentage are displayed in the [GitHub Actions workflow summary](https://github.com/physiomelinks/circulatory_autogen/actions/workflows/tests.yml). The badge above shows the overall test status (passing/failing) for `master` of this repository, which is where pull requests are merged. 
 
 # Tutorial
 


### PR DESCRIPTION
The README badge read **failing** while `master` was green.

It pointed at `FinbarArgus/circulatory_autogen`, whose `master` is **222 commits behind** upstream and last ran the Tests workflow on **2026-07-23**. So the badge had been frozen for three weeks on a red result describing a tree nobody works on, while upstream `master`'s most recent completed run is a success.

A badge has no cache to bust — it renders the latest run of that workflow on that repository's default branch. The only fix is to read the right repository.

```diff
-[![Tests](https://github.com/FinbarArgus/circulatory_autogen/workflows/Tests/badge.svg)](…)
+[![Tests](https://github.com/physiomelinks/circulatory_autogen/actions/workflows/tests.yml/badge.svg?branch=master&event=push)](…)
```

This also moves to the modern badge URL, which the legacy `/workflows/Tests/badge.svg` form cannot express:

- **`?branch=master`** pins it to master rather than "whichever branch ran most recently".
- **`&event=push`** keeps pull-request runs from flipping it, so the badge answers *is master green* rather than *was the last thing anyone pushed green*.

The note below the badge is updated to match, and now says which branch and repository it describes.

Verified before opening: the new URL returns `200 image/svg+xml` and currently renders **passing**.

## Unrelated, but worth doing

`FinbarArgus/circulatory_autogen`'s `master` being 222 commits stale is a trap for anyone who branches from it — it is why the last few PRs were branched from `upstream/master` rather than `origin/master`. `gh repo sync FinbarArgus/circulatory_autogen --source physiomelinks/circulatory_autogen` fast-forwards it. Not done here, since it is a push to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
