### PR TITLE
fix(uq): give each pyMC chain its own column in the live chain, NaN where it has not got there

### DIFF
--- a/src/param_id/paramID.py
+++ b/src/param_id/paramID.py
@@ -817,6 +817,7 @@ class CVS0DParamID():
             return
 
         samples = np.load(os.path.join(self.output_dir, 'mcmc_chain.npy'))
+        samples = drop_unsampled_draws(samples)
         num_steps = samples.shape[0]
         num_walkers = samples.shape[1]
         num_params = samples.shape[2]  #
@@ -3636,6 +3637,35 @@ def calculate_lnlikelihood(param_vals):
     and not all the attributes of the class instance.
     """
     return mcmc_object.get_lnlikelihood_lnprior_from_params(param_vals)
+
+
+def drop_unsampled_draws(samples):
+    """A chain cut back to the draws every walker actually reached.
+
+    Only a *partial* pyMC chain has anything to drop. Its chains are sampled one after another
+    (``cores=1``), so the file written mid-run carries NaN where a chain has not got to a draw
+    yet -- see ``pymc_backend._LiveChainWriter``. A finished chain is dense and this returns it
+    untouched.
+
+    It matters because a cancelled or killed run leaves that partial file exactly where the
+    finished one would be, and every statistic downstream (``np.mean``, ``np.percentile``,
+    arviz's ESS and R-hat) turns a single NaN into a NaN answer for the whole parameter.
+    Truncating to the shortest chain is the conservative reading: every walker is then a real
+    chain of the same length, which is the rectangle the rest of the code is written against.
+
+    Deliberately not ``np.nan_to_num`` or a per-walker compaction: substituting zeros invents
+    draws, and letting walkers have different lengths would push the raggedness into every
+    consumer instead of resolving it here.
+    """
+    samples = np.asarray(samples)
+    if samples.ndim != 3 or not np.isnan(samples).any():
+        return samples
+    complete = ~np.isnan(samples).any(axis=(1, 2))
+    if not complete.any():
+        return samples[:0]
+    # Draws are contiguous from the start, so the first gap ends the usable chain.
+    first_gap = np.argmax(~complete) if (~complete).any() else len(complete)
+    return samples[:first_gap]
 
 
 def save_chain_atomically(path, samples):

--- a/src/param_id/pymc_backend.py
+++ b/src/param_id/pymc_backend.py
@@ -72,15 +72,26 @@ class _LiveChainWriter:
     a tuning one. That is enough to write the same growing ``mcmc_chain.npy`` an emcee run
     writes, without pretending ``pm.sample`` can be stepped.
 
-    **The live file is the draws in the order pyMC produced them, as a single walker.** With
-    ``cores=1`` -- which is what CA asks for, because the parallelism is MPI ranks, not pyMC
-    processes -- chains are sampled one after another, not advanced together. So there is no
-    honest ``(steps, walkers, params)`` rectangle covering all of them until the last one
-    finishes: chain 2 has one draw while chain 1 has five thousand, and squaring that off means
-    either throwing away chain 1's draws or inventing chain 2's. Concatenating them instead is
-    exactly what happened, in the order it happened, and it grows monotonically for the whole
-    run -- which is what a progress view needs. The finished chain, written by the caller once
-    sampling returns, is the real ``(steps, chains, params)`` from every rank.
+    **The live file keeps each chain in its own column, NaN where it has not got there yet.**
+    With ``cores=1`` -- which is what CA asks for, because the parallelism is MPI ranks, not
+    pyMC processes -- chains are sampled one after another, not advanced together, so there is
+    no full ``(steps, chains, params)`` rectangle until the last one finishes: chain 2 has one
+    draw while chain 1 has five thousand.
+
+    This first shipped concatenating them into a single walker, on the reasoning that a
+    ragged set of chains has no honest rectangle and the concatenation at least invented
+    nothing. That was wrong in a way only a plot shows. The joined trace steps discontinuously
+    where one chain ends and the next begins, and every statistic computed along it -- the
+    autocorrelation, the running mean -- is taken *across* those joins, so a live view of a
+    healthy pyMC run looked like one badly-mixing chain. emcee advances all its walkers
+    together and never has this shape, so only pyMC looked broken.
+
+    Padding with NaN is the honest rectangle: each column is one real chain, and a draw that
+    has not happened is absent rather than fabricated. Consumers must use NaN-aware reductions
+    (``np.nanmean`` and friends) or drop the NaNs -- which is the right requirement, because
+    the alternative is a number no sampler produced. The finished chain, written by the caller
+    once sampling returns, is the real dense ``(steps, chains, params)`` from every rank and
+    carries no NaN at all.
 
     Tuning draws are dropped, because pyMC drops them: they are recorded in the same trace but
     do not appear in the posterior, and a live view that included them would disagree with the
@@ -120,20 +131,36 @@ class _LiveChainWriter:
                   'and the chain will be saved at the end of the run.')
 
     def chain_so_far(self):
-        """The post-tuning draws so far, ``(draws, 1, params)``, or None before there are any."""
-        parts = []
-        for trace in self.traces.values():
+        """The post-tuning draws so far as ``(draws, chains, params)``, or None before any.
+
+        One column per chain pyMC has started, in chain order, padded with NaN where a chain
+        has not reached that draw yet. A chain that has not started at all contributes no
+        column, so the array widens as sampling moves on to the next chain.
+
+        NaN rather than a fabricated number: "not sampled yet" is not a value, and anything
+        substituted for it -- zero, the last draw, the mean -- is a datum no sampler produced
+        and would be plotted and averaged as though it were real.
+        """
+        blocks = {}
+        for chain_idx, trace in self.traces.items():
             recorded = len(trace)
             if recorded <= self.num_tune:
                 continue
             # A trace still being filled is preallocated to its full length, so it has to be cut
             # to what has actually been recorded -- the tail is zeros, not draws.
-            parts.append(np.stack(
+            blocks[chain_idx] = np.stack(
                 [np.asarray(trace.get_values(name))[self.num_tune:recorded]
-                 for name in self.param_names], axis=-1))
-        if not parts:
+                 for name in self.param_names], axis=-1)
+        if not blocks:
             return None
-        return np.concatenate(parts, axis=0)[:, np.newaxis, :]
+        # Column index *is* the chain index, so a trace keeps its identity as the run goes on
+        # rather than shifting left when an earlier chain is skipped.
+        num_chains = max(blocks) + 1
+        longest = max(len(block) for block in blocks.values())
+        samples = np.full((longest, num_chains, len(self.param_names)), np.nan)
+        for chain_idx, block in blocks.items():
+            samples[:len(block), chain_idx, :] = block
+        return samples
 
 
 class PyMCSampler:

--- a/tests/test_uq_pymc_live_chain.py
+++ b/tests/test_uq_pymc_live_chain.py
@@ -22,7 +22,11 @@ from collections import namedtuple
 import numpy as np
 import pytest
 
-from param_id.paramID import sample_with_checkpoints, save_chain_atomically
+from param_id.paramID import (
+    drop_unsampled_draws,
+    sample_with_checkpoints,
+    save_chain_atomically,
+)
 from param_id.pymc_backend import PyMCSampler, _LiveChainWriter, _progressbar_wanted
 
 pymc_installed = True
@@ -69,23 +73,34 @@ class _FakeTrace:
 def _replay_pymc(writer, draws_per_chain, num_tune, num_chains, start=0.0):
     """Drive ``writer`` with the callback sequence pyMC produces at ``cores=1``.
 
-    Chain by chain, tuning draws first, one callback per recorded draw. Returns the draws that
-    should end up in the chain -- every chain's post-tuning draws, concatenated in the order
-    they were sampled.
+    Chain by chain, tuning draws first, one callback per recorded draw. Returns the post-tuning
+    draws per chain, ``[chain][draw][param]`` -- the shape the live file is expected to hold,
+    one column per chain, before any NaN padding is applied.
     """
     total = num_tune + draws_per_chain
-    expected = []
+    per_chain = []
     value = start
     for chain in range(num_chains):
         trace = _FakeTrace(total)
+        kept = []
         for idx in range(total):
             value += 1.0
             point = [value, -value]
             trace.record(point)
             if idx >= num_tune:
-                expected.append(point)
+                kept.append(point)
             writer(trace=trace, draw=Draw(chain, False, idx, idx < num_tune, {}, {}))
-    return np.asarray(expected)
+        per_chain.append(np.asarray(kept, dtype=float).reshape(-1, len(PARAM_NAMES)))
+    return per_chain
+
+
+def _padded(per_chain):
+    """``per_chain`` as the ``(draws, chains, params)`` rectangle, NaN where a chain is short."""
+    longest = max((len(c) for c in per_chain), default=0)
+    out = np.full((longest, len(per_chain), len(PARAM_NAMES)), np.nan)
+    for idx, block in enumerate(per_chain):
+        out[:len(block), idx, :] = block
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -103,20 +118,91 @@ def test_the_chain_is_written_every_save_every_draws_and_grows():
 
 
 @pytest.mark.unit
-def test_the_partial_chain_is_the_draws_so_far_in_the_order_they_were_sampled():
-    """The ordering assertion. Chain 0's draws, then chain 1's -- which is what happened, and is
-    the only arrangement of sequentially sampled chains that is all real draws and never
-    shrinks."""
+def test_each_chain_keeps_its_own_column():
+    """The fix. Chains sampled one after another must not be concatenated into one trace.
+
+    Joined end to end, the trace steps discontinuously where one chain ends and the next
+    begins, and the autocorrelation and running mean are then computed *across* that join --
+    so a healthy pyMC run was drawn as one badly-mixing chain.
+    """
     written = []
     writer = _LiveChainWriter(written.append, save_every=4, param_names=PARAM_NAMES, num_tune=3)
 
-    expected = _replay_pymc(writer, draws_per_chain=8, num_tune=3, num_chains=2)
+    per_chain = _replay_pymc(writer, draws_per_chain=8, num_tune=3, num_chains=2)
 
-    assert len(expected) == 16
-    np.testing.assert_allclose(written[-1], expected[:, np.newaxis, :])
-    # and every checkpoint on the way is a prefix of it, never a re-truncated view
-    for chunk in written:
-        np.testing.assert_allclose(chunk, expected[:chunk.shape[0], np.newaxis, :])
+    final = written[-1]
+    assert final.shape == (8, 2, 2), 'two chains of eight draws, side by side'
+    np.testing.assert_allclose(final, _padded(per_chain))
+    # column index is the chain index: chain 1's draws are not in chain 0's column
+    np.testing.assert_allclose(final[:, 0, :], per_chain[0])
+    np.testing.assert_allclose(final[:, 1, :], per_chain[1])
+
+
+@pytest.mark.unit
+def test_a_chain_that_has_not_caught_up_is_padded_with_nan():
+    """Mid-run, chain 1 has draws chain 2 does not. The gap is NaN -- not zero, not the last
+    value, not the mean -- because it is a draw no sampler has produced yet, and anything put
+    there would be plotted and averaged as though it had been."""
+    written = []
+    writer = _LiveChainWriter(written.append, save_every=3, param_names=PARAM_NAMES, num_tune=0)
+
+    # 6 draws for chain 0, then only 3 for chain 1 -> the writer is called mid-chain-1
+    _replay_pymc(writer, draws_per_chain=6, num_tune=0, num_chains=1)
+    trace = _FakeTrace(6)
+    for idx in range(3):
+        trace.record([100.0 + idx, -(100.0 + idx)])
+        writer(trace=trace, draw=Draw(1, False, idx, False, {}, {}))
+
+    partial = written[-1]
+    assert partial.shape == (6, 2, 2), 'full height, one column per started chain'
+    assert not np.isnan(partial[:, 0, :]).any(), 'the finished chain has no gaps'
+    assert not np.isnan(partial[:3, 1, :]).any(), "chain 1's real draws are present"
+    assert np.isnan(partial[3:, 1, :]).all(), 'and the draws it has not reached are NaN'
+    # a NaN-aware reduction still gets the right answer for the short chain
+    np.testing.assert_allclose(np.nanmean(partial[:, 1, 0]), 101.0)
+
+
+@pytest.mark.unit
+def test_a_cancelled_runs_partial_chain_is_cut_to_its_complete_draws():
+    """A killed run leaves the partial file where the finished one would be, so whatever reads
+    it must not turn a NaN into a NaN mean for the whole parameter."""
+    partial = np.arange(24, dtype=float).reshape(4, 2, 3)
+    partial[2:, 1, :] = np.nan            # chain 1 stopped two draws in
+
+    kept = drop_unsampled_draws(partial)
+
+    assert kept.shape == (2, 2, 3), 'cut to the draws both chains reached'
+    assert not np.isnan(kept).any()
+    np.testing.assert_allclose(kept, partial[:2])
+
+
+@pytest.mark.unit
+def test_a_finished_chain_is_returned_untouched():
+    """The common case: nothing to drop, and no copy of a chain that may be very large."""
+    dense = np.arange(24, dtype=float).reshape(4, 2, 3)
+    assert drop_unsampled_draws(dense) is dense
+
+
+@pytest.mark.unit
+def test_a_chain_with_no_complete_draw_comes_back_empty_rather_than_nan():
+    """Cancelled before the second chain produced anything. An empty chain reads as 'no
+    samples'; one full of NaN reads as samples whose every statistic is NaN."""
+    nothing = np.full((3, 2, 2), np.nan)
+    nothing[:, 0, :] = 1.0
+    assert drop_unsampled_draws(nothing).shape[0] == 0
+
+
+@pytest.mark.unit
+def test_the_finished_chain_carries_no_nan():
+    """The padding is a property of a *partial* chain only. Once every chain has run its full
+    length the rectangle is dense, and a consumer that forgot about NaN still gets a number."""
+    written = []
+    writer = _LiveChainWriter(written.append, save_every=5, param_names=PARAM_NAMES, num_tune=1)
+
+    _replay_pymc(writer, draws_per_chain=5, num_tune=1, num_chains=3)
+
+    assert written[-1].shape == (5, 3, 2)
+    assert not np.isnan(written[-1]).any()
 
 
 @pytest.mark.unit
@@ -127,10 +213,10 @@ def test_tuning_draws_are_left_out_because_pymc_leaves_them_out():
     written = []
     writer = _LiveChainWriter(written.append, save_every=2, param_names=PARAM_NAMES, num_tune=6)
 
-    expected = _replay_pymc(writer, draws_per_chain=4, num_tune=6, num_chains=1)
+    per_chain = _replay_pymc(writer, draws_per_chain=4, num_tune=6, num_chains=1)
 
     assert written[-1].shape[0] == 4, 'four post-tuning draws, not ten recorded ones'
-    np.testing.assert_allclose(written[-1], expected[:, np.newaxis, :])
+    np.testing.assert_allclose(written[-1], _padded(per_chain))
 
 
 @pytest.mark.unit
@@ -268,12 +354,11 @@ def test_a_real_pymc_run_writes_a_growing_chain_that_matches_what_it_returns(tmp
 
     # a checkpoint every 2 post-tuning draws over 2 chains x 6 draws, and never the tuning ones
     assert checkpoints == 6
-    assert [s[0] for s in shapes] == [2, 4, 6, 8, 10, 12]
-    assert all(s[1:] == (1, 2) for s in shapes)
+    # chain 0 grows to its full 6 draws, then chain 1 appears as a second column and grows
+    assert shapes == [(2, 1, 2), (4, 1, 2), (6, 1, 2), (6, 2, 2), (6, 2, 2), (6, 2, 2)]
 
-    # ...and the draws are the chains pyMC returned, chain 0 then chain 1
-    pooled = np.concatenate([chain[:, c, :] for c in range(num_chains)], axis=0)
-    np.testing.assert_allclose(np.load(path)[:, 0, :], pooled)
+    # ...and the last partial chain is exactly the chains pyMC went on to return, per column
+    np.testing.assert_allclose(np.load(path), chain)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
A pyMC run's live progress plot showed **one trace where the user asked for twenty**. `num_walkers` was read correctly and the plotting was fine — the partial chain itself was one column, by a decision I made in #422 and got wrong.

## What was wrong

pyMC at `cores=1` samples chains one after another, so mid-run there is no full `(steps, chains, params)` rectangle: chain 2 has one draw while chain 1 has five thousand. #422 concatenated them into a single walker, reasoning that this at least invented nothing.

It's wrong in a way only a plot shows. The joined trace **steps discontinuously** where one chain ends and the next begins, and the autocorrelation and running mean are then computed *across* those joins — so a healthy run was drawn as one badly-mixing chain. emcee advances all its walkers together and never has this shape, which is why only pyMC looked broken.

## The change

The partial chain keeps **one column per chain pyMC has started**, padded with NaN where a chain hasn't reached that draw. The array widens as sampling reaches each new chain, and column index stays chain index.

NaN rather than zero or a repeated last value: a draw that hasn't happened is not a number, and anything put there would be plotted and averaged as though it had been.

## The consequence, handled

This makes NaN reachable on disk for the first time — a cancelled or killed run leaves the partial file exactly where the finished one would be, and one NaN turns `np.mean`, `np.percentile` and arviz's ESS/R-hat into NaN for the whole parameter.

So `get_mcmc_samples` cuts a loaded chain back to the draws **every** walker reached (`drop_unsampled_draws`). Truncation rather than nan-aware statistics scattered everywhere: every walker is then a real chain of equal length, which is the rectangle the plotters, the diagnostics and the flattening are all already written against. A finished chain has no NaN and is returned untouched, without copying what can be a very large array.

## Tests

Per-chain columns, the NaN padding mid-run, a finished chain carrying no NaN, and three for the truncation — a cancelled run, an untouched dense chain, and one with no complete draw coming back empty rather than all-NaN.

The real-pyMC end-to-end now asserts the last partial chain equals what `pm.sample` went on to return **column for column**, rather than as a pooled concatenation. It also pins the growth pattern: `(2,1,2) (4,1,2) (6,1,2) (6,2,2) (6,2,2) (6,2,2)` — chain 0 filling, then chain 1 appearing as a second column.

43 UQ chain tests pass; full non-slow suite shows no new failures (only the pre-existing `test_mpi_utils` subprocess cases under the OpenCOR shell).

The CUFLynx side — skipping NaN in the live plots — follows separately.
