### PR TITLE
fix(tests): listing the suite is not a run to wait for

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1105,12 +1105,19 @@ def _set_expected_summary_totals(autogen_count: int, misc_count: int, solver_cou
     os.environ["SOLVER_SUMMARY_TOTAL"] = str(solver_count)
 
 
-def _should_wait_for_result_files(exitstatus, terminalreporter) -> bool:
+def _should_wait_for_result_files(exitstatus, terminalreporter, config) -> bool:
     """
     Only wait for one-rank result files when pytest completed normal test
     execution. Collection/import/internal errors never produce those files and
     would otherwise stall the summary for the full timeout.
+
+    ``--collect-only`` is the same trap wearing a clean exit status: collection
+    still counts the one-rank tests into the *_SUMMARY_TOTAL environment
+    variables, but no test runs, so nothing ever appends to the result files and
+    the summary blocks for 1800 s per file -- 90 minutes to list the suite.
     """
+    if config.getoption("collectonly", False):
+        return False
     if terminalreporter.stats.get("error"):
         return False
     return exitstatus in (0, 1)
@@ -1194,7 +1201,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if rank != 0:
         return
 
-    if _should_wait_for_result_files(exitstatus, terminalreporter):
+    if _should_wait_for_result_files(exitstatus, terminalreporter, config):
         _wait_for_expected_result_count(
             _AUTOGEN_RESULTS_FILE,
             int(os.environ.get("AUTOGEN_SUMMARY_TOTAL", "0")),

--- a/tests/test_collect_only_no_summary_wait.py
+++ b/tests/test_collect_only_no_summary_wait.py
@@ -1,0 +1,74 @@
+"""``--collect-only`` must not block in the one-rank result-file wait.
+
+Listing the suite runs no tests, but ``pytest_collection_modifyitems`` still counts the
+one-rank tests (autogeneration, solver, misc) into the ``*_SUMMARY_TOTAL`` environment
+variables, and pytest then exits 0 with no errors. That combination used to satisfy
+``_should_wait_for_result_files``, so ``pytest_terminal_summary`` waited on three result
+files that nothing would ever write -- 1800 s each, 90 minutes to answer "what tests are
+there". Only the three modules that populate those totals were affected
+(``test_autogeneration.py``, ``test_solvers.py``, ``test_omex_analysis_pipeline.py``);
+every other file listed in about three seconds, which is why the hang looked like a slow
+import rather than a wait.
+
+A real run is unaffected -- the tests execute and append their lines, so the wait returns
+on its first iteration. That is exactly why this needs a test: the bug is invisible to a
+green suite.
+
+These exercise ``_should_wait_for_result_files`` directly rather than launching a nested
+pytest, for the reason ``test_manual_marker.py`` documents: an inner session's
+``pytest_configure`` deletes the shared ``.pytest_*_results`` files, wiping the *outer*
+run's accumulated results and sending it into the very 1800 s wait this file is about.
+"""
+import pytest
+
+from conftest import _should_wait_for_result_files
+
+
+class _Config:
+    """The one thing ``_should_wait_for_result_files`` uses from a pytest Config."""
+
+    def __init__(self, collectonly):
+        self._collectonly = collectonly
+
+    def getoption(self, name, default=None):
+        assert name == "collectonly", name
+        return self._collectonly
+
+
+class _TerminalReporter:
+    def __init__(self, stats=None):
+        self.stats = stats or {}
+
+
+@pytest.mark.unit
+def test_collect_only_does_not_wait():
+    """The regression: a clean --collect-only exit must skip the wait."""
+    assert not _should_wait_for_result_files(
+        0, _TerminalReporter(), _Config(collectonly=True)
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("exitstatus", [0, 1])
+def test_normal_run_still_waits(exitstatus):
+    """A real run (pass or fail) still waits, so the rank-0 summary stays complete."""
+    assert _should_wait_for_result_files(
+        exitstatus, _TerminalReporter(), _Config(collectonly=False)
+    )
+
+
+@pytest.mark.unit
+def test_collection_error_still_does_not_wait():
+    """The pre-existing guard is untouched: errors never produce result files."""
+    assert not _should_wait_for_result_files(
+        1, _TerminalReporter({"error": [object()]}), _Config(collectonly=False)
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("exitstatus", [2, 3, 4, 5])
+def test_abnormal_exit_status_still_does_not_wait(exitstatus):
+    """Interrupted / internal-error / usage-error / no-tests-collected exits."""
+    assert not _should_wait_for_result_files(
+        exitstatus, _TerminalReporter(), _Config(collectonly=False)
+    )


### PR DESCRIPTION
## The problem

`pytest --collect-only` took up to **90 minutes**. Not collection — a wait.

`pytest_collection_modifyitems` counts the one-rank tests into `AUTOGEN_SUMMARY_TOTAL` / `SOLVER_SUMMARY_TOTAL` / `MISC_SUMMARY_TOTAL` whether or not anything is going to run. Under `--collect-only` pytest then exits 0 with no errors, which is exactly what `_should_wait_for_result_files` reads as "a normal run completed", so `pytest_terminal_summary` waits on three result files that nothing will ever write — 1800 s each.

Only the three modules that populate those totals were affected, which is why the symptom read as a slow import rather than a wait:

| Listing | Before | After |
|---|---|---|
| `test_solvers.py` + `test_autogeneration.py` + `test_omex_analysis_pipeline.py` | exceeded a 100 s timeout | **2.2 s** |
| Full suite (1034 tests) | up to 90 min | **4.4 s** |
| Any other single file | ~3 s | ~3 s |

A real run never hit this: the tests execute, append their lines, and the wait returns on its first iteration. **The bug is invisible to a green suite** — which is the case for a test.

## The fix

`_should_wait_for_result_files` takes `config` and bails when `collectonly` is set, ahead of the existing error and exit-status guards. Those guards are unchanged: an errored or abnormally-exiting session still skips the wait, and a real run — passing or failing — still waits, so the rank-0 aggregated summary stays complete.

## Tests

`tests/test_collect_only_no_summary_wait.py`, 8 unit tests: the collect-only case, both normal exit statuses, the error guard, and abnormal statuses 2–5.

They exercise the helper directly with a fake config rather than launching a nested pytest, for the reason `test_manual_marker.py` already documents — an inner session's `pytest_configure` deletes the shared `.pytest_*_results` files, wiping the outer run's results and dropping it into the very 1800 s wait this PR removes.

With the fix reverted all 8 fail, though on a `TypeError` from the old two-argument signature rather than on the behaviour: the signature change is inseparable from the fix, since the helper had no access to `config` before. The timing above is the direct evidence.

## Verification

- New tests: 8 passed
- `-m unit`: 553 passed, 3 skipped
- Full-suite `--collect-only`: 4.41 s, 1034 tests listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)