### PR TITLE
Give the three external_python examples a protocol_info

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -395,9 +395,10 @@ jobs:
 
   # The FEniCSx flagship for `model_type: external_python` (funcs_user/heat_fenics). It is a
   # finite-element solver written against dolfinx, and dolfinx is a conda-forge package that
-  # pip cannot provide -- so no other job here can install it, and without this one
-  # tests/test_heat_fenics_example.py skips at collection and the shipped example goes
-  # untested. That is the failure this job exists to prevent: an example that stops working
+  # pip cannot provide -- so no other job here can install it, and without this one every
+  # test in tests/test_heat_fenics_example.py that actually solves something skips and the
+  # shipped example goes untested. (Only its obs_data check runs elsewhere: that one reads a
+  # JSON file.) That is the failure this job exists to prevent: an example that stops working
   # against a new dolfinx, or against a change to the external backend, with CI still green.
   #
   # Its own job rather than extra cases on `test`, for the same reason test-uq is its own job:

--- a/funcs_user/example_model_external/README.md
+++ b/funcs_user/example_model_external/README.md
@@ -23,7 +23,7 @@ with [`../example_model_scipy/`](../example_model_scipy/) instead — same contr
 | `heat1d_model.py` | The solver class plus `SIM_HELPER = Heat1D`. |
 | `heat1d_params_for_id.csv` | Parameters to calibrate / sweep (`k`, `u_D`) with bounds. |
 | `heat1d_parameters.csv` | Default parameter values (the calibration start point). |
-| `heat1d_obs_data.json` | Target observables — the three probe means at the "true" `k=0.25, u_D=0.1`. |
+| `heat1d_obs_data.json` | The `protocol_info` (the run window) plus target observables — the three probe means at the "true" `k=0.25, u_D=0.1`. |
 
 ## The contract
 
@@ -92,13 +92,35 @@ solver_info:
   # Free-form; handed to init_solver as config['solver_info']['user_config']. This model uses
   # it for the explicit scheme's stability margin.
   user_config: {stability_target: 0.4}
-pre_time: 0.0
-sim_time: 0.5
+# No pre_time/sim_time here: the run window lives in heat1d_obs_data.json's protocol_info
+# (pre_times: [0.0], sim_times: [[0.5]]), because it is the window the target values were
+# computed on. dt is still a yaml setting.
 dt: 0.005
 param_id_method: genetic_algorithm
 ```
 
 There is **no code generation step**: `run_autogeneration.sh` only checks that the file exists.
+
+## The run window is in the obs_data
+
+`heat1d_obs_data.json` opens with a `protocol_info`:
+
+```json
+"protocol_info": {
+  "pre_times": [0.0],
+  "sim_times": [[0.5]],
+  "params_to_change": {}
+}
+```
+
+`pre_times` holds one entry per experiment and `sim_times` one list per experiment, one entry
+per subexperiment — here a single experiment of a single 0.5 s stretch, run from `t = 0` with no
+spin-up. That protocol is what CA drives the model with, and what the CUFLynx GUI reads to know
+the window; a `pre_time`/`sim_time` in `user_inputs.yaml` is only the fallback for an obs_data
+that has no `protocol_info` at all.
+
+The three probe means below it are computed **over exactly that window**, so changing
+`sim_times` invalidates them.
 
 ## Running
 

--- a/funcs_user/example_model_external/heat1d_obs_data.json
+++ b/funcs_user/example_model_external/heat1d_obs_data.json
@@ -1,38 +1,46 @@
-[
-  { "variable": "probe 1 mean temperature",
-    "name_for_plotting": "mean(T_p1)",
-    "data_type": "constant",
-    "operation": "mean",
-    "operands": ["heat/T_p1"],
-    "unit": "dimensionless",
-    "weight": 1.0,
-    "value": 0.25338190,
-    "std": 0.005,
-    "cost_type": "gaussian_MLE",
-    "plot_type": "horizontal"
+{
+  "protocol_info": {
+    "pre_times": [0.0],
+    "sim_times": [[0.5]],
+    "params_to_change": {},
+    "comment": "The window these targets were computed on: pre_time 0.0, sim_time 0.5 with dt 0.005 (100 steps). Changing it changes every value below."
   },
-  { "variable": "probe 2 mean temperature",
-    "name_for_plotting": "mean(T_p2)",
-    "data_type": "constant",
-    "operation": "mean",
-    "operands": ["heat/T_p2"],
-    "unit": "dimensionless",
-    "weight": 1.0,
-    "value": 0.23883291,
-    "std": 0.005,
-    "cost_type": "gaussian_MLE",
-    "plot_type": "horizontal"
-  },
-  { "variable": "probe 3 mean temperature",
-    "name_for_plotting": "mean(T_p3)",
-    "data_type": "constant",
-    "operation": "mean",
-    "operands": ["heat/T_p3"],
-    "unit": "dimensionless",
-    "weight": 1.0,
-    "value": 0.14911117,
-    "std": 0.005,
-    "cost_type": "gaussian_MLE",
-    "plot_type": "horizontal"
-  }
-]
+  "data_items": [
+    { "variable": "probe 1 mean temperature",
+      "name_for_plotting": "mean(T_p1)",
+      "data_type": "constant",
+      "operation": "mean",
+      "operands": ["heat/T_p1"],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 0.25338190,
+      "std": 0.005,
+      "cost_type": "gaussian_MLE",
+      "plot_type": "horizontal"
+    },
+    { "variable": "probe 2 mean temperature",
+      "name_for_plotting": "mean(T_p2)",
+      "data_type": "constant",
+      "operation": "mean",
+      "operands": ["heat/T_p2"],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 0.23883291,
+      "std": 0.005,
+      "cost_type": "gaussian_MLE",
+      "plot_type": "horizontal"
+    },
+    { "variable": "probe 3 mean temperature",
+      "name_for_plotting": "mean(T_p3)",
+      "data_type": "constant",
+      "operation": "mean",
+      "operands": ["heat/T_p3"],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 0.14911117,
+      "std": 0.005,
+      "cost_type": "gaussian_MLE",
+      "plot_type": "horizontal"
+    }
+  ]
+}

--- a/funcs_user/example_model_scipy/README.md
+++ b/funcs_user/example_model_scipy/README.md
@@ -33,7 +33,7 @@ one.
 | `oscillator_model.py` | The model class plus `SIM_HELPER = Oscillator`. |
 | `oscillator_params_for_id.csv` | Parameters to calibrate / sweep (`c`, `k`) with bounds. |
 | `oscillator_parameters.csv` | Default parameter values (the calibration start point). |
-| `oscillator_obs_data.json` | Target observables — `mean(x)`, `min(x)`, `range(v)` at the "true" `c=0.7, k=5.0`. |
+| `oscillator_obs_data.json` | The `protocol_info` (the run window) plus target observables — `mean(x)`, `min(x)`, `range(v)` at the "true" `c=0.7, k=5.0`. |
 
 `oscillator/energy` is exposed as an output but not scored by any observable; it is there to show
 that an algebraic quantity needs no special hook under this contract — it is one more key in the
@@ -106,13 +106,36 @@ solver_info:
   # Free-form; handed to init_solver as config['solver_info']['user_config']. This model uses it
   # for the solve_ivp settings CA used to own when it did the integrating.
   user_config: {method: RK45, rtol: 1.0e-8, atol: 1.0e-8}
-pre_time: 0.0
-sim_time: 10.0
+# No pre_time/sim_time here: the run window lives in oscillator_obs_data.json's
+# protocol_info (pre_times: [0.0], sim_times: [[10.0]]), because it is the window the
+# target values were computed on. dt is still a yaml setting.
 dt: 0.05
 param_id_method: genetic_algorithm
 ```
 
 There is **no code generation step**: `run_autogeneration.sh` only checks that the file exists.
+
+## The run window is in the obs_data
+
+`oscillator_obs_data.json` opens with a `protocol_info`:
+
+```json
+"protocol_info": {
+  "pre_times": [0.0],
+  "sim_times": [[10.0]],
+  "params_to_change": {}
+}
+```
+
+`pre_times` holds one entry per experiment and `sim_times` one list per experiment, one entry
+per subexperiment — here a single experiment of a single 10 s stretch, run from `t = 0` with no
+spin-up. That protocol is what CA drives the model with, and what the CUFLynx GUI reads to know
+the window; a `pre_time`/`sim_time` in `user_inputs.yaml` is only the fallback for an obs_data
+that has no `protocol_info` at all.
+
+The three values below it are `mean(x)`, `min(x)` and `range(v)` **over exactly that window**.
+Change `sim_times` and they no longer describe this model — regenerate them (below) rather than
+leaving the mismatch.
 
 ## Running
 

--- a/funcs_user/example_model_scipy/oscillator_obs_data.json
+++ b/funcs_user/example_model_scipy/oscillator_obs_data.json
@@ -1,38 +1,46 @@
-[
-  { "variable": "displacement mean",
-    "name_for_plotting": "mean(x)",
-    "data_type": "constant",
-    "operation": "mean",
-    "operands": ["oscillator/x"],
-    "unit": "dimensionless",
-    "weight": 1.0,
-    "value": 0.01663962,
-    "std": 0.002,
-    "cost_type": "gaussian_MLE",
-    "plot_type": "horizontal"
+{
+  "protocol_info": {
+    "pre_times": [0.0],
+    "sim_times": [[10.0]],
+    "params_to_change": {},
+    "comment": "The window these targets were computed on: pre_time 0.0, sim_time 10.0 with dt 0.05 (200 steps). Changing it changes every value below."
   },
-  { "variable": "displacement min",
-    "name_for_plotting": "min(x)",
-    "data_type": "constant",
-    "operation": "min",
-    "operands": ["oscillator/x"],
-    "unit": "dimensionless",
-    "weight": 1.0,
-    "value": -0.60704870,
-    "std": 0.03,
-    "cost_type": "gaussian_MLE",
-    "plot_type": "horizontal"
-  },
-  { "variable": "velocity range",
-    "name_for_plotting": "range(v)",
-    "data_type": "constant",
-    "operation": "max_minus_min",
-    "operands": ["oscillator/v"],
-    "unit": "dimensionless",
-    "weight": 1.0,
-    "value": 2.87274454,
-    "std": 0.1,
-    "cost_type": "gaussian_MLE",
-    "plot_type": "horizontal_from_min"
-  }
-]
+  "data_items": [
+    { "variable": "displacement mean",
+      "name_for_plotting": "mean(x)",
+      "data_type": "constant",
+      "operation": "mean",
+      "operands": ["oscillator/x"],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 0.01663962,
+      "std": 0.002,
+      "cost_type": "gaussian_MLE",
+      "plot_type": "horizontal"
+    },
+    { "variable": "displacement min",
+      "name_for_plotting": "min(x)",
+      "data_type": "constant",
+      "operation": "min",
+      "operands": ["oscillator/x"],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": -0.60704870,
+      "std": 0.03,
+      "cost_type": "gaussian_MLE",
+      "plot_type": "horizontal"
+    },
+    { "variable": "velocity range",
+      "name_for_plotting": "range(v)",
+      "data_type": "constant",
+      "operation": "max_minus_min",
+      "operands": ["oscillator/v"],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 2.87274454,
+      "std": 0.1,
+      "cost_type": "gaussian_MLE",
+      "plot_type": "horizontal_from_min"
+    }
+  ]
+}

--- a/funcs_user/heat_fenics/README.md
+++ b/funcs_user/heat_fenics/README.md
@@ -83,7 +83,7 @@ whole run **milliseconds** once the forms are compiled; the one-off FFCx compila
 |---|---|
 | `heat_fenics_model.py` | The solver class (`parameters`, `output_names`, `init_solver`, `update_times`, `set_param_vals`, `run`, `get_results`, `reset`, `extra_plots`, `close`) and `SIM_HELPER`. |
 | `heat_fenics_params_for_id.csv` | The calibration box: `heat/k ∈ [0.001, 0.2]`, `heat/u_D ∈ [-0.5, 0.5]`. |
-| `heat_fenics_obs_data.json` | Six scalar observables — `mean` and `min` of each of the three probes, so every probe is scored against a ground truth rather than only the centre one. |
+| `heat_fenics_obs_data.json` | The `protocol_info` (the `dt = 0.02` / `sim_time = 2.0` window, above) plus six scalar observables — `mean` and `min` of each of the three probes, so every probe is scored against a ground truth rather than only the centre one. |
 
 !!! warning "Why not `max(T_p*)`?"
     The maximum of every probe is its *initial* value, which is the uniform `1.0` for every
@@ -140,8 +140,9 @@ external_model_path: <CA_dir>/funcs_user/heat_fenics/heat_fenics_model.py
 resources_dir: <CA_dir>/funcs_user/heat_fenics
 param_id_obs_path: <CA_dir>/funcs_user/heat_fenics/heat_fenics_obs_data.json
 
-pre_time: 0.0
-sim_time: 2.0
+# No pre_time/sim_time here: the run window lives in heat_fenics_obs_data.json's
+# protocol_info (pre_times: [0.0], sim_times: [[2.0]]), because it is the window the six
+# target values were computed on. dt is still a yaml setting.
 dt: 0.02
 
 param_id_method: genetic_algorithm
@@ -180,8 +181,24 @@ See [Emulators](../../tutorial/docs/emulators.md) for the rest.
 
 ## About the numbers in `heat_fenics_obs_data.json`
 
+The file opens with the window they belong to, so the two travel together:
+
+```json
+"protocol_info": {
+  "pre_times": [0.0],
+  "sim_times": [[2.0]],
+  "params_to_change": {}
+}
+```
+
+`pre_times` holds one entry per experiment and `sim_times` one list per experiment, one entry
+per subexperiment — here a single experiment of a single 2 s stretch, run from `t = 0` with no
+spin-up. That protocol is what CA drives the model with, and what the CUFLynx GUI reads to know
+the window; a `pre_time`/`sim_time` in `user_inputs.yaml` is only the fallback for an obs_data
+that has no `protocol_info` at all.
+
 The six values are the model's own output at the default parameters `k = 0.05`,
-`u_D = 0.25` on the suggested `dt = 0.02` / `sim_time = 2.0` grid — **estimates**, computed
+`u_D = 0.25` on that `dt = 0.02` / `sim_time = 2.0` grid — **estimates**, computed
 from a matched finite-difference solve of the same problem rather than from dolfinx itself
 (the authoring machine had no FEniCSx), and quoted with a `std` that comfortably covers both
 the FD-vs-P1-FEM gap and the discretisation error of the 16×16 backward-Euler scheme. They
@@ -196,7 +213,9 @@ order):
 python funcs_user/heat_fenics/heat_fenics_model.py
 ```
 
-Changing `nx`, `dt` or `sim_time` changes them, so regenerate after any such change.
+Changing `nx`, `dt` or `sim_times` changes them, so regenerate after any such change — and
+change `sim_times` in the `protocol_info` above, not only in the `__main__` block, or the file
+will name one window and hold another's numbers.
 
 ## See also
 

--- a/funcs_user/heat_fenics/heat_fenics_obs_data.json
+++ b/funcs_user/heat_fenics/heat_fenics_obs_data.json
@@ -1,92 +1,100 @@
-[
-  {
-    "variable": "near probe mean",
-    "name_for_plotting": "mean(T_{p1})",
-    "data_type": "constant",
-    "operation": "mean",
-    "operands": [
-      "heat/T_p1"
-    ],
-    "unit": "dimensionless",
-    "weight": 1.0,
-    "value": 0.47,
-    "std": 0.02,
-    "cost_type": "gaussian_MLE",
-    "plot_type": "horizontal"
+{
+  "protocol_info": {
+    "pre_times": [0.0],
+    "sim_times": [[2.0]],
+    "params_to_change": {},
+    "comment": "The window these targets were computed on: pre_time 0.0, sim_time 2.0 with dt 0.02 (100 steps). Changing it changes every value below."
   },
-  {
-    "variable": "near probe minimum",
-    "name_for_plotting": "min(T_{p1})",
-    "data_type": "constant",
-    "operation": "min",
-    "operands": [
-      "heat/T_p1"
-    ],
-    "unit": "dimensionless",
-    "weight": 1.0,
-    "value": 0.215,
-    "std": 0.015,
-    "cost_type": "gaussian_MLE",
-    "plot_type": "horizontal"
-  },
-  {
-    "variable": "centre probe mean",
-    "name_for_plotting": "mean(T_{p2})",
-    "data_type": "constant",
-    "operation": "mean",
-    "operands": [
-      "heat/T_p2"
-    ],
-    "unit": "dimensionless",
-    "weight": 1.0,
-    "value": 0.645,
-    "std": 0.02,
-    "cost_type": "gaussian_MLE",
-    "plot_type": "horizontal"
-  },
-  {
-    "variable": "centre probe minimum",
-    "name_for_plotting": "min(T_{p2})",
-    "data_type": "constant",
-    "operation": "min",
-    "operands": [
-      "heat/T_p2"
-    ],
-    "unit": "dimensionless",
-    "weight": 1.0,
-    "value": 0.278,
-    "std": 0.015,
-    "cost_type": "gaussian_MLE",
-    "plot_type": "horizontal"
-  },
-  {
-    "variable": "far probe mean",
-    "name_for_plotting": "mean(T_{p3})",
-    "data_type": "constant",
-    "operation": "mean",
-    "operands": [
-      "heat/T_p3"
-    ],
-    "unit": "dimensionless",
-    "weight": 1.0,
-    "value": 0.403,
-    "std": 0.02,
-    "cost_type": "gaussian_MLE",
-    "plot_type": "horizontal"
-  },
-  {
-    "variable": "far probe minimum",
-    "name_for_plotting": "min(T_{p3})",
-    "data_type": "constant",
-    "operation": "min",
-    "operands": [
-      "heat/T_p3"
-    ],
-    "unit": "dimensionless",
-    "weight": 1.0,
-    "value": 0.125,
-    "std": 0.015,
-    "cost_type": "gaussian_MLE",
-    "plot_type": "horizontal"
-  }
-]
+  "data_items": [
+    {
+      "variable": "near probe mean",
+      "name_for_plotting": "mean(T_{p1})",
+      "data_type": "constant",
+      "operation": "mean",
+      "operands": [
+        "heat/T_p1"
+      ],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 0.47,
+      "std": 0.02,
+      "cost_type": "gaussian_MLE",
+      "plot_type": "horizontal"
+    },
+    {
+      "variable": "near probe minimum",
+      "name_for_plotting": "min(T_{p1})",
+      "data_type": "constant",
+      "operation": "min",
+      "operands": [
+        "heat/T_p1"
+      ],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 0.215,
+      "std": 0.015,
+      "cost_type": "gaussian_MLE",
+      "plot_type": "horizontal"
+    },
+    {
+      "variable": "centre probe mean",
+      "name_for_plotting": "mean(T_{p2})",
+      "data_type": "constant",
+      "operation": "mean",
+      "operands": [
+        "heat/T_p2"
+      ],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 0.645,
+      "std": 0.02,
+      "cost_type": "gaussian_MLE",
+      "plot_type": "horizontal"
+    },
+    {
+      "variable": "centre probe minimum",
+      "name_for_plotting": "min(T_{p2})",
+      "data_type": "constant",
+      "operation": "min",
+      "operands": [
+        "heat/T_p2"
+      ],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 0.278,
+      "std": 0.015,
+      "cost_type": "gaussian_MLE",
+      "plot_type": "horizontal"
+    },
+    {
+      "variable": "far probe mean",
+      "name_for_plotting": "mean(T_{p3})",
+      "data_type": "constant",
+      "operation": "mean",
+      "operands": [
+        "heat/T_p3"
+      ],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 0.403,
+      "std": 0.02,
+      "cost_type": "gaussian_MLE",
+      "plot_type": "horizontal"
+    },
+    {
+      "variable": "far probe minimum",
+      "name_for_plotting": "min(T_{p3})",
+      "data_type": "constant",
+      "operation": "min",
+      "operands": [
+        "heat/T_p3"
+      ],
+      "unit": "dimensionless",
+      "weight": 1.0,
+      "value": 0.125,
+      "std": 0.015,
+      "cost_type": "gaussian_MLE",
+      "plot_type": "horizontal"
+    }
+  ]
+}

--- a/tests/test_external_simulation_helper.py
+++ b/tests/test_external_simulation_helper.py
@@ -10,6 +10,7 @@ files, because what they need is a class that is *wrong* in one specific way. Th
 example, the scipy ODE in ``funcs_user/example_model_scipy/``, has its own file
 (``tests/test_scipy_ode_example.py``).
 """
+import json
 import os
 import shutil
 import textwrap
@@ -18,7 +19,7 @@ import numpy as np
 import pytest
 from mpi4py import MPI
 
-from parsers.PrimitiveParsers import YamlFileParser
+from parsers.PrimitiveParsers import ObsAndParamDataParser, YamlFileParser
 from solver_wrappers import get_simulation_helper, get_simulation_helper_from_inp_data_dict
 from solver_wrappers.external_simulation_helper import SimulationHelper as ExternalSimulationHelper
 from scripts.script_generate_with_new_architecture import generate_with_new_architecture
@@ -30,8 +31,11 @@ _EXAMPLE_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), '..', 'funcs_user', 'example_model_external')
 )
 _MODEL_PATH = os.path.join(_EXAMPLE_DIR, 'heat1d_model.py')
+_OBS_DATA_PATH = os.path.join(_EXAMPLE_DIR, 'heat1d_obs_data.json')
 # Ground truth used to build heat1d_obs_data.json (the defaults are k=0.4, u_D=0.0).
 _TRUE_K, _TRUE_U_D = 0.25, 0.1
+# The window the three probe means in heat1d_obs_data.json were computed on.
+_DT, _SIM_TIME = 0.005, 0.5
 _SOLVER_INFO = {'solver': 'external', 'method': 'external'}
 
 
@@ -64,8 +68,8 @@ def _heat1d_config(base_user_inputs, temp_output_dir, temp_generated_models_dir)
         'resources_dir': resources_dir,
         'param_id_method': 'genetic_algorithm',
         'pre_time': 0.0,
-        'sim_time': 0.5,
-        'dt': 0.005,
+        'sim_time': _SIM_TIME,
+        'dt': _DT,
         'DEBUG': True,
         'do_uq': False,
         'do_ad': False,
@@ -116,6 +120,40 @@ _MINIMAL_MODEL = '''
 
     SIM_HELPER = Tiny
 '''
+
+
+# ---------------------------------------------------------------------------
+# The shipped obs_data
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_the_shipped_obs_data_carries_the_window_its_values_were_computed_on():
+    """``heat1d_obs_data.json`` must name its own run window in ``protocol_info``.
+
+    The three probe means below it are means over the 0.5 s window and nothing else, so the
+    window belongs in the file rather than in whatever ``user_inputs.yaml`` happens to say. It
+    is also the only place the CUFLynx GUI looks when it sizes a run: an example with no
+    ``protocol_info`` cannot be run from it at all.
+
+    (This is about what the *example* ships, not about what the parser allows. CA still
+    accepts a bare list of data_items and synthesises a protocol from the yaml's window;
+    ``tests/test_operation_kwargs.py::test_shipped_extra_ops_obs_data_json_still_validates``
+    is where that support is pinned.)
+    """
+    with open(_OBS_DATA_PATH) as handle:
+        shipped = json.load(handle)
+
+    protocol = shipped['protocol_info']
+    # pre_times is per experiment; sim_times is per experiment, per subexperiment. One
+    # experiment of one 0.5 s stretch, from t = 0, with no spin-up to discard.
+    assert protocol['pre_times'] == [0.0]
+    assert protocol['sim_times'] == [[_SIM_TIME]]
+
+    # And it still parses -- with no pre_time/sim_time offered, so the file has to be
+    # self-sufficient rather than falling back on the yaml's window.
+    parsed = ObsAndParamDataParser().parse_obs_data_json(param_id_obs_path=_OBS_DATA_PATH)
+    assert parsed['protocol_info']['pre_times'] == [0.0]
+    assert parsed['protocol_info']['sim_times'] == [[_SIM_TIME]]
+    assert len(parsed['gt_df']) == len(shipped['data_items']) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_heat_fenics_example.py
+++ b/tests/test_heat_fenics_example.py
@@ -6,8 +6,11 @@ tests that run the real library rather than a stub -- which is what the ``test-f
 job in ``.github/workflows/tests.yml`` exists for: it installs ``fenics-dolfinx`` from
 conda-forge and runs this file.
 
-Five layers, in increasing order of how much of CA they involve:
+Six layers, in increasing order of how much of CA they involve:
 
+* **the shipped obs_data** -- ``heat_fenics_obs_data.json`` names the run window its six
+  values were computed on, in its ``protocol_info``. Plain JSON, so this one runs without
+  dolfinx: it is a statement about the fixture, not about the solver.
 * **smoke** -- load the file, set it up, run it, and check the record grid is exactly the
   length the contract promises. Also that a second ``run()`` at the same parameters is
   bit-identical, because a calibration reuses one instance for thousands of samples.
@@ -26,8 +29,9 @@ Five layers, in increasing order of how much of CA they involve:
   fingerprint covers ``protocol_info``'s ``pre_times``/``sim_times``, so training on one
   timeline and calibrating on another is refused as stale rather than answered.
 
-Everything here skips cleanly without dolfinx (and the last two without autoemulate), so the
-file collects on a machine with neither.
+Everything that touches the solver skips cleanly without dolfinx (and the last two without
+autoemulate), so the file collects on a machine with neither -- and the obs_data layer still
+runs there.
 """
 import importlib.util
 import json
@@ -38,9 +42,13 @@ import time
 import numpy as np
 import pytest
 
-# dolfinx is a conda-forge package that most CA environments do not have. Nothing below this
-# line can be imported without it, so the whole file skips rather than erroring at collection.
-dolfinx = pytest.importorskip('dolfinx')
+
+# dolfinx is a conda-forge package that most CA environments do not have, so every test that
+# actually solves something skips through this. It is *not* module level: the shipped obs_data
+# is plain JSON, and the test that it names its window is worth running everywhere rather than
+# only on the one CI job with FEniCSx installed.
+def _require_dolfinx():
+    return pytest.importorskip('dolfinx')
 
 
 _EXAMPLE_DIR = os.path.realpath(
@@ -72,6 +80,18 @@ _FAST_CONFIG = {
 _OVERSHOOT_TOL = 0.02
 
 
+#: The window ``heat_fenics_obs_data.json``'s six values were computed on, and therefore the
+#: window its ``protocol_info`` has to name. From the README's "Time scales" section: 100 steps
+#: of 0.02 s, which at the default k = 0.05 is about two time constants of the plate.
+_SHIPPED_WINDOW = {'pre_time': 0.0, 'sim_time': 2.0, 'dt': 0.02}
+
+
+def _shipped_obs_data():
+    """The whole shipped obs_data document: its ``protocol_info`` and its ``data_items``."""
+    with open(_OBS_DATA_PATH) as handle:
+        return json.load(handle)
+
+
 def _shipped_obs_items():
     """The data_items the example actually ships, in file order.
 
@@ -79,12 +99,12 @@ def _shipped_obs_items():
     ``heat_fenics_obs_data.json`` -- which has happened once already, from two items to six --
     does not leave a stale number behind here to fail on.
     """
-    with open(_OBS_DATA_PATH) as handle:
-        return json.load(handle)
+    return _shipped_obs_data()['data_items']
 
 
 def _load_model_class():
     """Load the example exactly the way CA's external backend does: by file path."""
+    _require_dolfinx()
     spec = importlib.util.spec_from_file_location('heat_fenics_model_under_test', _MODEL_PATH)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -110,6 +130,47 @@ def model(model_class):
 def _expected_num_samples(config):
     """The contract's own arithmetic, spelled out so a mismatch names the rule it broke."""
     return int(config['pre_time'] / config['dt']) + int(config['sim_time'] / config['dt']) + 1
+
+
+# ---------------------------------------------------------------------------------------
+# The shipped obs_data. No dolfinx: this is a statement about a JSON file.
+# ---------------------------------------------------------------------------------------
+@pytest.mark.unit
+def test_the_shipped_obs_data_carries_the_window_its_values_were_computed_on():
+    """``heat_fenics_obs_data.json`` must name its own run window in ``protocol_info``.
+
+    The six values in it are the model's output on the README's ``dt = 0.02`` /
+    ``sim_time = 2.0`` grid -- ``min(T_p*)`` is *the temperature reached by the end of the
+    window*, so read off a shorter one it is a different number entirely. Carrying the window
+    in the file is what keeps the two from being separately editable.
+
+    It is also the only place the CUFLynx GUI looks when it sizes a run, so an example with no
+    ``protocol_info`` cannot be run from the GUI at all. (CA itself still accepts a bare list
+    of data_items -- that is about the parser, and is pinned in
+    ``tests/test_operation_kwargs.py``. This is about what the example ships.)
+
+    Deliberately outside the dolfinx skip: nothing here solves anything, and this is exactly
+    the assertion that must not go quiet on the machines without FEniCSx -- which is most of
+    them.
+    """
+    shipped = _shipped_obs_data()
+
+    protocol = shipped['protocol_info']
+    # pre_times is per experiment; sim_times is per experiment, per subexperiment. One
+    # experiment of one 2 s stretch, from t = 0, with no spin-up to discard.
+    assert protocol['pre_times'] == [_SHIPPED_WINDOW['pre_time']]
+    assert protocol['sim_times'] == [[_SHIPPED_WINDOW['sim_time']]]
+
+    # And it still parses -- with no pre_time/sim_time offered, so the file has to be
+    # self-sufficient rather than falling back on a yaml's window.
+    from parsers.PrimitiveParsers import ObsAndParamDataParser
+
+    parsed = ObsAndParamDataParser().parse_obs_data_json(param_id_obs_path=_OBS_DATA_PATH)
+    assert parsed['protocol_info']['pre_times'] == [_SHIPPED_WINDOW['pre_time']]
+    assert parsed['protocol_info']['sim_times'] == [[_SHIPPED_WINDOW['sim_time']]]
+    assert len(parsed['gt_df']) == len(shipped['data_items'])
+    # The window and dt divide into the whole number of steps the README quotes.
+    assert _expected_num_samples(_SHIPPED_WINDOW) == 101
 
 
 @pytest.mark.integration
@@ -334,20 +395,46 @@ def test_extra_plots_before_a_run_says_so(model):
 #: GUI, and the point of stating the timeline once here is that this file cannot reproduce it
 #: by accident -- it reproduces it deliberately, at the end of the calibration test.
 #:
+#: ``pre_time``/``sim_time`` here are not yaml keys any more: the obs_data's ``protocol_info``
+#: is the run window, so ``_copy_resources`` writes them into the copy it hands these tests.
+#: ``dt`` still is a yaml key.
+#:
 #: A coarse grid on a coarse mesh: 10 steps of an 8x8 problem per training sample, over the 1 s
-#: window the k in [0.001, 0.2] box actually shows cooling in. The features still move over the
-#: whole params_for_id box, which is all the emulator needs, and a few dozen of them take
-#: seconds rather than minutes.
+#: window the k in [0.001, 0.2] box actually shows cooling in -- a third of the shipped window,
+#: which none of the assertions below need. The features still move over the whole
+#: params_for_id box, which is all the emulator needs, and a few dozen of them take seconds
+#: rather than minutes.
 _EMULATOR_TIMELINE = {'pre_time': 0.0, 'sim_time': 1.0, 'dt': 0.1}
 
 
-def _copy_resources(temp_output_dir):
+def _copy_resources(temp_output_dir, sim_time=None, subdir='heat_fenics_resources'):
     """The example's CSV/JSON in a per-test directory, so a run never writes back into the
-    repo's ``funcs_user/heat_fenics``."""
-    resources_dir = os.path.join(temp_output_dir, 'heat_fenics_resources')
+    repo's ``funcs_user/heat_fenics``.
+
+    The copy's ``protocol_info`` is rewritten to ``sim_time`` on the way (default:
+    ``_EMULATOR_TIMELINE``'s). The shipped file names the 2 s window its six values were
+    computed on; these tests want the shorter one, and since the window now lives in the
+    obs_data rather than in ``user_inputs.yaml``, wanting a different window means writing a
+    different obs_data. That is also how the stale-emulator check below gets a *second*
+    timeline to ask for -- a ``sim_time`` key in the config would no longer change anything.
+    """
+    if sim_time is None:
+        sim_time = _EMULATOR_TIMELINE['sim_time']
+    resources_dir = os.path.join(temp_output_dir, subdir)
     os.makedirs(resources_dir, exist_ok=True)
     for name in _RESOURCE_FILES:
         shutil.copy(os.path.join(_EXAMPLE_DIR, name), os.path.join(resources_dir, name))
+
+    obs_path = os.path.join(resources_dir, 'heat_fenics_obs_data.json')
+    obs_data = _shipped_obs_data()
+    obs_data['protocol_info']['pre_times'] = [_EMULATOR_TIMELINE['pre_time']]
+    obs_data['protocol_info']['sim_times'] = [[sim_time]]
+    obs_data['protocol_info']['comment'] = (
+        f'Test copy: the window has been shortened to {sim_time} s. The values below are the '
+        f'shipped ones, computed on the 2 s window, so nothing here may assert that they are '
+        f'recovered.')
+    with open(obs_path, 'w') as handle:
+        json.dump(obs_data, handle, indent=2)
     return resources_dir
 
 
@@ -372,7 +459,9 @@ def _emulator_config(base_user_inputs, temp_output_dir, temp_generated_models_di
         'resources_dir': resources_dir,
         'param_id_method': 'genetic_algorithm',
         # See _EMULATOR_TIMELINE: shared with the calibration that uses the emulator, because
-        # the bundle's fingerprint covers it.
+        # the bundle's fingerprint covers it. pre_time/sim_time are the fallback the parser
+        # only reaches for when an obs_data has no protocol_info -- this one has, written by
+        # _copy_resources -- and are set to the same values so the two cannot disagree.
         **_EMULATOR_TIMELINE,
         'solver_info': {'user_config': {'nx': 8}},
         'DEBUG': False,
@@ -447,6 +536,7 @@ def test_an_emulator_trained_on_the_fenics_model_agrees_with_it(
     The comparison is against the *solver's own* features at a held-out theta rather than
     against a hardcoded number, so it does not need to know what the right answer is.
     """
+    _require_dolfinx()
     pytest.importorskip('autoemulate')
 
     from emulators.emulator_trainer import EmulatorTrainer
@@ -554,6 +644,7 @@ def test_a_calibration_through_the_emulator_completes_with_parameters_in_the_box
     this grid, so there is no theta that reproduces them and a recovery assertion would be
     measuring the fixture's provenance rather than CA.
     """
+    _require_dolfinx()
     pytest.importorskip('autoemulate')
 
     from mpi4py import MPI
@@ -613,8 +704,21 @@ def test_a_calibration_through_the_emulator_completes_with_parameters_in_the_box
     # calibration at the wrong sim_time look like a successful one. (Found through the GUI:
     # train at one sim_time, calibrate at another, EmulatorQualityError. Everything above uses
     # _EMULATOR_TIMELINE for both halves precisely so it never happens by accident here.)
+    #
+    # The other timeline is a second obs_data naming a doubled window, because that is now the
+    # only place a window is stated: a `sim_time` key in the config is the fallback the parser
+    # never reaches for once a protocol_info exists, so perturbing it would perturb nothing and
+    # this assertion would pass on an emulator that was never asked to be stale. The file name
+    # is unchanged, so resolve_emulator_dir still points at the bundle just trained.
     # one_rank because only rank 0 gets here: CVS0DParamID's constructor barriers otherwise,
     # and a barrier one rank reaches alone is a hang, not a failure.
-    stale = dict(calibration, sim_time=2.0 * calibration['sim_time'], one_rank=True)
+    stale_resources = _copy_resources(temp_output_dir,
+                                      sim_time=2.0 * _EMULATOR_TIMELINE['sim_time'],
+                                      subdir='heat_fenics_resources_other_window')
+    stale = dict(calibration,
+                 param_id_obs_path=os.path.join(stale_resources, 'heat_fenics_obs_data.json'),
+                 one_rank=True)
+    assert resolve_emulator_dir(stale) == resolve_emulator_dir(config), (
+        'the stale check must reach the bundle just trained, or it proves nothing')
     with pytest.raises(EmulatorQualityError, match='stale'):
         CVS0DParamID.init_from_dict(stale)

--- a/tests/test_scipy_ode_example.py
+++ b/tests/test_scipy_ode_example.py
@@ -7,6 +7,7 @@ users arriving with "I have an ODE" need, so it gets its own coverage rather tha
 ``tests/test_external_simulation_helper.py`` (which exercises the wrapper's contract enforcement
 against a hand-marched PDE).
 """
+import json
 import os
 import shutil
 
@@ -14,7 +15,7 @@ import numpy as np
 import pytest
 from mpi4py import MPI
 
-from parsers.PrimitiveParsers import YamlFileParser
+from parsers.PrimitiveParsers import ObsAndParamDataParser, YamlFileParser
 from solver_wrappers import get_simulation_helper, get_simulation_helper_from_inp_data_dict
 from solver_wrappers.external_simulation_helper import SimulationHelper as ExternalSimulationHelper
 from scripts.script_generate_with_new_architecture import generate_with_new_architecture
@@ -25,6 +26,7 @@ _EXAMPLE_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), '..', 'funcs_user', 'example_model_scipy')
 )
 _MODEL_PATH = os.path.join(_EXAMPLE_DIR, 'oscillator_model.py')
+_OBS_DATA_PATH = os.path.join(_EXAMPLE_DIR, 'oscillator_obs_data.json')
 # Ground truth used to build oscillator_obs_data.json (the defaults are c=0.5, k=4.0).
 _TRUE_C, _TRUE_K = 0.7, 5.0
 _SOLVER_INFO = {'solver': 'external', 'method': 'external'}
@@ -80,6 +82,36 @@ def _oscillator_config(base_user_inputs, temp_output_dir, temp_generated_models_
         'debug_optimiser_options': {'num_calls_to_function': 160, 'cost_type': 'gaussian_MLE'},
     })
     return config
+
+
+# ---------------------------------------------------------------------------
+# The shipped obs_data
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_the_shipped_obs_data_carries_the_window_its_values_were_computed_on():
+    """``oscillator_obs_data.json`` must name its own run window in ``protocol_info``.
+
+    The three targets below it are ``mean(x)``, ``min(x)`` and ``range(v)`` over the 10 s
+    window and nothing else -- read them off a different window and they are simply wrong. So
+    the window travels in the file rather than in whatever ``user_inputs.yaml`` happens to say,
+    which is also the only thing the CUFLynx GUI reads to size a run: an example with no
+    ``protocol_info`` cannot be run from it at all.
+    """
+    with open(_OBS_DATA_PATH) as handle:
+        shipped = json.load(handle)
+
+    protocol = shipped['protocol_info']
+    # pre_times is per experiment; sim_times is per experiment, per subexperiment. One
+    # experiment of one 10 s stretch, from t = 0, with no spin-up to discard.
+    assert protocol['pre_times'] == [0.0]
+    assert protocol['sim_times'] == [[_SIM_TIME]]
+
+    # And it still parses -- with no pre_time/sim_time offered, so the file has to be
+    # self-sufficient rather than falling back on the yaml's window.
+    parsed = ObsAndParamDataParser().parse_obs_data_json(param_id_obs_path=_OBS_DATA_PATH)
+    assert parsed['protocol_info']['pre_times'] == [0.0]
+    assert parsed['protocol_info']['sim_times'] == [[_SIM_TIME]]
+    assert len(parsed['gt_df']) == len(shipped['data_items']) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tutorial/docs/external-python-solvers.md
+++ b/tutorial/docs/external-python-solvers.md
@@ -286,8 +286,8 @@ external_model_path: <CA_dir>/funcs_user/heat_fenics/heat_fenics_model.py
 resources_dir: <CA_dir>/funcs_user/heat_fenics
 param_id_obs_path: <CA_dir>/funcs_user/heat_fenics/heat_fenics_obs_data.json
 
-pre_time: 0.0
-sim_time: 2.0
+# No pre_time/sim_time: the run window comes from the obs_data's protocol_info
+# (pre_times: [0.0], sim_times: [[2.0]]). dt is still a yaml setting.
 dt: 0.02
 
 param_id_method: genetic_algorithm
@@ -306,8 +306,11 @@ heat,         k,           const,       0.001, 0.2,   k
 heat,         u_D,         const,       -0.5,  0.5,   u_{D}
 ```
 
-and `heat_fenics_obs_data.json` holds six scalar targets — the `mean` and the `min` of each of
-the three probes, so every probe is scored rather than just the centre one.
+and `heat_fenics_obs_data.json` holds the run window and six scalar targets — the `mean` and the
+`min` of each of the three probes, so every probe is scored rather than just the centre one. The
+window is its `protocol_info` (`pre_times: [0.0]`, `sim_times: [[2.0]]`), which is where it
+belongs: the six values are what *that* window produces, so the two cannot drift apart, and the
+CUFLynx GUI reads the window from there rather than from the yaml.
 
 ### 5. Calibrate and sweep it
 


### PR DESCRIPTION
Each shipped `external_python` example's obs_data was a bare list of `data_items`, so the run window its values were computed on lived only in its README. Read on a different window every target in the file is a different number — `min(T_p1)` is *the temperature reached by the end of the window* — and nothing in the repo said so in a form anything could check.

Each now carries a `protocol_info` naming that window, with a comment saying that changing it changes every value below:

| example | pre_time | sim_time | dt | items |
|---|---|---|---|---|
| `funcs_user/heat_fenics` | 0.0 | 2.0 | 0.02 (100 steps) | 6 |
| `funcs_user/example_model_external` (heat1d) | 0.0 | 0.5 | 0.005 (100 steps) | 3 |
| `funcs_user/example_model_scipy` (oscillator) | 0.0 | 10.0 | 0.05 (200 steps) | 3 |

The `data_items` are **byte-identical** to before. The values were re-derived by running each example on the stated window (heat_fenics in a FEniCSx env) and confirming every target lands inside its quoted std.

CA still accepts a bare list of `data_items` — that parser behaviour is unchanged and still pinned by `tests/test_operation_kwargs.py`. This is about what the *examples* ship. It also makes them loadable in CUFLynx, which sizes a run from `protocol_info` alone.

### Tests

A `@pytest.mark.unit` test per example asserts the window is stated, and that the file parses with no yaml `pre_time`/`sim_time` fallback offered — so the obs_data has to be self-sufficient. READMEs updated to point at the file rather than at a number to type in.

Two structural changes worth a reviewer's eye:

* **`tests/test_heat_fenics_example.py` no longer does a module-level `importorskip('dolfinx')`.** The new obs_data assertion is a statement about a JSON file, and is exactly the one that must not go quiet on machines without FEniCSx — which is most of them. The solver tests skip through a `_require_dolfinx()` helper instead. The `test-fenics` CI job's comment is updated to match.
* **The stale-emulator check in that file had to be reworked.** It used to double the config's `sim_time` to get a second timeline. Now that the obs_data's `protocol_info` wins over the yaml, that key is a fallback the parser never reaches — so the perturbation would have perturbed nothing and the test would have *silently stopped testing anything*. It now writes a second obs_data naming the doubled window, and asserts both resolve to the same emulator dir so the check still reaches the bundle just trained.

Fast suite: **898 passed, 3 skipped** (baseline 895 / 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)