### PR TITLE
fix(myokit): a constant is not in the log, so do not look for it there

### DIFF
--- a/src/libcuflynx/solver_wrappers/myokit_helper.py
+++ b/src/libcuflynx/solver_wrappers/myokit_helper.py
@@ -1242,7 +1242,13 @@ class SimulationHelper:
             # get_time() and to the OpenCOR backend's time axis.
             return self.tSim - self.pre_time
         kind, qname = self._resolve_name(name)
-        if self.last_log and kind in ("state", "var"):
+        # `qname in self.last_log` is not redundant: _make_log deliberately leaves constants
+        # out ("Myokit cannot log constants"), while _resolve_name classifies them as "var"
+        # like every other non-state. So a constant reached this branch, was indexed out of a
+        # log that never contained it, and raised KeyError -- even though the `kind == "var"`
+        # arm below already knows how to answer for one, by evaluating it. Falling through is
+        # all that was missing (issue #453).
+        if self.last_log and kind in ("state", "var") and qname in self.last_log:
             data = np.asarray(self.last_log[qname])
             return data
         if kind == "state":

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1847,3 +1847,38 @@ def test_aadc_semi_implicit_signed_forward_tracks_cvode(temp_model_dir,
     assert not np.all(np.isfinite(np.array(traj, dtype=float))), (
         "jac_lag=10 without sub-stepping is expected to diverge on this stiff model; if it no "
         "longer does, the coupling documented on solver_info['jac_lag'] has changed")
+
+
+@pytest.mark.solver
+def test_myokit_reads_a_constant_that_was_never_logged():
+    """Regression test for issue #453: a constant could not be read back.
+
+    ``_make_log`` deliberately excludes constants -- Myokit cannot log them -- while
+    ``_resolve_name`` classifies them as ``"var"`` like every other non-state. ``_extract``
+    then indexed the log by name for any ``"var"``, so asking for a constant raised
+    ``KeyError`` out of a log that was never going to contain it.
+
+    The arm that answers correctly was already there, two lines below: for a ``"var"`` it
+    evaluates the variable. It was simply unreachable while a log existed. So this asserts
+    the value, not merely the absence of an exception -- reaching the evaluation path is the
+    whole point.
+    """
+    tests_dir = os.path.dirname(__file__)
+    cellml_path = os.path.join(tests_dir, "test_inputs", "Lotka_Volterra_forced.cellml")
+    assert os.path.exists(cellml_path), f"CellML model not found: {cellml_path}"
+
+    sim = get_simulation_helper(
+        model_path=cellml_path, model_type="cellml", solver="CVODE_myokit",
+        dt=0.01, sim_time=1.0, solver_info={"MaximumStep": 0.05})
+    assert sim.run(), "the model did not run"
+
+    constants = [q for q, v in sim.qname_to_var.items()
+                 if v.is_constant() and q not in (sim.last_log or {})]
+    assert constants, "this model has no unlogged constant, so the test proves nothing"
+
+    qname = constants[0]
+    values = sim.get_results([qname], flatten=True)[0]
+
+    expected = sim.qname_to_var[qname].eval()
+    assert np.asarray(values).size >= 1
+    assert float(np.asarray(values).ravel()[0]) == pytest.approx(expected)


### PR DESCRIPTION
Fixes #453. Same one-line change as #454, rebased onto current `master` — #454 predates the `libcuflynx` namespace move, so both files it touches have since moved.

## The bug

Reading a constant back raised `KeyError`.

`_make_log` deliberately leaves constants out — its own comment says *"Myokit cannot log constants, only states and certain other variable types"* — while `_resolve_name` classifies them as `"var"`, like every other non-state. `_extract` then indexed the log by name for any `"var"`:

```python
if self.last_log and kind in ("state", "var"):
    data = np.asarray(self.last_log[qname])   # KeyError: the constant was never logged
```

So a constant went looking in a log that was never going to contain it.

## Why it is one line

The arm that answers correctly was **already there**, two lines below — for a `"var"` it evaluates the variable:

```python
if kind == "var":
    if qname in self.qname_to_var:
        current_value = self.qname_to_var[qname].eval()
        return np.asarray([current_value])
```

It was simply unreachable while a log existed. Falling through to it is the whole fix.

## Test

`test_myokit_reads_a_constant_that_was_never_logged` asserts the **value**, not merely the absence of an exception — reaching that evaluation path is the point. It also asserts the model actually has an unlogged constant, so it cannot pass vacuously.

On the old code it fails with `KeyError: 'Lotka_Volterra_module.alpha'`.

`tests/test_solvers.py -m "not need_opencor"`: 24 passed, 1 skipped, 1 failed — the failure is `test_aadc_semi_implicit_vs_cvode_3compartment`, which is pre-existing and deliberate (its own message: *"Expected to fail at ~35%: semi_implicit is not convergent on this stiff model … kept strict so the limitation stays visible"*). Confirmed identical with this change stashed.

## Not included from #454

#454 also adds `mean_heart_rate_bpm_in_range` to `funcs_user/operation_funcs_user.py`, marked *"included by Aaloka (temporarily)"*. That file is now `libcuflynx/funcs/operation_funcs_user.py` — library code that `pip install --upgrade` replaces, so an addition there is lost on the next upgrade. Its home is either the author's own file via `operation_funcs_external_path` (see `funcs_user/README.md`), or a built-in in its own PR if it is generally useful. Left out rather than silently relocated, since that is the author's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)