### PR TITLE
fix(param_id): an unsupported model_type says so, instead of crashing later

### DIFF
--- a/src/libcuflynx/param_id/paramID.py
+++ b/src/libcuflynx/param_id/paramID.py
@@ -192,6 +192,13 @@ _require_casadi = casadi_backend.require_casadi
 _as_casadi_column = casadi_backend.as_casadi_column
 
 
+#: The model types parameter identification can actually run. Deliberately not every entry
+#: in SOLVER_SCHEMA's model types: `cpp` is a valid model_type for *generation*, but neither
+#: this module nor solver_wrappers can simulate one, so it cannot be calibrated. Naming the
+#: set here keeps the check and the error message reading from one list.
+PARAM_ID_MODEL_TYPES = ('cellml', 'python', 'casadi_python', 'aadc_python', 'external_python')
+
+
 class CVS0DParamID():
     """Parameter identification (calibration) for a 0D CVS model.
 
@@ -389,8 +396,7 @@ class CVS0DParamID():
                                            emulator_settings=self.emulator_settings)
             self.n_steps = mcmc_object.n_steps
         else:
-            if model_type in ['cellml', 'python', 'casadi_python', 'aadc_python',
-                              'external_python']:
+            if model_type in PARAM_ID_MODEL_TYPES:
                 self.param_id = OpencorParamID(self.model_path, self.param_id_method,
                                                self.obs_info, self.param_id_info, self.protocol_info,
                                                self.prediction_info, self.solver_info, dt=self.dt,
@@ -403,6 +409,20 @@ class CVS0DParamID():
                                                emulator_dir=self.emulator_dir,
                                                emulator_settings=self.emulator_settings)
                 self.n_steps = self.param_id.n_steps
+            else:
+                # Say so here rather than leaving self.param_id unset. set_output_dir()
+                # dereferences it a few lines below, so an unsupported model_type used to
+                # surface as `'CVS0DParamID' object has no attribute 'param_id'` -- a
+                # message about an attribute, several frames from the config key that
+                # actually caused it (CUFLynx #270). `cpp` is the one that reaches here by
+                # being *valid*: it is a real model_type for generation, but nothing in
+                # param_id or solver_wrappers can run one, so calibrating it was never
+                # going to work and should say which part is missing.
+                raise ValueError(
+                    f'model_type {model_type!r} cannot be used for parameter '
+                    f'identification. Supported: {sorted(PARAM_ID_MODEL_TYPES)}. '
+                    f'(cpp models can be generated, but not calibrated or simulated by '
+                    f'libcuflynx -- build and run the generated code yourself.)')
         if self.rank == 0:
             self.set_output_dir(self.output_dir)
         

--- a/tests/test_param_id_model_type.py
+++ b/tests/test_param_id_model_type.py
@@ -1,0 +1,40 @@
+"""An unsupported model_type must say so, not crash on a missing attribute later.
+
+CUFLynx #270 reported `AttributeError: 'CVS0DParamID' object has no attribute 'param_id'`
+from inside EmulatorTrainer.init_from_dict. The attribute was never the problem: __init__
+only builds `self.param_id` for the model types parameter identification supports, and
+`set_output_dir` -- called a few lines later, unconditionally -- then dereferenced it. So
+any unsupported model_type surfaced several frames from the config key that caused it, in
+terms that name an internal attribute rather than the setting the user chose.
+
+`cpp` is the case that reaches this by being *valid*: a real model_type for generation that
+neither param_id nor solver_wrappers can run.
+"""
+import pytest
+
+from libcuflynx.param_id.paramID import CVS0DParamID, PARAM_ID_MODEL_TYPES
+
+
+@pytest.mark.unit
+def test_cpp_is_valid_to_generate_but_not_to_calibrate():
+    """The list is a capability statement, so pin what it excludes and why."""
+    from libcuflynx.parsers.PrimitiveParsers import SOLVER_SCHEMA
+
+    assert 'cpp' in SOLVER_SCHEMA['solvers_by_model_type'], 'cpp is a real model type'
+    assert 'cpp' not in PARAM_ID_MODEL_TYPES, 'and param-id cannot run one'
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('model_type', ['cpp', 'not_a_model_type', None])
+def test_an_unsupported_model_type_names_itself(model_type):
+    with pytest.raises(ValueError) as excinfo:
+        CVS0DParamID(model_path='/nonexistent/model.cellml', model_type=model_type,
+                     param_id_method='genetic_algorithm')
+
+    message = str(excinfo.value)
+    assert 'parameter identification' in message
+    assert repr(model_type) in message, 'the message must name what was actually passed'
+    for supported in PARAM_ID_MODEL_TYPES:
+        assert supported in message, 'and say what it could have been'
+    # The symptom this replaces.
+    assert 'has no attribute' not in message


### PR DESCRIPTION
Closes physiomelinks/CUFLynx#270.

## What was actually wrong

The report was `AttributeError: 'CVS0DParamID' object has no attribute 'param_id'`, raised from inside `EmulatorTrainer.init_from_dict`. The attribute was never the problem:

```python
if model_type in ['cellml', 'python', 'casadi_python', 'aadc_python', 'external_python']:
    self.param_id = OpencorParamID(...)     # only for these
if self.rank == 0:
    self.set_output_dir(self.output_dir)    # -> self.param_id.set_output_dir(...)  unconditionally
```

`__init__` builds `self.param_id` only for the model types parameter identification supports, and `set_output_dir` dereferences it a few lines below regardless. So **any** unsupported `model_type` surfaced several frames from the config key that caused it, in terms naming an internal attribute rather than the setting the user chose.

## `cpp` reaches this by being valid

It is a real `model_type` — `SOLVER_SCHEMA['solvers_by_model_type']` lists it with `CVODE`/`RK4`/`PETSC`. But `cpp` appears nowhere in `param_id/` and nowhere in `solver_wrappers/`: libcuflynx generates C++ for you to build and run yourself, and cannot simulate or calibrate one. So calibrating a `cpp` model was never going to work, and it now says which part is missing rather than failing on an attribute.

```
ValueError: model_type 'cpp' cannot be used for parameter identification.
Supported: ['aadc_python', 'casadi_python', 'cellml', 'external_python', 'python'].
(cpp models can be generated, but not calibrated or simulated by libcuflynx --
build and run the generated code yourself.)
```

The supported set is now a named constant, so the check and the message read from one list.

## About the original report

Its traceback is from a pre-`libcuflynx` checkout, and the trigger was most likely a `model_type` spelling mismatch across the `cellml_only` → `cellml` rename — which the alias handling has since fixed. This closes the *class* rather than that instance: whatever the value, the failure now names it.

## Test

`tests/test_param_id_model_type.py` — four tests. The parametrised one covers `cpp`, an invalid name, and `None`, asserting the message names what was passed, lists what it could have been, and does **not** say "has no attribute".

On the old control flow all three fail with exactly the reported `AttributeError: 'CVS0DParamID' object has no attribute 'param_id'`.

`-m unit`: 1240 passed, 1 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)