### PR TITLE
fix(mpi): imported is not initialised, so ask before calling into MPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@ next release; add to that section as you land a change.
 
 ## Unreleased
 
-Nothing yet.
+### Fixed — an mpi4py that is imported but not initialised no longer kills the process
+
+`mpi_utils` treated "`mpi4py.MPI` is in `sys.modules`" as "MPI is open", and read the rank
+through it. There is a third state: `MPI4PY_RC_INITIALIZE=0` (or `mpi4py.rc.initialize = False`)
+loads the library and skips `MPI_Init`. In that state every routine except `MPI_Initialized` and
+`MPI_Finalized` is erroneous, and MPICH and Microsoft MPI both answer by printing
+
+```
+Attempting to use an MPI routine before initializing MPI
+```
+
+and killing the process — not raising, so the `except Exception` around the call could not help.
+
+`PrimitiveParsers` reads `rank = mpi_utils.rank()` at module scope, so *importing* libcuflynx
+was enough to hit it. It killed the CUFLynx v0.4.0 Windows release build twice: PyInstaller
+imports every bundled package into one isolated child, mpi4py.futures loaded MPI uninitialised,
+and the child then died importing `libcuflynx.solver_wrappers`.
+
+`rank`/`size`/`is_root` and `get_MPI` now ask `mpi_is_live()` first and fall back to the
+one-rank answers, which are the right ones for a process whose MPI was never opened. Nothing
+changes when MPI is genuinely open, and a rank started by a launcher is left alone — N ranks
+each believing they are rank 0 would be worse than the abort.
 
 ## 0.4.0 — 2026-08-18
 

--- a/src/libcuflynx/utilities/mpi_utils.py
+++ b/src/libcuflynx/utilities/mpi_utils.py
@@ -91,22 +91,59 @@ def configure_mpi4py(env=None):
     return True
 
 
+def mpi_is_live(MPI):
+    """Whether MPI routines may be called on this ``mpi4py.MPI`` at all.
+
+    ``MPI_Initialized`` and ``MPI_Finalized`` are the only two routines the
+    standard permits before ``MPI_Init`` and after ``MPI_Finalize``. Calling any
+    other one in that state is erroneous, and MPICH and Microsoft MPI both handle
+    it by printing
+
+        Attempting to use an MPI routine before initializing MPI
+
+    and killing the process. That is *not* a Python exception -- a ``try/except``
+    around the call cannot make it survivable -- so the question has to be asked
+    first, which is what this is for.
+
+    mpi4py being imported does not answer it. ``MPI4PY_RC_INITIALIZE=0`` (or
+    ``mpi4py.rc.initialize = False``) loads the library and deliberately skips the
+    init, so ``'mpi4py.MPI' in sys.modules`` can be true with MPI never opened.
+    CUFLynx's release build sets exactly that while PyInstaller analyses the
+    bundle -- PyInstaller imports every collected package in one isolated child to
+    scan for DLLs, mpi4py.futures comes first and loads MPI uninitialised, and the
+    child then died importing ``libcuflynx.solver_wrappers``, whose chain reaches
+    ``PrimitiveParsers``' module-scope ``rank = mpi_utils.rank()``.
+    """
+    try:
+        return bool(MPI.Is_initialized()) and not bool(MPI.Is_finalized())
+    except Exception:
+        return False
+
+
 def _comm_or_none():
     """``MPI.COMM_WORLD`` if MPI is already in play, else None.
 
     Deliberately does not *cause* an import: it uses mpi4py only when a launcher
-    started this process, or when something else has already imported it (in
-    which case MPI is initialised anyway and asking costs nothing).
+    started this process, or when something else has already imported it. Having
+    been imported is not enough on its own -- see :func:`mpi_is_live` -- so the
+    communicator is only handed back once MPI is confirmed open.
     """
     import sys
 
-    if not launched_by_mpiexec() and 'mpi4py.MPI' not in sys.modules:
+    launched = launched_by_mpiexec()
+    if not launched and 'mpi4py.MPI' not in sys.modules:
         return None
     try:
         from mpi4py import MPI
-        return MPI.COMM_WORLD
     except Exception:
         return None
+    # Imported is not open. A bare process whose MPI was never initialised really
+    # is rank 0 of 1, so answering serially is right. A rank of a real job is not:
+    # N ranks all believing they are rank 0 would overwrite each other's output,
+    # so there the MPI error is left to stand rather than papered over.
+    if not launched and not mpi_is_live(MPI):
+        return None
+    return MPI.COMM_WORLD
 
 
 def rank():
@@ -342,8 +379,11 @@ def get_MPI(env=None):
     mpi4py, so MPI is never initialised and there is no ``MPI_Finalize`` to
     abort in.
 
-    mpi4py already being imported means MPI is initialised regardless, so the
-    real module is handed back -- a stub would then be the odd one out.
+    mpi4py already being imported *and initialised* means MPI is open regardless,
+    so the real module is handed back -- a stub would then be the odd one out.
+    Imported but never initialised is a third state (``MPI4PY_RC_INITIALIZE=0``),
+    and there the real module is the wrong answer: the first collective would kill
+    the process, where the stub gives the one-rank result correctly.
 
     Under a launcher with mpi4py missing there is no honest fallback -- the stub
     would answer "rank 0 of 1" in every one of N ranks, and N duplicate runs
@@ -355,8 +395,10 @@ def get_MPI(env=None):
     """
     import sys
 
-    if launched_by_mpiexec(env) or 'mpi4py.MPI' in sys.modules:
+    if launched_by_mpiexec(env):
         require_mpi4py()
         from mpi4py import MPI
         return MPI
+    if 'mpi4py.MPI' in sys.modules and mpi_is_live(sys.modules['mpi4py.MPI']):
+        return sys.modules['mpi4py.MPI']
     return _SerialMPI

--- a/tests/test_mpi_utils.py
+++ b/tests/test_mpi_utils.py
@@ -151,6 +151,126 @@ def test_the_real_mpi_wins_if_something_else_already_imported_it():
 
 
 # ---------------------------------------------------------------------------
+# Imported is not initialised
+#
+# `MPI4PY_RC_INITIALIZE=0` (or `mpi4py.rc.initialize = False`) loads mpi4py and
+# skips MPI_Init, so `'mpi4py.MPI' in sys.modules` can be true with MPI never
+# opened. Every routine other than Is_initialized/Is_finalized is then erroneous,
+# and MPICH and Microsoft MPI both answer by printing
+#
+#     Attempting to use an MPI routine before initializing MPI
+#
+# and killing the process -- not raising, so no try/except can survive it.
+#
+# That state is not hypothetical: CUFLynx's release build sets the variable while
+# PyInstaller analyses the bundle (MPI_Init aborts in the Linux runners' UCX). All
+# collected packages are imported into ONE isolated child; mpi4py.futures comes
+# first and loads MPI uninitialised, and the child then died importing
+# libcuflynx.solver_wrappers, whose chain reaches PrimitiveParsers' module-scope
+# `rank = mpi_utils.rank()`. It failed the v0.4.0 Windows release build twice.
+# ---------------------------------------------------------------------------
+
+def _mpi_stub(initialised):
+    """Source that puts a stand-in ``mpi4py.MPI`` into ``sys.modules``.
+
+    A real uninitialised MPI cannot be used here: the process death is the thing
+    under test, so it has to be observable rather than fatal to the test run. The
+    stub reproduces the two behaviours that matter -- what ``Is_initialized``
+    answers, and that any other routine in that state kills the process rather
+    than raising.
+    """
+    return textwrap.dedent("""
+        import importlib.machinery
+        import os
+        import sys
+        import types
+
+        _mpi4py = types.ModuleType('mpi4py')
+        _mpi4py.__spec__ = importlib.machinery.ModuleSpec('mpi4py', None)
+        _mpi4py.__path__ = []
+        _MPI = types.ModuleType('mpi4py.MPI')
+        _MPI.__spec__ = importlib.machinery.ModuleSpec('mpi4py.MPI', None)
+        _INITIALISED = %r
+
+
+        def _routine(name, answer):
+            def call(*args, **kwargs):
+                if not _INITIALISED:
+                    print('Attempting to use an MPI routine before initializing MPI')
+                    os._exit(1)
+                return answer
+            return staticmethod(call)
+
+
+        class _Comm(object):
+            Get_rank = _routine('MPI_Comm_rank', 3)
+            Get_size = _routine('MPI_Comm_size', 8)
+
+
+        _MPI.COMM_WORLD = _Comm()
+        _MPI.Is_initialized = staticmethod(lambda: _INITIALISED)
+        _MPI.Is_finalized = staticmethod(lambda: False)
+        _mpi4py.MPI = _MPI
+        sys.modules['mpi4py'] = _mpi4py
+        sys.modules['mpi4py.MPI'] = _MPI
+        """ % initialised)
+
+
+def test_is_live_distinguishes_imported_from_initialised():
+    """The two routines it asks with are the two the standard allows to be asked."""
+    class _Uninitialised(object):
+        Is_initialized = staticmethod(lambda: False)
+        Is_finalized = staticmethod(lambda: False)
+
+    class _Open(object):
+        Is_initialized = staticmethod(lambda: True)
+        Is_finalized = staticmethod(lambda: False)
+
+    class _Closed(object):
+        Is_initialized = staticmethod(lambda: True)
+        Is_finalized = staticmethod(lambda: True)
+
+    assert mpi_utils.mpi_is_live(_Uninitialised) is False
+    assert mpi_utils.mpi_is_live(_Open) is True
+    assert mpi_utils.mpi_is_live(_Closed) is False
+    # An mpi4py too old to answer, or anything else that raises, is not a reason to
+    # gamble a process abort on the answer.
+    assert mpi_utils.mpi_is_live(object()) is False
+
+
+def test_rank_does_not_call_into_an_uninitialised_mpi():
+    out = _run(_mpi_stub(False) + textwrap.dedent("""
+        from libcuflynx.utilities import mpi_utils
+        print(mpi_utils.rank(), mpi_utils.size(),
+              mpi_utils.get_MPI() is mpi_utils._SerialMPI)
+        """))
+    assert out.split() == ['0', '1', 'True']
+
+
+def test_importing_the_solver_wrappers_survives_an_uninitialised_mpi():
+    """The failure verbatim: the isolated PyInstaller child imports mpi4py first,
+    then this, and the module-scope rank read in PrimitiveParsers killed it."""
+    out = _run(_mpi_stub(False) + textwrap.dedent("""
+        from libcuflynx.solver_wrappers import get_simulation_helper  # noqa: F401
+        from libcuflynx.parsers.PrimitiveParsers import rank
+        print('rank', rank)
+        """))
+    assert out.split() == ['rank', '0']
+
+
+def test_an_initialised_mpi_is_still_the_one_that_answers():
+    """The guard must cost nothing when MPI is genuinely open -- a process that
+    initialised MPI is not rank 0 of 1 just because it never used mpiexec."""
+    out = _run(_mpi_stub(True) + textwrap.dedent("""
+        import sys
+        from libcuflynx.utilities import mpi_utils
+        print(mpi_utils.rank(), mpi_utils.size(),
+              mpi_utils.get_MPI() is sys.modules['mpi4py.MPI'])
+        """))
+    assert out.split() == ['3', '8', 'True']
+
+
+# ---------------------------------------------------------------------------
 # No module may reintroduce the import
 # ---------------------------------------------------------------------------
 def test_no_module_imports_mpi4py_at_module_scope():


### PR DESCRIPTION
`mpi_utils` has two states in mind — MPI never touched, and MPI open. There is a third, and it kills the process.

## The state

`MPI4PY_RC_INITIALIZE=0` (or `mpi4py.rc.initialize = False`) loads mpi4py and skips `MPI_Init`. `'mpi4py.MPI' in sys.modules` is then true with MPI never opened, and `_comm_or_none` reads that as "MPI is initialised anyway and asking costs nothing" — its own comment.

Asking costs everything. `MPI_Initialized` and `MPI_Finalized` are the only two routines the standard permits in that state; every other one is erroneous, and MPICH and Microsoft MPI both answer by printing

```
Attempting to use an MPI routine before initializing MPI
```

and killing the process. **Not raising** — so the `except Exception` wrapped around `comm.Get_rank()` never runs, and no caller can defend itself.

## Where it fires

`PrimitiveParsers` reads `rank = mpi_utils.rank()` at module scope, so *importing* libcuflynx is enough. It killed CUFLynx's v0.4.0 Windows release build twice:

```
SubprocessDiedError: Isolated subprocess crashed while importing package
'libcuflynx.solver_wrappers'
```

PyInstaller imports every bundled package into **one** isolated child to scan for DLLs. `mpi4py.futures` goes first and loads MPI uninitialised (CUFLynx sets the variable there because MPI_Init aborts in the Linux runners' UCX), and the same child then imports:

```
solver_wrappers/__init__.py:97   -> aadc_python_solver_helper   (inside try/except)
aadc_python_solver_helper.py:27  -> PrimitiveParsers
PrimitiveParsers.py:43           -> rank = _mpi_utils.rank()
mpi_utils.py:118                 -> comm.Get_rank()
```

Two earlier explanations were wrong and are worth recording: it is not `collect_all` (that list comes from everything bundled), and an AST sweep for a module-scope `import mpi4py` finds nothing — because the import is *inside* `mpi_utils` and it is the **call** that is at module scope.

## The change

`mpi_is_live()` asks with the two routines that are legal to ask, and `rank`/`size`/`is_root`/`get_MPI` fall back to the one-rank answers — which are the correct answers for a process whose MPI was never opened, not a fudge. Nothing changes when MPI is genuinely open: `get_MPI` still hands back the real module, and `rank()` still comes from `COMM_WORLD`.

A rank started by a launcher is deliberately **not** given the fallback. N ranks each believing they are rank 0 would overwrite each other's output, and this module already says so about the mpi4py-missing case; the MPI error is left to stand there instead.

## Verification

Reproduced on Windows. A real uninitialised MPI cannot be used in a test — the process death is the thing under test, so it has to be observable rather than fatal to the test run — so a stand-in `mpi4py.MPI` supplies the two behaviours that matter: what `Is_initialized` answers, and that any other routine kills the process.

Before, importing `libcuflynx.solver_wrappers`:

```
Attempting to use an MPI routine before initializing MPI
exit=1
```

After: `rank = 0`, exit 0. With an MPI that *is* open, rank and size still come from it (3 and 8 from the stub) and `get_MPI()` still returns the real module.

Four tests added to `tests/test_mpi_utils.py`, including the import chain verbatim. `tests/test_mpi_utils.py`: 29 passed, 2 failed — both pre-existing on the machine this was written on, which has mpi4py installed and no MPI library for it to load.

The matching CUFLynx change is physiomelinks/CUFLynx#276: it stops setting the variable on Windows, because the pin there is `libcuflynx>=0.4.0` and its release build cannot wait for this to land. Once this is released, that split becomes belt-and-braces rather than load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
