### PR TITLE
chore(release): cut 0.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ resources/vessel_array_module_files.csv
 # project to libcuflynx made `pip install -e .` (a prerequisite for every user_run_files
 # launcher now) drop an untracked src/libcuflynx.egg-info/ into every checkout. Match any name.
 src/*.egg-info/
+# `python -m build` output. CONTRIBUTING's release checklist tells every releaser to run it
+# before tagging, so cutting a release leaves ~2 MB of untracked wheel and sdist in the
+# checkout -- exactly where a `git add -A` would sweep them into the release commit.
+build/
+dist/
 src/nohup.out
 tests/TEST_REFACTORING_SUMMARY.md
 tests/test_outputs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ next release; add to that section as you land a change.
 
 ## Unreleased
 
+Nothing yet.
+
+## 0.4.1 — 2026-08-19
+
+Three bug fixes, all found by running 0.4.0. Nothing about the API or the packaging changed,
+so upgrading is a `pip install -U libcuflynx`.
+
 ### Fixed — an mpi4py that is imported but not initialised no longer kills the process
 
 `mpi_utils` treated "`mpi4py.MPI` is in `sys.modules`" as "MPI is open", and read the rank
@@ -27,6 +34,30 @@ and the child then died importing `libcuflynx.solver_wrappers`.
 one-rank answers, which are the right ones for a process whose MPI was never opened. Nothing
 changes when MPI is genuinely open, and a rank started by a launcher is left alone — N ranks
 each believing they are rank 0 would be worse than the abort.
+
+### Fixed — reading a constant back from a Myokit run raised KeyError
+
+`get_results('component/some_constant')` on the `CVODE_myokit` backend raised
+`KeyError: 'component.some_constant'` (issue #453). `_make_log` deliberately leaves constants
+out of the log — Myokit cannot log something that never varies — while `_resolve_name`
+classifies a constant as a `"var"`, like every other non-state. So the read indexed a log that
+was never going to contain it.
+
+The arm that answers correctly was already two lines below and simply unreachable while a log
+existed: for a `"var"`, evaluate the variable. It now falls through to it.
+
+### Fixed — an unsupported `model_type` says so, instead of failing several frames later
+
+Calibrating a `model_type` that parameter identification cannot run — `cpp` is the case that
+gets there by being *valid*, a real model type for generation that neither `param_id` nor
+`solver_wrappers` can simulate — surfaced as
+`AttributeError: 'CVS0DParamID' object has no attribute 'param_id'`, from inside
+`EmulatorTrainer.init_from_dict` (CUFLynx #270). `__init__` built `self.param_id` only for the
+supported types and `set_output_dir` then dereferenced it unconditionally, so the failure named
+an internal attribute rather than the setting the user chose.
+
+`CVS0DParamID` now checks `model_type` against `PARAM_ID_MODEL_TYPES` up front and says which
+part is missing, quoting the list it was checked against.
 
 ## 0.4.0 — 2026-08-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "libcuflynx"
 # the `libcuflynx` namespace. The flat import names (`parsers`, `param_id`, ...) keep working
 # through this release as deprecation shims and are removed in 0.5.0 -- see
 # libcuflynx/_deprecated_aliases.py::REMOVAL_VERSION, which the shims' warning text quotes.
-version = "0.4.0"
+version = "0.4.1"
 description = "Generation and calibration of CellML circulatory system models from module/vessel arrays"
 readme = "README.md"
 # 3.9 is the real floor, not a conservative label: utilities/package_resources.py needs


### PR DESCRIPTION
Cuts **libcuflynx 0.4.1** — the release checklist steps that happen *before* the tag: `version` in `pyproject.toml` bumped to match, and the `Unreleased` entries moved into a dated section.

Three bug fixes, all found by running 0.4.0. No API or packaging change, so upgrading is a `pip install -U libcuflynx`.

| | Fix |
|---|---|
| #457 | an `mpi4py` that is imported but not initialised no longer kills the process |
| #453 | reading a constant back from a Myokit run raised `KeyError` |
| CUFLynx #270 | an unsupported `model_type` says so, instead of failing several frames later as an `AttributeError` |

## Verified against the built wheel

Not against the checkout — `python -m build`, `twine check` (both PASSED), then installed into a clean venv and run from a directory that is not the checkout, per CONTRIBUTING steps 4–5:

- `from libcuflynx.param_id.paramID import CVS0DParamID, PARAM_ID_MODEL_TYPES` — both fixed code paths are in the wheel
- `cuflynx-generate --help` runs from the entry point
- **nothing written into `site-packages`** during the run (file count unchanged either side)

And the scenario that actually killed the CUFLynx v0.4.0 Windows release build, twice:

```
$ MPI4PY_RC_INITIALIZE=0 python -c \
    "import mpi4py.MPI; import libcuflynx.solver_wrappers; ..."
SURVIVED. rank=0 size=1 is_root=True live=False
```

On 0.4.0 the same command aborted natively — `The MPI_Comm_rank() function was called before MPI_INIT was invoked` — because `PrimitiveParsers` reads `rank = mpi_utils.rank()` at module scope. The one-rank answers are the right ones for a process whose MPI was never opened.

The other direction still holds, which is the risk worth checking here — N ranks each believing they are rank 0 would be worse than the abort:

```
$ mpiexec -n 2 python -c "... print(mpi_utils.rank(), mpi_utils.size())"
rank 0 of 2 root True
rank 1 of 2 root False
```

## After merge

Tag `v0.4.1` on `physiomelinks/circulatory_autogen` `master` and push it — the workflow checks the tag against `pyproject.toml`, builds, and publishes to PyPI by trusted publishing. CUFLynx pins `libcuflynx>=0.4.0`, so its next build picks this up with no change on that side.
