### PR TITLE
ci: go straight to an apt mirror that answers, from one place instead of nine

### DIFF
--- a/.github/actions/install-system-deps/action.yml
+++ b/.github/actions/install-system-deps/action.yml
@@ -1,0 +1,46 @@
+name: Install system libraries (MPI, SUNDIALS)
+description: >-
+  Install the OpenMPI/SUNDIALS/toolchain packages every Linux job here needs, going
+  straight to an Ubuntu mirror that answers.
+
+runs:
+  using: composite
+  steps:
+    - name: Drop the Azure apt mirror if it is not answering
+      shell: bash
+      run: |
+        # The runner image points apt at a mirrorlist (/etc/apt/apt-mirrors.txt) listing
+        # azure.archive.ubuntu.com first and archive.ubuntu.com as fallback. When the Azure
+        # mirror is down, apt does not fail over quickly: it spends its connect timeout plus
+        # retries on the dead host for *every* index and *every* package.
+        #
+        # That is not hypothetical. It hung CUFLynx's release build for 1h40m in a step whose
+        # healthy cost is 32 seconds, and it is the best explanation for the spread here --
+        # in one run of this workflow the identical step took 1m22s in `test (3.10)` and
+        # 22m35s in `test-param-id-serial`, which is what winning or losing the mirror
+        # lottery looks like.
+        #
+        # Probe rather than delete unconditionally: when Azure is healthy it is the faster
+        # mirror (it is in the same datacentre), so it is worth keeping on a good day.
+        #
+        # --max-time, not a connect check: the failure mode is a *stalled transfer*, not a
+        # refused connection. Probing it by hand while it was down returned 13287 of 270087
+        # bytes and then stopped -- the socket opens and data starts flowing, so anything that
+        # only tests reachability is fooled, which is precisely why apt sits there.
+        # Ask for this runner's own release: ubuntu-latest is noble now and was jammy not
+        # long ago, and a hardcoded codename would silently probe the wrong thing.
+        codename="$(lsb_release -cs)"
+        if ! curl -fsS --max-time 10 -o /dev/null \
+             "http://azure.archive.ubuntu.com/ubuntu/dists/${codename}/InRelease"; then
+          echo "azure.archive.ubuntu.com is not answering -- using archive.ubuntu.com"
+          sudo sed -i '/azure.archive.ubuntu.com/d' /etc/apt/apt-mirrors.txt || true
+        fi
+        # Backstop for whichever mirror goes down next: fail a fetch in seconds, not minutes.
+        echo 'Acquire::http::Timeout "15"; Acquire::https::Timeout "15"; Acquire::Retries "3";' \
+          | sudo tee /etc/apt/apt.conf.d/99-ca-timeouts > /dev/null
+
+    - name: Install the packages
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,10 +37,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install system libraries (MPI, SUNDIALS)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+      - uses: ./.github/actions/install-system-deps
 
       - name: Install package and docs tooling
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Runs 13-31 minutes depending on the apt weather. This is a backstop, not a budget:
+    # without one, `test (3.11)` sat in the apt step for 45 minutes and had to be cancelled
+    # by hand, because the job would otherwise have run to GitHub's 360-minute default.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -28,10 +32,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
     
-    - name: Install MPI
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+    - uses: ./.github/actions/install-system-deps
     
     - name: Run tests (Myokit-first, skip OpenCOR-only)
       id: pytest
@@ -144,10 +145,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
 
-    - name: Install MPI and Myokit build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+    - uses: ./.github/actions/install-system-deps
 
     - name: Run the full-scale model calibration with MPI
       run: |
@@ -170,10 +168,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
 
-    - name: Install MPI and Myokit build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+    - uses: ./.github/actions/install-system-deps
 
     - name: Run param_id and sensitivity analysis tests with MPI
       run: |
@@ -198,10 +193,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
 
-    - name: Install MPI and Myokit build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+    - uses: ./.github/actions/install-system-deps
 
     - name: Run the full-scale model calibration in serial mode
       run: |
@@ -224,10 +216,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
 
-    - name: Install MPI and Myokit build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+    - uses: ./.github/actions/install-system-deps
 
     - name: Run param_id and sensitivity analysis tests in serial mode
       run: |
@@ -284,10 +273,7 @@ jobs:
         # the pyMC backend stayed unproven for as long as it did.
         pip install -e ".[dev,uq,emulation]"
 
-    - name: Install MPI and Myokit build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+    - uses: ./.github/actions/install-system-deps
 
     # Seconds, and the only place the pyMC-sampling half of these runs: without [uq] they skip,
     # which is exactly how the backend's live-chain checkpointing could regress unnoticed.
@@ -367,10 +353,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev,uq,emulation]"
 
-    - name: Install MPI and Myokit build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+    - uses: ./.github/actions/install-system-deps
 
     - name: Run the emulator UQ tests on two ranks
       timeout-minutes: 30
@@ -458,6 +441,7 @@ jobs:
   # This can be enabled if OpenCOR is set up in CI environment
   test-with-opencor:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: false  # Disabled by default - enable if OpenCOR is available in CI
     steps:
     - uses: actions/checkout@v4
@@ -472,10 +456,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
     
-    - name: Install MPI
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+    - uses: ./.github/actions/install-system-deps
     
     - name: Download and setup OpenCOR
       run: |


### PR DESCRIPTION
The identical apt step took **1m22s** in `test (3.10)` and **22m35s** in `test-param-id-serial` — in the *same run* of this workflow, same packages, same push. That 17x spread is not load. `azure.archive.ubuntu.com` stalls, and apt does not fail over quickly.

## What is actually happening

The runner image points apt at a mirrorlist (`/etc/apt/apt-mirrors.txt`) listing `azure.archive.ubuntu.com` first and `archive.ubuntu.com` as fallback. When Azure is unhealthy, apt spends its connect timeout plus retries on the dead host for *every* index and *every* package.

CUFLynx's release build showed the extreme version of this — a 32-second step hanging for 1h40m, then 25 minutes more on the rerun:

| Host | Result in that job |
|---|---|
| `azure.archive.ubuntu.com` | **22 × `Ign`, 0 successes** |
| `archive.ubuntu.com` | 1 Hit, 3 Get ✓ |
| `packages.microsoft.com` | 7 Get ✓ |
| `dl.google.com` | 2 Get ✓ |

Here it shows up less dramatically but more often: `test-uq` cancelled at its 25-minute ceiling **having never run a test**, and `test (3.11)` sitting 45 minutes in the same step.

## Nine copies became one

The step was copy-pasted nine times — eight in `tests.yml`, one in `benchmarks.yml` — so the fix would have been copy-pasted nine times too. It is now a composite action, which is what #461 asked for. Net **-36/+9** lines in the workflows.

Two details in it are deliberate:

**It probes rather than dropping Azure unconditionally.** When healthy it is the faster mirror — same datacentre — so it is worth keeping on a good day.

**The probe is `curl --max-time`, not a reachability check.** The failure mode is a *stalled transfer*, not a refused connection. Probing it by hand while it was down returned **13287 of 270087 bytes and then stopped** — the socket opens and data starts flowing, so anything that only tests reachability is fooled. That is precisely why apt sits there rather than failing over.

It also asks for the runner's own codename via `lsb_release -cs` rather than hardcoding one: `ubuntu-latest` is noble now and was jammy recently, and a hardcoded codename would silently probe the wrong path and always "succeed".

## Also here

`test` and `test-with-opencor` had no `timeout-minutes` — every other job in the file does. `test` is the one that mattered: it is where 3.11 could hang indefinitely, since without a value a job runs to GitHub's 360-minute default.

## Relationship to #461

**Not a substitute.** Caching is still worth doing for the 106-minutes-per-push it saves, but it would not have prevented any of the above: a cache miss — a dependency bump, a new runner image — walks into the same stall. Three layers, each catching what the previous misses: go to a working mirror → fail a dead one fast (`Acquire::*::Timeout 15`) → job timeout.

## Verified

Both workflows and the action parse; all nine call sites resolved; every job that uses the local action runs `actions/checkout` first (a `./` action is unavailable before checkout). The probe logic was exercised against the live outage — it correctly detects Azure as unhealthy today.
