### PR TITLE
test(ci): drive the released CUFLynx executable against this checkout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -439,6 +439,89 @@ jobs:
 
   # Job to run full test suite if OpenCOR is available (optional)
   # This can be enabled if OpenCOR is set up in CI environment
+  # The released CUFLynx desktop app, driven against this checkout.
+  #
+  # CUFLynx ships a frozen binary with a libcuflynx bundled inside it, frozen at whatever
+  # was current when it was released. Neither repo's CI tests the pairing: CUFLynx tests
+  # its own bundle, CA tests its own source, and "the app people have downloaded can still
+  # run this engine" is asserted nowhere. This is that assertion, from CA's side.
+  test-cuflynx-executable:
+    runs-on: ubuntu-latest
+    # The five analyses take ~10 minutes on Lotka-Volterra; the rest is the one-off 645 MB
+    # download on a cache miss. Generous enough to survive a slow release download, tight
+    # enough that a hang is reported rather than run to GitHub's 360-minute default.
+    timeout-minutes: 45
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    # The cache key, and the answer to "has a new one been released": the tag of the
+    # current release. A new release is a new key, hence a miss, hence a fresh download.
+    - name: Find the current CUFLynx release
+      id: release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        tag="$(gh api repos/physiomelinks/CUFLynx/releases/latest --jq .tag_name)"
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        echo "current CUFLynx release: $tag"
+
+    # No `restore-keys`, deliberately. A prefix fallback would cheerfully restore last
+    # month's binary when the key misses, which is precisely the case this job exists to
+    # catch -- the test would then pass against an executable nobody can download any more.
+    - name: Cache the executable
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/cuflynx
+        key: cuflynx-linux-x86_64-full-${{ steps.release.outputs.tag }}
+
+    # The -full asset rather than the ordinary one: it is the only build carrying
+    # autoemulate and pymc, and without them the emulator and the UQ-on-the-emulator
+    # tests have nothing to run against.
+    - name: Download the executable
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        set -euo pipefail
+        mkdir -p ~/.cache/cuflynx
+        curl -fL --retry 3 --retry-all-errors -o ~/.cache/cuflynx/CUFLynx-full \
+          "https://github.com/physiomelinks/CUFLynx/releases/download/${{ steps.release.outputs.tag }}/CUFLynx-linux-x86_64-full"
+
+    # Restored from a cache, the executable bit does not survive.
+    - name: Make it executable
+      run: chmod +x ~/.cache/cuflynx/CUFLynx-full
+
+    # Only pytest is needed here: the app runs the analyses in its own bundled interpreter,
+    # and reaches this checkout through CIRCULATORY_AUTOGEN_SRC rather than through an
+    # install. Installing CA's dependencies into the runner's python would prove nothing
+    # about the bundle and would hide a missing one.
+    - name: Install pytest
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+
+    - name: Run the executable end-to-end tests
+      env:
+        CUFLYNX_EXECUTABLE: /home/runner/.cache/cuflynx/CUFLynx-full
+        # Turns "no binary, skip everything" into a failure. A suite that silently skips
+        # its only end-to-end coverage is indistinguishable from one that passes it.
+        CUFLYNX_EXECUTABLE_REQUIRED: "1"
+      run: |
+        python -m pytest tests/test_cuflynx_executable.py -v --tb=short \
+          --junitxml=junit-cuflynx-executable.xml
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: cuflynx-executable-results
+        path: junit-cuflynx-executable.xml
+
   test-with-opencor:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -505,6 +505,13 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
 
+    # --confcutdir is what makes the line above true, and the test lives in its own
+    # directory so that it can be passed. `tests/conftest.py` imports yaml, numpy, mpi4py
+    # and libcuflynx at module scope; pytest loads every conftest from the rootdir down to
+    # the test, so collecting from `tests/` killed this job with ModuleNotFoundError before
+    # a single test ran -- pytest exit code 4, no junit file, nothing driven at all.
+    # The fix has to keep that conftest out of reach rather than install its imports:
+    # installing them is exactly what this job exists not to do.
     - name: Run the executable end-to-end tests
       env:
         CUFLYNX_EXECUTABLE: /home/runner/.cache/cuflynx/CUFLynx-full
@@ -512,7 +519,8 @@ jobs:
         # its only end-to-end coverage is indistinguishable from one that passes it.
         CUFLYNX_EXECUTABLE_REQUIRED: "1"
       run: |
-        python -m pytest tests/test_cuflynx_executable.py -v --tb=short \
+        python -m pytest tests/executable/test_cuflynx_executable.py -v --tb=short \
+          --confcutdir=tests/executable \
           --junitxml=junit-cuflynx-executable.xml
 
     - name: Upload test results

--- a/tests/executable/test_cuflynx_executable.py
+++ b/tests/executable/test_cuflynx_executable.py
@@ -35,7 +35,14 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+# tests/executable/this_file.py -> parents[2] is the repo root. This test lives one level
+# deeper than the rest of the suite on purpose: `tests/conftest.py` imports yaml, numpy,
+# mpi4py and libcuflynx at module scope, and the CI job that runs this one deliberately
+# installs nothing but pytest -- the whole point being that the app carries its own
+# environment. Collected from `tests/`, that conftest is loaded first and the job dies
+# with ModuleNotFoundError before a single test runs. The job passes --confcutdir so
+# nothing above this directory is loaded.
+ROOT = Path(__file__).resolve().parents[2]
 INPUTS = ROOT / "tests" / "test_inputs"
 SRC = ROOT / "src"
 MODEL = INPUTS / "Lotka_Volterra_forced.cellml"

--- a/tests/test_cuflynx_executable.py
+++ b/tests/test_cuflynx_executable.py
@@ -1,0 +1,350 @@
+"""The released CUFLynx executable, driven against *this* checkout of libcuflynx.
+
+CUFLynx ships a frozen desktop app with a libcuflynx bundled inside it. That bundled copy
+is whatever was current when the app was released, so nothing in either repo's CI notices
+when a change here breaks the app people actually downloaded -- CUFLynx tests its bundle,
+and CA tests its source, and the pairing of the two is tested nowhere.
+
+This closes that gap from CA's side: take the *released* binary, point it at the working
+tree, and drive the five things a user does with it -- moving a slider, training an
+emulator, sensitivity, calibration, and UQ evaluated on the emulator. A break here means a
+merged PR would leave the current download unable to run this engine.
+
+**The override is the whole premise, so it is asserted first.** Pointing Settings at a
+checkout only works because ``ca_imports`` puts that directory's ``src`` at the front of
+``sys.path`` and ``libcuflynx.*`` then resolves there rather than to the frozen copy. If
+that ever stopped working the app would quietly fall back to its own bundled engine and
+every test below would pass while testing nothing at all -- the failure mode this file
+exists to prevent, arriving disguised as a green run. ``test_the_app_runs_this_checkout``
+is not a nicety; it is what makes the rest evidence.
+
+Skipped unless ``CUFLYNX_EXECUTABLE`` names the binary. In CI the workflow downloads and
+caches it and sets ``CUFLYNX_EXECUTABLE_REQUIRED``, which turns the skip into a failure --
+a suite that silently skips its only end-to-end coverage is indistinguishable from one
+that passes it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+INPUTS = ROOT / "tests" / "test_inputs"
+SRC = ROOT / "src"
+MODEL = INPUTS / "Lotka_Volterra_forced.cellml"
+OBS = INPUTS / "Lotka_Volterra_forced_obs_data.json"
+PARAMS = INPUTS / "Lotka_Volterra_forced_params_for_id.csv"
+
+BINARY = os.environ.get("CUFLYNX_EXECUTABLE", "").strip()
+REQUIRED = os.environ.get("CUFLYNX_EXECUTABLE_REQUIRED", "").strip() not in ("", "0")
+PORT = int(os.environ.get("CUFLYNX_EXECUTABLE_PORT", "8791"))
+BASE = f"http://127.0.0.1:{PORT}"
+
+# Lotka-Volterra rather than a circulatory model on purpose: two states, no stiffness and
+# no compile worth speaking of, so the whole file is minutes. The point here is the
+# *pairing* of a released binary with this source -- an expensive model would test the
+# solver, which CA's own suite already does far more thoroughly.
+if not BINARY:
+    if REQUIRED:  # pragma: no cover - CI misconfiguration
+        raise RuntimeError(
+            "CUFLYNX_EXECUTABLE_REQUIRED is set but CUFLYNX_EXECUTABLE is empty: the "
+            "executable end-to-end tests would have skipped silently, which reads as a "
+            "pass. Check the download/cache step in the workflow."
+        )
+    pytestmark = pytest.mark.skip(
+        reason="set CUFLYNX_EXECUTABLE to a released CUFLynx binary to run these"
+    )
+
+
+def _req(method: str, path: str, data=None, timeout: float = 60):
+    """One JSON call, with the server's own explanation kept on failure.
+
+    urllib raises HTTPError with the body unread, so an unhandled 422 reaches CI as a bare
+    status line -- and these endpoints answer with the sentence that says what is wrong
+    ("no emulator has been trained for this study", say). Losing that turns a two-second
+    diagnosis into a rerun with extra logging.
+    """
+    body = json.dumps(data).encode() if data is not None else None
+    headers = {"Content-Type": "application/json"} if data is not None else {}
+    req = urllib.request.Request(BASE + path, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")[:2000]
+        raise AssertionError(f"{method} {path} -> HTTP {exc.code}: {detail}") from None
+
+
+def _upload(path: str, field: str, file: Path, extra: dict) -> dict:
+    boundary = "----cacuflynxsmoke"
+    parts: list[bytes] = []
+    for k, v in extra.items():
+        parts.append(
+            f"--{boundary}\r\nContent-Disposition: form-data; "
+            f'name="{k}"\r\n\r\n{v}\r\n'.encode()
+        )
+    parts.append(
+        f"--{boundary}\r\nContent-Disposition: form-data; "
+        f'name="{field}"; filename="{file.name}"\r\n'
+        f"Content-Type: application/octet-stream\r\n\r\n".encode()
+    )
+    parts.append(file.read_bytes())
+    parts.append(f"\r\n--{boundary}--\r\n".encode())
+    req = urllib.request.Request(
+        BASE + path,
+        data=b"".join(parts),
+        headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _poll(kind: str, job_id: str, timeout: float) -> dict:
+    """Wait for an analysis job, returning its final payload.
+
+    Deadline rather than an iteration count: these runs are minutes and the interesting
+    failure is a hang, which a bounded loop of sleeps reports as "still running" forever.
+    """
+    deadline = time.monotonic() + timeout
+    last: dict = {}
+    while time.monotonic() < deadline:
+        last = _req("GET", f"/api/{kind}/{job_id}/status")
+        if last.get("state") in ("done", "error", "cancelled"):
+            return last
+        time.sleep(2)
+    lines = "\n".join((last.get("lines") or [])[-25:])
+    raise AssertionError(f"{kind} did not finish within {timeout:.0f}s. Tail:\n{lines}")
+
+
+def _fail_with_log(kind: str, payload: dict) -> str:
+    return (
+        f"{kind} ended in state {payload.get('state')!r}. Tail:\n"
+        + "\n".join((payload.get("lines") or [])[-25:])
+    )
+
+
+@pytest.fixture(scope="session")
+def app(tmp_path_factory):
+    """The released binary, serving, pointed at this working tree.
+
+    ``CIRCULATORY_AUTOGEN_SRC`` rather than a POST to /api/config after startup: the
+    directory has to be in place *before* the app first imports libcuflynx, or the bundled
+    copy is already in ``sys.modules`` and the checkout can never win. A stale settings
+    file would otherwise decide which engine gets tested, so the config dir is a throwaway
+    too.
+    """
+    config_dir = tmp_path_factory.mktemp("cuflynx_config")
+    binary = Path(BINARY).resolve()
+    assert binary.is_file(), f"CUFLYNX_EXECUTABLE does not exist: {binary}"
+    assert os.access(binary, os.X_OK), f"not executable (chmod +x?): {binary}"
+    for fixture in (MODEL, OBS, PARAMS):
+        assert fixture.is_file(), f"fixture missing: {fixture}"
+
+    env = dict(os.environ)
+    env["CIRCULATORY_AUTOGEN_SRC"] = str(ROOT)
+    env["CUFLYNX_CONFIG_DIR"] = str(config_dir)
+
+    proc = subprocess.Popen(
+        [str(binary), "--port", str(PORT), "--browser"],
+        cwd=str(ROOT), env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    try:
+        deadline = time.monotonic() + 180
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                raise AssertionError(
+                    f"the app exited during startup (code {proc.returncode})"
+                )
+            try:
+                urllib.request.urlopen(BASE + "/api/health", timeout=3).read()
+                break
+            except (urllib.error.URLError, OSError):
+                time.sleep(1)
+        else:
+            raise AssertionError("the app never became healthy")
+
+        conf = _req("POST", "/api/config", {
+            "ca_dir": str(ROOT),
+            # Pin the backend: analyses inherit the engine's solver, and leaving it at a
+            # CA default of CVODE_opencor -- which is not installed and never will be
+            # here -- makes the run depend on what was persisted.
+            "generated_model_format": "cellml",
+            "solver": "CVODE_myokit",
+            "solver_info": {"dt": 0.01},
+        })
+        assert conf.get("ca_exists"), f"checkout not accepted as a CA dir: {conf!r}"
+        yield conf
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:  # pragma: no cover - only on a wedged app
+            proc.kill()
+
+
+@pytest.fixture(scope="session")
+def study(app):
+    """Model, obs_data and params_for_id uploaded once, as a user would."""
+    up = _upload("/api/models/upload", "file", MODEL, {})
+    model_id = up["model_id"]
+    _upload("/api/obs_data/upload", "file", OBS, {"model_id": model_id})
+    _upload("/api/params_for_id/upload", "file", PARAMS, {"model_id": model_id})
+    return model_id
+
+
+def test_the_app_runs_this_checkout_not_its_own_bundle(app, tmp_path_factory):
+    """Everything else here is meaningless if this fails.
+
+    The binary carries its own libcuflynx. If the checkout does not take precedence, the
+    tests below exercise the *released* engine and pass no matter what this PR does to the
+    source -- a green run that proves nothing. Ask the bundle which file it actually
+    imports rather than trusting that pointing at a directory was enough.
+
+    Asked through the app's runner mode, which is how the app runs its own analyses, so
+    this is the same import machinery the tests below depend on and not a simulation of it.
+    """
+    info = _req("GET", "/api/config")
+    assert info.get("packaged") is True, (
+        "the app does not report itself as packaged, so this is not the released "
+        "executable and the pairing is not being tested"
+    )
+
+    work = tmp_path_factory.mktemp("ca_override")
+    probe = work / "probe.py"
+    probe.write_text(
+        "import sys, importlib\n"
+        # Whether the bundled copy is already in sys.modules decides whether this check
+        # can conclude anything at all: once it is imported, a sys.path entry cannot
+        # displace it and the answer below would be the bundle's no matter what. Report
+        # it, so the guard can say "I cannot tell" instead of quietly passing.
+        "print('PREIMPORTED:', 'libcuflynx' in sys.modules)\n"
+        # The app's own mechanism: ca_imports.ensure_ca_path() puts the configured
+        # directory's src at the front before the first CA import.
+        f"sys.path.insert(0, {str(SRC)!r})\n"
+        "m = importlib.import_module('libcuflynx.parsers.PrimitiveParsers')\n"
+        "print('RESOLVED:', m.__file__)\n",
+        encoding="utf-8",
+    )
+    cfg = work / "cfg.json"  # runner mode expects a config path as argv[2]
+    cfg.write_text("{}", encoding="utf-8")
+    out = subprocess.run(
+        [BINARY, "--_cuflynx-run-analysis", str(probe), str(cfg)],
+        capture_output=True, text=True, timeout=300,
+    )
+    combined = out.stdout + out.stderr
+    assert "PREIMPORTED: False" in combined, (
+        "the bundle imported libcuflynx before the probe ran, so nothing this check does "
+        "could displace it and its answer would be meaningless. The result below is not "
+        f"evidence either way -- treat this as inconclusive, not as a pass.\n{combined[-2000:]}"
+    )
+    assert f"RESOLVED: {SRC}" in combined, (
+        "the frozen app resolved libcuflynx to its own bundled copy rather than to this "
+        f"checkout, so these tests would prove nothing about this source.\n{combined[-2000:]}"
+    )
+
+
+def test_param_sliding_runs_the_model(study):
+    """What dragging a slider does: change a constant, re-simulate, get a trace back.
+
+    The live tier, not the analysis tier -- it runs *in* the app's own process against
+    this checkout's solver_wrappers, and it is the one interaction every user performs.
+    """
+    base = _req("POST", "/api/simulate",
+                {"model_id": study, "params": {}, "sim_time": 5.0}, timeout=300)
+    assert "detail" not in base, f"baseline simulation failed: {base.get('detail')}"
+    assert len(base["time"]) > 1 and base["outputs"], f"no usable trace: {base.keys()}"
+
+    moved = _req("POST", "/api/simulate",
+                 {"model_id": study,
+                  "params": {"Lotka_Volterra_module/alpha": 2.5},
+                  "sim_time": 5.0}, timeout=300)
+    assert "detail" not in moved, f"simulation after the slider move failed: {moved.get('detail')}"
+
+    key = next(iter(base["outputs"]))
+    assert moved["outputs"][key] != base["outputs"][key], (
+        f"moving alpha changed nothing in {key}: the parameter never reached the solver, "
+        f"which is the failure a slider shows as a dead control"
+    )
+
+
+@pytest.fixture(scope="session")
+def emulator(study):
+    """Train a surrogate -- and hand it to whatever needs one trained.
+
+    A fixture rather than test ordering: the UQ-on-the-emulator test genuinely depends on
+    this having happened, and depending on declaration order makes that invisible and
+    breaks under -k or -p xdist.
+    """
+    started = _req("POST", "/api/emulator/train", {
+        "model_id": study,
+        # Far below CA's default of 128. This asks whether the emulator can be trained and
+        # then evaluated by the other analyses, not whether it is accurate; a real
+        # training run would dominate the job.
+        "settings": {"num_train_samples": 16, "sample_type": "sobol",
+                     "random_seed": 0, "n_iter": 2, "n_splits": 2, "min_r2": -1e9},
+    })
+    done = _poll("emulator", started["job_id"], 900)
+    assert done["state"] == "done", _fail_with_log("emulator training", done)
+    return done
+
+
+def test_emulator_training(emulator):
+    """It has to leave a bundle behind, not merely exit cleanly."""
+    meta = emulator.get("metadata") or {}
+    assert meta, (
+        "training finished with no metadata, so nothing was written for the other "
+        "analyses to load"
+    )
+
+
+def test_sensitivity_analysis(study):
+    """Local sensitivity about the current point -- the cheapest real analysis run."""
+    started = _req("POST", "/api/sensitivity/run", {
+        "model_id": study,
+        "settings": {"method": "local", "gradient_method": "FD", "nominal": "current",
+                     "rel_step": 0.05, "dt": 0.01, "num_cores": 1},
+    })
+    done = _poll("sensitivity", started["job_id"], 900)
+    assert done["state"] == "done", _fail_with_log("sensitivity", done)
+
+
+def test_calibration(study):
+    """A short genetic-algorithm identification; DEBUG keeps the population small."""
+    started = _req("POST", "/api/calibration/run", {
+        "model_id": study,
+        "settings": {"param_id_method": "genetic_algorithm",
+                     "num_calls_to_function": 30, "DEBUG": True, "dt": 0.01},
+    })
+    done = _poll("calibration", started["job_id"], 900)
+    assert done["state"] == "done", _fail_with_log("calibration", done)
+    best = done.get("best_params") or {}
+    assert best and all(isinstance(v, (int, float)) for v in best.values()), (
+        f"calibration produced no usable best_params: {best!r}"
+    )
+
+
+def test_uq_evaluated_on_the_emulator(study, emulator):
+    """UQ with ``use_emulator`` on -- the combination nothing else covers.
+
+    Worth its own test rather than folding into the UQ run: sampling against a surrogate
+    goes through a different path in CA from sampling against the solver, and it is the
+    one the -full bundle exists to make possible.
+    """
+    started = _req("POST", "/api/uq/run", {
+        "model_id": study,
+        "settings": {"method": "mcmc", "library": "emcee",
+                     # Enough to move the sampler through its real code path and no more.
+                     "num_steps": 60, "burn_in": 0.5, "dt": 0.01,
+                     "use_emulator": True},
+    })
+    done = _poll("uq", started["job_id"], 900)
+    assert done["state"] == "done", _fail_with_log("UQ on the emulator", done)

--- a/tests/test_inputs/Lotka_Volterra_forced_obs_data.json
+++ b/tests/test_inputs/Lotka_Volterra_forced_obs_data.json
@@ -14,7 +14,7 @@
     "data_items": [
         {
             "variable": "Lotka_Volterra_module/x",
-            "name_for_plotting": "x_{max}",
+            "name_for_plotting": "x",
             "data_type": "constant",
             "operation": "max",
             "operands": [
@@ -30,7 +30,7 @@
         },
         {
             "variable": "Lotka_Volterra_module/y",
-            "name_for_plotting": "y_{max}",
+            "name_for_plotting": "y",
             "data_type": "constant",
             "operation": "max",
             "operands": [

--- a/tests/test_inputs/Lotka_Volterra_forced_obs_data.json
+++ b/tests/test_inputs/Lotka_Volterra_forced_obs_data.json
@@ -1,0 +1,48 @@
+{
+    "protocol_info": {
+        "pre_times": [
+            0.0
+        ],
+        "sim_times": [
+            [
+                5
+            ]
+        ],
+        "params_to_change": {}
+    },
+    "prediction_items": [],
+    "data_items": [
+        {
+            "variable": "Lotka_Volterra_module/x",
+            "name_for_plotting": "x_{max}",
+            "data_type": "constant",
+            "operation": "max",
+            "operands": [
+                "Lotka_Volterra_module/x"
+            ],
+            "unit": "dimensionless",
+            "weight": 1.0,
+            "value": 30,
+            "std": 3,
+            "experiment_idx": 0,
+            "subexperiment_idx": 0,
+            "plot_type": "horizontal"
+        },
+        {
+            "variable": "Lotka_Volterra_module/y",
+            "name_for_plotting": "y_{max}",
+            "data_type": "constant",
+            "operation": "max",
+            "operands": [
+                "Lotka_Volterra_module/y"
+            ],
+            "unit": "dimensionless",
+            "weight": 1.0,
+            "value": 35.1,
+            "std": 2,
+            "experiment_idx": 0,
+            "subexperiment_idx": 0,
+            "plot_type": "horizontal"
+        }
+    ]
+}

--- a/tests/test_inputs/Lotka_Volterra_forced_params_for_id.csv
+++ b/tests/test_inputs/Lotka_Volterra_forced_params_for_id.csv
@@ -1,0 +1,5 @@
+vessel_name, param_name, min, max, name_for_plotting, prior
+Lotka_Volterra_module, alpha, 0.1, 7, \alpha , uniform
+Lotka_Volterra_module, beta, 0.01, 2, \beta, uniform
+Lotka_Volterra_module, delta, 0.01, 2, \delta, uniform
+Lotka_Volterra_module, gamma, 0.1, 10, \gamma, uniform


### PR DESCRIPTION
CUFLynx ships a frozen desktop app with a `libcuflynx` bundled inside it, frozen at whatever was current when it was released. **Neither repo's CI tests the pairing**: CUFLynx tests its own bundle, CA tests its own source, and "the app people have already downloaded can still run this engine" is asserted nowhere. A PR here can break the current download and every check stays green.

This asserts it from CA's side: take the released binary, point it at the working tree, and drive the five things a user does with it.

| Test | What breaks if it fails |
|---|---|
| param sliding | the live tier — a slider that moves nothing |
| emulator training | the Emulator tab produces no bundle |
| sensitivity | analysis tier in the app's own interpreter |
| calibration | ditto, plus `best_params` actually usable |
| UQ **on the emulator** | the path only the `-full` bundle can run |

Lotka-Volterra rather than a circulatory model: two states, no stiffness, no compile worth speaking of, so the whole file is **under three minutes**. The point is the pairing, not the solver — CA's own suite covers that far better.

## The premise is asserted first

Pointing Settings at a checkout only works because `ca_imports` puts that directory's `src` ahead of the frozen copy. If that ever stops working, the app quietly falls back to its own bundled engine and **all five tests pass while testing nothing** — a green run that proves the opposite of what it claims.

`test_the_app_runs_this_checkout_not_its_own_bundle` is therefore not a nicety; it is what makes the rest evidence. It also reports whether `libcuflynx` had already been imported before it looked: if it had, a `sys.path` entry could not have displaced it and the answer proves nothing either way, so the test says *inconclusive* rather than passing.

This is not hypothetical. While writing this I based the branch on the wrong master (the fork's, which is still flat-layout `circulatory-autogen 0.3.0`), and the guard caught that the analyses were running against the **released** engine rather than the source. Five green tests, zero coverage. Without the guard it would have merged and kept passing.

## Caching, and noticing a new release

The cache key is the tag of the current release, which is also how "has a new one been released" gets answered — a new release is a new key, hence a miss, hence a fresh download:

```yaml
key: cuflynx-linux-x86_64-full-${{ steps.release.outputs.tag }}
```

**Deliberately no `restore-keys`.** A prefix fallback would cheerfully restore last month's binary on a miss, which is precisely the case this job exists to catch — the test would then pass against an executable nobody can download any more.

`CUFLYNX_EXECUTABLE_REQUIRED=1` turns "no binary, skip everything" into a failure. A suite that silently skips its only end-to-end coverage is indistinguishable from one that passes it.

## Why two new fixtures

CA's own `resources/Lotka_Volterra_obs_data.json` and `..._params_for_id.csv` target the model CA *generates* from the vessel array, where the component is `Lotka_Volterra`. The raw `.cellml` the app uploads names it `Lotka_Volterra_module`. Same model, different spelling — so these sit in `tests/test_inputs/` beside the `.cellml` they belong to, rather than changing files CA's own tests depend on.

## Verified

- **6 passed in 2:47** against the real v0.4.1 `CUFLynx-linux-x86_64-full`
- the premise check is mutation-verified: pointed at a directory that is not this checkout, it fails with "resolved libcuflynx to its own bundled copy"
- the `-full` asset specifically, because it is the only build carrying autoemulate and pymc — without them the emulator and UQ-on-emulator tests have nothing to run against

## Notes

- Only `pytest` is installed in the job. The app runs analyses in its **own** bundled interpreter and reaches this checkout through `CIRCULATORY_AUTOGEN_SRC`, so installing CA's dependencies into the runner's python would prove nothing about the bundle and would hide a missing one.
- Reading "SE" in the request as sensitivity analysis.
