### PR TITLE
Defer the corner import so concurrent MPI ranks cannot race arviz

### DIFF
--- a/src/libcuflynx/identifiabilty_analysis/identifiabilityAnalysis.py
+++ b/src/libcuflynx/identifiabilty_analysis/identifiabilityAnalysis.py
@@ -7,10 +7,10 @@ import os
 import sys
 from sys import exit
 from matplotlib.ticker import FuncFormatter
-try:
-    import corner
-except ImportError:
-    corner = None
+# Deferred to its single call site in plot_laplace_results(); see
+# libcuflynx/utilities/lazy_imports.py for why this is not a module-level
+# `try: import corner / except ImportError`.
+from libcuflynx.utilities.lazy_imports import require_corner
 import math as math
 try:
     import opencor as oc
@@ -342,9 +342,17 @@ class IdentifiabilityAnalysis():
           parameter_names: List of parameter names corresponding to the best_param_vals.
           output_dir: Directory to save the plots.
         """
-        if corner is None:
-            raise ImportError("corner is required to plot Laplace results.")
-          
+        # Rank 0 only, like plot_mcmc(). Its caller -- scripts/plot_param_id_script.py --
+        # runs on every rank and had no guard of its own, so under `mpiexec -n 4
+        # cuflynx-plot` all four ranks drew this figure and wrote it to the same path.
+        # Concurrent writes to one PDF were the visible half of that; the invisible half
+        # was four ranks importing corner (and therefore arviz) in lockstep, which is the
+        # race described in utilities/lazy_imports.py.
+        if self.rank != 0:
+            return
+
+        corner = require_corner("plot Laplace results")
+
 
         if self.covariance_matrix_Laplace is None or self.mean_Laplace is None:
             try:

--- a/src/libcuflynx/param_id/paramID.py
+++ b/src/libcuflynx/param_id/paramID.py
@@ -55,10 +55,17 @@ try:
     import zeus
 except ImportError:
     zeus = None
-try:
-    import corner
-except ImportError:
-    corner = None
+# corner is NOT imported here, deliberately. It is a core dependency, so this was once a
+# plain module-level import -- but it is used at exactly four call sites, all of them inside
+# plot_mcmc(), and importing it drags in arviz and xarray on every rank of every calibration,
+# the vast majority of which never draw a corner plot.
+#
+# It also cannot be guarded with `except ImportError`. arviz 0.23.4 writes a once-a-day stamp
+# file at import time through a fixed temporary name, so concurrent MPI ranks race and the
+# losers get FileNotFoundError -- which sails straight through an ImportError guard and takes
+# the rank, and then via MPI_ABORT the whole job, down with it. See
+# utilities/lazy_imports.py, which carries the measurements and the reasoning.
+from libcuflynx.utilities.lazy_imports import require_corner
 import csv
 import shutil
 from datetime import date, datetime
@@ -880,6 +887,10 @@ class CVS0DParamID():
         flat_samples, samples, num_params = self.get_mcmc_samples()
         if self.rank != 0:
             return
+
+        # Imported here rather than at module scope: this is the only method in the file
+        # that needs it, and on rank 0 only. See the note beside the import at the top.
+        corner = require_corner("plot MCMC corner plots")
 
         means = np.zeros((num_params))
         conf_ivals = np.zeros((num_params, 3))

--- a/src/libcuflynx/utilities/lazy_imports.py
+++ b/src/libcuflynx/utilities/lazy_imports.py
@@ -1,0 +1,129 @@
+"""Deferred imports of dependencies that are only needed to draw a plot.
+
+Two separate problems live here, and the second one is why this module exists rather
+than a bare ``try: import x`` at the top of each caller.
+
+**1. It puts a whole scientific stack on the import path of every calibration.**
+``param_id/paramID.py`` is imported by *every* calibration, whether or not it will
+ever draw anything, and ``import corner`` drags in ``arviz``, ``xarray`` and
+``xarray_einstats`` behind it. The *time* saved is small and worth stating honestly
+-- measured at **0.05 s**, because ``paramID`` imports matplotlib and numpy anyway
+and those dominate. The point is not speed. It is that three large third-party
+packages, and every import-time side effect they carry, were being executed by every
+rank of every run to support four call sites in one method that most runs never
+reach.
+
+**2. An import can fail with something that is not an ``ImportError``.**
+This is the one that actually bit. ``arviz`` 0.23.4 runs ``_warn_once_per_day()`` at
+module scope, which writes a stamp file through a *fixed* temporary name::
+
+    tmp = path.with_suffix(path.suffix + ".tmp")   # ~/.cache/arviz/daily_warning.tmp
+    tmp.write_text(text)
+    tmp.replace(path)
+
+Every MPI rank computes the same temporary path. Rank A writes it, rank B writes it,
+rank A renames it away, and rank B's ``replace()`` raises::
+
+    FileNotFoundError: '~/.cache/arviz/daily_warning.tmp' -> '~/.cache/arviz/daily_warning'
+
+``FileNotFoundError`` is not an ``ImportError``, so the ``except ImportError`` guards
+around ``import corner`` -- both the one here and the identical one inside
+``corner/corner.py`` -- let it through. It killed rank 3 of a four-rank job, and
+MPI_ABORT took the other three down with it.
+
+Measured on a 20-core machine with a cold ``~/.cache/arviz``: 33 of 60 ranks lost at
+``mpiexec -n 4``, 14 of 30 at ``-n 2``, and **0 of 20** once the stamp file existed.
+That last number is the trap -- the failure is real for exactly one run per day, so
+re-running "fixes" it and it reads as random.
+
+So the rule this module encodes is **narrow scope, wide exception, loud log**: catch
+``Exception`` rather than ``ImportError``, say exactly what was swallowed, and never
+let an optional *plotting* dependency abort a calibration that had already run for
+an hour.
+
+``CUFLYNX_STRICT_STARTUP=1`` turns the swallow back into a raise. Production wants
+the wide catch; CI wants to know. Set it in any job that is meant to prove the
+import path is clean.
+"""
+import importlib
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+#: Sentinel distinguishing "not tried yet" from "tried and failed" -- ``None`` is the
+#: documented answer for the latter, so it cannot also mean the former.
+_UNSET = object()
+
+_cache = {}
+
+
+def strict_startup():
+    """Whether a failed optional import should raise instead of returning ``None``.
+
+    Read at call time rather than at import time so a test can set it with
+    ``monkeypatch.setenv`` without having to reload this module.
+    """
+    return os.environ.get("CUFLYNX_STRICT_STARTUP", "").strip() not in ("", "0")
+
+
+def load_optional(name):
+    """Import *name* on first use; return the module, or ``None`` if it will not load.
+
+    The result -- including the failure -- is cached, so a broken optional dependency
+    costs one import attempt per process rather than one per plot.
+
+    Catches ``Exception``, deliberately. See the module docstring: the failure this
+    was written for is a ``FileNotFoundError`` raised by a third-party module's
+    import-time side effect, and an ``except ImportError`` does not see it.
+    ``BaseException`` is *not* caught -- a ``KeyboardInterrupt`` during an import is
+    still a ``KeyboardInterrupt``.
+    """
+    cached = _cache.get(name, _UNSET)
+    if cached is not _UNSET:
+        return cached
+
+    try:
+        module = importlib.import_module(name)
+    except Exception as exc:
+        if strict_startup():
+            raise
+        # exc_info so the traceback names the *third-party* frame that actually
+        # failed. Without it this reads as "corner is missing", which sent the
+        # original investigation looking in the wrong place entirely.
+        logger.warning(
+            "optional dependency %r could not be imported (%s: %s); anything that "
+            "needs it will be skipped. This does not affect the calibration itself.",
+            name, type(exc).__name__, exc, exc_info=True,
+        )
+        module = None
+
+    _cache[name] = module
+    return module
+
+
+def load_corner():
+    """``corner``, or ``None``. Import it here, not at module scope -- see above."""
+    return load_optional("corner")
+
+
+def require_corner(what):
+    """``corner``, or raise ``ImportError`` naming *what* could not be drawn.
+
+    For the call sites that have nothing useful to do without it, as opposed to the
+    ones that can carry on and skip a figure.
+    """
+    module = load_corner()
+    if module is None:
+        raise ImportError(
+            f"corner is required to {what}. It is a core dependency, so this is "
+            f"usually a broken environment rather than a missing install -- run "
+            f"`python -c \"import corner\"` to see the underlying error, or set "
+            f"CUFLYNX_STRICT_STARTUP=1 to have it raised rather than logged."
+        )
+    return module
+
+
+def reset_cache():
+    """Forget what has been tried. For tests only."""
+    _cache.clear()

--- a/tests/test_import_races.py
+++ b/tests/test_import_races.py
@@ -1,0 +1,282 @@
+"""Concurrent ranks must be able to import the calibration stack.
+
+The failure this file exists to prevent, in full, because it is not obvious and it cost
+a day:
+
+``arviz`` 0.23.4 (and 0.23.3 -- both, checked) runs ``_warn_once_per_day()`` at module
+scope. That writes a stamp file through a **fixed** temporary name::
+
+    tmp = path.with_suffix(path.suffix + ".tmp")   # ~/.cache/arviz/daily_warning.tmp
+    tmp.write_text(text)
+    tmp.replace(path)
+
+Every process computes the same temporary path, so concurrent MPI ranks race: one renames
+it away and the others' ``replace()`` raises ``FileNotFoundError``. That is not an
+``ImportError``, so it went straight through the ``except ImportError`` around
+``import corner`` -- ours *and* the identical one inside ``corner/corner.py`` -- and killed
+a rank. MPI_ABORT then killed the job.
+
+Three properties of that bug decide how these tests are written:
+
+1. **It needs a cold cache.** After one process writes the stamp, ``last_date == today``
+   short-circuits and the whole day is clean. Measured: 33/60 ranks lost at ``-n 4`` with
+   a cold cache, **0/20** with a warm one. So every test here points ``XDG_CACHE_HOME``
+   at a fresh directory. Without that they would pass on the second run of the day and
+   for the rest of it.
+
+2. **It needs the ranks in lockstep, which pytest destroys.** Measured on the same
+   machine, same cold cache, same ``-n 4``, the same import: an app-shaped script lost
+   33/60 ranks; ``mpiexec -n 4 pytest`` with the import at module scope lost **0/40**.
+   pytest's plugin loading, conftest and collection stagger the ranks by tens to hundreds
+   of milliseconds and the vulnerable window is microseconds. **So these tests launch
+   their own subprocesses and must never be run under ``mpiexec`` themselves** -- an
+   in-process version cannot fail, and would be a test that reports a pass having
+   probed nothing. (``test_uq_pymc_mpi.py`` launches its own ranks for the same reason.)
+
+3. **It is probabilistic, and the odds are tunable.** One green run is not evidence, and
+   neither is one red one. Every constant in this file was chosen by measuring the catch
+   rate against deliberately broken code rather than by picking a round number -- see the
+   table beside ``RANKS``. The first version of this file used four ranks and no
+   pre-warm, which catches the bug three times in ten: it passed against the restored bug
+   and would have shipped as a test that mostly lies.
+
+``test_paramid_does_not_import_corner_or_arviz`` is the deterministic guard and the one
+that runs everywhere; the concurrent tests are the ones that reproduce the original
+failure, and they need ``arviz`` actually installed to mean anything.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = str(REPO_ROOT / "src")
+
+#: Rank count and trial count are *measured*, not guessed. Against deliberately broken
+#: code (the module-level ``import corner`` restored), the fraction of trials that caught
+#: it on a 20-core machine was:
+#:
+#:     ranks=4, no pre-warm ->  3/10      <- what this file shipped with first; too flaky
+#:     ranks=4, pre-warm    ->  9/10
+#:     ranks=8, no pre-warm -> 10/10
+#:     ranks=8, pre-warm    ->  9/10
+#:
+#: Eight ranks with the pre-warm below is ~0.9 per trial, so three trials miss a real
+#: regression about once in a thousand runs. Four ranks without the pre-warm -- the
+#: obvious choice -- would have missed it seven times in ten, which is a test that mostly
+#: lies. --oversubscribe covers CI runners with fewer slots than RANKS.
+RANKS = 8
+
+#: Probabilistic, so a single trial proves nothing; see the table above.
+TRIALS = 3
+
+
+def _mpiexec():
+    for name in ("mpiexec", "mpirun"):
+        found = shutil.which(name)
+        if found:
+            return found
+    return None
+
+
+needs_mpiexec = pytest.mark.skipif(_mpiexec() is None, reason="no mpiexec on PATH")
+
+
+def _run_on_ranks(program, env_extra=None, timeout=600):
+    """Run *program* on RANKS ranks and return (returncode, combined output).
+
+    Ranks are launched directly rather than through pytest, deliberately -- see the
+    module docstring, point 2.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = SRC + os.pathsep + env.get("PYTHONPATH", "")
+    # Agg so a rank without a display does not fail for an unrelated reason.
+    env["MPLBACKEND"] = "Agg"
+    env.update(env_extra or {})
+    cmd = [_mpiexec(), "--oversubscribe", "-n", str(RANKS), sys.executable, "-c", program]
+    proc = subprocess.run(
+        cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        universal_newlines=True, timeout=timeout,
+    )
+    return proc.returncode, proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# The deterministic guard
+# ---------------------------------------------------------------------------
+
+_IMPORT_PROBE = textwrap.dedent(
+    """
+    import json, sys
+    import libcuflynx.param_id.paramID          # noqa: F401
+    import libcuflynx.identifiabilty_analysis.identifiabilityAnalysis  # noqa: F401
+    print("RESULT " + json.dumps(sorted(
+        m for m in ("corner", "arviz", "xarray") if m in sys.modules)))
+    """
+)
+
+
+def test_paramid_does_not_import_corner_or_arviz():
+    """The calibration stack must not drag a plotting stack onto the import path.
+
+    This is the fix stated as a property rather than as an implementation, so it survives
+    the next refactor: whatever ``paramID`` does internally, importing it must not execute
+    ``corner`` (and therefore ``arviz``, ``xarray``, ``xarray_einstats``) or any
+    import-time side effect they carry.
+
+    Deterministic and cheap, unlike everything below it, and it is the assertion that
+    actually fails if someone restores the module-level ``import corner``.
+    """
+    env = dict(os.environ, PYTHONPATH=SRC + os.pathsep + os.environ.get("PYTHONPATH", ""),
+               MPLBACKEND="Agg")
+    proc = subprocess.run(
+        [sys.executable, "-c", _IMPORT_PROBE], env=env, stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT, universal_newlines=True, timeout=600,
+    )
+    assert proc.returncode == 0, f"the probe itself failed:\n{proc.stdout}"
+    line = [ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT ")]
+    assert line, f"probe printed no result:\n{proc.stdout}"
+    leaked = json.loads(line[-1][len("RESULT "):])
+    assert leaked == [], (
+        f"importing the calibration stack pulled in {leaked}. corner must stay deferred "
+        f"to its call sites in plot_mcmc()/plot_laplace_results() -- see "
+        f"libcuflynx/utilities/lazy_imports.py for why this is not merely tidiness."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The concurrent tests -- the ones that reproduce the original failure
+# ---------------------------------------------------------------------------
+
+# BARRIER-AT-THE-IMPORT, and why a plain barrier is not enough.
+#
+# The obvious probe -- barrier, then import -- does not work, and shipping it would have
+# been worse than shipping nothing. Measured on a 20-core machine, four ranks released
+# from a barrier and then importing the calibration stack reach `import corner`
+# **277-326 ms apart**, because the 2.4 s of libcellml/myokit/matplotlib imports in
+# between is not identical work at identical speed. The vulnerable window inside arviz is
+# the microseconds between `tmp.write_text()` and `tmp.replace()`. A 300 ms spread never
+# lands in it, and the test passes against known-broken code -- verified: it did.
+#
+# That is the same effect that makes `mpiexec -n N pytest` a weak probe (module docstring,
+# point 2), arriving from a different direction. Any work between the synchronisation
+# point and the import under test destroys the probe.
+#
+# So the barrier is moved to the import itself. A meta-path finder sits in front of
+# `sys.meta_path`, and the first time any rank asks for the target module it calls
+# `comm.Barrier()` and then returns None so the ordinary finders load it as usual. Every
+# rank therefore begins executing the module body within microseconds of the others, no
+# matter how staggered they were beforehand.
+#
+# This is a deliberate **worst case**, not a simulation of production timing -- and that is
+# the right thing for a test to be. It answers "if these ranks did arrive together, would
+# they collide?", deterministically, instead of rolling dice on the scheduler.
+#
+# Deadlock note: every rank must reach the barrier or it hangs. Ranks run the same
+# program, so they do -- and if a change ever makes them diverge, the subprocess timeout
+# reports it as a failure, which is the correct answer to "some ranks import this and
+# some do not".
+_CONCURRENT_PROBE = textwrap.dedent(
+    """
+    import importlib.abc, sys
+    # Pre-warm what the target's own module body will need. Anything it has to import
+    # *after* the barrier is work that re-staggers the ranks before they reach the
+    # vulnerable lines. Measured: this alone takes the catch rate at four ranks from
+    # 3/10 to 9/10.
+    import matplotlib, matplotlib.colors, matplotlib.pyplot  # noqa: F401
+    import platformdirs, packaging.version, re, logging      # noqa: F401
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+
+    class BarrierOn(importlib.abc.MetaPathFinder):
+        '''Synchronise every rank immediately before *name*'s module body runs.'''
+        def __init__(self, name):
+            self.name = name
+            self.fired = False
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == self.name and not self.fired:
+                self.fired = True
+                comm.Barrier()
+            return None      # never claim the module; let the real finders load it
+
+    sys.meta_path.insert(0, BarrierOn({target!r}))
+
+    try:
+        {import_line}
+    except BaseException as exc:            # noqa: BLE001 - reporting, not handling
+        print("FAIL rank %d %s: %s" % (comm.rank, type(exc).__name__, exc), flush=True)
+        sys.exit(1)
+    print("OK rank %d" % comm.rank, flush=True)
+    """
+)
+
+
+@needs_mpiexec
+def test_concurrent_ranks_import_the_calibration_stack_with_a_cold_cache(tmp_path):
+    """Four ranks importing the calibration stack at once, on a cache that does not exist.
+
+    The regression test for the original crash. ``XDG_CACHE_HOME`` points at a fresh
+    directory per trial, which is what makes a once-per-day failure fire on every run
+    instead of once -- the single most useful line in this file.
+
+    Under the fix this passes for a reason worth stating: nothing on the calibration
+    import path asks for ``corner`` at all, so the barrier never fires and there is no
+    race to lose. Restore the module-level ``import corner`` and it fires on every rank
+    at once, and the trials go red. That is the mutation this test is verified against.
+    """
+    program = _CONCURRENT_PROBE.format(
+        target="arviz",
+        import_line="import libcuflynx.param_id.paramID  # noqa: F401")
+    failures = []
+    for trial in range(TRIALS):
+        cache = tmp_path / f"cache_{trial}"
+        cache.mkdir()
+        code, out = _run_on_ranks(program, {"XDG_CACHE_HOME": str(cache)})
+        if code != 0 or "FAIL" in out:
+            failures.append(f"--- trial {trial} (exit {code}) ---\n{out}")
+    assert not failures, (
+        f"{len(failures)} of {TRIALS} cold-cache trials lost a rank while importing the "
+        f"calibration stack on {RANKS} ranks:\n\n" + "\n".join(failures)
+    )
+
+
+@needs_mpiexec
+def test_concurrent_ranks_import_corner_itself_with_a_cold_cache(tmp_path):
+    """The upstream defect, pinned directly, so we find out when it is fixed or spreads.
+
+    The test above passes because ``paramID`` no longer imports ``corner``. That is the
+    fix, and it is the right fix -- but it makes the upstream bug invisible to our suite,
+    and ``corner`` is still a core dependency that ``plot_mcmc()`` imports on rank 0. This
+    test imports ``corner`` on every rank on purpose.
+
+    It is *expected to fail* against arviz 0.23.3/0.23.4, so it is skipped unless
+    ``CUFLYNX_ASSERT_UPSTREAM_IMPORTS`` is set. Run it deliberately (and in the weekly
+    dependency-upgrade job) to learn when a fixed arviz ships -- at which point this
+    becomes an ordinary test and the skip comes off.
+    """
+    if not os.environ.get("CUFLYNX_ASSERT_UPSTREAM_IMPORTS", "").strip().strip("0"):
+        pytest.skip(
+            "set CUFLYNX_ASSERT_UPSTREAM_IMPORTS=1 to assert that `import corner` is "
+            "safe on concurrent ranks; it is known-broken on arviz 0.23.3 and 0.23.4"
+        )
+    pytest.importorskip("arviz", reason="no arviz installed, so there is no race to run")
+    program = _CONCURRENT_PROBE.format(
+        target="arviz", import_line="import corner  # noqa: F401")
+    failures = []
+    for trial in range(TRIALS):
+        cache = tmp_path / f"cache_{trial}"
+        cache.mkdir()
+        code, out = _run_on_ranks(program, {"XDG_CACHE_HOME": str(cache)})
+        if code != 0 or "FAIL" in out:
+            failures.append(f"--- trial {trial} (exit {code}) ---\n{out}")
+    assert not failures, (
+        f"`import corner` still races on {RANKS} concurrent ranks with a cold cache "
+        f"({len(failures)}/{TRIALS} trials):\n\n" + "\n".join(failures)
+    )

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,137 @@
+"""``utilities/lazy_imports`` -- the wide-exception, cached, optional import.
+
+The behaviour that matters here is the one an ``except ImportError`` does not have:
+surviving an import that fails with something else. See the module under test for the
+arviz race that made that distinction load-bearing.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from libcuflynx.utilities import lazy_imports
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    lazy_imports.reset_cache()
+    yield
+    lazy_imports.reset_cache()
+
+
+def _install_module(monkeypatch, name, exc):
+    """Make ``import <name>`` raise *exc*, the way a bad import-time side effect does."""
+    real_import = lazy_imports.importlib.import_module
+
+    def fake(mod_name, *args, **kwargs):
+        if mod_name == name:
+            raise exc
+        return real_import(mod_name, *args, **kwargs)
+
+    monkeypatch.setattr(lazy_imports.importlib, "import_module", fake)
+
+
+def test_a_missing_module_is_none():
+    assert lazy_imports.load_optional("a_module_that_does_not_exist_xyzzy") is None
+
+
+def test_an_import_that_fails_with_something_other_than_importerror_is_survived(monkeypatch):
+    """The whole point. arviz raised FileNotFoundError from its module body.
+
+    An ``except ImportError`` here would let this through and kill the rank -- which is
+    precisely what happened, so this is the assertion that encodes the bug.
+    """
+    _install_module(monkeypatch, "pretend_pkg",
+                    FileNotFoundError(2, "No such file or directory",
+                                      "/tmp/daily_warning.tmp"))
+    assert lazy_imports.load_optional("pretend_pkg") is None
+
+
+@pytest.mark.parametrize("exc", [
+    RuntimeError("import-time side effect blew up"),
+    OSError("read-only filesystem"),
+    ValueError("bad cache contents"),
+])
+def test_any_ordinary_exception_is_survived(monkeypatch, exc):
+    _install_module(monkeypatch, "pretend_pkg", exc)
+    assert lazy_imports.load_optional("pretend_pkg") is None
+
+
+def test_keyboardinterrupt_is_not_swallowed(monkeypatch):
+    """``except Exception`` is wide on purpose, but not that wide.
+
+    Catching BaseException would make Ctrl-C during a slow import do nothing visible.
+    """
+    _install_module(monkeypatch, "pretend_pkg", KeyboardInterrupt())
+    with pytest.raises(KeyboardInterrupt):
+        lazy_imports.load_optional("pretend_pkg")
+
+
+def test_strict_startup_reraises(monkeypatch):
+    """CI wants the failure; a queued eight-hour job wants to keep going."""
+    monkeypatch.setenv("CUFLYNX_STRICT_STARTUP", "1")
+    _install_module(monkeypatch, "pretend_pkg", FileNotFoundError("gone"))
+    with pytest.raises(FileNotFoundError):
+        lazy_imports.load_optional("pretend_pkg")
+
+
+def test_strict_startup_is_off_for_the_empty_string_and_zero(monkeypatch):
+    for value in ("", "0"):
+        monkeypatch.setenv("CUFLYNX_STRICT_STARTUP", value)
+        assert lazy_imports.strict_startup() is False
+    monkeypatch.setenv("CUFLYNX_STRICT_STARTUP", "1")
+    assert lazy_imports.strict_startup() is True
+
+
+def test_a_failure_is_cached_so_it_is_attempted_once(monkeypatch):
+    calls = []
+    real_import = lazy_imports.importlib.import_module
+
+    def fake(mod_name, *args, **kwargs):
+        if mod_name == "pretend_pkg":
+            calls.append(mod_name)
+            raise FileNotFoundError("gone")
+        return real_import(mod_name, *args, **kwargs)
+
+    monkeypatch.setattr(lazy_imports.importlib, "import_module", fake)
+    assert lazy_imports.load_optional("pretend_pkg") is None
+    assert lazy_imports.load_optional("pretend_pkg") is None
+    assert calls == ["pretend_pkg"], "a broken optional import must not be retried per call"
+
+
+def test_a_success_is_cached_and_returns_the_module():
+    first = lazy_imports.load_optional("json")
+    second = lazy_imports.load_optional("json")
+    assert first is second is sys.modules["json"]
+
+
+def test_the_warning_names_the_underlying_error(monkeypatch, caplog):
+    """The log has to name the *third-party* failure, not just 'corner is missing'.
+
+    Reading it as a missing install is what sent the original investigation looking in
+    entirely the wrong place.
+    """
+    _install_module(monkeypatch, "pretend_pkg",
+                    FileNotFoundError(2, "No such file or directory", "/x/daily_warning.tmp"))
+    with caplog.at_level("WARNING", logger=lazy_imports.__name__):
+        assert lazy_imports.load_optional("pretend_pkg") is None
+    text = caplog.text
+    assert "pretend_pkg" in text
+    assert "FileNotFoundError" in text, f"the log did not name the real error:\n{text}"
+
+
+def test_require_corner_raises_naming_what_failed(monkeypatch):
+    monkeypatch.setattr(lazy_imports, "load_corner", lambda: None)
+    with pytest.raises(ImportError) as excinfo:
+        lazy_imports.require_corner("plot the thing")
+    message = str(excinfo.value)
+    assert "plot the thing" in message
+    assert "CUFLYNX_STRICT_STARTUP" in message, (
+        "the error should say how to see the underlying cause"
+    )
+
+
+def test_require_corner_returns_the_module_when_it_loads():
+    corner = pytest.importorskip("corner")
+    assert lazy_imports.require_corner("plot") is corner


### PR DESCRIPTION
## The crash

An `mpiexec -n 4` calibration (3compartment, launched through CUFLynx) died on three of four ranks:

```
File ".../libcuflynx/param_id/paramID.py", line 59, in <module>
    import corner
...
FileNotFoundError: [Errno 2] No such file or directory:
    '~/.cache/arviz/daily_warning.tmp' -> '~/.cache/arviz/daily_warning'
MPI_ABORT was invoked on rank 3
```

## Root cause — upstream, in arviz

`arviz/__init__.py` runs `_warn_once_per_day()` at module scope, which writes a stamp file through a **fixed** temporary name:

```python
tmp = path.with_suffix(path.suffix + ".tmp")   # ~/.cache/arviz/daily_warning.tmp
tmp.write_text(text)
tmp.replace(path)
```

Every rank computes the same `daily_warning.tmp`. One renames it away; the others' `replace()` raises `FileNotFoundError`.

It is *fatal* rather than degraded because **both guards catch the wrong exception** — ours at `paramID.py:59` and the identical one inside `corner/corner.py` both use `except ImportError`, and `FileNotFoundError` is not one.

Measured on a 20-core machine:

| condition | rank failures |
|---|---|
| `-n 4`, cold cache | 33 / 60 |
| `-n 2`, cold cache | 14 / 30 |
| `-n 4`, stamp already written today | **0 / 20** |

That last row is the difficulty: **the bug is live for one run per day.** The first launch after midnight kills the job and every launch after it is clean, so it reads as random and re-running "fixes" it.

## No version pin, deliberately

`arviz!=0.23.4` looks like the obvious first move. It is wrong: **0.23.3 has identical code** (checked by reading the published wheel), and it is the only other candidate — arviz 1.x requires Python ≥3.12 while `autoemulate` pins `arviz<1.0`. A pin would force a downgrade to an equally broken release and imply the problem was handled.

Worth reporting upstream; the fix there is `tempfile.mkstemp(dir=path.parent)`.

## The fix

Structural, not defensive. `corner` is used at exactly five call sites — four in `plot_mcmc()`, one in `plot_laplace_results()` — and both are rank-0 work. Importing it there instead of at module scope means **concurrent ranks never import it at all**, which removes the race rather than surviving it, and takes `arviz`, `xarray` and `xarray_einstats` off the import path of every calibration.

The time saved is small and stated honestly in the code: **0.05 s**, because `paramID` imports matplotlib and numpy anyway and those dominate. The point is the import surface, not speed.

Two smaller things fall out:

- **`plot_laplace_results()` gains the rank-0 guard `plot_mcmc()` already had.** Its caller, `scripts/plot_param_id_script.py`, runs on every rank with no guard, so under `mpiexec -n 4 cuflynx-plot` all four ranks drew the same figure and wrote it to the same path.
- **`utilities/lazy_imports.py`** carries the rule — *narrow scope, wide exception, loud log* — and `CUFLYNX_STRICT_STARTUP=1` turns the swallow back into a raise, so CI can assert what a production run must survive.

## Why the tests are shaped the way they are

Two obvious tests here do not work, and both were written and discarded:

**1. `mpiexec -n N pytest` cannot see this.** Same machine, same cold cache, same import:

| harness | rank failures |
|---|---|
| app-shaped script | 33 / 60 |
| `mpiexec -n 4 pytest`, import at module scope | **0 / 40** |

pytest's plugin loading, conftest and collection stagger the ranks by 10–100 ms; the vulnerable window is microseconds. So these tests launch their own subprocesses and must never be run under `mpiexec` themselves.

**2. A plain barrier-then-import is no better.** Released from a barrier, four ranks then reach `import corner` **277–326 ms apart**, because the 2.4 s of libcellml/myokit/matplotlib imports in between is not identical work at identical speed. The probe therefore puts the barrier *at* the import, with a meta-path finder that calls `comm.Barrier()` the first time the target module is requested — so the ranks enter its body together regardless of how staggered they were.

**Every constant is measured, not chosen.** Catch rate against deliberately restored broken code:

| config | caught |
|---|---|
| 4 ranks, no pre-warm | 3 / 10 |
| 4 ranks, pre-warm | 9 / 10 |
| **8 ranks, no pre-warm** | **10 / 10** |
| 8 ranks, pre-warm | 9 / 10 |

The first draft of this file used four ranks and no pre-warm — it **passed against known-broken code**. It ships at eight ranks with the pre-warm, three trials.

## Verification

- `1601 passed, 4 skipped, 0 failed` on the fast suite.
- Both new tests go red against the restored module-level import (`3/3` and `2/3` trials across two runs) and green with the fix.
- The upstream probe reproduces the arviz race `3/3` and is skipped unless `CUFLYNX_ASSERT_UPSTREAM_IMPORTS=1`, since it is expected to fail until arviz ships a fix.

## Scope

This is the source fix only. The testing work it came out of — running CUFLynx's integration tier against an *installed* libcuflynx, and a serial/parallel run matrix — lands in a companion CUFLynx PR, because a CUFLynx test cannot fix a libcuflynx import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
