### PR TITLE
Let every stage command take --user-inputs PATH

### DIFF
--- a/src/libcuflynx/scripts/_cli.py
+++ b/src/libcuflynx/scripts/_cli.py
@@ -17,13 +17,17 @@ Two things every one of them needs, defined once here:
   killed by hand.
 """
 import argparse
+import os
 import traceback
+
+import yaml
 
 #: Every stage takes its configuration from the same file, and none of them take
 #: options. Saying so in ``--help`` is the whole of the help text people need.
 CONFIG_EPILOG = (
-    "Configuration is read from user_run_files/user_inputs.yaml under the user directory,\n"
-    "or from the file named by user_inputs_path_override in it.\n"
+    "Configuration is read from the file named by --user-inputs; otherwise from\n"
+    "user_run_files/user_inputs.yaml under the user directory, or from the file named by\n"
+    "user_inputs_path_override in it.\n"
     "\n"
     "The user directory is $CUFLYNX_USER_DIR if set; otherwise the circulatory_autogen\n"
     "checkout this libcuflynx was run from, if it is one; otherwise the current directory.\n"
@@ -42,11 +46,43 @@ def build_parser(description, epilog=CONFIG_EPILOG):
     text names whichever way the user reached the script: the console command, or
     ``python -m libcuflynx.scripts...``.
     """
-    return argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(
         description=description,
         epilog=epilog,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    # The one option every stage shares. Without it a run is configured by editing
+    # user_inputs.yaml in place, setting user_inputs_path_override inside it, or moving
+    # CUFLYNX_USER_DIR -- none of which lets one checkout hold several configurations
+    # (a training run and a per-dataset run, say) and choose between them per command.
+    parser.add_argument(
+        '--user-inputs', dest='user_inputs', metavar='PATH', default=None,
+        help='read the configuration from PATH instead of the default '
+             'user_run_files/user_inputs.yaml')
+    return parser
+
+
+def load_user_inputs(args):
+    """The configuration named by ``--user-inputs``, or None for the default file.
+
+    None is what every stage's ``inp_data_dict`` parameter already means: "go and read
+    the configured file yourself". So a stage passes this straight through and behaves
+    exactly as before when the option is absent.
+
+    Every rank reads the file. That matches how the default file is already loaded, and
+    a broadcast would only move the same failure to a later collective.
+    """
+    path = getattr(args, 'user_inputs', None)
+    if not path:
+        return None
+    if not os.path.isfile(path):
+        raise SystemExit("user inputs file not found: %s" % path)
+    with open(path, 'r') as file:
+        inp_data_dict = yaml.load(file, Loader=yaml.FullLoader)
+    if not isinstance(inp_data_dict, dict):
+        raise SystemExit(
+            "user inputs file %s did not parse to a mapping of settings" % path)
+    return inp_data_dict
 
 
 _TRUE = frozenset(('true', 't', 'yes', 'y', '1'))

--- a/src/libcuflynx/scripts/identifiability_run_script.py
+++ b/src/libcuflynx/scripts/identifiability_run_script.py
@@ -88,8 +88,10 @@ def main(argv=None):
     parser = _cli.build_parser(
         'Run identifiability analysis (Laplace or profile likelihood) around the parameter '
         'values a previous calibration wrote to the param_id output directory.')
-    parser.parse_args(argv)
-    return _cli.run_stage(run_identifiability_analysis, MPI)
+    args = parser.parse_args(argv)
+    inp_data_dict = _cli.load_user_inputs(args)
+    return _cli.run_stage(
+        lambda: run_identifiability_analysis(inp_data_dict), MPI)
 
 
 if __name__ == '__main__':

--- a/src/libcuflynx/scripts/param_id_run_script.py
+++ b/src/libcuflynx/scripts/param_id_run_script.py
@@ -172,8 +172,9 @@ def main(argv=None):
     parser = _cli.build_parser(
         'Calibrate a generated model against the observables named in the configuration, '
         'then optionally run MCMC and identifiability analysis on the result.')
-    parser.parse_args(argv)
-    return _cli.run_stage(run_param_id, MPI)
+    args = parser.parse_args(argv)
+    inp_data_dict = _cli.load_user_inputs(args)
+    return _cli.run_stage(lambda: run_param_id(inp_data_dict), MPI)
 
 
 if __name__ == '__main__':

--- a/src/libcuflynx/scripts/plot_param_id_script.py
+++ b/src/libcuflynx/scripts/plot_param_id_script.py
@@ -164,7 +164,10 @@ def main(argv=None):
 
     # finalize=False: this stage never called MPI.Finalize(). It is single-rank by
     # construction -- plot_param_id() returns immediately on every rank but 0.
-    return _cli.run_stage(lambda: plot_param_id(generate=args.generate), MPI, finalize=False)
+    inp_data_dict = _cli.load_user_inputs(args)
+    return _cli.run_stage(
+        lambda: plot_param_id(inp_data_dict, generate=args.generate),
+        MPI, finalize=False)
 
 
 if __name__ == '__main__':

--- a/src/libcuflynx/scripts/script_generate_with_new_architecture.py
+++ b/src/libcuflynx/scripts/script_generate_with_new_architecture.py
@@ -285,7 +285,8 @@ def main(argv=None):
     # or not it succeeded (one branch returns None outright), and run_param_id.sh tests that
     # status. Turning a False return into a non-zero exit here would silently change which
     # runs continue past generation, which belongs in its own change.
-    generate_with_new_architecture(args.with_fit_parameters)
+    generate_with_new_architecture(
+        args.with_fit_parameters, _cli.load_user_inputs(args))
     return 0
 
 

--- a/src/libcuflynx/scripts/sensitivity_analysis_run_script.py
+++ b/src/libcuflynx/scripts/sensitivity_analysis_run_script.py
@@ -39,8 +39,9 @@ def main(argv=None):
     parser = _cli.build_parser(
         'Run a Sobol sensitivity analysis of the configured observables with respect to the '
         'parameters listed for identification.')
-    parser.parse_args(argv)
-    return _cli.run_stage(run_SA, MPI)
+    args = parser.parse_args(argv)
+    inp_data_dict = _cli.load_user_inputs(args)
+    return _cli.run_stage(lambda: run_SA(inp_data_dict), MPI)
 
 
 if __name__ == '__main__':

--- a/src/libcuflynx/scripts/sequential_param_id_run_script.py
+++ b/src/libcuflynx/scripts/sequential_param_id_run_script.py
@@ -119,7 +119,8 @@ def main(argv=None):
     parser = _cli.build_parser(
         'Staged parameter identification: fit, drop the parameters that prove unidentifiable, '
         'refit. NOT CURRENTLY IMPLEMENTED -- ' + _MISSING_MESSAGE)
-    parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    inp_data_dict = _cli.load_user_inputs(args)
 
     # Checked here, before any rank starts work, so that the missing implementation is one
     # line on stderr and a non-zero status -- not a traceback and an MPI_Abort from whichever
@@ -131,7 +132,8 @@ def main(argv=None):
             print('ERROR: %s' % exc, file=sys.stderr)
         return 2
 
-    return _cli.run_stage(run_sequential_param_id, MPI, finalize=False)
+    return _cli.run_stage(
+        lambda: run_sequential_param_id(inp_data_dict), MPI, finalize=False)
 
 
 if __name__ == '__main__':

--- a/src/libcuflynx/scripts/train_emulator_run_script.py
+++ b/src/libcuflynx/scripts/train_emulator_run_script.py
@@ -58,8 +58,9 @@ def main(argv=None):
     parser = _cli.build_parser(
         "Train a surrogate (emulator) of the model's scalar observable features, so that "
         'later calibration, sensitivity or UQ runs can be driven by it instead of the solver.')
-    parser.parse_args(argv)
-    return _cli.run_stage(train_emulator, MPI)
+    args = parser.parse_args(argv)
+    inp_data_dict = _cli.load_user_inputs(args)
+    return _cli.run_stage(lambda: train_emulator(inp_data_dict), MPI)
 
 
 if __name__ == '__main__':

--- a/tests/test_console_entry_points.py
+++ b/tests/test_console_entry_points.py
@@ -336,8 +336,25 @@ def test_launcher_reports_a_missing_install_before_launching_mpi():
 
 # --- --user-inputs -------------------------------------------------------------------
 
+#: Console commands that are **not** pipeline stages, and so have no user_inputs.yaml to be
+#: pointed at. The two tests below are table-driven off ``[project.scripts]`` so that a new
+#: stage cannot be added without being covered -- which is right, but it also means a one-off
+#: utility declared there is asserted to take an option that would mean nothing to it.
+#:
+#: Named rather than inferred: "does this command have a configuration file" is a fact about
+#: what the command is for, and guessing it from the module path or from the parser would let
+#: the test pass for a stage that simply forgot the option.
+#:
+#: ``cuflynx-migrate-obs-data`` (arriving with #466) rewrites obs_data files given a path. A
+#: name here that is not in [project.scripts] is never reached, so this may name a command
+#: before the PR adding it lands.
+NON_STAGE_COMMANDS = {
+    "cuflynx-migrate-obs-data",
+}
+
+
 @pytest.mark.unit
-@pytest.mark.parametrize("name", sorted(PROJECT_SCRIPTS))
+@pytest.mark.parametrize("name", sorted(set(PROJECT_SCRIPTS) - NON_STAGE_COMMANDS))
 def test_entry_point_offers_user_inputs(name):
     """Every stage takes ``--user-inputs``, and says so.
 
@@ -355,7 +372,7 @@ def test_entry_point_offers_user_inputs(name):
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("name", sorted(PROJECT_SCRIPTS))
+@pytest.mark.parametrize("name", sorted(set(PROJECT_SCRIPTS) - NON_STAGE_COMMANDS))
 def test_entry_point_reports_a_missing_user_inputs_file(name):
     """A bad path fails immediately, by name -- not once a rank is deep in a run."""
     module = PROJECT_SCRIPTS[name].split(":")[0]

--- a/tests/test_console_entry_points.py
+++ b/tests/test_console_entry_points.py
@@ -332,3 +332,74 @@ def test_launcher_reports_a_missing_install_before_launching_mpi():
     assert "pip install -e ." in result.stdout
     assert "Traceback" not in result.stdout
     assert "mpiexec" not in result.stdout, "the launcher got as far as MPI before complaining"
+
+
+# --- --user-inputs -------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", sorted(PROJECT_SCRIPTS))
+def test_entry_point_offers_user_inputs(name):
+    """Every stage takes ``--user-inputs``, and says so.
+
+    Without it, choosing between configurations means editing user_inputs.yaml,
+    setting user_inputs_path_override inside it, or moving CUFLYNX_USER_DIR -- so a
+    checkout cannot hold a training config and a per-dataset config and pick one per
+    command.
+    """
+    module = PROJECT_SCRIPTS[name].split(":")[0]
+    result = _run(["-m", module, "--help"])
+    assert result.returncode == 0, result.stdout
+    assert "--user-inputs" in result.stdout, (
+        f"{name} --help does not offer --user-inputs:\n{result.stdout}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", sorted(PROJECT_SCRIPTS))
+def test_entry_point_reports_a_missing_user_inputs_file(name):
+    """A bad path fails immediately, by name -- not once a rank is deep in a run."""
+    module = PROJECT_SCRIPTS[name].split(":")[0]
+    missing = str(_REPO_ROOT / "no_such_user_inputs.yaml")
+    result = _run(["-m", module, "--user-inputs", missing])
+    assert result.returncode != 0, (
+        f"{name} accepted a missing --user-inputs file:\n{result.stdout}"
+    )
+    assert "no_such_user_inputs.yaml" in result.stdout, (
+        f"{name} did not name the missing file:\n{result.stdout}"
+    )
+
+
+@pytest.mark.unit
+def test_load_user_inputs_defaults_to_none():
+    """No option means None, which is what every stage already treats as "read the
+    configured file yourself" -- so behaviour is unchanged when it is absent."""
+    from libcuflynx.scripts import _cli
+
+    parser = _cli.build_parser("test")
+    assert _cli.load_user_inputs(parser.parse_args([])) is None
+
+
+@pytest.mark.unit
+def test_load_user_inputs_reads_the_named_file(tmp_path):
+    from libcuflynx.scripts import _cli
+
+    path = tmp_path / "elsewhere.yaml"
+    path.write_text("file_prefix: someprefix\nDEBUG: true\n")
+
+    parser = _cli.build_parser("test")
+    loaded = _cli.load_user_inputs(parser.parse_args(["--user-inputs", str(path)]))
+    assert loaded == {"file_prefix": "someprefix", "DEBUG": True}
+
+
+@pytest.mark.unit
+def test_load_user_inputs_rejects_a_non_mapping(tmp_path):
+    """A yaml that parses to a list or a bare scalar would otherwise fail much later,
+    on the first ``inp_data_dict['...']`` deep inside a stage."""
+    from libcuflynx.scripts import _cli
+
+    path = tmp_path / "not_a_mapping.yaml"
+    path.write_text("- one\n- two\n")
+
+    parser = _cli.build_parser("test")
+    with pytest.raises(SystemExit, match="mapping of settings"):
+        _cli.load_user_inputs(parser.parse_args(["--user-inputs", str(path)]))


### PR DESCRIPTION
## The problem

Every console command reads its configuration from `user_run_files/user_inputs.yaml`, or from whatever `user_inputs_path_override` inside that file points at, under a user directory chosen by `$CUFLYNX_USER_DIR`. `_cli.py` said as much: *"none of them take options"*.

That makes a checkout hold exactly one configuration at a time. Switching between two — a training run and a per-dataset run, or one `obs_data.json` and another — means editing a file in place, hand-editing a redirect key, or moving an environment variable. None of those is something a script can do safely while another rank is reading the file.

## What this does

The engine already supported the alternative:

- `parse_user_inputs_file` only opens the default file when `inp_data_dict is None`;
- every stage's `run_*` function already takes `inp_data_dict` as its first parameter.

So this adds the CLI surface and nothing else. `--user-inputs PATH` loads the named yaml, and the stage passes it to the function it was already calling.

Absent, the value is `None` — which is exactly what the stages already treat as *"read the configured file yourself"*. **Behaviour with no option is unchanged.**

```
mpiexec -n 4 cuflynx-param-id --user-inputs /path/to/ox1_user_inputs.yaml
cuflynx-train-emulator --user-inputs /path/to/full_user_inputs.yaml
```

Failures are reported by name at parse time rather than from inside a run: a missing file, and a yaml that parses to a list or a scalar instead of a mapping of settings.

Every rank reads the file. That matches how the default file is already loaded; broadcasting would only move the same failure to a later collective.

## Tests

`tests/test_console_entry_points.py` is table-driven off `[project.scripts]`, so all seven commands are covered automatically:

- each offers `--user-inputs` in `--help`;
- each reports a missing file by name, non-zero, before doing any work.

`load_user_inputs` is covered directly for the three cases that decide behaviour — absent, a real file, and a non-mapping.

124 passed (up from 107).

## Checked by hand

Driving a real generation from an out-of-tree yaml:

```
python -m libcuflynx.scripts.script_generate_with_new_architecture \
    --user-inputs .../SN_full/resources/ox1_user_inputs.yaml
# Model generation has been successful. Validation status: Myokit run succeeded.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)