### PR TITLE
Hold Cython below 3.3 when pip has to build the emulation extra's sdists

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -271,7 +271,10 @@ jobs:
         # [uq] brings pymc/pytensor and [emulation] brings autoemulate. Without them the
         # corresponding tests skip, and those code paths go unexercised in CI -- which is how
         # the pyMC backend stayed unproven for as long as it did.
-        pip install -e ".[dev,uq,emulation]"
+        # --build-constraint, not a runtime pin: [emulation] reaches harmonic, which has no
+        # cp310 wheel and so is built here. See build-constraints.txt for what it holds back.
+        pip install --build-constraint "${{ github.workspace }}/build-constraints.txt" \
+          -e ".[dev,uq,emulation]"
 
     - uses: ./.github/actions/install-system-deps
 
@@ -351,7 +354,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev,uq,emulation]"
+        # See build-constraints.txt: [emulation] reaches harmonic, built from sdist on 3.10.
+        pip install --build-constraint "${{ github.workspace }}/build-constraints.txt" \
+          -e ".[dev,uq,emulation]"
 
     - uses: ./.github/actions/install-system-deps
 
@@ -424,7 +429,9 @@ jobs:
         python -m pip install --upgrade pip
         # [emulation] brings autoemulate, which the emulator round-trip test needs; without
         # it that test skips and the external backend's integration with CA goes unchecked.
-        pip install -e ".[dev,emulation]"
+        # See build-constraints.txt: autoemulate reaches harmonic, built from sdist on 3.10.
+        pip install --build-constraint "${{ github.workspace }}/build-constraints.txt" \
+          -e ".[dev,emulation]"
 
     # A skipped test is a green step, and every test in this file sits behind an
     # importorskip. If the conda environment failed to activate, or the extra failed to

--- a/build-constraints.txt
+++ b/build-constraints.txt
@@ -1,0 +1,22 @@
+# Constraints for the *build* environments pip creates for sdists
+# (`pip install --build-constraint build-constraints.txt`), not for what libcuflynx
+# runs against. Only ever needed for a dependency that has no wheel for the
+# interpreter CI uses.
+#
+# Cython<3.3 — `harmonic` (pulled in by autoemulate, so only via the `emulation`
+# extra) ships wheels for cp311+ only, so the Python 3.10 jobs build its sdist.
+# Cython 3.3.0 (released 2026-08-22) made an implicit double->long assignment an
+# error, and harmonic 1.3.0's `model_legacy.pyx:433` does exactly that:
+#
+#     harmonic/model_legacy.pyx:433:21: Cannot assign type 'double' to 'long'
+#
+# That broke `pip install -e ".[dev,uq,emulation]"` outright — test-uq and
+# test-uq-mpi started failing in 20s, at dependency install, on branches that had
+# touched nothing related. harmonic's own `[build-system] requires` is an unpinned
+# `Cython`, so the ceiling has to come from here.
+#
+# The same ceiling, for the same reason, is in CUFLynx's build-constraints.txt.
+#
+# Remove when harmonic ships a cp310 wheel or fixes the .pyx — not before, or
+# every job that installs the emulation extra goes red again.
+Cython<3.3

--- a/tests/test_build_constraints.py
+++ b/tests/test_build_constraints.py
@@ -1,0 +1,115 @@
+"""Every CI install that reaches the ``emulation`` extra has to carry the build ceiling.
+
+``autoemulate`` depends on ``harmonic``, which ships wheels for cp311+ only, so the
+Python 3.10 jobs build it from its sdist. Cython 3.3.0 made an implicit
+``double -> long`` assignment an error and harmonic 1.3.0's ``model_legacy.pyx``
+does exactly that, so those installs started failing outright -- in 20 seconds, at
+dependency install, on branches that had touched nothing related.
+
+``build-constraints.txt`` holds Cython below 3.3 for the *build* environments pip
+creates for sdists. Nothing in these tests can stop harmonic from breaking again;
+they stop the ceiling from being quietly dropped, and stop a new job that installs
+the extra from being added without it.
+
+The workflow is parsed as YAML rather than grepped, because the property is "this
+step installs the extra *and this same step* passes the flag", and a regex cannot
+tell a step's script from the comment above the next one.
+"""
+import pathlib
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONSTRAINTS = REPO_ROOT / "build-constraints.txt"
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+#: The extra that reaches harmonic. Anything installing it needs the ceiling.
+EMULATION_EXTRA = "emulation"
+
+
+def _install_steps():
+    """``(workflow, job, step_name, script)`` for every step running a shell script."""
+    steps = []
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        doc = yaml.safe_load(path.read_text()) or {}
+        for job_name, job in (doc.get("jobs") or {}).items():
+            for step in job.get("steps") or []:
+                script = step.get("run")
+                if script:
+                    steps.append(
+                        (path.name, job_name, step.get("name", "<unnamed>"), script)
+                    )
+    return steps
+
+
+def _steps_installing_the_extra():
+    return [
+        entry for entry in _install_steps()
+        if "pip install" in entry[3] and f",{EMULATION_EXTRA}" in entry[3]
+    ]
+
+
+@pytest.mark.unit
+def test_the_ceiling_is_present():
+    assert CONSTRAINTS.is_file(), f"{CONSTRAINTS} is missing"
+    text = CONSTRAINTS.read_text()
+    assert "Cython<3.3" in text, (
+        "the Cython ceiling is gone from build-constraints.txt. Remove it only when "
+        "harmonic ships a cp310 wheel or fixes its .pyx -- not before, or every job "
+        "installing the emulation extra goes red again.\n" + text
+    )
+
+
+@pytest.mark.unit
+def test_some_job_actually_installs_the_extra():
+    """Guard the guard: the sweep below is vacuous if nothing matches."""
+    found = _steps_installing_the_extra()
+    assert found, (
+        "no workflow step installs the emulation extra, so the checks below prove "
+        "nothing. Did the extra get renamed?"
+    )
+
+
+@pytest.mark.unit
+def test_every_install_of_the_extra_passes_the_constraints():
+    offenders = [
+        f"{wf}:{job}:{name}"
+        for wf, job, name, script in _steps_installing_the_extra()
+        if "--build-constraint" not in script
+    ]
+    assert not offenders, (
+        "these steps install the emulation extra without --build-constraint, so pip "
+        "will build harmonic's sdist with whatever Cython it resolves:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.unit
+def test_every_constrained_install_upgrades_pip_first():
+    """``--build-constraint`` is a pip 25.1+ option.
+
+    Passing it to the runner image's pip is the same red build by a different
+    route -- an unknown-option error instead of a Cython one.
+    """
+    offenders = [
+        f"{wf}:{job}:{name}"
+        for wf, job, name, script in _install_steps()
+        if "--build-constraint" in script
+        and "pip install --upgrade pip" not in script
+    ]
+    assert not offenders, (
+        "these steps pass --build-constraint without upgrading pip first, and it is "
+        "a pip 25.1+ option:\n  " + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.unit
+def test_the_constraints_file_says_why():
+    """A bare pin gets deleted by whoever next tidies dependencies."""
+    text = CONSTRAINTS.read_text()
+    for expected in ("harmonic", "autoemulate", "cp310"):
+        assert expected in text, (
+            f"build-constraints.txt does not mention {expected!r}, so the next person "
+            "cannot tell what the ceiling is holding back or when it can go"
+        )


### PR DESCRIPTION
## What happened

`test-uq` and `test-uq-mpi` started failing **in twenty seconds, at dependency install**, on branches that had touched nothing related ([#469](https://github.com/physiomelinks/circulatory_autogen/pull/469), [#471](https://github.com/physiomelinks/circulatory_autogen/pull/471)). `test-uq` passed on master two days ago.

Cython 3.3.0 was published on 2026-08-22 and made an implicit `double -> long` assignment an error. `harmonic` — reached through `autoemulate`, so only via the `emulation` extra — ships wheels for cp311+ only, so the Python 3.10 jobs build its sdist, and harmonic 1.3.0's `model_legacy.pyx:433` does exactly that assignment:

```
harmonic/model_legacy.pyx:433:21: Cannot assign type 'double' to 'long'
Cython.Compiler.Errors.CompileError: harmonic/model_legacy.pyx
ERROR: Failed to build 'harmonic' when getting requirements to build wheel
```

## The fix

harmonic's own `[build-system] requires` is an unpinned `Cython`, so the ceiling has to come from our side: `build-constraints.txt`, passed with `--build-constraint` to every workflow install that reaches the extra.

That constrains the *build* environments pip creates for sdists and nothing libcuflynx runs against — which is why it is not a `pyproject` pin.

Three install steps reach the extra (`test-uq`, `test-uq-mpi`, `test-fenics-emulator`); all three already upgrade pip first, which `--build-constraint` needs.

CUFLynx hit this first and [fixed it the same way](https://github.com/physiomelinks/CUFLynx/commit/afd01b9); the two ceilings are for the same reason and should go at the same time.

## Guards

`tests/test_build_constraints.py`, four of them:

- the ceiling is present, with a message saying when it may go;
- *some* job actually installs the extra — otherwise the sweep below proves nothing;
- every such install passes the constraints file;
- every step that passes it upgrades pip first — `--build-constraint` is a pip 25.1+ option, and passing it to the runner image's pip is the same red build by a different route.

The workflows are parsed as YAML rather than scanned: the property is "this step installs the extra **and this same step** passes the flag", and a regex cannot tell a step's script from the comment above the next one.

## Removing it

When harmonic ships a cp310 wheel or fixes the `.pyx` — not before, or every job installing the emulation extra goes red again. `build-constraints.txt` says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)