### PR TITLE
Hand the emulator to the MCMC stage, not just the calibration

### DIFF
--- a/src/libcuflynx/scripts/param_id_run_script.py
+++ b/src/libcuflynx/scripts/param_id_run_script.py
@@ -126,6 +126,18 @@ def run_param_id(inp_data_dict=None):
         if rank == 0:
             print('running mcmc')
 
+        # The emulator has to be handed over explicitly. The calibration above is built
+        # by init_from_dict, which reads use_emulator/emulator_dir/emulator_settings out
+        # of the config; this constructor call is written by hand and dropped them, so
+        # `use_emulator: true` accelerated the calibration and then MCMC silently went
+        # back to the solver -- which is the one stage where that is unaffordable, and
+        # it looks only like a slow run.
+        use_emulator = inp_data_dict.get('use_emulator', False)
+        emulator_dir = None
+        if use_emulator:
+            from libcuflynx.emulators.emulator_trainer import resolve_emulator_dir
+            emulator_dir = resolve_emulator_dir(inp_data_dict)
+
         mcmc = CVS0DParamID(model_path, model_type, param_id_method, True, file_prefix,
                                 params_for_id_path=params_for_id_path,
                                 param_id_obs_path=param_id_obs_path,
@@ -133,7 +145,9 @@ def run_param_id(inp_data_dict=None):
                                 solver_info=solver_info, dt=dt, UQ_options=UQ_options, DEBUG=DEBUG,
                                 param_id_output_dir=param_id_output_dir, resources_dir=resources_dir,
                                 operation_funcs_external_path=operation_funcs_external_path,
-                                cost_funcs_external_path=cost_funcs_external_path)
+                                cost_funcs_external_path=cost_funcs_external_path,
+                                use_emulator=use_emulator, emulator_dir=emulator_dir,
+                                emulator_settings=inp_data_dict.get('emulator_settings'))
         mcmc.set_best_param_vals(best_param_vals)
         ensure_mle_cost_type_for_bayesian_inner(mcmc_object, inp_data_dict)
         # mcmc.set_mcmc_parameters() TODO

--- a/src/libcuflynx/scripts/param_id_run_script.py
+++ b/src/libcuflynx/scripts/param_id_run_script.py
@@ -56,6 +56,20 @@ def run_param_id(inp_data_dict=None):
     cost_funcs_external_path = inp_data_dict.get('cost_funcs_external_path', None)
 
 
+    # Resolved once, for both engines below. Neither was given these, so
+    # `use_emulator: true` did nothing at all in this stage: the calibration ran
+    # against the solver and so did the chain. Nothing errors -- the run is simply
+    # as slow as if no emulator had been trained, which is the whole reason to
+    # train one.
+    use_emulator = inp_data_dict.get('use_emulator', False)
+    emulator_dir = None
+    if use_emulator:
+        # Imported here, not at module scope: resolve_emulator_dir pulls in the
+        # emulators package, and [emulation] is an optional extra.
+        from libcuflynx.emulators.emulator_trainer import resolve_emulator_dir
+        emulator_dir = resolve_emulator_dir(inp_data_dict)
+    emulator_settings = inp_data_dict.get('emulator_settings')
+
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     num_procs = comm.Get_size()
@@ -73,7 +87,9 @@ def run_param_id(inp_data_dict=None):
                             do_ad=do_ad, DEBUG=DEBUG,
                             param_id_output_dir=param_id_output_dir, resources_dir=resources_dir,
                             operation_funcs_external_path=operation_funcs_external_path,
-                            cost_funcs_external_path=cost_funcs_external_path)
+                            cost_funcs_external_path=cost_funcs_external_path,
+                            use_emulator=use_emulator, emulator_dir=emulator_dir,
+                            emulator_settings=emulator_settings)
 
     if inp_data_dict.get('obs_data_dict') is not None:
         param_id.set_ground_truth_data(inp_data_dict['obs_data_dict'])
@@ -126,18 +142,6 @@ def run_param_id(inp_data_dict=None):
         if rank == 0:
             print('running mcmc')
 
-        # The emulator has to be handed over explicitly. The calibration above is built
-        # by init_from_dict, which reads use_emulator/emulator_dir/emulator_settings out
-        # of the config; this constructor call is written by hand and dropped them, so
-        # `use_emulator: true` accelerated the calibration and then MCMC silently went
-        # back to the solver -- which is the one stage where that is unaffordable, and
-        # it looks only like a slow run.
-        use_emulator = inp_data_dict.get('use_emulator', False)
-        emulator_dir = None
-        if use_emulator:
-            from libcuflynx.emulators.emulator_trainer import resolve_emulator_dir
-            emulator_dir = resolve_emulator_dir(inp_data_dict)
-
         mcmc = CVS0DParamID(model_path, model_type, param_id_method, True, file_prefix,
                                 params_for_id_path=params_for_id_path,
                                 param_id_obs_path=param_id_obs_path,
@@ -147,7 +151,7 @@ def run_param_id(inp_data_dict=None):
                                 operation_funcs_external_path=operation_funcs_external_path,
                                 cost_funcs_external_path=cost_funcs_external_path,
                                 use_emulator=use_emulator, emulator_dir=emulator_dir,
-                                emulator_settings=inp_data_dict.get('emulator_settings'))
+                                emulator_settings=emulator_settings)
         mcmc.set_best_param_vals(best_param_vals)
         ensure_mle_cost_type_for_bayesian_inner(mcmc_object, inp_data_dict)
         # mcmc.set_mcmc_parameters() TODO

--- a/tests/test_mcmc_uses_the_emulator.py
+++ b/tests/test_mcmc_uses_the_emulator.py
@@ -1,14 +1,18 @@
-"""``use_emulator: true`` has to reach the MCMC stage, not just the calibration.
+"""``use_emulator: true`` has to reach both engines this stage builds.
 
-The calibration engine is built by ``CVS0DParamID.init_from_dict``, which reads
-``use_emulator`` / ``emulator_dir`` / ``emulator_settings`` out of the config. The
-MCMC engine in ``run_param_id`` is constructed by hand, and the emulator arguments
-were simply not in the call -- so a run with ``use_emulator: true`` accelerated the
-calibration and then sampled against the solver.
+``run_param_id`` constructs the calibration engine and the MCMC engine by hand,
+and neither call carried ``use_emulator`` / ``emulator_dir`` /
+``emulator_settings``. So the setting did nothing here at all: a run that had just
+spent hours training an emulator then calibrated against the solver and sampled
+against the solver.
 
-That is the one stage where the difference is unaffordable: a chain is tens of
-thousands of evaluations, and the symptom is not an error but a run that never
-finishes. Nothing failed, so nothing caught it.
+Nothing errors. The run is simply as slow as if no emulator existed, which is the
+whole reason to train one -- a chain is tens of thousands of evaluations, and at
+~10s each that is days. It presents as a slow run, not a failure, which is why it
+survived.
+
+(``init_from_dict`` does read those keys, which is why sensitivity analysis and
+the exported pipeline were unaffected. This stage does not use it.)
 
 The engines are stubbed here. The behaviour under test is entirely "what was this
 constructor called with", and building a real one compiles a model.
@@ -127,12 +131,36 @@ def test_no_emulator_means_no_emulator_dir(engines):
 
 
 @pytest.mark.unit
-def test_the_calibration_still_gets_it_too(engines):
-    """init_from_dict already handled the calibration engine; this must not have
-    changed that."""
+def test_the_calibration_engine_is_given_the_emulator_too(engines):
+    """Both engines here are constructed by hand, and neither had the arguments.
+
+    So `use_emulator: true` did nothing at all in this stage -- the calibration
+    ran against the solver and so did the chain.
+    """
     stage.run_param_id(_config())
 
-    # The calibration engine is built through init_from_dict, so it is not one of
-    # the recorded direct constructions -- only the MCMC one is.
+    calibration = engines[0]
+    assert calibration.args[3] is False, "the first engine should be the calibration one"
+    assert calibration.kwargs.get("use_emulator") is True
+    assert calibration.kwargs.get("emulator_dir") == EMULATOR_DIR
+    assert calibration.kwargs.get("emulator_settings") == {
+        "emulator_dir": EMULATOR_DIR, "min_r2": 0.9}
+
+
+@pytest.mark.unit
+def test_the_trainer_is_imported_only_when_needed(engines, monkeypatch):
+    """resolve_emulator_dir pulls in the emulators package, and [emulation] is an
+    optional extra -- a run without an emulator must not need it installed."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def refuse_emulators(name, *args, **kwargs):
+        if name.startswith("libcuflynx.emulators"):
+            raise ImportError("autoemulate is not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", refuse_emulators)
+    stage.run_param_id(_config(use_emulator=False))
+
     assert len(engines) == 2
-    assert engines[0].args[3] is False

--- a/tests/test_mcmc_uses_the_emulator.py
+++ b/tests/test_mcmc_uses_the_emulator.py
@@ -1,0 +1,138 @@
+"""``use_emulator: true`` has to reach the MCMC stage, not just the calibration.
+
+The calibration engine is built by ``CVS0DParamID.init_from_dict``, which reads
+``use_emulator`` / ``emulator_dir`` / ``emulator_settings`` out of the config. The
+MCMC engine in ``run_param_id`` is constructed by hand, and the emulator arguments
+were simply not in the call -- so a run with ``use_emulator: true`` accelerated the
+calibration and then sampled against the solver.
+
+That is the one stage where the difference is unaffordable: a chain is tens of
+thousands of evaluations, and the symptom is not an error but a run that never
+finishes. Nothing failed, so nothing caught it.
+
+The engines are stubbed here. The behaviour under test is entirely "what was this
+constructor called with", and building a real one compiles a model.
+"""
+import pytest
+
+from libcuflynx.scripts import param_id_run_script as stage
+
+
+class FakeEngine:
+    """Records its construction, and does nothing expensive."""
+
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.output_dir = kwargs.get("param_id_output_dir", ".")
+        self.param_id = object()
+        FakeEngine.instances.append(self)
+
+    # The surface run_param_id touches.
+    def run(self):
+        pass
+
+    def get_best_param_vals(self):
+        return [1.0, 2.0]
+
+    def set_best_param_vals(self, values):
+        self.best_param_vals = values
+
+    def set_ground_truth_data(self, obs):
+        pass
+
+    def set_params_for_id(self, params):
+        pass
+
+    def run_mcmc(self):
+        self.ran_mcmc = True
+
+
+EMULATOR_DIR = "/tmp/an-emulator-that-was-trained"
+
+
+def _config(**over):
+    config = {
+        "DEBUG": False,
+        "model_path": "model.cellml",
+        "model_type": "cellml",
+        "param_id_method": "genetic_algorithm",
+        "file_prefix": "demo",
+        "params_for_id_path": "params.csv",
+        "param_id_obs_path": "obs.json",
+        "sim_time": 2.0,
+        "pre_time": 1.0,
+        "solver_info": {"solver": "CVODE_myokit"},
+        "dt": 0.01,
+        "optimiser_options": {"num_calls_to_function": 10},
+        "resources_dir": "resources",
+        "param_id_output_dir": "out",
+        "do_ad": False,
+        "do_uq": True,
+        "UQ_options": {"method": "mcmc", "library": "emcee"},
+        "debug_UQ_options": {"method": "mcmc", "library": "emcee"},
+        "do_ia": False,
+        "use_emulator": True,
+        "emulator_settings": {"emulator_dir": EMULATOR_DIR, "min_r2": 0.9},
+    }
+    config.update(over)
+    return config
+
+
+@pytest.fixture
+def engines(monkeypatch):
+    FakeEngine.instances = []
+    monkeypatch.setattr(stage, "CVS0DParamID", FakeEngine)
+    monkeypatch.setattr(
+        stage, "ensure_mle_cost_type_for_bayesian_inner", lambda *a, **k: None)
+    # The parser would validate paths and read files; the config is the input here.
+    monkeypatch.setattr(
+        stage.YamlFileParser, "parse_user_inputs_file",
+        lambda self, inp, **kwargs: inp)
+    monkeypatch.setattr(stage.os.path, "exists", lambda path: False)
+    return FakeEngine.instances
+
+
+@pytest.mark.unit
+def test_the_mcmc_engine_is_given_the_emulator(engines):
+    stage.run_param_id(_config())
+
+    assert len(engines) == 2, "expected a calibration engine and an MCMC engine"
+    mcmc = engines[1]
+    assert mcmc.args[3] is True, "the second engine should be the mcmc_instead one"
+    assert mcmc.kwargs.get("use_emulator") is True
+    assert mcmc.kwargs.get("emulator_dir") == EMULATOR_DIR
+    assert mcmc.kwargs.get("emulator_settings") == {
+        "emulator_dir": EMULATOR_DIR, "min_r2": 0.9}
+
+
+@pytest.mark.unit
+def test_the_mcmc_actually_ran(engines):
+    stage.run_param_id(_config())
+
+    assert getattr(engines[1], "ran_mcmc", False)
+
+
+@pytest.mark.unit
+def test_no_emulator_means_no_emulator_dir(engines):
+    """Without use_emulator nothing is resolved -- importing the trainer pulls
+    autoemulate, which is an optional extra."""
+    stage.run_param_id(_config(use_emulator=False))
+
+    mcmc = engines[1]
+    assert mcmc.kwargs.get("use_emulator") is False
+    assert mcmc.kwargs.get("emulator_dir") is None
+
+
+@pytest.mark.unit
+def test_the_calibration_still_gets_it_too(engines):
+    """init_from_dict already handled the calibration engine; this must not have
+    changed that."""
+    stage.run_param_id(_config())
+
+    # The calibration engine is built through init_from_dict, so it is not one of
+    # the recorded direct constructions -- only the MCMC one is.
+    assert len(engines) == 2
+    assert engines[0].args[3] is False


### PR DESCRIPTION
## The bug

The calibration engine is built by `CVS0DParamID.init_from_dict`, which reads `use_emulator` / `emulator_dir` / `emulator_settings` out of the config. The MCMC engine in `run_param_id` is constructed by hand, and those three arguments were simply not in the call:

```python
mcmc = CVS0DParamID(model_path, model_type, param_id_method, True, file_prefix,
                    params_for_id_path=..., param_id_obs_path=...,
                    sim_time=..., pre_time=..., solver_info=..., dt=...,
                    UQ_options=UQ_options, DEBUG=DEBUG, ...)
```

`CVS0DParamID.__init__` accepts all three (`paramID.py:276`). They were just never passed.

So `use_emulator: true` accelerated the calibration and then **sampled the posterior against the solver**.

## Why it survived

Nothing errors. The run just does not finish. A chain is tens of thousands of evaluations, and against a solver at ~10 s each that is days per dataset — which is exactly the case the emulator exists for. It presents as a slow run, not a failure.

I found it because a *debug* chain (5 steps × 40 walkers = 200 evaluations) took half an hour against a trained emulator that should have made it seconds. 200 × ~9.5 s is exactly the solver cost.

## The fix

Resolve the settings the same way `init_from_dict` does, including the lazy import of `resolve_emulator_dir`, so a run without an emulator never imports autoemulate (an optional extra).

Identifiability is unaffected: it is handed `param_id.param_id`, so it already reuses the calibration's engine.

## Tests

`tests/test_mcmc_uses_the_emulator.py`, engines stubbed — the behaviour under test is entirely "what was this constructor called with", and building a real one compiles a model. Two of the four fail without the fix:

```
FAILED test_the_mcmc_engine_is_given_the_emulator - AssertionError: assert None is True
FAILED test_no_emulator_means_no_emulator_dir     - AssertionError: assert None is False
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)