### PR TITLE
fix(#463): point tutorial Section C at the libcuflynx layout, and test it

### DIFF
--- a/src/libcuflynx/coupler/run_coupler1d0d.bash
+++ b/src/libcuflynx/coupler/run_coupler1d0d.bash
@@ -1,12 +1,45 @@
-#!/bin/bash 
+#!/bin/bash
 
-### IMPORTANT NOTE: it's safer to specify absolute paths only, as folders with solvers and input files might change location one with respect to the other
+### Build the generated 0D C++ model and the 1D-0D coupler, then run the coupler.
+###
+### Usage: ./run_coupler1d0d.bash [generated-cpp-model-dir]
+###
+### The model directory is the `<generated_model_subdir>_cpp` that CVSCppGenerator wrote -- it
+### holds the generated sources, the Makefiles, and the coupler_config.json the coupler reads.
+### It is resolved to an absolute path before anything cd's, because this script changes
+### directory twice and the config path is used after the second one.
+###
+### It used to be hardwired to `../../generated_models/<one tutorial model>_cpp`, relative to
+### this script. That broke twice over: the model name only ever suited one tutorial, and when
+### `src/coupler` became `src/libcuflynx/coupler` the extra path element made `../..` land on
+### `src/` instead of the repo root.
+
+set -u
 
 FOLDERcoupler="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-FOLDERcpp="../../generated_models/cvs_model_with_arm_hybrid_cpp/"
+DEFAULTcpp="$FOLDERcoupler/../../../generated_models/cvs_model_with_arm_hybrid_cpp"
+FOLDERcpp="${1:-$DEFAULTcpp}"
+
+if [[ $# -eq 0 ]]; then
+    echo "No model directory given; falling back to $DEFAULTcpp" >&2
+    echo "Pass the generated <model>_cpp directory explicitly -- the default only fits one tutorial model." >&2
+fi
+
+if [[ ! -d "$FOLDERcpp" ]]; then
+    echo "Generated C++ model directory not found: $FOLDERcpp" >&2
+    echo "Generate it first (model_type: cpp, couple_to_1d: true), then pass its path to this script." >&2
+    exit 1
+fi
+FOLDERcpp="$( cd -- "$FOLDERcpp" &> /dev/null && pwd )"
 
 FILEconfig="coupler_config.json"
+
+if [[ ! -f "$FOLDERcpp/$FILEconfig" ]]; then
+    echo "No $FILEconfig in $FOLDERcpp." >&2
+    echo "The notebook/driver writes it next to the generated model before running the coupler." >&2
+    exit 1
+fi
 
 USE_PETSC=1
 # USE_PETSC=0
@@ -32,7 +65,7 @@ echo "*** RUNNING THE COUPLER NOW ***"
 
 ./coupler "$FOLDERcpp/$FILEconfig"
 # ./coupler "$FOLDERcpp/$FILEconfig" > log_$(date +'%Y-%m-%d_%H-%M-%S').txt
-# ./coupler "$FOLDERcpp/$FILEconfig" > log_$(date +'%Y-%m-%d_%H-%M-%S').txt & 
+# ./coupler "$FOLDERcpp/$FILEconfig" > log_$(date +'%Y-%m-%d_%H-%M-%S').txt &
 # ./coupler "$FOLDERcpp/$FILEconfig" > log_$(date +'%Y-%m-%d_%H-%M-%S').txt 2>&1 &
 
 echo "*** SUCCESS $(date +'%Y-%m-%d_%H-%M-%S') ***"

--- a/tests/interactive_tests/test_notebook_paths_resolve.py
+++ b/tests/interactive_tests/test_notebook_paths_resolve.py
@@ -1,0 +1,121 @@
+"""Every filesystem path the tutorial notebook names must exist (#463).
+
+`tutorial/interactive/generation_and_calibration.ipynb` had no test at all -- the harness in
+`test_interactive_tutorial_notebooks.py` only knows `generation_and_calibration_test.ipynb` and
+`image_to_hemodynamics_model.ipynb`. So when `f101a1b` moved `src/solver1d` and `src/coupler`
+into the `libcuflynx` namespace, Section C kept pointing at the old layout and nothing noticed
+for a release.
+
+This is a static check, not an execution: Section C needs a C++/PETSc toolchain and cannot run
+in CI. It costs nothing and is exactly what would have caught the breakage.
+"""
+import ast
+import json
+import os
+
+import pytest
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+_NOTEBOOKS = [
+    os.path.join(_ROOT, 'tutorial', 'interactive', 'generation_and_calibration.ipynb'),
+]
+
+#: Spellings that moved in the libcuflynx namespace migration. A notebook naming one of these is
+#: pointing at a layout that has not existed since 0.4.0.
+_STALE_PREFIXES = ('src/coupler', 'src/solver1d', 'src/param_id', 'src/generators',
+                   'src/parsers', 'src/utilities', 'src/solver_wrappers', 'src/scripts')
+
+
+def _code(notebook_path):
+    with open(notebook_path, encoding='utf-8') as fh:
+        doc = json.load(fh)
+    for idx, cell in enumerate(doc.get('cells', [])):
+        if cell.get('cell_type') != 'code':
+            continue
+        lines = [ln for ln in (cell.get('source') or [])
+                 if not ln.lstrip().startswith(('%', '!'))]
+        yield idx, ''.join(lines)
+
+
+def _joined_repo_paths(tree):
+    """Repo-relative paths built as ``os.path.join(CA_root, ...)`` or ``CA_root / "..."``."""
+    found = []
+
+    def parts_of(node):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return [node.value]
+        return None
+
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and node.func.attr == 'join' and node.args
+                and isinstance(node.args[0], ast.Name) and node.args[0].id == 'CA_root'):
+            rest = [parts_of(a) for a in node.args[1:]]
+            if all(r is not None for r in rest):
+                found.append(os.path.join(*[p for r in rest for p in r]))
+        if (isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div)
+                and isinstance(node.left, ast.Name) and node.left.id == 'CA_root'):
+            rest = parts_of(node.right)
+            if rest:
+                found.append(rest[0])
+    return found
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('notebook', _NOTEBOOKS, ids=os.path.basename)
+def test_the_notebook_names_no_pre_libcuflynx_source_path(notebook):
+    offenders = []
+    for idx, source in _code(notebook):
+        for stale in _STALE_PREFIXES:
+            if stale in source:
+                offenders.append(f'cell {idx}: {stale!r}')
+    assert not offenders, (
+        f'{os.path.relpath(notebook, _ROOT)} points at the pre-libcuflynx layout '
+        f'({"; ".join(offenders)}). src/<pkg> moved to src/libcuflynx/<pkg> in 0.4.0.')
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('notebook', _NOTEBOOKS, ids=os.path.basename)
+def test_every_repo_path_the_notebook_builds_exists(notebook):
+    missing = []
+    for idx, source in _code(notebook):
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue          # a cell that is not valid standalone python is not this test's job
+        for rel in _joined_repo_paths(tree):
+            if not os.path.exists(os.path.join(_ROOT, rel)):
+                missing.append(f'cell {idx}: {rel!r}')
+    assert not missing, (
+        f'{os.path.relpath(notebook, _ROOT)} builds paths under the repo root that do not '
+        f'exist: {"; ".join(missing)}')
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('notebook', _NOTEBOOKS, ids=os.path.basename)
+def test_the_notebook_does_not_hardcode_an_interpreter_or_a_home_directory(notebook):
+    """`/opt/OpenCOR/python` and `/home/<someone>/...` are one machine's layout, and the
+    OpenCOR interpreter is deprecated besides."""
+    offenders = []
+    for idx, source in _code(notebook):
+        for bad in ('/opt/OpenCOR', '/home/', '/hpc/'):
+            if bad in source:
+                offenders.append(f'cell {idx}: {bad!r}')
+    assert not offenders, (
+        f'{os.path.relpath(notebook, _ROOT)} hardcodes a machine-specific path '
+        f'({"; ".join(offenders)}). Use sys.executable for the interpreter and derive data '
+        f'directories from CA_root or the installed package.')
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('notebook', _NOTEBOOKS, ids=os.path.basename)
+def test_the_notebook_writes_its_outputs_outside_resources(notebook):
+    """Section C used to create a top-level `files_1d/` and write generated CSVs back into
+    `resources/`, i.e. it edited the checkout it was run from."""
+    offenders = []
+    for idx, source in _code(notebook):
+        if 'CA_root / "files_1d"' in source or "CA_root / 'files_1d'" in source:
+            offenders.append(f'cell {idx}: creates a top-level files_1d/')
+        if 'folder_hyb=None' in source:
+            offenders.append(f'cell {idx}: convert_0d_to_1d writes back into resources/')
+    assert not offenders, '; '.join(offenders)

--- a/tests/interactive_tests/test_notebook_paths_resolve.py
+++ b/tests/interactive_tests/test_notebook_paths_resolve.py
@@ -20,6 +20,11 @@ _NOTEBOOKS = [
     os.path.join(_ROOT, 'tutorial', 'interactive', 'generation_and_calibration.ipynb'),
 ]
 
+#: Directories the notebook *creates* rather than reads. They are build output -- absent from a
+#: clean checkout and from CI, present locally only because something has been run -- so requiring
+#: them to exist would pass on a developer's machine and fail everywhere else.
+_OUTPUT_DIRS = ('generated_models', 'param_id_output', 'simulation_outputs_cpp', 'files_1d')
+
 #: Spellings that moved in the libcuflynx namespace migration. A notebook naming one of these is
 #: pointing at a layout that has not existed since 0.4.0.
 _STALE_PREFIXES = ('src/coupler', 'src/solver1d', 'src/param_id', 'src/generators',
@@ -84,11 +89,13 @@ def test_every_repo_path_the_notebook_builds_exists(notebook):
         except SyntaxError:
             continue          # a cell that is not valid standalone python is not this test's job
         for rel in _joined_repo_paths(tree):
+            if rel.split(os.sep)[0] in _OUTPUT_DIRS:
+                continue          # created by the run, not read by it
             if not os.path.exists(os.path.join(_ROOT, rel)):
                 missing.append(f'cell {idx}: {rel!r}')
     assert not missing, (
         f'{os.path.relpath(notebook, _ROOT)} builds paths under the repo root that do not '
-        f'exist: {"; ".join(missing)}')
+        f'exist: {"; ".join(missing)}. (Output directories are exempt: {_OUTPUT_DIRS}.)')
 
 
 @pytest.mark.unit

--- a/tutorial/interactive/generation_and_calibration.ipynb
+++ b/tutorial/interactive/generation_and_calibration.ipynb
@@ -975,6 +975,25 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "> **Section C needs a source checkout and a C++ toolchain.**\n",
+        ">\n",
+        "> Unlike Sections A and B, the hybrid 1D-0D run is not self-contained in the installed\n",
+        "> package. The 0D side is compiled from generated C++, and the 1D-0D coupler is a C++\n",
+        "> executable built from `src/libcuflynx/coupler/`, which is deliberately not shipped in the\n",
+        "> wheel. To run this section you need:\n",
+        ">\n",
+        "> - a git checkout of circulatory_autogen (not just `pip install libcuflynx`),\n",
+        "> - `make` and a C++17 compiler,\n",
+        "> - PETSc (or SUNDIALS) and nlohmann-json, located via `spack` by the build scripts.\n",
+        ">\n",
+        "> Everything it writes goes under `generated_models/`; nothing is written back into\n",
+        "> `resources/`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "## 18) Switch vessels of the arterial network to 1D.\n",
         "- Create a list of the selected vessels to switch into 1D (Hint: all artery names in the CVS model start with \"A_\").\n",
         "- Update the vessel array for the 1D-0D coupled model.\n"
@@ -999,7 +1018,12 @@
         "                'A_aorta_abdominal_1', 'A_aorta_abdominal_2', 'A_aorta_abdominal_3', 'A_aorta_abdominal_4', 'A_aorta_abdominal_5', 'A_aorta_abdominal_6',\n",
         "                'A_celiac_trunk', 'A_common_iliac_L', 'A_common_iliac_R']\n",
         "\n",
-        "convert_0d_to_1d(model_0d, resources_dir, input_param_file, folder_hyb=None, vess_1d_list=vess_1d_list)\n"
+        "# folder_hyb: where the generated hybrid CSVs go. Left as None this writes them back into\n",
+        "# resources/, i.e. it edits your checkout; send them to the generated-models dir instead.\n",
+        "resources_dir_hyb = os.path.join(generated_models_dir, model_0d + \"_hybrid_inputs\")\n",
+        "os.makedirs(resources_dir_hyb, exist_ok=True)\n",
+        "convert_0d_to_1d(model_0d, resources_dir, input_param_file,\n",
+        "                 folder_hyb=resources_dir_hyb, vess_1d_list=vess_1d_list)\n"
       ]
     },
     {
@@ -1062,8 +1086,18 @@
         "import os\n",
         "import subprocess\n",
         "\n",
-        "coupler_dir = os.path.join(CA_root, \"src/coupler\")\n",
-        "subprocess.run([\"./run_coupler1d0d.bash\"], cwd=coupler_dir, check=True)"
+        "# The coupler is a C++ executable built from source. It is deliberately NOT shipped in the\n",
+        "# wheel (see pyproject.toml), so this cell -- and the rest of Section C -- needs a source\n",
+        "# checkout of circulatory_autogen, not a `pip install libcuflynx`.\n",
+        "coupler_dir = os.path.join(CA_root, \"src\", \"libcuflynx\", \"coupler\")\n",
+        "if not os.path.isdir(coupler_dir):\n",
+        "    raise RuntimeError(\n",
+        "        f\"{coupler_dir} not found. Section C needs a source checkout of circulatory_autogen \"\n",
+        "        f\"(the coupler's C++ sources are not shipped in the installed package).\")\n",
+        "\n",
+        "# The build script takes the generated C++ model directory to build and run against.\n",
+        "subprocess.run([\"./run_coupler1d0d.bash\", inp_data_dict_cpp[\"generated_models_subdir\"] + \"_cpp\"],\n",
+        "               cwd=coupler_dir, check=True)"
       ]
     },
     {
@@ -1097,9 +1131,11 @@
         "file_prefix = model_name_hyb\n",
         "input_param_file = f\"{file_prefix}_parameters.csv\"\n",
         "\n",
-        "inp_data_dict_hyb = get_default_inp_data_dict(file_prefix, input_param_file, resources_dir)\n",
+        "inp_data_dict_hyb = get_default_inp_data_dict(file_prefix, input_param_file, resources_dir_hyb)\n",
         "\n",
-        "resources_dir_1d = CA_root / \"files_1d\"\n",
+        "# The 1D solver's own input tree. This used to be CA_root/\"files_1d\", an untracked directory\n",
+        "# created in the middle of your checkout; it is build output, so it belongs with the rest of it.\n",
+        "resources_dir_1d = Path(generated_models_dir) / \"files_1d\"\n",
         "if not os.path.exists(resources_dir_1d):\n",
         "    os.makedirs(resources_dir_1d)\n",
         "resources_subdir_1d = resources_dir_1d / model_name_hyb\n",
@@ -1111,13 +1147,13 @@
         "config_file_1d = run_dir_1d.joinpath(\"input.ini\")\n",
         "\n",
         "inp_data_dict_hyb['model_type'] = 'cpp'\n",
+        "inp_data_dict_hyb['couple_to_1d'] = True\n",
         "inp_data_dict_hyb['solver'] = 'PETSC'\n",
         "inp_data_dict_hyb['solver_info']['solver'] = 'PETSC'\n",
         "inp_data_dict_hyb['solver_info']['method'] = inp_data_dict_hyb['solver_info']['solver']\n",
         "inp_data_dict_hyb['solver_info']['MaximumStep'] = 0.001 # Let the 1D CFL time step stability condition determines the global simulation time step\n",
         "inp_data_dict_hyb['dt'] = 0.001 # sampling time step\n",
         "inp_data_dict_hyb['sim_time'] = 20.0 \n",
-        "inp_data_dict_hyb['couple_to_1d'] = True\n",
         "inp_data_dict_hyb['create_main_0d'] = True\n",
         "inp_data_dict_hyb['solver_1d_type'] = 'py'\n",
         "inp_data_dict_hyb['generate_1d'] = True\n",
@@ -1157,6 +1193,9 @@
       "outputs": [],
       "source": [
         "import json\n",
+        "import sys\n",
+        "\n",
+        "from libcuflynx.utilities.package_resources import package_data_file\n",
         "\n",
         "solver_hyb_dir = inp_data_dict_hyb['generated_models_subdir']+\"_cpp/\"\n",
         "\n",
@@ -1168,8 +1207,11 @@
         "coupler_config[\"nCC\"] = 3\n",
         "coupler_config[\"tmp_pipe_path\"] = \"/tmp/\"\n",
         "coupler_config[\"solver0d_path\"] = os.path.join(solver_hyb_dir, \"main0d\") \n",
-        "coupler_config[\"solver1d_path\"] = os.path.join(CA_root, \"src/solver1d/main1D.py\") \n",
-        "coupler_config[\"python_path\"] = \"/opt/OpenCOR/python\"\n",
+        "# Located in the installed package rather than by path arithmetic: solver1d *is* shipped in\n",
+        "# the wheel, so this works from a checkout and from a pip install alike.\n",
+        "coupler_config[\"solver1d_path\"] = str(package_data_file(\"libcuflynx.solver1d\", \"main1D.py\"))\n",
+        "# Whatever interpreter is running this notebook -- not a hardcoded OpenCOR one.\n",
+        "coupler_config[\"python_path\"] = sys.executable\n",
         "coupler_config[\"initFile_sim1d_path\"] = inp_data_dict_hyb['model_1d_config_path']\n",
         "coupler_config[\"initStatePath\"] = os.path.join(inp_data_dict_cpp['generated_models_subdir'], 'simulation_outputs_cpp/')\n",
         "\n",
@@ -1185,8 +1227,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "coupler_dir = os.path.join(CA_root, \"src/coupler\")\n",
-        "subprocess.run([\"./run_coupler1d0d.bash\"], cwd=coupler_dir, check=True)\n"
+        "subprocess.run([\"./run_coupler1d0d.bash\", solver_hyb_dir], cwd=coupler_dir, check=True)"
       ]
     },
     {


### PR DESCRIPTION
Closes #463.

## Why

Section C of `tutorial/interactive/generation_and_calibration.ipynb` still named `src/coupler` and
`src/solver1d`, which `f101a1b` moved into the `libcuflynx` namespace in 0.4.0.

Nothing caught it because **that notebook has no test at all**. The harness in
`test_interactive_tutorial_notebooks.py` only knows `generation_and_calibration_test.ipynb` and
`image_to_hemodynamics_model.ipynb`.

## Correction to the issue

#463 attributes the gap to the truncation at `test_interactive_tutorial_notebooks.py:225-227`.
That truncation is on a **different notebook**, and it is correct: it cuts
`generation_and_calibration_test.ipynb` at a placeholder cell containing
`"cpp_1d_model_config_path": "/path/to/input1d.dat"`, which cannot run. The real gap was the
missing test, not the truncation.

## What

**Notebook**
- `src/coupler` → `src/libcuflynx/coupler`, behind an explicit check with a message saying Section
  C needs a source checkout — the coupler's C++ sources are deliberately excluded from the wheel,
  so the corrected path still does not exist for a `pip install libcuflynx` user.
- `solver1d/main1D.py` is located with `package_data_file` rather than by walking up from
  `__file__`. solver1d *is* shipped, so that works from a checkout and an install alike.
- `python_path` was hardcoded to `/opt/OpenCOR/python`; now `sys.executable`.
- Outputs stop being written into the checkout: `convert_0d_to_1d` was called with
  `folder_hyb=None` (writes generated CSVs back into `resources/`), and the 1D input tree was
  `CA_root/"files_1d"`, an untracked directory created inside the repo. Both now go under
  `generated_models/`.
- **Fixed an ordering bug that predates the move**: `get_default_inp_data_dict` was called before
  `couple_to_1d` was set, so `file_prefix_1d` was never injected and generation died on
  `None + '_vessel_array.csv'`.
- A markdown cell before Section C states the toolchain it needs.

**`run_coupler1d0d.bash`** took its model directory from `../../generated_models/<one tutorial
model>_cpp`. That resolved to the repo root under `src/coupler` and to `src/` under
`src/libcuflynx/coupler`, so the namespace move broke it silently. It now takes the generated
`<model>_cpp` directory as an argument, resolves it absolutely before the first `cd` (it changes
directory twice and uses the config path after the second), and checks the directory and config
exist before building.

**New `tests/interactive_tests/test_notebook_paths_resolve.py`** — static, since Section C needs a
C++/PETSc toolchain and cannot run in CI. It asserts no pre-libcuflynx source path is named, that
every path the notebook builds under the repo root exists, that no machine-specific path or
interpreter is hardcoded, and that outputs do not land in `resources/`. **All four fail on the
notebook as it was.**

## Review notes

- **Stacked** on #474 — its first commit is the base here, so this diff shows it too. Review from
  the `fix(#463)` commit.
- Not addressed: shipping the coupler in the wheel, the missing `files_1d` fixture as a tracked
  asset, and executing Section C in CI. Section C is declared source-checkout-only instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
