### PR TITLE
Say the duplicate-name rule in two sentences

### DIFF
--- a/src/libcuflynx/parsers/PrimitiveParsers.py
+++ b/src/libcuflynx/parsers/PrimitiveParsers.py
@@ -695,12 +695,9 @@ def check_data_item_names_unique(gt_df, prediction_info=None):
             f"{name!r} x{len(where)} (in {', '.join(sorted(set(where)))})"
             for name, where in sorted(duplicated.items()))
         raise ValueError(
-            f"Duplicate 'data_item_name' in obs_data: {detail}. Each data_item and "
-            f"prediction_item needs its own name -- it is the item's identity and the key an "
-            f"operation_kwargs reference resolves against, so a repeat makes a reference "
-            f"ambiguous and silently picks whichever was evaluated last. Note this is not the "
-            f"plotting label: 'trace_name_for_plotting' may repeat freely (the mean and the max "
-            f"of one trace share it).")
+            f"Duplicate 'data_item_name' in obs_data: {detail}. Each item needs its own name: "
+            f"an operation_kwargs reference to a repeated one silently resolves to whichever "
+            f"item was evaluated last. The plotting label 'trace_name_for_plotting' may repeat.")
 
 
 def default_trace_names_for_plotting(gt_df):

--- a/src/libcuflynx/utilities/obs_data_helpers.py
+++ b/src/libcuflynx/utilities/obs_data_helpers.py
@@ -299,9 +299,7 @@ class ObsDataCreator:
         if entry.get('data_item_name') in existing:
             raise ValueError(
                 f"data_item_name {entry['data_item_name']!r} is already used by another item. "
-                f"Each data_item and prediction_item needs its own name -- it is the item's "
-                f"identity and the key an operation_kwargs reference resolves against. The "
-                f"plotting label may repeat: put the shared spelling in "
+                f"Each item needs its own name; a shared spelling goes in "
                 f"'trace_name_for_plotting' instead.")
 
         if 'trace_name_for_plotting' not in entry:


### PR DESCRIPTION
Two error messages explained the whole design of the #466 name/label split to someone who is trying to load a file: what a `data_item_name` is for, what a repeat does to an `operation_kwargs` reference, and which label may repeat freely. Cut to the collision, what it costs, and where a shared spelling belongs.

`check_data_item_names_unique`, before:

> Duplicate 'data_item_name' in obs_data: 'pressure aortic root' x3 (in data_items). Each data_item and prediction_item needs its own name -- it is the item's identity and the key an operation_kwargs reference resolves against, so a repeat makes a reference ambiguous and silently picks whichever was evaluated last. Note this is not the plotting label: 'trace_name_for_plotting' may repeat freely (the mean and the max of one trace share it).

after:

> Duplicate 'data_item_name' in obs_data: 'pressure aortic root' x3 (in data_items). Each item needs its own name: an operation_kwargs reference to a repeated one silently resolves to whichever item was evaluated last. The plotting label 'trace_name_for_plotting' may repeat.

`ObsDataCreator.add_data_item` carried a second copy of the same explanation in different words, which is how two statements of one rule drift apart; it is cut the same way.

### Why

This is the message a CUFLynx user meets when they load an obs_data written before the split -- CUFLynx shows CA's own complaint verbatim, so that the message at upload is the message a run would have failed with. Ninety words of design rationale in front of that is not what someone loading a file needs; the rule itself is documented where rules belong.

Nothing asserts the removed sentences -- only `"Duplicate 'data_item_name'"`, which is unchanged. `test_obs_data_vocabulary.py`, `test_migrate_obs_data.py` and `test_obs_data_conventions.py` pass (85).

The same change is already on `integration/next` (`fef12e4`), committed there directly before this branch existed; this is the same diff as a reviewable PR, so it survives a rebuild of that branch.