### PR TITLE
Draw the recorded trace behind the posterior draws, and stop the emulator path refusing it

### DIFF
--- a/src/libcuflynx/emulators/emulator_bundle.py
+++ b/src/libcuflynx/emulators/emulator_bundle.py
@@ -33,6 +33,33 @@ REQUIRED_META_KEYS = ('param_entry_labels', 'param_mins', 'param_maxs', 'feature
                       'feature_r2', 'x_scale', 'y_scale', 'fingerprint')
 
 
+def weighted_non_scalar_obs(obs_info):
+    """Data_items an emulator would have to predict but cannot: non-scalar *and* weighted.
+
+    The emulator predicts scalar features, so a ``series`` or ``frequency`` item in the
+    cost is a shape mismatch waiting to happen. A **zero-weighted** one is not in the cost
+    at all -- ``emulated_feature_labels`` is built from ``const_idx_to_obs_idx`` and
+    excludes non-constants already -- so refusing it stops a legitimate and useful thing:
+    carrying a recorded trace purely so it can be drawn behind the model.
+
+    Returns ``{obs index: data_type}`` for the ones that really do have to be refused.
+    Shared by the trainer and by the use-time check in ``paramID``, which had this rule
+    written out twice and drifted: the trainer learned about weights and the other did not.
+    """
+    unweighted = set()
+    for kind in ('series', 'amp', 'phase'):
+        weights = obs_info.get('weight_%s_vec' % kind)
+        idx_map = obs_info.get('%s_idx_to_obs_idx' % kind)
+        if weights is None or idx_map is None:
+            continue
+        for weight, obs_idx in zip(weights, idx_map):
+            if not np.any(np.asarray(weight, dtype=float)):
+                unweighted.add(int(obs_idx))
+
+    return {jj: dtype for jj, dtype in enumerate(obs_info['data_types'])
+            if dtype != 'constant' and jj not in unweighted}
+
+
 def fingerprint(param_id_info, obs_info, protocol_info, model_path=None):
     """A stable digest of everything an emulator was trained against.
 

--- a/src/libcuflynx/emulators/emulator_trainer.py
+++ b/src/libcuflynx/emulators/emulator_trainer.py
@@ -119,27 +119,13 @@ class EmulatorTrainer:
         """Refuse non-scalar data_items up front, where it is a config error rather than a
         confusing shape mismatch a hundred simulations later.
 
-        Zero-weighted ones are exempt. A weight of 0 drops an item from the cost entirely,
-        so the emulator is never asked for it -- ``emulated_feature_labels`` is built from
-        ``const_idx_to_obs_idx`` and excludes non-constants already. Carrying a recorded
-        trace at weight 0 purely so it can be drawn behind the model is a real use (it is
-        the only way to have anything to compare a simulated trace against on an
-        output-vs-time plot), and refusing it forced a second obs_data file that existed
-        only to keep the emulator happy.
+        Zero-weighted ones are exempt -- see
+        :func:`libcuflynx.emulators.emulator_bundle.weighted_non_scalar_obs`, which owns the
+        rule so that this and the use-time check in ``paramID`` cannot drift apart.
         """
-        obs_info = self.pid.obs_info
-        unweighted = set()
-        for kind in ('series', 'amp', 'phase'):
-            weights = obs_info.get('weight_%s_vec' % kind)
-            idx_map = obs_info.get('%s_idx_to_obs_idx' % kind)
-            if weights is None or idx_map is None:
-                continue
-            for weight, obs_idx in zip(weights, idx_map):
-                if not np.any(np.asarray(weight, dtype=float)):
-                    unweighted.add(int(obs_idx))
+        from libcuflynx.emulators.emulator_bundle import weighted_non_scalar_obs
 
-        bad = {jj: dtype for jj, dtype in enumerate(obs_info['data_types'])
-               if dtype != 'constant' and jj not in unweighted}
+        bad = weighted_non_scalar_obs(self.pid.obs_info)
         if bad:
             raise ValueError(
                 f'the emulator predicts scalar data_item features only, but obs_data.json has '

--- a/src/libcuflynx/param_id/paramID.py
+++ b/src/libcuflynx/param_id/paramID.py
@@ -2100,15 +2100,21 @@ class OpencorParamID():
         from libcuflynx.emulators.emulator_bundle import fingerprint
         bundle = self.sim_helper.bundle
 
-        bad = {jj: dtype for jj, dtype in enumerate(self.obs_info['data_types'])
-               if dtype != 'constant'}
+        # Zero-weighted non-scalars are exempt: they are not in the cost, so the emulator is
+        # never asked for them. The rule lives in emulator_bundle so this and the trainer's
+        # copy cannot drift -- they already had, and a recorded trace carried at weight 0 for
+        # plotting was refused here after the trainer had accepted it.
+        from libcuflynx.emulators.emulator_bundle import weighted_non_scalar_obs
+
+        bad = weighted_non_scalar_obs(self.obs_info)
         if bad:
             raise ValueError(
                 f'use_emulator is set, but obs_data.json has data_type(s) '
                 f'{sorted(set(bad.values()))} at data_item index(es) {sorted(bad)}. The emulator '
                 f'predicts scalar data_item features only; those need the full simulated trace '
                 f'("series") or its FFT ("frequency"). Emulating series outputs is not supported '
-                f'yet -- run with use_emulator: false, or drop those items.')
+                f'yet -- give them weight 0 if they are only there to be plotted, run with '
+                f'use_emulator: false, or drop those items.')
 
         bundle.check_matches(
             fingerprint(self.param_id_info, self.obs_info, self.protocol_info, self.model_path),

--- a/src/libcuflynx/param_id/paramID.py
+++ b/src/libcuflynx/param_id/paramID.py
@@ -2976,16 +2976,23 @@ class OpencorParamID():
             #                                 self.obs_info["std_series_vec"].reshape(-1, 1))) / min_len_series
 
             for series_idx in range(len(series)):
+                obs_idx = self.obs_info['series_idx_to_obs_idx'][series_idx]
+                weight_entry = updated_weight_series_vec[obs_idx]
+                if weight_entry == 0:
+                    # Nothing to add, and nothing to align either. The alignment was
+                    # happening first and raising on items whose cost was then thrown
+                    # away -- which made a recorded trace carried at weight 0 purely for
+                    # plotting break every run that used an emulator, since the emulator
+                    # returns scalars and there is no trace to interpolate.
+                    continue
+
                 # interpolates the simulated series onto the observation times when
                 # dt != obs_dt; shared with the symbolic cost so both agree exactly
                 series_entry, obs_entry, std_entry = self._align_series_to_ground_truth(
                     np.asarray(series[series_idx], dtype=float).flatten(), series_idx)
 
-                obs_idx = self.obs_info['series_idx_to_obs_idx'][series_idx]
-                weight_entry = updated_weight_series_vec[obs_idx]
-                if weight_entry != 0:
-                    series_cost += call_cost_func(cost_funcs_dict[self.cost_type[obs_idx]], series_entry, obs_entry,
-                                                  std=std_entry, weight=weight_entry, cost_kwargs=self._cost_kwargs_for(obs_idx))
+                series_cost += call_cost_func(cost_funcs_dict[self.cost_type[obs_idx]], series_entry, obs_entry,
+                                              std=std_entry, weight=weight_entry, cost_kwargs=self._cost_kwargs_for(obs_idx))
 
 
         amp_cost = 0

--- a/src/libcuflynx/param_id/posterior_predictive.py
+++ b/src/libcuflynx/param_id/posterior_predictive.py
@@ -518,12 +518,17 @@ def _resolve_model_path(config):
         'model first, or set model_path' % candidate)
 
 
-def series_metadata(client, series, ground_truth, std):
+def series_metadata(client, series, ground_truth, std, predictions=None):
     """Everything a plot needs to place the traces: axes, and what to draw on them.
 
     The observables are carried alongside because a trace on its own says
     nothing about whether it is right -- what makes the figure readable is the
     measured value drawn across it in the style its ``plot_type`` asks for.
+
+    ``predictions`` (draws x observables) adds the *model's* value of the same
+    statistic beside the measured one. Without it a reader can see that the
+    traces sit above the measured max but not by how much the reduced number
+    disagrees, which is the quantity the cost is actually built from.
     """
     if not series:
         return {}
@@ -566,6 +571,14 @@ def series_metadata(client, series, ground_truth, std):
             'std': float(std[const_idx]),
             'plot_type': str(plot_types[obs_idx]) if obs_idx < len(plot_types) else 'None',
             'kind': 'constant',
+            # What the model made of the same statistic. The median over draws
+            # rather than the mean: one diverged draw should not move the line
+            # the reader compares against.
+            'operation': str((obs_info.get('operations') or [None] * (obs_idx + 1))[obs_idx]
+                             or ''),
+            'model_value': (float(np.median(predictions[:, const_idx]))
+                            if predictions is not None and const_idx < predictions.shape[1]
+                            else None),
         })
 
     # Recorded traces, which are what a simulated trace can actually be compared
@@ -694,7 +707,8 @@ def posterior_predictive(inp_data_dict=None, num_samples=100, burn_in=0.5,
         coverage_summary=coverage(predictions, ground_truth, std, levels),
         chain_info=chain_info, failures=failures, used_emulator=bool(use_emulator),
         series=series,
-        series_meta=series_metadata(client, series, ground_truth, std))
+        series_meta=series_metadata(client, series, ground_truth, std,
+                                    predictions=predictions))
 
     if save:
         result.save(resolved_dir)

--- a/src/libcuflynx/scripts/generate_pipeline_script.py
+++ b/src/libcuflynx/scripts/generate_pipeline_script.py
@@ -1642,7 +1642,17 @@ def plot_sample_traces():
             for row in traces:
                 ax.plot(t, row, color="#2a78d6", linewidth=0.8, alpha=0.35)
 
+            drew_recording = False
             for obs in marks.get(key, []):
+                if obs.get("kind") == "series":
+                    # The recorded trace itself. This is the comparison that
+                    # matters: a horizontal line says an amplitude is right or
+                    # wrong, and only this says whether the shape is.
+                    ax.plot(obs["time"], obs["values"], color="#111417",
+                            linewidth=1.1, zorder=4,
+                            label="recorded" if not drew_recording else None)
+                    drew_recording = True
+                    continue
                 if obs["plot_type"] != "horizontal":
                     # Nothing sensible to draw for a frequency on a voltage
                     # axis; those observables are reported by the scalar panels.
@@ -1652,6 +1662,8 @@ def plot_sample_traces():
                     ax.axhspan(obs["value"] - abs(obs["std"]),
                                obs["value"] + abs(obs["std"]),
                                color="#eb6834", alpha=0.15, zorder=0)
+            if drew_recording:
+                ax.legend(fontsize=6, loc="best", frameon=False)
 
             exp_sub = segments.get(str(segment))
             where = ("exp %s sub %s" % tuple(exp_sub)) if exp_sub else "segment %d" % segment

--- a/src/libcuflynx/scripts/generate_pipeline_script.py
+++ b/src/libcuflynx/scripts/generate_pipeline_script.py
@@ -1639,10 +1639,17 @@ def plot_sample_traces():
             if t is None or len(t) != traces.shape[1]:
                 t = np.arange(traces.shape[1])
 
-            for row in traces:
-                ax.plot(t, row, color="#2a78d6", linewidth=0.8, alpha=0.35)
+            for index, row in enumerate(traces):
+                ax.plot(t, row, color="#2a78d6", linewidth=0.8, alpha=0.35,
+                        label=("simulation (%d draws)" % len(traces)) if index == 0 else None)
 
-            drew_recording = False
+            # Named after what the statistic is, so "data max" and "sim max" read
+            # as the same quantity measured two ways rather than two mystery lines.
+            def _named(obs, who):
+                op = (obs.get("operation") or "").replace("_in_range", "").replace("_", " ")
+                return "%s %s" % (who, op) if op else who
+
+            drew_recording = drew_data = drew_model = False
             for obs in marks.get(key, []):
                 if obs.get("kind") == "series":
                     # The recorded trace itself. This is the comparison that
@@ -1650,20 +1657,33 @@ def plot_sample_traces():
                     # wrong, and only this says whether the shape is.
                     ax.plot(obs["time"], obs["values"], color="#111417",
                             linewidth=1.1, zorder=4,
-                            label="recorded" if not drew_recording else None)
+                            label=None if drew_recording else "data (recorded trace)")
                     drew_recording = True
                     continue
                 if obs["plot_type"] != "horizontal":
                     # Nothing sensible to draw for a frequency on a voltage
                     # axis; those observables are reported by the scalar panels.
                     continue
-                ax.axhline(obs["value"], color="#eb6834", linewidth=1.2, zorder=3)
+                ax.axhline(obs["value"], color="#eb6834", linewidth=1.2, zorder=3,
+                           label=None if drew_data else _named(obs, "data"))
+                drew_data = True
                 if obs["std"]:
                     ax.axhspan(obs["value"] - abs(obs["std"]),
                                obs["value"] + abs(obs["std"]),
                                color="#eb6834", alpha=0.15, zorder=0)
-            if drew_recording:
-                ax.legend(fontsize=6, loc="best", frameon=False)
+                # The model's value of that same statistic. Dashed and in the
+                # simulation colour: the gap between this and the solid orange
+                # line is what the cost is built from, and on a badly fitting
+                # observable it is the whole story.
+                if obs.get("model_value") is not None:
+                    ax.axhline(obs["model_value"], color="#2a78d6", linewidth=1.2,
+                               linestyle="--", zorder=3,
+                               label=None if drew_model else _named(obs, "sim"))
+                    drew_model = True
+
+            if drew_recording or drew_data or drew_model:
+                ax.legend(fontsize=5.5, loc="best", frameon=True, framealpha=.75,
+                          borderpad=.3, handlelength=1.4)
 
             exp_sub = segments.get(str(segment))
             where = ("exp %s sub %s" % tuple(exp_sub)) if exp_sub else "segment %d" % segment

--- a/tests/test_posterior_predictive.py
+++ b/tests/test_posterior_predictive.py
@@ -526,3 +526,38 @@ def test_no_recordings_leaves_the_metadata_as_it_was():
     meta = _series_meta(client)
 
     assert all(o.get("kind") == "constant" for o in meta["observables"])
+
+
+@pytest.mark.unit
+def test_the_model_s_own_value_of_each_statistic_is_carried():
+    """A measured max drawn across a trace says the amplitude is wrong; it cannot
+    say by how much the number the cost is built from disagrees. Carrying the
+    model's value of the same statistic is what lets a plot draw both."""
+    client = SeriesClient()
+    predictions = np.array([[3.0], [5.0], [4.0]])   # three draws, one observable
+    meta = pp.series_metadata(client, {(0, "x/v"): np.zeros((3, 12))},
+                              client.obs_info["ground_truth_const"],
+                              client.obs_info["std_const_vec"],
+                              predictions=predictions)
+
+    constant = next(o for o in meta["observables"] if o.get("kind") == "constant")
+    # the median over draws, not the mean: one diverged draw should not move the
+    # line the reader compares against
+    assert constant["model_value"] == 4.0
+
+
+@pytest.mark.unit
+def test_without_predictions_the_field_is_absent_rather_than_wrong():
+    meta = _series_meta(SeriesClient())
+    constant = next(o for o in meta["observables"] if o.get("kind") == "constant")
+    assert constant["model_value"] is None
+
+
+@pytest.mark.unit
+def test_the_operation_name_travels_with_it():
+    """So a plot can label the pair "data max" and "sim max" rather than guessing."""
+    client = SeriesClient()
+    client.obs_info["operations"] = ["max_in_range"]
+    meta = _series_meta(client)
+    constant = next(o for o in meta["observables"] if o.get("kind") == "constant")
+    assert constant["operation"] == "max_in_range"

--- a/tests/test_zero_weighted_observables.py
+++ b/tests/test_zero_weighted_observables.py
@@ -85,3 +85,55 @@ def test_a_vector_weight_of_all_zeros_still_counts_as_off():
     }
     pid = type('FakePID', (), {'obs_info': obs_info})()
     _check(type('FakeTrainer', (), {'pid': pid})())
+
+
+# ── the same rule, at both places that enforce it ──────────────────────────
+"""There are two checks, not one: the trainer refuses before simulating, and
+paramID refuses at use time when ``use_emulator`` is set. They had the rule
+written out separately and drifted -- the trainer learned about zero weights and
+the use-time check did not, so a recorded trace carried for plotting trained an
+emulator successfully and then failed every run that tried to use it.
+"""
+
+from libcuflynx.emulators.emulator_bundle import weighted_non_scalar_obs
+
+
+def _obs_info(data_types, series_weights=(), series_idx=()):
+    return {
+        'data_types': list(data_types),
+        'weight_series_vec': np.array(series_weights, dtype=float),
+        'series_idx_to_obs_idx': list(series_idx),
+    }
+
+
+def test_the_shared_rule_exempts_a_zero_weighted_series():
+    assert weighted_non_scalar_obs(
+        _obs_info(['constant', 'series'], [0.0], [1])) == {}
+
+
+def test_the_shared_rule_still_names_a_weighted_series():
+    assert weighted_non_scalar_obs(
+        _obs_info(['constant', 'series'], [1.0], [1])) == {1: 'series'}
+
+
+def test_the_use_time_check_agrees_with_the_trainer():
+    """The property that matters: whatever one refuses, so does the other."""
+    from libcuflynx.emulators.emulator_trainer import EmulatorTrainer
+
+    for weights, idx, types in (
+            ([0.0], [1], ['constant', 'series']),
+            ([1.0], [1], ['constant', 'series']),
+            ([0.0, 1.0], [1, 2], ['constant', 'series', 'series']),
+            ([], [], ['constant', 'constant']),
+    ):
+        info = _obs_info(types, weights, idx)
+        shared = weighted_non_scalar_obs(info)
+
+        trainer = type('T', (), {'pid': type('P', (), {'obs_info': info})()})()
+        try:
+            EmulatorTrainer._check_observables_are_scalar(trainer)
+            trainer_refused = False
+        except ValueError:
+            trainer_refused = True
+
+        assert trainer_refused == bool(shared), (types, weights)


### PR DESCRIPTION
Rebased onto current `master`. These five commits were sitting on #478 and #479,
both of which predate several merges — this replaces those unpushed parts rather
than pushing over a stale base.

## The problem

A simulated trace was drawn against horizontal lines reduced from the same
recording. The panel could say *an amplitude is wrong* and nothing at all about
whether the **shape** is — which is what an AP-clamp or current-step experiment is
for.

The recorded trace was in the obs_data (carried at `weight: 0`, so it is drawn and
not fitted) and never reached a plot. Three separate places stopped it.

## 1. `EmulatorTrainer` and `paramID` disagreed about weight-0 series

Two checks refuse non-scalar observables: the trainer before simulating, and
`paramID._configure_emulator` at use time. Each had the rule written out
separately, so when the trainer learned that a zero-weighted item is not in the
cost, the other did not.

The visible failure: an obs_data carrying recorded traces **trained an emulator
successfully and then failed every run that used it**, telling the user to drop the
items the trainer had just accepted.

`weighted_non_scalar_obs()` in `emulator_bundle` now owns the rule and both ask
it. A test asserts the property directly — whatever one refuses, so does the other.

## 2. The cost interpolated series it was about to discard

`cost_calc` aligned every simulated series onto its observation times and *then*
checked the weight. Wasted work in the ordinary case, fatal in this one: an
emulator returns scalar features and no trace, so a weight-0 recording hit
`cannot interpolate series observable 1: the simulation produced 1 sample(s)` on
every emulator-backed run. The weight test moves above the alignment.

## 3. `series_metadata` only walked the constants

It iterated `const_idx_to_obs_idx`, so recorded series never reached the plot
payload at all. They now come through with their own time axis — a recording is
sampled at `obs_dt` and the kept draws are decimated, so the two rarely share a
length.

It also carries the **model's own value** of each scalar statistic (median over
draws) and the operation name, so a panel can draw `data max` and `sim max` as one
comparison. The gap between them is what the cost is built from.

## The plots

`plot_sample_traces` draws the recording as a line and the model's statistic as a
dashed one, with a four-entry legend: **simulation (N draws)** · **data (recorded
trace)** · **data max** · **sim max**. Labels derive from the operation, so a
`min_in_range` reads "data min" and a `steady_state_min` reads as itself.

## Verified

All three were found by running a full pipeline — train, calibrate, MCMC,
posterior predictive — against one obs_data on a 512-sample scout. Only the first
was reachable until it was fixed, then the second, then the third.

`test_zero_weighted_observables`, `test_posterior_predictive`,
`test_generate_pipeline_script`: **83 passed**.

`test_param_id`'s `test_aadc_gradient_rejects_untapeable_observables` fails here and
on pristine `master` alike — environmental, this venv has `autoemulate` installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)