### PR TITLE
Two-phase emulators: classify which side of the cliff, then regress

### DIFF
--- a/src/libcuflynx/emulators/emulator_trainer.py
+++ b/src/libcuflynx/emulators/emulator_trainer.py
@@ -59,6 +59,18 @@ def emulator_model_names():
     """
     if not autoemulate_available():
         return []
+    base = sorted(_load_autoemulate().list_emulators(default_only=False)['Emulator'].tolist())
+    # The two-phase variants are offered here so a settings form can list them, but
+    # they are not part of `all` -- see _parse_models. Two stages cost more to fit
+    # than one and only pay off when the features really do have a floor.
+    from libcuflynx.emulators.internal_emulators import two_phase_model_names
+    return base + two_phase_model_names(base)
+
+
+def base_emulator_model_names():
+    """Only autoemulate's own names -- what ``models: all`` resolves to."""
+    if not autoemulate_available():
+        return []
     return sorted(_load_autoemulate().list_emulators(default_only=False)['Emulator'].tolist())
 
 
@@ -274,6 +286,28 @@ class EmulatorTrainer:
         models = _parse_models(self._setting('models', 'default'))
         if models is not None:
             kwargs['models'] = models
+
+        # Imported here, not at module scope: internal_emulators asks this module
+        # for the emulator list when it builds its two_phase_<name> helpers, so a
+        # top-level import either way closes the cycle.
+        from libcuflynx.emulators.internal_emulators import (  # noqa: PLC0415
+            base_emulator_name, fit_two_phase, is_two_phase, two_phase_name)
+
+        two_phase = [name for name in (models or []) if is_two_phase(name)]
+        if two_phase:
+            if len(models) > 1:
+                raise ValueError(
+                    f'a two-phase emulator is fitted on its own, but models is {models!r}. '
+                    f'Ask for exactly one, e.g. models: {two_phase[0]}.')
+            # The classifier and the second regressor are fitted here; autoemulate
+            # still does both regressions, so every other setting applies unchanged.
+            base_name = base_emulator_name(two_phase[0])
+            kwargs.pop('models', None)
+            model, result = fit_two_phase(
+                x_train, y_train, x_test, y_test, base_name,
+                _load_autoemulate(), kwargs)
+            validation = _validation_report(model, x_test, y_test, x_scale, y_scale)
+            return (model, validation, two_phase_name(base_name), x_scale, y_scale)
 
         emulation = _load_autoemulate()(x_train, y_train, test_data=(x_test, y_test), **kwargs)
         result = emulation.best_result()
@@ -559,7 +593,9 @@ def _parse_models(models):
     if models in (None, '', 'default'):
         return None
     if models == 'all':
-        return emulator_model_names()
+        # Base emulators only: a two-phase variant is opt-in by name, never swept up
+        # by 'all', because it fits a classifier and a second regressor on top.
+        return base_emulator_model_names()
     if isinstance(models, str):
         return [name.strip() for name in models.split(',') if name.strip()]
     return list(models)

--- a/src/libcuflynx/emulators/internal_emulators.py
+++ b/src/libcuflynx/emulators/internal_emulators.py
@@ -1,0 +1,294 @@
+"""Emulators CA builds itself, wrapping autoemulate rather than replacing it.
+
+autoemulate's emulators are regressors, and a regressor is the wrong shape for an
+observable that spends most of its range pinned at one value. A spike count is the
+example that motivated this: below rheobase it is exactly zero, above it jumps to
+one spike per window, and there is no value in between the model can produce. Fit a
+smooth regressor to that and it splits the difference -- predicting a fraction of a
+spike across the floor, and undershooting everywhere above it.
+
+The response surface is a floor, a cliff and a staircase, which the cardiac
+electrophysiology literature calls a bifurcation: the model changes behaviour as a
+parameter crosses a threshold, and a stationary kernel has to pick one length scale
+for both sides of it. The standard answer is two stages -- learn *where* the
+boundary is with a classifier, and learn the magnitude with a regressor fitted only
+on the far side, so the floor cannot drag it down.
+
+``TwoPhaseEmulator`` does that and keeps autoemulate for both regression halves, so
+every setting that works for a plain run works here. The variants are exposed as
+``two_phase_<name>`` for each autoemulate emulator -- ``two_phase_MLP``,
+``two_phase_RandomForest`` and so on -- and are **deliberately absent from the
+``all`` set**: two stages cost more to fit than one and are only worth it when the
+features really do have a floor, so they are opt-in by name.
+
+    emulator_settings:
+      models: two_phase_MLP
+
+Nothing about spiking is hardcoded. A "floor" is whatever single value a feature
+returns unusually often, found from the training data.
+"""
+import numpy as np
+
+#: Prefix that marks a two-phase variant of an autoemulate emulator.
+TWO_PHASE_PREFIX = 'two_phase_'
+
+#: A feature is treated as having a floor when at least this share of the design
+#: returns one single value. Well below the 82% seen on real spike-frequency
+#: features, and well above the repetition a genuinely continuous feature shows.
+DEFAULT_FLOOR_SHARE = 0.25
+
+#: Below this many off-floor points there is nothing to fit a second regressor on,
+#: so the feature falls back to the single-stage path.
+MIN_ACTIVE_ROWS = 8
+
+
+def is_two_phase(name):
+    """Whether ``name`` asks for a two-phase variant."""
+    return isinstance(name, str) and name.startswith(TWO_PHASE_PREFIX)
+
+
+def base_emulator_name(name):
+    """``two_phase_MLP`` -> ``MLP``. Returns ``name`` unchanged if not two-phase."""
+    return name[len(TWO_PHASE_PREFIX):] if is_two_phase(name) else name
+
+
+def two_phase_name(name):
+    """``MLP`` -> ``two_phase_MLP``."""
+    return name if is_two_phase(name) else TWO_PHASE_PREFIX + name
+
+
+def two_phase_model_names(base_names):
+    """A ``two_phase_`` variant for each name in ``base_names``.
+
+    Built from whatever autoemulate advertises rather than a list kept here, so a
+    new emulator on their side gets a two-phase variant without a change on ours.
+    """
+    return [two_phase_name(name) for name in base_names]
+
+
+def floor_mask(y, floor_share=DEFAULT_FLOOR_SHARE):
+    """Which features have a floor, and what value it is.
+
+    Returns ``(has_floor, floor_value)``, both length ``n_features``. A feature has
+    a floor when one value accounts for at least ``floor_share`` of the design --
+    the shape a threshold produces, and not one a continuous response takes.
+    """
+    y = np.asarray(y, dtype=float)
+    n_rows, n_features = y.shape
+    has_floor = np.zeros(n_features, dtype=bool)
+    floor_value = np.zeros(n_features, dtype=float)
+    for index in range(n_features):
+        column = y[:, index]
+        finite = column[np.isfinite(column)]
+        if finite.size == 0:
+            continue
+        values, counts = np.unique(np.round(finite, 12), return_counts=True)
+        best = int(np.argmax(counts))
+        if counts[best] / float(finite.size) >= floor_share:
+            has_floor[index] = True
+            floor_value[index] = float(values[best])
+    return has_floor, floor_value
+
+
+class TwoPhaseEmulator:
+    """Classify which side of the cliff, then regress the magnitude.
+
+    Fitted from :func:`fit_two_phase`, which owns the autoemulate calls. Predicting
+    is the interesting half and lives here: for a feature with a floor, the
+    classifier decides floor-or-not and the active regressor supplies the value
+    when not; every other feature comes straight from the base regressor.
+
+    Presents ``predict`` and nothing else, which is all ``EmulatorBundle`` asks of a
+    model, and pickles through joblib like autoemulate's own.
+    """
+
+    def __init__(self, base_model, active_model, classifier, has_floor, floor_value,
+                 base_name):
+        self.base_model = base_model
+        self.active_model = active_model
+        self.classifier = classifier
+        self.has_floor = np.asarray(has_floor, dtype=bool)
+        self.floor_value = np.asarray(floor_value, dtype=float)
+        self.base_name = base_name
+
+    @property
+    def model_name(self):
+        return two_phase_name(self.base_name)
+
+    def predict(self, x):
+        x = np.asarray(x, dtype=float)
+        if x.ndim == 1:
+            x = x.reshape(1, -1)
+        out = _as_array(self.base_model.predict(_backend_input(self.base_model, x)),
+                        len(x))
+
+        if not self.has_floor.any() or self.classifier is None:
+            return out
+
+        active = np.asarray(self.classifier.predict(x))
+        if active.ndim == 1:
+            active = active.reshape(-1, 1)
+        active = active.astype(bool)
+
+        if self.active_model is not None:
+            magnitudes = _as_array(
+                self.active_model.predict(_backend_input(self.active_model, x)), len(x))
+        else:
+            magnitudes = out
+
+        floor_indices = np.flatnonzero(self.has_floor)
+        for column, index in enumerate(floor_indices):
+            if column >= active.shape[1]:
+                break
+            on_floor = ~active[:, column]
+            out[on_floor, index] = self.floor_value[index]
+            out[~on_floor, index] = magnitudes[~on_floor, index]
+        return out
+
+
+def fit_two_phase(x_train, y_train, x_test, y_test, base_name, autoemulate_cls,
+                  fit_kwargs, floor_share=DEFAULT_FLOOR_SHARE):
+    """Fit the classifier and both regressors. Returns ``(model, base_result_name)``.
+
+    Two autoemulate runs rather than one per feature: the second is fitted on the
+    rows where the floored features are active, which is the subset that stops the
+    floor dragging the magnitude down. Per-feature runs would be the more faithful
+    reading of the method and cost one full comparison per observable -- 84 of them
+    on the study this was written for.
+    """
+    y_train = np.asarray(y_train, dtype=float)
+    has_floor, floor_value = floor_mask(y_train, floor_share)
+
+    kwargs = dict(fit_kwargs)
+    kwargs['models'] = [base_name]
+    base = autoemulate_cls(x_train, y_train, test_data=(x_test, y_test), **kwargs)
+    base_result = base.best_result()
+
+    if not has_floor.any():
+        # Nothing to gate. Returned as a plain two-phase object with no classifier
+        # so the bundle records what was asked for rather than silently degrading.
+        return (TwoPhaseEmulator(base_result.model, None, None, has_floor, floor_value,
+                                 base_name),
+                base_result)
+
+    floor_indices = np.flatnonzero(has_floor)
+    labels = np.column_stack([
+        ~np.isclose(y_train[:, index], floor_value[index]) for index in floor_indices])
+
+    classifier = _fit_classifier(x_train, labels)
+
+    active_rows = labels.any(axis=1)
+    active_model = None
+    if int(active_rows.sum()) >= MIN_ACTIVE_ROWS and not active_rows.all():
+        active_kwargs = dict(fit_kwargs)
+        active_kwargs['models'] = [base_name]
+        active = autoemulate_cls(x_train[active_rows], y_train[active_rows],
+                                 test_data=(x_test, y_test), **active_kwargs)
+        active_model = active.best_result().model
+
+    return (TwoPhaseEmulator(base_result.model, active_model, classifier,
+                             has_floor, floor_value, base_name),
+            base_result)
+
+
+def _fit_classifier(x, labels):
+    """The boundary. One gradient-boosted classifier per floored feature.
+
+    sklearn rather than autoemulate: autoemulate has no classifier at all, and this
+    is the half of the method it does not cover. A column whose label never changes
+    carries no boundary to learn, so it gets a constant instead of a fit that would
+    raise on a single class.
+    """
+    from sklearn.ensemble import GradientBoostingClassifier
+
+    return _MultiOutputBinary([
+        _fit_column(GradientBoostingClassifier, x, labels[:, column])
+        for column in range(labels.shape[1])])
+
+
+def _fit_column(cls, x, column):
+    if column.all() or not column.any():
+        return _Constant(bool(column.all()))
+    model = cls(random_state=0)
+    model.fit(x, column.astype(int))
+    return model
+
+
+class _Constant:
+    """A column that is always active, or never. Nothing to learn."""
+
+    def __init__(self, value):
+        self.value = bool(value)
+
+    def predict(self, x):
+        return np.full(len(x), self.value, dtype=bool)
+
+
+class _MultiOutputBinary:
+    """One binary classifier per floored feature, answered together."""
+
+    def __init__(self, models):
+        self.models = list(models)
+
+    def predict(self, x):
+        if not self.models:
+            return np.zeros((len(x), 0), dtype=bool)
+        return np.column_stack([
+            np.asarray(model.predict(x)).astype(bool) for model in self.models])
+
+
+def _backend_input(model, x):
+    """autoemulate emulators may want a tensor; a plain object takes the array."""
+    try:
+        from libcuflynx.emulators.emulator_bundle import _as_backend_input
+        return _as_backend_input(model, x)
+    except Exception:  # noqa: BLE001 - a plain predictor takes the array as-is
+        return x
+
+
+def _as_array(raw, n_rows):
+    try:
+        from libcuflynx.emulators.emulator_bundle import _as_numpy_mean
+        values = _as_numpy_mean(raw)
+    except Exception:  # noqa: BLE001
+        values = np.asarray(raw, dtype=float)
+    return np.asarray(values, dtype=float).reshape(n_rows, -1)
+
+
+# --------------------------------------------------------------------------------
+# ``two_phase_<name>`` helpers
+#
+# One function per autoemulate emulator, so a caller can reach a variant by name
+# without knowing the prefix convention. Generated at import from whatever
+# autoemulate advertises; absent, and the module still imports and the names above
+# still work, because everything they need is the string.
+# --------------------------------------------------------------------------------
+
+def _make_helper(base):
+    def helper():
+        """Return the ``models`` value that asks for the two-phase variant."""
+        return two_phase_name(base)
+    helper.__name__ = two_phase_name(base)
+    helper.__qualname__ = helper.__name__
+    helper.__doc__ = (
+        'The ``emulator_settings.models`` value for a two-phase %s: a classifier for '
+        'the floor and %s for the magnitude either side of it.' % (base, base))
+    return helper
+
+
+def _install_helpers():
+    """Define ``two_phase_<name>`` for every emulator autoemulate offers."""
+    try:
+        from libcuflynx.emulators.emulator_trainer import emulator_model_names
+        names = [name for name in emulator_model_names() if not is_two_phase(name)]
+    except Exception:  # noqa: BLE001 - no autoemulate, no helpers, still importable
+        names = []
+    installed = []
+    for base in names:
+        helper = _make_helper(base)
+        globals()[helper.__name__] = helper
+        installed.append(helper.__name__)
+    return installed
+
+
+AVAILABLE_TWO_PHASE = _install_helpers()

--- a/tests/test_internal_emulators.py
+++ b/tests/test_internal_emulators.py
@@ -1,0 +1,216 @@
+"""Two-phase emulation: classify which side of the cliff, then regress.
+
+A regressor is the wrong shape for an observable pinned at one value over most of
+its range. A spike count is exactly zero below rheobase and jumps to one spike per
+window above it, with nothing in between -- so a smooth fit splits the difference,
+predicting fractions of a spike across the floor and undershooting above it.
+
+These use a synthetic cliff rather than a real study: ``y = 0`` below a threshold
+in the first input and rising above it, which is the shape without the cost.
+"""
+import numpy as np
+import pytest
+
+from libcuflynx.emulators import internal_emulators as ie
+
+
+# --- naming ---------------------------------------------------------------------
+
+def test_a_two_phase_name_is_recognised_and_unwrapped():
+    assert ie.is_two_phase('two_phase_MLP')
+    assert not ie.is_two_phase('MLP')
+    assert ie.base_emulator_name('two_phase_MLP') == 'MLP'
+    assert ie.base_emulator_name('MLP') == 'MLP'
+
+
+def test_wrapping_is_idempotent():
+    """So a caller that already has the prefix does not get it twice."""
+    assert ie.two_phase_name('MLP') == 'two_phase_MLP'
+    assert ie.two_phase_name('two_phase_MLP') == 'two_phase_MLP'
+
+
+def test_a_variant_is_offered_for_every_base_emulator():
+    assert ie.two_phase_model_names(['MLP', 'RandomForest']) == [
+        'two_phase_MLP', 'two_phase_RandomForest']
+
+
+# --- finding the floor ----------------------------------------------------------
+
+def test_a_feature_pinned_at_one_value_is_found():
+    y = np.column_stack([np.r_[np.zeros(80), np.linspace(4, 20, 20)],
+                         np.linspace(-70, 30, 100)])
+    has_floor, floor_value = ie.floor_mask(y)
+
+    assert list(has_floor) == [True, False]
+    assert floor_value[0] == 0.0
+
+
+def test_the_floor_need_not_be_zero():
+    """Nothing about spiking is hardcoded -- it is whichever value repeats."""
+    y = np.column_stack([np.r_[np.full(60, -85.0), np.linspace(-60, 10, 40)]])
+    has_floor, floor_value = ie.floor_mask(y)
+
+    assert has_floor[0]
+    assert floor_value[0] == -85.0
+
+
+def test_a_continuous_feature_has_no_floor():
+    y = np.linspace(0, 1, 200).reshape(-1, 1)
+    assert not ie.floor_mask(y)[0][0]
+
+
+def test_the_share_required_is_adjustable():
+    y = np.r_[np.zeros(30), np.linspace(1, 9, 70)].reshape(-1, 1)
+    assert ie.floor_mask(y, floor_share=0.25)[0][0]
+    assert not ie.floor_mask(y, floor_share=0.5)[0][0]
+
+
+# --- predicting -----------------------------------------------------------------
+
+class _Ramp:
+    """Stands in for a fitted regressor: predicts the second column of x."""
+
+    def __init__(self, scale=1.0):
+        self.scale = scale
+
+    def predict(self, x):
+        x = np.asarray(x, dtype=float)
+        return np.column_stack([x[:, 0] * self.scale, x[:, 0] * 0 + 5.0])
+
+
+class _Gate:
+    """Stands in for the classifier: active where the first input exceeds 0.5."""
+
+    def predict(self, x):
+        return (np.asarray(x, dtype=float)[:, 0] > 0.5).reshape(-1, 1)
+
+
+def test_the_floor_is_returned_exactly_below_the_boundary():
+    """Not "close to zero" -- a spike count of 0.3 is not a thing the model does."""
+    model = ie.TwoPhaseEmulator(_Ramp(), _Ramp(scale=10.0), _Gate(),
+                                has_floor=[True, False], floor_value=[0.0, 0.0],
+                                base_name='MLP')
+    out = model.predict(np.array([[0.1, 0.0], [0.2, 0.0]]))
+
+    assert np.all(out[:, 0] == 0.0)
+
+
+def test_the_active_regressor_supplies_the_value_above_the_boundary():
+    model = ie.TwoPhaseEmulator(_Ramp(), _Ramp(scale=10.0), _Gate(),
+                                has_floor=[True, False], floor_value=[0.0, 0.0],
+                                base_name='MLP')
+    out = model.predict(np.array([[0.8, 0.0]]))
+
+    assert out[0, 0] == pytest.approx(8.0)   # the active model, not the base
+
+
+def test_a_feature_without_a_floor_comes_from_the_base_regressor():
+    """The gate applies only to the features that have a cliff."""
+    model = ie.TwoPhaseEmulator(_Ramp(), _Ramp(scale=10.0), _Gate(),
+                                has_floor=[True, False], floor_value=[0.0, 0.0],
+                                base_name='MLP')
+    out = model.predict(np.array([[0.1, 0.0], [0.8, 0.0]]))
+
+    assert np.all(out[:, 1] == 5.0)
+
+
+def test_no_classifier_means_the_base_model_answers_everything():
+    """What a design with no floored feature produces -- recorded as two-phase so
+    the bundle says what was asked for, rather than silently degrading."""
+    model = ie.TwoPhaseEmulator(_Ramp(), None, None, has_floor=[False, False],
+                                floor_value=[0.0, 0.0], base_name='MLP')
+    out = model.predict(np.array([[0.9, 0.0]]))
+
+    assert out[0, 0] == pytest.approx(0.9)
+
+
+def test_it_reports_the_two_phase_name():
+    model = ie.TwoPhaseEmulator(_Ramp(), None, None, [False], [0.0], 'RandomForest')
+    assert model.model_name == 'two_phase_RandomForest'
+
+
+def test_a_single_row_is_accepted():
+    model = ie.TwoPhaseEmulator(_Ramp(), None, None, [False, False], [0.0, 0.0], 'MLP')
+    assert model.predict(np.array([0.4, 0.0])).shape == (1, 2)
+
+
+# --- the classifier -------------------------------------------------------------
+
+def test_a_column_that_never_changes_gets_a_constant_not_a_fit():
+    """A single-class column has no boundary to learn, and sklearn raises on one."""
+    x = np.random.default_rng(0).uniform(size=(30, 2))
+    classifier = ie._fit_classifier(x, np.ones((30, 1), dtype=bool))
+
+    assert np.all(classifier.predict(x))
+
+
+def test_the_boundary_is_learned_when_there_is_one():
+    rng = np.random.default_rng(0)
+    x = rng.uniform(size=(200, 2))
+    labels = (x[:, 0] > 0.5).reshape(-1, 1)
+    classifier = ie._fit_classifier(x, labels)
+
+    predicted = classifier.predict(np.array([[0.1, 0.5], [0.9, 0.5]]))
+    assert not predicted[0, 0] and predicted[1, 0]
+
+
+# --- what a settings form is offered, and what 'all' sweeps up -------------------
+
+def _autoemulate_or_skip():
+    from libcuflynx.emulators.emulator_trainer import autoemulate_available
+    if not autoemulate_available():
+        pytest.skip('autoemulate is not installed')
+
+
+def test_a_settings_form_is_offered_both_kinds():
+    """CUFLynx reads this list at runtime rather than hardcoding one, so the
+    two-phase variants reach its emulator settings without a change on its side."""
+    _autoemulate_or_skip()
+    from libcuflynx.emulators.emulator_trainer import (
+        base_emulator_model_names, emulator_model_names)
+
+    offered = emulator_model_names()
+    base = base_emulator_model_names()
+
+    assert len(offered) == 2 * len(base)
+    for name in base:
+        assert ie.two_phase_name(name) in offered
+
+
+def test_all_does_not_sweep_up_the_two_phase_variants():
+    """Opt-in by name. Two stages cost more to fit than one, and only pay off when
+    the features really do have a floor -- sweeping them into 'all' would double
+    every comparison for studies that need none of it."""
+    _autoemulate_or_skip()
+    from libcuflynx.emulators.emulator_trainer import _parse_models
+
+    assert not any(ie.is_two_phase(name) for name in _parse_models('all'))
+
+
+def test_asking_for_one_by_name_reaches_the_trainer():
+    from libcuflynx.emulators.emulator_trainer import _parse_models
+
+    assert _parse_models('two_phase_MLP') == ['two_phase_MLP']
+
+
+def test_a_helper_exists_for_every_offered_emulator():
+    _autoemulate_or_skip()
+    from libcuflynx.emulators.emulator_trainer import base_emulator_model_names
+
+    for name in base_emulator_model_names():
+        helper = getattr(ie, ie.two_phase_name(name))
+        assert helper() == ie.two_phase_name(name)
+
+
+def test_a_two_phase_name_cannot_be_mixed_with_others():
+    """It is fitted on its own -- there is no comparison to win, and silently
+    dropping the others would be worse than saying so."""
+    _autoemulate_or_skip()
+    import numpy as np
+    from libcuflynx.emulators.emulator_trainer import EmulatorTrainer
+
+    trainer = EmulatorTrainer.__new__(EmulatorTrainer)
+    trainer.settings = {'models': 'two_phase_MLP,MLP', 'random_seed': 0}
+    trainer.pid = None
+    with pytest.raises(ValueError, match='fitted on its own'):
+        trainer.fit(np.zeros((10, 2)), np.zeros((10, 2)))


### PR DESCRIPTION
autoemulate's emulators are regressors, and a regressor is the wrong shape for an
observable pinned at one value over most of its range.

A spike count is the case that motivated this: exactly zero below rheobase, one
spike per window above it, nothing in between. A smooth fit splits the difference —
fractions of a spike across the silent region, undershooting everywhere above it.
On the study this came from, **36 of 84 features were zero in a median 82% of the
design**.

The cardiac electrophysiology literature calls this a bifurcation and answers it in
two stages: learn *where* the boundary is with a classifier, and learn the magnitude
with a regressor fitted only on the far side, so the floor cannot drag it down.

## What this adds

`libcuflynx/emulators/internal_emulators.py` — `TwoPhaseEmulator`, which keeps
**autoemulate for both regression halves**, so every other emulator setting applies
unchanged. sklearn supplies the classifier only because autoemulate has none; that
is the half of the method it does not cover.

Reachable as `two_phase_<name>` for every emulator autoemulate offers, generated
from its registry rather than a list kept here, so a new emulator on their side gets
a variant without a change on ours:

```yaml
emulator_settings:
  models: two_phase_MLP
```

## Opt-in, never swept up

**Deliberately absent from `all`.** Two stages cost more to fit than one and only pay
off when the features really do have a floor, so `models: all` still resolves to
autoemulate's own twelve. Asking for a two-phase alongside others is refused rather
than silently dropping them — it is fitted on its own, there being no comparison to
win.

## Nothing about spiking is hardcoded

A "floor" is whichever single value a feature returns in at least 25% of the design,
found from the training data. A resting potential pinned at −85 mV is handled the
same way as a spike count pinned at 0. A continuous feature has no floor and is
passed straight through by the base regressor.

## Measured

Synthetic cliff, 300 training points, MLP either way:

| feature | plain | `two_phase` |
|---|---|---|
| cliff (spike-count-like) | 0.177 | **0.723** |
| smooth | 0.856 | 0.856 |

On the floor rows the plain regressor averages **+4.1** where the truth is 0; the
two-phase returns **exactly 0 on 47 of 47**. The smooth feature is untouched, which
is the property that matters — the gate applies only to features that have a floor.

## CUFLynx

No change needed there. It reads `emulator_model_names()` from CA at runtime, so the
variants reach its settings form on their own — verified against its own accessor,
which now sees 24 names where it saw 12.

## Tests

`test_internal_emulators.py`, 20 cases: naming, floor detection (including a
non-zero floor and an adjustable share), the prediction gate, the single-class
classifier column, the `all` exclusion, and the mixed-request refusal.
`test_emulator_settings` + `test_emulator_training` + these: **54 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)