### PR TITLE
Multi-stage emulator designs: spend the second stage where the model is hard

### DIFF
--- a/src/libcuflynx/emulators/adaptive_design.py
+++ b/src/libcuflynx/emulators/adaptive_design.py
@@ -21,11 +21,28 @@ and a firing rate near 10 count the same. New points are drawn *along* the segme
 joining a chosen pair, which is what puts them inside the shell rather than merely
 near it: a cliff detected between two points is somewhere between those two points.
 
-This is adaptive sampling, and the usual caution applies -- the second stage can only
-refine structure the first stage found. A feature whose active region no Sobol point
-ever landed in has no pair to draw a gradient from, and no amount of stage two will
-discover it. Stage one has to be big enough to see the phenomenon; stage two makes it
-sharp.
+Two ways to ask where to look next, and they are different questions:
+
+``gradient_weighted_design`` asks where the *model* changes fastest, from the samples
+themselves. ``error_weighted_design`` asks where a cheap surrogate of those samples is
+*wrong*, which is not the same thing -- a response can be steep and easy to fit, or
+flat and hard -- and because it interpolates that error across the whole box rather
+than reading it between pairs, it can propose points nowhere near an existing sample.
+
+This is adaptive sampling, and two cautions apply.
+
+The first: a later stage can only refine structure an earlier one found. A feature
+whose active region no Sobol point ever landed in has no pair to draw a gradient from
+and no measured error to interpolate, and no amount of stage two will discover it.
+Stage one has to be big enough to see the phenomenon; stage two makes it sharp.
+
+The second is sharper, and is asserted in the tests rather than left as advice:
+clustering points across a discontinuity helps an emulator that can represent one --
+a forest, or the classifier half of a two-phase emulator -- and *hurts* a smooth
+global fit, which is then forced through steeply-disagreeing neighbours and rings
+around the jump. Measured on a step response, a thin-plate spline gets worse when the
+second stage is added while a random forest gets better. So an adaptive stage is not
+free improvement: it has to be matched to the emulator being fitted.
 """
 import numpy as np
 
@@ -39,6 +56,14 @@ DEFAULT_NEIGHBOURS = 8
 #: at the cost of covering fewer of them.
 DEFAULT_POWER = 1.0
 
+#: Candidate points drawn per requested sample before weighting, when a stage picks
+#: from a pool rather than from pairs. Large enough that the weighting has something to
+#: prefer, small enough to stay a rounding error next to running the model.
+CANDIDATES_PER_SAMPLE = 32
+
+#: Folds used to estimate how wrong a cheap surrogate is at each existing sample.
+DEFAULT_ERROR_FOLDS = 5
+
 #: New points land on the segment between the chosen pair, plus a nudge of this much of
 #: the pair's separation. Without it every point for a given pair falls on one line,
 #: which in more than two dimensions is a set of measure zero and a poor basis to fit
@@ -46,13 +71,167 @@ DEFAULT_POWER = 1.0
 DEFAULT_JITTER = 0.1
 
 
+def error_weighted_design(x, y, n_samples, mins, maxs, seed=0, log_scale=False,
+                          weight=1.0, folds=DEFAULT_ERROR_FOLDS):
+    """``n_samples`` new points, concentrated where a surrogate is currently wrong.
+
+    Where ``gradient_weighted_design`` asks where the *model* changes fastest, this asks
+    where the *emulator* is failing -- which is not the same question. A response can be
+    steep and easy to fit, and flat and hard: what an emulator needs is points where its
+    own prediction is poor, wherever those happen to be.
+
+    The error at the existing samples is measured by cross-validating a cheap radial
+    basis surrogate over them, so it costs no simulations. Those errors are then
+    interpolated by a second radial basis fit to give an error surface over the whole
+    box, and candidate points are drawn against it. The surface is the reason this can
+    propose points nowhere near an existing sample: a gradient is only defined between
+    points that exist, but an interpolated error is defined everywhere.
+
+    Falls back to a uniform draw whenever the surrogate cannot be fitted or says nothing
+    -- too few points for the dimension, a degenerate response, a singular system.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    mins = np.asarray(mins, dtype=float)
+    maxs = np.asarray(maxs, dtype=float)
+    n_samples = int(n_samples)
+    rng = np.random.default_rng(seed)
+
+    if n_samples <= 0:
+        return np.empty((0, mins.size), dtype=float)
+    if x.ndim != 2 or len(x) < 2 or len(y) != len(x):
+        return _uniform(rng, n_samples, mins, maxs, log_scale)
+
+    unit = _to_unit(x, mins, maxs, log_scale)
+    scaled = _scale_features(y)
+    if scaled.shape[1] == 0:
+        return _uniform(rng, n_samples, mins, maxs, log_scale)
+
+    errors = _cross_validated_error(unit, scaled, folds)
+    if errors is None or not np.any(errors > 0):
+        return _uniform(rng, n_samples, mins, maxs, log_scale)
+
+    candidates = rng.random((n_samples * CANDIDATES_PER_SAMPLE, unit.shape[1]))
+    predicted = _interpolate(unit, errors, candidates)
+    if predicted is None:
+        return _uniform(rng, n_samples, mins, maxs, log_scale)
+    # An interpolant is free to go negative between samples; a negative error is not a
+    # reason to avoid a region, it is the interpolant saying "about zero here".
+    predicted = np.clip(predicted, 0.0, None)
+
+    chosen = _weighted_choice(rng, predicted, n_samples, weight)
+    return _from_unit(candidates[chosen], mins, maxs, log_scale)
+
+
+def _cross_validated_error(unit, scaled, folds):
+    """Held-out error of a cheap surrogate at every existing sample.
+
+    Cross-validated rather than measured in place: a surrogate that interpolates its
+    own training points reports zero error everywhere, which would say the design is
+    finished no matter how bad it is.
+    """
+    n_points = len(unit)
+    folds = int(min(max(int(folds), 2), n_points))
+    if n_points <= unit.shape[1] + 1:
+        return None
+
+    # Deterministic folds: this runs inside a seeded design, and a training run has to
+    # be repeatable.
+    assignment = np.arange(n_points) % folds
+    errors = np.full(n_points, np.nan, dtype=float)
+    for fold in range(folds):
+        test = assignment == fold
+        train = ~test
+        if train.sum() <= unit.shape[1] + 1 or not test.any():
+            continue
+        predicted = _interpolate(unit[train], scaled[train], unit[test])
+        if predicted is None:
+            return None
+        residual = predicted.reshape(test.sum(), -1) - scaled[test]
+        errors[test] = np.sqrt(np.mean(np.square(residual), axis=1))
+    if not np.any(np.isfinite(errors)):
+        return None
+    # A fold that could not be fitted leaves gaps; they carry no claim either way, so
+    # they get the average rather than a zero that would steer sampling away from them.
+    return np.nan_to_num(errors, nan=float(np.nanmean(errors)))
+
+
+def _interpolate(points, values, at):
+    """Radial basis interpolation, or ``None`` if the system cannot be solved."""
+    try:
+        from scipy.interpolate import RBFInterpolator
+    except ImportError:  # pragma: no cover - scipy ships with the solver stack
+        return None
+    values = np.asarray(values, dtype=float)
+    flat = values.ndim == 1
+    values = values.reshape(len(values), -1)
+    try:
+        # `neighbors` keeps this local and keeps the solve small; a global fit over
+        # thousands of points in a dozen dimensions is both slower and less stable.
+        neighbours = int(min(len(points), max(points.shape[1] + 2, 50)))
+        interpolator = RBFInterpolator(points, values, neighbors=neighbours,
+                                       kernel='thin_plate_spline', smoothing=1e-8)
+        predicted = np.asarray(interpolator(at), dtype=float)
+    except Exception:  # noqa: BLE001 - singular, degenerate or unsupported: caller falls back
+        return None
+    if not np.all(np.isfinite(predicted)):
+        return None
+    return predicted.reshape(len(at)) if flat else predicted
+
+
+def _weighted_choice(rng, weights, n_samples, weight, replace=False):
+    """Indices drawn against ``weights``, mixed with a uniform draw by ``weight``.
+
+    ``weight`` is a single dial over the whole range from ignoring the weights to
+    following them closely:
+
+    * ``0``   -- uniform. The weights are computed and then not used, which is the
+      honest way to turn an adaptive stage into a plain random top-up.
+    * ``0.5`` -- half the probability mass spread uniformly, half distributed by weight.
+    * ``1``   -- drawn by weight.
+    * ``>1``  -- drawn by weight raised to that power, concentrating harder on the
+      worst regions and covering fewer of them.
+
+    Mixing in probability space rather than drawing two separate batches keeps every
+    point a single draw from one distribution, so the stage has no seam in it.
+    """
+    weight = float(weight)
+    n_candidates = len(weights)
+    # Without replacement a pool cannot hand back more points than it holds; with it,
+    # the same pair can be drawn from repeatedly, which is how a handful of steep pairs
+    # can absorb a whole stage.
+    take = int(n_samples if replace else min(n_samples, n_candidates))
+
+    if weight <= 0:
+        return rng.choice(n_candidates, size=take, replace=replace)
+
+    weights = np.asarray(weights, dtype=float)
+    largest = weights.max()
+    if not np.isfinite(largest) or largest <= 0:
+        return rng.choice(n_candidates, size=take, replace=replace)
+
+    # Normalised before the power so the exponent means the same thing whatever units
+    # the weights arrived in.
+    shaped = np.power(weights / largest, max(weight, 1.0))
+    total = shaped.sum()
+    if not np.isfinite(total) or total <= 0:
+        return rng.choice(n_candidates, size=take, replace=replace)
+
+    mix = min(weight, 1.0)
+    probability = (1.0 - mix) / n_candidates + mix * (shaped / total)
+    probability = probability / probability.sum()
+    return rng.choice(n_candidates, size=take, replace=replace, p=probability)
+
+
 def gradient_weighted_design(x, y, n_samples, mins, maxs, seed=0,
-                             log_scale=False, n_neighbours=DEFAULT_NEIGHBOURS,
-                             power=DEFAULT_POWER, jitter=DEFAULT_JITTER):
+                             log_scale=False, weight=DEFAULT_POWER,
+                             n_neighbours=DEFAULT_NEIGHBOURS, jitter=DEFAULT_JITTER):
     """``n_samples`` new points, concentrated where neighbouring outputs disagree.
 
     ``x``/``y`` are the first stage's design and its simulated features. Returns points
-    in the same units as ``x``, inside ``[mins, maxs]``.
+    in the same units as ``x``, inside ``[mins, maxs]``. ``weight`` is the same dial as
+    everywhere else: 0 ignores the gradients, 0.5 half-follows them, 1 follows them, and
+    above 1 concentrates harder on the steepest pairs (see :func:`_weighted_choice`).
 
     Falls back to a uniform draw over the box whenever there is nothing to be adaptive
     about -- fewer than two simulated points, or a response with no variation anywhere.
@@ -83,12 +262,7 @@ def gradient_weighted_design(x, y, n_samples, mins, maxs, seed=0,
     if left.size == 0 or not np.any(weights > 0):
         return _uniform(rng, n_samples, mins, maxs, log_scale)
 
-    weights = np.power(weights, float(power))
-    total = weights.sum()
-    if not np.isfinite(total) or total <= 0:
-        return _uniform(rng, n_samples, mins, maxs, log_scale)
-
-    chosen = rng.choice(len(weights), size=n_samples, replace=True, p=weights / total)
+    chosen = _weighted_choice(rng, weights, n_samples, weight, replace=True)
     a = unit[left[chosen]]
     b = unit[right[chosen]]
     # Uniform along the segment: the crossing is somewhere between the two points and

--- a/src/libcuflynx/emulators/adaptive_design.py
+++ b/src/libcuflynx/emulators/adaptive_design.py
@@ -1,0 +1,183 @@
+"""A second sampling stage that spends its points where the model changes fastest.
+
+A Sobol design spreads points evenly over the parameter box, which is the right thing
+to do when nothing is known about the response. It is the wrong thing to do once
+something *is*: an evenly-spread design spends as many simulations describing a region
+where the output barely moves as it does resolving the place where it jumps.
+
+Neuron models make that expensive. Below rheobase a spike count is exactly zero, above
+it the cell fires, and the whole of what an emulator gets wrong lives in the thin shell
+between the two. Points on the flat side are nearly free to predict and nearly useless
+to have.
+
+So: run a Sobol design, look at what came back, and draw the rest of the budget near
+the pairs of neighbouring points whose outputs disagree most. The gradient estimate is
+literally between points -- for neighbours i and j,
+
+    g = ||y_i - y_j|| / ||x_i - x_j||
+
+with x on the unit cube and each output scaled by its own range, so a current near 1e-9
+and a firing rate near 10 count the same. New points are drawn *along* the segment
+joining a chosen pair, which is what puts them inside the shell rather than merely
+near it: a cliff detected between two points is somewhere between those two points.
+
+This is adaptive sampling, and the usual caution applies -- the second stage can only
+refine structure the first stage found. A feature whose active region no Sobol point
+ever landed in has no pair to draw a gradient from, and no amount of stage two will
+discover it. Stage one has to be big enough to see the phenomenon; stage two makes it
+sharp.
+"""
+import numpy as np
+
+#: Neighbours per point used to estimate a local gradient. Small enough to stay local
+#: -- the estimate is meaningless across the box -- and large enough that a point does
+#: not hang the whole estimate on its single nearest neighbour.
+DEFAULT_NEIGHBOURS = 8
+
+#: Exponent on the pair gradients before they become sampling weights. 1.0 makes the
+#: draw proportional to the gradient; higher concentrates harder on the steepest pairs
+#: at the cost of covering fewer of them.
+DEFAULT_POWER = 1.0
+
+#: New points land on the segment between the chosen pair, plus a nudge of this much of
+#: the pair's separation. Without it every point for a given pair falls on one line,
+#: which in more than two dimensions is a set of measure zero and a poor basis to fit
+#: from; the nudge gives the cliff some thickness in the other directions.
+DEFAULT_JITTER = 0.1
+
+
+def gradient_weighted_design(x, y, n_samples, mins, maxs, seed=0,
+                             log_scale=False, n_neighbours=DEFAULT_NEIGHBOURS,
+                             power=DEFAULT_POWER, jitter=DEFAULT_JITTER):
+    """``n_samples`` new points, concentrated where neighbouring outputs disagree.
+
+    ``x``/``y`` are the first stage's design and its simulated features. Returns points
+    in the same units as ``x``, inside ``[mins, maxs]``.
+
+    Falls back to a uniform draw over the box whenever there is nothing to be adaptive
+    about -- fewer than two simulated points, or a response with no variation anywhere.
+    Falling back is the honest answer there: a weight vector of zeros carries no
+    information about where to look, and inventing one would concentrate the budget on
+    whatever numerical dust happened to be largest.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    mins = np.asarray(mins, dtype=float)
+    maxs = np.asarray(maxs, dtype=float)
+    n_samples = int(n_samples)
+    rng = np.random.default_rng(seed)
+
+    if n_samples <= 0:
+        return np.empty((0, mins.size), dtype=float)
+    if x.ndim != 2 or len(x) < 2 or len(y) != len(x):
+        return _uniform(rng, n_samples, mins, maxs, log_scale)
+
+    unit = _to_unit(x, mins, maxs, log_scale)
+    scaled = _scale_features(y)
+    if scaled.shape[1] == 0:
+        # Every feature came back constant, so no pair disagrees with any other and
+        # there is no cliff to refine. A plain space-filling top-up is what is left.
+        return _uniform(rng, n_samples, mins, maxs, log_scale)
+
+    left, right, weights = _pair_gradients(unit, scaled, n_neighbours)
+    if left.size == 0 or not np.any(weights > 0):
+        return _uniform(rng, n_samples, mins, maxs, log_scale)
+
+    weights = np.power(weights, float(power))
+    total = weights.sum()
+    if not np.isfinite(total) or total <= 0:
+        return _uniform(rng, n_samples, mins, maxs, log_scale)
+
+    chosen = rng.choice(len(weights), size=n_samples, replace=True, p=weights / total)
+    a = unit[left[chosen]]
+    b = unit[right[chosen]]
+    # Uniform along the segment: the crossing is somewhere between the two points and
+    # nothing in the pair says where, so no position on it is preferred.
+    t = rng.random((n_samples, 1))
+    points = a + t * (b - a)
+    if jitter > 0:
+        separation = np.linalg.norm(b - a, axis=1, keepdims=True)
+        points = points + rng.normal(scale=float(jitter), size=points.shape) * separation
+    np.clip(points, 0.0, 1.0, out=points)
+    return _from_unit(points, mins, maxs, log_scale)
+
+
+def _pair_gradients(unit, scaled, n_neighbours):
+    """``(i, j, gradient)`` over each point's nearest neighbours, deduplicated.
+
+    A pair reached from both ends is one pair; keeping both would double the weight of
+    exactly the mutual-nearest-neighbour pairs, which are the ones most likely to
+    straddle a cliff.
+    """
+    n_points = len(unit)
+    k = int(min(max(n_neighbours, 1), n_points - 1))
+    neighbours = _nearest(unit, k)
+
+    left = np.repeat(np.arange(n_points), k)
+    right = neighbours.reshape(-1)
+    keep = left != right
+    left, right = left[keep], right[keep]
+
+    low = np.minimum(left, right)
+    high = np.maximum(left, right)
+    _, unique = np.unique(np.stack([low, high], axis=1), axis=0, return_index=True)
+    left, right = low[unique], high[unique]
+
+    dx = np.linalg.norm(unit[left] - unit[right], axis=1)
+    dy = np.linalg.norm(scaled[left] - scaled[right], axis=1)
+    # Coincident points carry no direction to step in; their gradient is undefined
+    # rather than infinite, so they are dropped instead of dominating the draw.
+    usable = dx > 0
+    return left[usable], right[usable], dy[usable] / dx[usable]
+
+
+def _nearest(unit, k):
+    """Indices of each point's ``k`` nearest neighbours, itself excluded."""
+    try:
+        from scipy.spatial import cKDTree
+    except ImportError:  # pragma: no cover - scipy ships with the solver stack
+        distances = np.linalg.norm(unit[:, None, :] - unit[None, :, :], axis=-1)
+        np.fill_diagonal(distances, np.inf)
+        return np.argsort(distances, axis=1)[:, :k]
+    # k+1 because the query returns the point itself first.
+    _, indices = cKDTree(unit).query(unit, k=k + 1)
+    indices = np.atleast_2d(indices)
+    return indices[:, 1:k + 1]
+
+
+def _scale_features(y):
+    """Each feature divided by its own range; features with no range dropped.
+
+    Without this the norm is whichever feature happens to carry the largest numbers.
+    A membrane current near 1e-9 and a firing rate near 10 have to count the same,
+    because a jump is a jump in whichever of them it happens.
+    """
+    finite = np.isfinite(y)
+    y = np.where(finite, y, np.nan)
+    lows = np.nanmin(y, axis=0)
+    highs = np.nanmax(y, axis=0)
+    spans = highs - lows
+    keep = np.isfinite(spans) & (spans > 0)
+    if not keep.any():
+        return np.zeros((len(y), 0), dtype=float)
+    scaled = (y[:, keep] - lows[keep]) / spans[keep]
+    # A feature that failed on one sample must not delete that sample's whole row;
+    # it contributes nothing to the distance instead.
+    return np.nan_to_num(scaled, nan=0.0, posinf=0.0, neginf=0.0)
+
+
+def _uniform(rng, n_samples, mins, maxs, log_scale):
+    return _from_unit(rng.random((n_samples, mins.size)), mins, maxs, log_scale)
+
+
+def _to_unit(x, mins, maxs, log_scale):
+    if log_scale:
+        return (np.log(x) - np.log(mins)) / (np.log(maxs) - np.log(mins))
+    spans = np.where(maxs > mins, maxs - mins, 1.0)
+    return (x - mins) / spans
+
+
+def _from_unit(unit, mins, maxs, log_scale):
+    if log_scale:
+        return np.exp(np.log(mins) + unit * (np.log(maxs) - np.log(mins)))
+    return mins + unit * (maxs - mins)

--- a/src/libcuflynx/emulators/emulator_trainer.py
+++ b/src/libcuflynx/emulators/emulator_trainer.py
@@ -30,12 +30,23 @@ AUTOEMULATE_MISSING_MESSAGE = (
 
 SAMPLE_TYPES = ('sobol', 'latin_hypercube', 'random')
 
+#: How strongly an adaptive stage follows its own scores when nothing is said:
+#: 1.0 draws in proportion to them. 0 ignores them, above 1 concentrates harder.
+DEFAULT_STAGE_WEIGHT = 1.0
+
 #: A stage that places its points using what the earlier stages simulated,
 #: rather than over the box in ignorance of the response. Never the first stage.
 GRADIENT_WEIGHTED = 'gradient_weighted'
 
-#: What method_per_stage accepts: any space-filling design, or the adaptive one.
-STAGE_METHODS = SAMPLE_TYPES + (GRADIENT_WEIGHTED,)
+#: A stage that places its points where a cheap surrogate of the samples so far is
+#: worst, rather than where the response is steepest. Never the first stage.
+ERROR_WEIGHTED = 'error_weighted'
+
+#: The methods that place points using earlier results, and so cannot come first.
+ADAPTIVE_METHODS = (GRADIENT_WEIGHTED, ERROR_WEIGHTED)
+
+#: What method_per_stage accepts: any space-filling design, or an adaptive one.
+STAGE_METHODS = SAMPLE_TYPES + ADAPTIVE_METHODS
 
 
 def autoemulate_available():
@@ -195,12 +206,20 @@ class EmulatorTrainer:
                            + [GRADIENT_WEIGHTED] * (num_stages - 1))
         fractions = _as_list(self._setting('frac_per_stage', None), float)
         methods = _as_list(self._setting('method_per_stage', None), str)
+        weights = _as_list(self._setting('weight_per_stage', None), float)
         if fractions is None:
             fractions = [1.0 / num_stages] * num_stages
         if methods is None:
             methods = default_methods
+        if weights is None:
+            weights = [DEFAULT_STAGE_WEIGHT] * num_stages
+        elif len(weights) == 1 and num_stages > 1:
+            # One value for every stage: the common case is a single dial for the whole
+            # design, and spelling it out per stage adds nothing.
+            weights = weights * num_stages
 
-        for name, values in (('frac_per_stage', fractions), ('method_per_stage', methods)):
+        for name, values in (('frac_per_stage', fractions), ('method_per_stage', methods),
+                             ('weight_per_stage', weights)):
             if len(values) != num_stages:
                 raise ValueError(
                     f'emulator_settings.{name} has {len(values)} entries but num_stages is '
@@ -217,12 +236,15 @@ class EmulatorTrainer:
             if method not in STAGE_METHODS:
                 raise ValueError(f'unknown method_per_stage entry "{method}", expected one of '
                                  f'{", ".join(STAGE_METHODS)}')
-        if methods[0] == GRADIENT_WEIGHTED:
+        if any(value < 0 for value in weights):
+            raise ValueError(f'emulator_settings.weight_per_stage is {weights}; a weight is '
+                             f'how strongly a stage follows its own scores, so it cannot be '
+                             f'negative. 0 ignores them entirely.')
+        if methods[0] in ADAPTIVE_METHODS:
             raise ValueError(
-                f'method_per_stage starts with "{GRADIENT_WEIGHTED}", which places points '
-                f'using the features an earlier stage simulated -- at the first stage there '
-                f'are none. Start with one of '
-                f'{", ".join(m for m in STAGE_METHODS if m != GRADIENT_WEIGHTED)}.')
+                f'method_per_stage starts with "{methods[0]}", which places points using the '
+                f'features an earlier stage simulated -- at the first stage there are none. '
+                f'Start with one of {", ".join(SAMPLE_TYPES)}.')
 
         # The last stage takes the remainder so the stages sum to num_train_samples
         # exactly, however the fractions round.
@@ -232,8 +254,8 @@ class EmulatorTrainer:
             raise ValueError(f'frac_per_stage {fractions} leaves the last stage {counts[-1]} '
                              f'samples of {total}; the earlier stages have taken more than the '
                              f'whole budget.')
-        return [{'method': method, 'num_samples': count}
-                for method, count in zip(methods, counts)]
+        return [{'method': method, 'num_samples': count, 'weight': float(weight)}
+                for method, count, weight in zip(methods, counts, weights)]
 
     def design(self, n_samples=None, sample_type=None, seed_offset=0):
         """Training points over the ``params_for_id`` box, shape ``(n_samples, num_params)``.
@@ -324,18 +346,25 @@ class EmulatorTrainer:
         if n_samples <= 0:
             return x, y
 
-        if method == GRADIENT_WEIGHTED:
+        if method in ADAPTIVE_METHODS:
             points = None
             if self.rank == 0:
-                from libcuflynx.emulators.adaptive_design import gradient_weighted_design
-                points = gradient_weighted_design(
+                from libcuflynx.emulators import adaptive_design
+                builder = (adaptive_design.gradient_weighted_design
+                           if method == GRADIENT_WEIGHTED
+                           else adaptive_design.error_weighted_design)
+                points = builder(
                     x, y, n_samples,
                     self.pid.param_id_info['param_mins'],
                     self.pid.param_id_info['param_maxs'],
                     seed=int(self._setting('random_seed', 0)) + index,
-                    log_scale=bool(self._setting('log_scale_params', False)))
+                    log_scale=bool(self._setting('log_scale_params', False)),
+                    weight=float(stage.get('weight', DEFAULT_STAGE_WEIGHT)))
+                towards = ('the steepest gradients' if method == GRADIENT_WEIGHTED
+                           else 'where a surrogate of them is worst')
                 print(f'[emulator] stage {index + 1}/{num_stages}: {len(points)} points drawn '
-                      f'towards the steepest gradients among the {len(x)} simulated so far')
+                      f'towards {towards} among the {len(x)} simulated so far '
+                      f'(weight {stage.get("weight", DEFAULT_STAGE_WEIGHT)})')
             if self.comm is not None:
                 points = self.comm.bcast(points, root=0)
         else:
@@ -366,7 +395,7 @@ class EmulatorTrainer:
             return x, y
         return np.vstack([x, new_x]), np.vstack([y, new_y])
 
-    def fit(self, x, y):
+    def fit(self, x, y, space_filling=None):
         """Fit and compare emulators; returns ``(model, r2, rmse, name, x_scale, y_scale)``.
 
         Both x and y are mapped onto a well-conditioned range first. CA parameters routinely
@@ -386,7 +415,8 @@ class EmulatorTrainer:
 
         seed = int(self._setting('random_seed', 0))
         x_train, y_train, x_test, y_test = _train_test_split(
-            x_scaled, y_scaled, float(self._setting('test_fraction', 0.2)), seed)
+            x_scaled, y_scaled, float(self._setting('test_fraction', 0.2)), seed,
+            test_candidates=space_filling)
 
         kwargs = dict(n_iter=int(self._setting('n_iter', 10)),
                       n_splits=int(self._setting('n_splits', 5)),
@@ -558,6 +588,10 @@ class EmulatorTrainer:
         require_autoemulate()
         if self.reuse_samples:
             x, y, design_meta = self.load_previous_samples()
+            # Reuse fits a saved design and the saved metadata does not record which
+            # stage each of its samples came from, so the split falls back to treating
+            # them all as candidates -- which is what it did before stages existed.
+            space_filling = None
             if self.rank != 0:
                 return None
         else:
@@ -570,10 +604,22 @@ class EmulatorTrainer:
                       + (f'; {len(stages)} stages: {plan}' if len(stages) > 1 else ''))
 
             x = y = None
+            # Which stage produced each surviving sample. Needed after the loop to keep
+            # the held-out set space-filling: an adaptive stage deliberately clusters its
+            # points on the hard parts, and scoring an emulator on those would report the
+            # error of the worst corner of the box as though it were the error everywhere.
+            origins = []
             for index, stage in enumerate(stages):
+                before = 0 if x is None else len(x)
                 x, y = self._run_stage(x, y, stage, index, len(stages))
+                if self.rank == 0:
+                    origins.extend([index] * ((0 if x is None else len(x)) - before))
             if self.rank != 0:
                 return None
+            for index, stage in enumerate(stages):
+                stage['num_used'] = int(origins.count(index))
+            space_filling = np.array(
+                [stages[index]['method'] in SAMPLE_TYPES for index in origins], dtype=bool)
             design_meta = {'sample_type': self._setting('sample_type', 'sobol'),
                            'stages': stages,
                            'num_stages': len(stages),
@@ -585,7 +631,8 @@ class EmulatorTrainer:
                            # So provenance never has to be read as "presumably simulated here".
                            'reused_samples': False}
 
-        model, validation, model_name, x_scale, y_scale = self.fit(x, y)
+        model, validation, model_name, x_scale, y_scale = self.fit(
+            x, y, space_filling=space_filling)
         meta = {
             'param_entry_labels': [str(label) for label in _param_labels(self.pid)],
             'param_mins': [float(v) for v in self.pid.param_id_info['param_mins']],
@@ -798,14 +845,43 @@ def _result_model_name(result):
     return type(getattr(result, 'model', result)).__name__
 
 
-def _train_test_split(x, y, test_fraction, seed):
-    """A seeded split, with at least one test point and at least two training points."""
+def _train_test_split(x, y, test_fraction, seed, test_candidates=None):
+    """A seeded split, with at least one test point and at least two training points.
+
+    ``test_candidates`` marks the samples the held-out set may be drawn from. It exists
+    for multi-stage designs: an adaptive stage puts its points exactly where the model
+    is hardest, so a split that could hold those out would measure the emulator on the
+    worst corner of the box and report it as the error everywhere -- and would do it
+    inconsistently, since how many such points landed in the test set is chance. Holding
+    out only space-filling samples keeps the reported R2 the answer to "how wrong is
+    this emulator over the box", which is the question it is read as, and lets every
+    hard-won adaptive point do what it was simulated for and train the emulator.
+
+    ``None`` -- or a mask that admits everything, which is what a single-stage design
+    gives -- takes the original path, so an existing study splits exactly as before.
+    """
     n_samples = len(x)
     n_test = int(round(test_fraction * n_samples))
     n_test = max(1, min(n_test, n_samples - 2))
-    order = np.random.default_rng(seed).permutation(n_samples)
-    test_idx, train_idx = order[:n_test], order[n_test:]
-    return x[train_idx], y[train_idx], x[test_idx], y[test_idx]
+    rng = np.random.default_rng(seed)
+
+    candidates = None
+    if test_candidates is not None:
+        candidates = np.flatnonzero(np.asarray(test_candidates, dtype=bool))
+        if len(candidates) == n_samples or len(candidates) == 0:
+            candidates = None
+
+    if candidates is None:
+        order = rng.permutation(n_samples)
+        test_idx, train_idx = order[:n_test], order[n_test:]
+        return x[train_idx], y[train_idx], x[test_idx], y[test_idx]
+
+    # Never hold out so much that the fit is starved, however few candidates there are.
+    n_test = max(1, min(n_test, len(candidates), n_samples - 2))
+    held_out = rng.permutation(candidates)[:n_test]
+    is_test = np.zeros(n_samples, dtype=bool)
+    is_test[held_out] = True
+    return x[~is_test], y[~is_test], x[is_test], y[is_test]
 
 
 def _validation_report(model, x_test, y_test, x_scale, y_scale):

--- a/src/libcuflynx/emulators/emulator_trainer.py
+++ b/src/libcuflynx/emulators/emulator_trainer.py
@@ -30,6 +30,13 @@ AUTOEMULATE_MISSING_MESSAGE = (
 
 SAMPLE_TYPES = ('sobol', 'latin_hypercube', 'random')
 
+#: A stage that places its points using what the earlier stages simulated,
+#: rather than over the box in ignorance of the response. Never the first stage.
+GRADIENT_WEIGHTED = 'gradient_weighted'
+
+#: What method_per_stage accepts: any space-filling design, or the adaptive one.
+STAGE_METHODS = SAMPLE_TYPES + (GRADIENT_WEIGHTED,)
+
 
 def autoemulate_available():
     """Whether the optional backend is installed, without importing it.
@@ -169,18 +176,79 @@ class EmulatorTrainer:
 
     # ------------------------------------------------------------------ stages
 
-    def design(self):
+    @property
+    def sampling_stages(self):
+        """The design as a list of ``{method, num_samples}``, in the order they run.
+
+        One stage is the default and is exactly the single-stage design CA has always
+        built. More than one splits ``num_train_samples`` by ``frac_per_stage`` and draws
+        each share with its own method, which is what lets a later stage place its points
+        using what the earlier ones actually returned.
+        """
+        total = self.num_train_samples
+        num_stages = int(self._setting('num_stages', 1))
+        if num_stages < 1:
+            raise ValueError(f'emulator_settings.num_stages is {num_stages}; a design needs '
+                             f'at least one stage.')
+
+        default_methods = ([self._setting('sample_type', 'sobol')]
+                           + [GRADIENT_WEIGHTED] * (num_stages - 1))
+        fractions = _as_list(self._setting('frac_per_stage', None), float)
+        methods = _as_list(self._setting('method_per_stage', None), str)
+        if fractions is None:
+            fractions = [1.0 / num_stages] * num_stages
+        if methods is None:
+            methods = default_methods
+
+        for name, values in (('frac_per_stage', fractions), ('method_per_stage', methods)):
+            if len(values) != num_stages:
+                raise ValueError(
+                    f'emulator_settings.{name} has {len(values)} entries but num_stages is '
+                    f'{num_stages}; give one entry per stage.')
+        if any(fraction <= 0 for fraction in fractions):
+            raise ValueError(f'emulator_settings.frac_per_stage is {fractions}; every stage '
+                             f'must get a positive share of num_train_samples. Drop the stage '
+                             f'instead of giving it zero.')
+        if abs(sum(fractions) - 1.0) > 1e-6:
+            raise ValueError(f'emulator_settings.frac_per_stage sums to {sum(fractions)}, not 1. '
+                             f'The entries are shares of num_train_samples ({total}), so they '
+                             f'have to add up to the whole budget.')
+        for method in methods:
+            if method not in STAGE_METHODS:
+                raise ValueError(f'unknown method_per_stage entry "{method}", expected one of '
+                                 f'{", ".join(STAGE_METHODS)}')
+        if methods[0] == GRADIENT_WEIGHTED:
+            raise ValueError(
+                f'method_per_stage starts with "{GRADIENT_WEIGHTED}", which places points '
+                f'using the features an earlier stage simulated -- at the first stage there '
+                f'are none. Start with one of '
+                f'{", ".join(m for m in STAGE_METHODS if m != GRADIENT_WEIGHTED)}.')
+
+        # The last stage takes the remainder so the stages sum to num_train_samples
+        # exactly, however the fractions round.
+        counts = [int(round(total * fraction)) for fraction in fractions[:-1]]
+        counts.append(total - sum(counts))
+        if counts[-1] < 0:
+            raise ValueError(f'frac_per_stage {fractions} leaves the last stage {counts[-1]} '
+                             f'samples of {total}; the earlier stages have taken more than the '
+                             f'whole budget.')
+        return [{'method': method, 'num_samples': count}
+                for method, count in zip(methods, counts)]
+
+    def design(self, n_samples=None, sample_type=None, seed_offset=0):
         """Training points over the ``params_for_id`` box, shape ``(n_samples, num_params)``.
 
         Deterministic given the seed, so every rank builds the identical design and no
-        broadcast is needed to agree on who evaluates which sample.
+        broadcast is needed to agree on who evaluates which sample. ``seed_offset``
+        separates one stage from the next: two stages of the same method on the same seed
+        would otherwise draw the same points twice.
         """
         mins = np.asarray(self.pid.param_id_info['param_mins'], dtype=float)
         maxs = np.asarray(self.pid.param_id_info['param_maxs'], dtype=float)
         num_params = mins.size
-        n_samples = self.num_train_samples
-        sample_type = self._setting('sample_type', 'sobol')
-        seed = int(self._setting('random_seed', 0))
+        n_samples = self.num_train_samples if n_samples is None else int(n_samples)
+        sample_type = sample_type or self._setting('sample_type', 'sobol')
+        seed = int(self._setting('random_seed', 0)) + int(seed_offset)
 
         if sample_type == 'sobol':
             with warnings.catch_warnings():
@@ -239,10 +307,64 @@ class EmulatorTrainer:
         n_failed = n_samples - len(rows)
         if n_failed:
             print(f'[emulator] {n_failed}/{n_samples} training simulations failed and were dropped')
-        self._n_failed = n_failed
+        self._n_failed = getattr(self, '_n_failed', 0) + n_failed
         x = np.asarray([design[idx] for idx, _ in rows], dtype=float)
         y = np.asarray([features for _, features in rows], dtype=float)
         return x, y
+
+    def _run_stage(self, x, y, stage, index, num_stages):
+        """Run one stage of the design and return everything simulated so far.
+
+        Only rank 0 holds the results, so only rank 0 can place an adaptive stage; those
+        points are broadcast and then evaluated by every rank exactly like a space-filling
+        stage. A space-filling stage needs no broadcast because every rank derives the
+        same design from the seed.
+        """
+        method, n_samples = stage['method'], int(stage['num_samples'])
+        if n_samples <= 0:
+            return x, y
+
+        if method == GRADIENT_WEIGHTED:
+            points = None
+            if self.rank == 0:
+                from libcuflynx.emulators.adaptive_design import gradient_weighted_design
+                points = gradient_weighted_design(
+                    x, y, n_samples,
+                    self.pid.param_id_info['param_mins'],
+                    self.pid.param_id_info['param_maxs'],
+                    seed=int(self._setting('random_seed', 0)) + index,
+                    log_scale=bool(self._setting('log_scale_params', False)))
+                print(f'[emulator] stage {index + 1}/{num_stages}: {len(points)} points drawn '
+                      f'towards the steepest gradients among the {len(x)} simulated so far')
+            if self.comm is not None:
+                points = self.comm.bcast(points, root=0)
+        else:
+            points = self.design(n_samples, sample_type=method, seed_offset=index)
+            if self.rank == 0 and num_stages > 1:
+                print(f'[emulator] stage {index + 1}/{num_stages}: {n_samples} {method} points')
+
+        try:
+            new_x, new_y = self.evaluate(points)
+        except RuntimeError:
+            # evaluate refuses a stage in which every simulation failed. For the first
+            # stage that is fatal and stays fatal; for a later one it is not -- the
+            # design so far still stands, and losing a top-up is a smaller emulator
+            # rather than no emulator. The raise happens on rank 0 after the gather, so
+            # catching it leaves no other rank waiting in a collective.
+            if x is None and self.rank == 0:
+                raise
+            if self.rank == 0:
+                print(f'[emulator] stage {index + 1}/{num_stages} produced nothing usable; '
+                      f'continuing with the {len(x)} samples already simulated')
+            return x, y
+
+        if self.rank != 0:
+            return None, None
+        if x is None:
+            return new_x, new_y
+        if new_x is None or len(new_x) == 0:
+            return x, y
+        return np.vstack([x, new_x]), np.vstack([y, new_y])
 
     def fit(self, x, y):
         """Fit and compare emulators; returns ``(model, r2, rmse, name, x_scale, y_scale)``.
@@ -439,15 +561,23 @@ class EmulatorTrainer:
             if self.rank != 0:
                 return None
         else:
-            design = self.design()
+            stages = self.sampling_stages
             if self.rank == 0:
-                print(f'[emulator] training on {len(design)} samples across '
-                      f'{self.num_procs} rank(s)')
-            x, y = self.evaluate(design)
+                plan = ', '.join(f'{stage["num_samples"]} {stage["method"]}'
+                                 for stage in stages)
+                print(f'[emulator] training on {self.num_train_samples} samples across '
+                      f'{self.num_procs} rank(s)'
+                      + (f'; {len(stages)} stages: {plan}' if len(stages) > 1 else ''))
+
+            x = y = None
+            for index, stage in enumerate(stages):
+                x, y = self._run_stage(x, y, stage, index, len(stages))
             if self.rank != 0:
                 return None
             design_meta = {'sample_type': self._setting('sample_type', 'sobol'),
-                           'num_train_samples': int(len(design)),
+                           'stages': stages,
+                           'num_stages': len(stages),
+                           'num_train_samples': int(self.num_train_samples),
                            'num_used': int(len(x)),
                            'num_failed': int(getattr(self, '_n_failed', 0)),
                            'random_seed': int(self._setting('random_seed', 0)),
@@ -546,6 +676,29 @@ def resolve_emulator_dir(inp_data_dict):
     obs_path = inp_data_dict.get('param_id_obs_path') or ''
     obs_prefix = os.path.splitext(os.path.basename(obs_path))[0] if obs_path else 'obs'
     return os.path.join(root, 'emulators', f'{prefix}_{obs_prefix}')
+
+
+def _as_list(value, cast):
+    """A per-stage setting as a list, from either a YAML list or a comma-separated string.
+
+    Both spellings appear in practice: a hand-written user_inputs.yaml naturally says
+    ``[0.6, 0.4]``, while the settings descriptors are scalar-typed, so a tool that
+    builds one from a form has only a string to offer -- the same reason ``models`` is a
+    comma-separated string.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        parts = [part.strip() for part in value.split(',') if part.strip()]
+    elif isinstance(value, (list, tuple)):
+        parts = list(value)
+    else:
+        parts = [value]
+    try:
+        return [cast(part) for part in parts]
+    except (TypeError, ValueError) as error:
+        raise ValueError(f'cannot read {value!r} as a list of '
+                         f'{cast.__name__}: {error}') from error
 
 
 def _block_for_rank(n_samples, rank, num_procs):

--- a/src/libcuflynx/parsers/PrimitiveParsers.py
+++ b/src/libcuflynx/parsers/PrimitiveParsers.py
@@ -1776,6 +1776,43 @@ ANALYSIS_OPTIONS = {
              'choices': ['sobol', 'latin_hypercube', 'random'],
              'description': ('Design of experiments over the params_for_id box. Same vocabulary '
                              'as optimiser_options.start_sampling.')},
+            {'name': 'num_stages', 'type': 'int', 'default': 1, 'required': False,
+             'description': ('How many sampling stages the design is drawn in. 1 (the '
+                             'default) is the single-stage design described by sample_type, '
+                             'and nothing changes. Above 1, num_train_samples is split by '
+                             'frac_per_stage and each share is drawn with its own '
+                             'method_per_stage entry -- which is what lets a later stage '
+                             'place its points using the features the earlier stages '
+                             'actually returned, instead of over the box in ignorance of '
+                             'the response.')},
+            # Comma-separated strings for the same reason `models` is one: descriptor types
+            # are scalar, so a form-driven tool has only a string to offer. A hand-written
+            # yaml can give a real list and both are accepted.
+            {'name': 'frac_per_stage', 'type': 'str', 'default': None, 'required': False,
+             'per_stage': True,
+             'description': ('Share of num_train_samples for each stage, as a list or a '
+                             'comma-separated string with one entry per stage, adding up to '
+                             '1 (e.g. "0.6,0.4"). Defaults to an even split.')},
+            # item_choices, not choices: the value is a list, so a tool renders one
+            # menu per stage from this rather than a single menu for the whole setting.
+            # Listed here so a method added to CA appears in those menus without a
+            # change on the tool's side.
+            {'name': 'method_per_stage', 'type': 'str', 'default': None, 'required': False,
+             'item_choices': ['sobol', 'latin_hypercube', 'random', 'gradient_weighted'],
+             'per_stage': True,
+             'description': ('How each stage draws its points: sobol, latin_hypercube, '
+                             'random, or gradient_weighted, one entry per stage (e.g. '
+                             '"sobol,gradient_weighted"). Defaults to sample_type for the '
+                             'first stage and gradient_weighted for the rest. '
+                             'gradient_weighted draws points between the pairs of '
+                             'neighbouring samples whose simulated features differ most, '
+                             'spending the budget on the thresholds and cliffs an even '
+                             'design resolves poorly rather than on regions where the model '
+                             'barely moves -- worth it for a model with a bifurcation in the '
+                             'parameter box, such as a neuron that only fires above a '
+                             'rheobase. It can only sharpen structure an earlier stage '
+                             'already found, so leave the first stage big enough to find it, '
+                             'and it cannot be the first stage.')},
             {'name': 'log_scale_params', 'type': 'bool', 'default': False, 'required': False,
              'description': ('Space the design logarithmically in each parameter. Worth setting '
                              'when a bound spans decades; requires every min to be positive.')},
@@ -2496,6 +2533,9 @@ class YamlFileParser(object):
         emulator_settings.setdefault('num_train_samples', 128)
         emulator_settings.setdefault('reuse_samples', False)
         emulator_settings.setdefault('sample_type', 'sobol')
+        emulator_settings.setdefault('num_stages', 1)
+        emulator_settings.setdefault('frac_per_stage', None)
+        emulator_settings.setdefault('method_per_stage', None)
         emulator_settings.setdefault('log_scale_params', False)
         emulator_settings.setdefault('random_seed', 0)
         emulator_settings.setdefault('test_fraction', 0.2)

--- a/src/libcuflynx/parsers/PrimitiveParsers.py
+++ b/src/libcuflynx/parsers/PrimitiveParsers.py
@@ -1798,21 +1798,40 @@ ANALYSIS_OPTIONS = {
             # Listed here so a method added to CA appears in those menus without a
             # change on the tool's side.
             {'name': 'method_per_stage', 'type': 'str', 'default': None, 'required': False,
-             'item_choices': ['sobol', 'latin_hypercube', 'random', 'gradient_weighted'],
+             'item_choices': ['sobol', 'latin_hypercube', 'random', 'gradient_weighted',
+                              'error_weighted'],
              'per_stage': True,
-             'description': ('How each stage draws its points: sobol, latin_hypercube, '
-                             'random, or gradient_weighted, one entry per stage (e.g. '
-                             '"sobol,gradient_weighted"). Defaults to sample_type for the '
-                             'first stage and gradient_weighted for the rest. '
-                             'gradient_weighted draws points between the pairs of '
-                             'neighbouring samples whose simulated features differ most, '
-                             'spending the budget on the thresholds and cliffs an even '
-                             'design resolves poorly rather than on regions where the model '
-                             'barely moves -- worth it for a model with a bifurcation in the '
-                             'parameter box, such as a neuron that only fires above a '
-                             'rheobase. It can only sharpen structure an earlier stage '
-                             'already found, so leave the first stage big enough to find it, '
-                             'and it cannot be the first stage.')},
+             'description': ('How each stage draws its points, one entry per stage (e.g. '
+                             '"sobol,gradient_weighted"). sobol, latin_hypercube and '
+                             'random spread points over the box; gradient_weighted and '
+                             'error_weighted place them using what the earlier stages '
+                             'simulated, and so cannot come first. Defaults to sample_type '
+                             'for the first stage and gradient_weighted for the rest. '
+                             'gradient_weighted draws between the pairs of neighbouring '
+                             'samples whose features differ most, which resolves a '
+                             'threshold an even design straddles -- a neuron that only '
+                             'fires above a rheobase, say. error_weighted cross-validates '
+                             'a cheap radial-basis surrogate over the samples so far, '
+                             'interpolates its error across the whole box, and draws '
+                             'against that, so it can propose points nowhere near an '
+                             'existing sample and does not need the response to be steep '
+                             'to find it hard. Both can only sharpen structure an earlier '
+                             'stage already found, so leave the first stage big enough to '
+                             'find it. Note that clustering points across a discontinuity '
+                             'helps a model that can represent one (a forest, or the '
+                             'classifier half of a two_phase emulator) and HURTS a smooth '
+                             'global fit, which rings around the jump -- so match the '
+                             'stage to the emulator in models.')},
+            {'name': 'weight_per_stage', 'type': 'str', 'default': None, 'required': False,
+             'per_stage': True,
+             'description': ('How strongly each stage follows its own scores, as a list, a '
+                             'comma-separated string, or one value for every stage. 0 '
+                             'ignores them and makes the stage a plain random top-up; 0.5 '
+                             'spreads half the probability uniformly and distributes half '
+                             'by score; 1 (the default) draws in proportion to the scores; '
+                             'above 1 raises them to that power, concentrating harder on '
+                             'the worst regions and covering fewer of them. Ignored by the '
+                             'space-filling methods, which have no scores.')},
             {'name': 'log_scale_params', 'type': 'bool', 'default': False, 'required': False,
              'description': ('Space the design logarithmically in each parameter. Worth setting '
                              'when a bound spans decades; requires every min to be positive.')},
@@ -2536,6 +2555,7 @@ class YamlFileParser(object):
         emulator_settings.setdefault('num_stages', 1)
         emulator_settings.setdefault('frac_per_stage', None)
         emulator_settings.setdefault('method_per_stage', None)
+        emulator_settings.setdefault('weight_per_stage', None)
         emulator_settings.setdefault('log_scale_params', False)
         emulator_settings.setdefault('random_seed', 0)
         emulator_settings.setdefault('test_fraction', 0.2)

--- a/tests/test_adaptive_design.py
+++ b/tests/test_adaptive_design.py
@@ -1,0 +1,220 @@
+"""The second sampling stage has to spend its points on the cliff, or it is pure cost.
+
+``gradient_weighted_design`` is worth testing directly rather than only through a
+training run: the claim it makes is geometric -- that its points land near a threshold
+an even design straddles -- and that claim can be checked exactly, against a response
+whose threshold is known, without simulating anything.
+
+The fallbacks matter as much as the concentration. This runs after a first stage that
+may have produced a flat, degenerate or nearly-empty set of results, and in every one
+of those cases it has to return a usable design rather than raise or return points
+piled on top of each other.
+"""
+import numpy as np
+import pytest
+
+from libcuflynx.emulators.adaptive_design import gradient_weighted_design
+from libcuflynx.emulators.emulator_trainer import EmulatorTrainer
+
+MINS = np.array([0.0, 0.0])
+MAXS = np.array([1.0, 1.0])
+THRESHOLD = 0.5
+
+
+def _step_response(x):
+    """A cliff at ``x0 = 0.5`` and nothing else: the shape a rheobase makes."""
+    return np.column_stack([(x[:, 0] > THRESHOLD).astype(float)])
+
+
+def _first_stage(n=200, seed=0):
+    x = np.random.default_rng(seed).random((n, 2))
+    return x, _step_response(x)
+
+
+def test_the_second_stage_lands_on_the_cliff():
+    """The whole point: closer to the threshold than the design it was drawn from.
+
+    Compared against the first stage rather than an absolute tolerance -- the useful
+    property is *concentration relative to spreading points evenly*, which is the
+    alternative use of the same simulations.
+    """
+    x, y = _first_stage()
+    follow_up = gradient_weighted_design(x, y, 400, MINS, MAXS, seed=1)
+
+    before = np.median(np.abs(x[:, 0] - THRESHOLD))
+    after = np.median(np.abs(follow_up[:, 0] - THRESHOLD))
+    assert after < before / 3, (
+        f'stage 2 sits {after:.3f} from the cliff and stage 1 sat {before:.3f}; it is not '
+        f'concentrating, so the extra simulations buy nothing an even design would not')
+
+
+def test_it_does_not_concentrate_in_the_direction_that_carries_no_signal():
+    """``x1`` does nothing to the response, so the points must stay spread across it.
+
+    A method that narrowed here would be finding structure that is not there, and would
+    leave the emulator blind along a parameter it still has to cover.
+    """
+    x, y = _first_stage()
+    follow_up = gradient_weighted_design(x, y, 400, MINS, MAXS, seed=1)
+    assert follow_up[:, 1].std() > 0.2, (
+        'stage 2 collapsed along the parameter the response does not depend on')
+
+
+def test_every_point_stays_inside_the_box():
+    """Jitter pushes points off the segment, and the bounds are not negotiable."""
+    x, y = _first_stage()
+    follow_up = gradient_weighted_design(x, y, 500, MINS, MAXS, seed=3)
+    assert follow_up.shape == (500, 2)
+    assert (follow_up >= MINS).all() and (follow_up <= MAXS).all()
+
+
+def test_the_same_seed_gives_the_same_design():
+    """A training run has to be repeatable, and this stage is part of the design."""
+    x, y = _first_stage()
+    first = gradient_weighted_design(x, y, 50, MINS, MAXS, seed=7)
+    second = gradient_weighted_design(x, y, 50, MINS, MAXS, seed=7)
+    assert np.array_equal(first, second)
+    assert not np.array_equal(first, gradient_weighted_design(x, y, 50, MINS, MAXS, seed=8))
+
+
+def test_a_flat_response_falls_back_to_covering_the_box():
+    """No gradient anywhere means no information about where to look.
+
+    The honest answer is a space-filling top-up. Concentrating on whatever floating-point
+    dust happened to be largest would be worse than useless -- it would look adaptive.
+    """
+    x = np.random.default_rng(0).random((100, 2))
+    y = np.ones((100, 3))
+    follow_up = gradient_weighted_design(x, y, 300, MINS, MAXS, seed=1)
+    assert follow_up.shape == (300, 2)
+    assert follow_up[:, 0].std() > 0.2 and follow_up[:, 1].std() > 0.2
+
+
+def test_features_are_weighed_by_their_own_range():
+    """A tiny-magnitude feature that jumps must not be drowned by a large smooth one.
+
+    CA parameters and observables routinely span decades -- a current near 1e-9 beside a
+    firing rate near 10 -- so an unscaled norm would be decided entirely by the feature
+    with the biggest numbers, and the cliff would never be seen.
+    """
+    x = np.random.default_rng(0).random((200, 2))
+    y = np.column_stack([
+        1e-9 * (x[:, 0] > THRESHOLD).astype(float),   # the cliff, in tiny units
+        1e3 * x[:, 1],                                # a large, smooth ramp
+    ])
+    follow_up = gradient_weighted_design(x, y, 400, MINS, MAXS, seed=1)
+    assert np.median(np.abs(follow_up[:, 0] - THRESHOLD)) < 0.1, (
+        'the 1e-9 cliff was ignored in favour of the 1e3 ramp, so features are being '
+        'compared in their own units instead of by range')
+
+
+@pytest.mark.parametrize('n_points', [0, 1])
+def test_too_few_points_to_estimate_anything(n_points):
+    """One point has no neighbour, so there is no between-points gradient to weight by."""
+    x = np.random.default_rng(0).random((n_points, 2))
+    follow_up = gradient_weighted_design(x, _step_response(x) if n_points else
+                                         np.empty((0, 1)), 20, MINS, MAXS, seed=1)
+    assert follow_up.shape == (20, 2)
+    assert (follow_up >= MINS).all() and (follow_up <= MAXS).all()
+
+
+def test_asking_for_nothing_returns_nothing():
+    """fraction_2nd_stage rounding to zero points must not produce a stray sample."""
+    x, y = _first_stage()
+    assert gradient_weighted_design(x, y, 0, MINS, MAXS).shape == (0, 2)
+
+
+def test_log_scaled_parameters_come_back_inside_their_bounds():
+    """A design spanning decades is placed in log space and has to return in real units."""
+    mins, maxs = np.array([1e-9, 1e-3]), np.array([1e-6, 1e0])
+    unit = np.random.default_rng(0).random((100, 2))
+    x = np.exp(np.log(mins) + unit * (np.log(maxs) - np.log(mins)))
+    y = np.column_stack([(x[:, 0] > 1e-7).astype(float)])
+    follow_up = gradient_weighted_design(x, y, 200, mins, maxs, seed=1, log_scale=True)
+    assert (follow_up >= mins).all() and (follow_up <= maxs).all()
+
+
+# ---------------------------------------------------------------------------------
+# How num_stages / frac_per_stage / method_per_stage turn into a plan.
+#
+# Exercised against the property rather than a training run: the arithmetic and the
+# refusals are where a multi-stage design goes wrong silently -- a budget that does not
+# add up, or a stage order that cannot work -- and none of that needs a simulation.
+# ---------------------------------------------------------------------------------
+
+class _Stages:
+    """Just enough trainer to ask for a sampling plan, with no model behind it."""
+
+    def __init__(self, **settings):
+        self.settings = settings
+
+    def _setting(self, name, default):
+        value = self.settings.get(name, default)
+        return default if value is None else value
+
+    @property
+    def num_train_samples(self):
+        return int(self.settings.get('num_train_samples', 1000))
+
+
+def _plan(**settings):
+    trainer = _Stages(**settings)
+    return EmulatorTrainer.sampling_stages.fget(trainer)
+
+
+def test_one_stage_is_the_design_ca_has_always_built():
+    """The default has to be untouched: every existing study depends on it."""
+    assert _plan(num_train_samples=128) == [{'method': 'sobol', 'num_samples': 128}]
+    assert _plan(num_train_samples=128, sample_type='latin_hypercube') == [
+        {'method': 'latin_hypercube', 'num_samples': 128}]
+
+
+def test_the_stages_spend_exactly_the_budget():
+    """Rounding must not lose or invent a simulation; the last stage takes the remainder."""
+    stages = _plan(num_train_samples=1000, num_stages=3, frac_per_stage=[1/3, 1/3, 1/3])
+    assert sum(stage['num_samples'] for stage in stages) == 1000
+
+
+def test_defaults_put_the_space_filling_stage_first():
+    """"Two stages" without further instruction means sobol, then adapt."""
+    stages = _plan(num_train_samples=800, num_stages=2)
+    assert [stage['method'] for stage in stages] == ['sobol', 'gradient_weighted']
+    assert [stage['num_samples'] for stage in stages] == [400, 400]
+
+
+def test_a_comma_separated_string_reads_the_same_as_a_list():
+    """A form-driven tool has only strings to offer; a yaml naturally has lists."""
+    as_list = _plan(num_train_samples=1000, num_stages=2, frac_per_stage=[0.6, 0.4],
+                    method_per_stage=['sobol', 'gradient_weighted'])
+    as_string = _plan(num_train_samples=1000, num_stages=2, frac_per_stage='0.6,0.4',
+                      method_per_stage='sobol,gradient_weighted')
+    assert as_list == as_string == [{'method': 'sobol', 'num_samples': 600},
+                                    {'method': 'gradient_weighted', 'num_samples': 400}]
+
+
+def test_an_adaptive_first_stage_is_refused():
+    """It places points using features from earlier stages, and there are none.
+
+    Refused up front rather than at run time: the alternative is discovering it after
+    the model has been generated and the first simulations have been paid for.
+    """
+    with pytest.raises(ValueError, match='there are none'):
+        _plan(num_stages=2, method_per_stage=['gradient_weighted', 'sobol'])
+
+
+def test_fractions_that_do_not_add_up_are_refused():
+    """Silently normalising would spend a budget the user did not ask to spend."""
+    with pytest.raises(ValueError, match='sums to'):
+        _plan(num_stages=2, frac_per_stage=[0.5, 0.2])
+
+
+@pytest.mark.parametrize('settings, match', [
+    ({'num_stages': 3, 'frac_per_stage': [0.5, 0.5]}, 'one entry per stage'),
+    ({'num_stages': 2, 'method_per_stage': ['sobol']}, 'one entry per stage'),
+    ({'num_stages': 2, 'frac_per_stage': [1.0, 0.0]}, 'positive share'),
+    ({'num_stages': 2, 'method_per_stage': ['sobol', 'nonesuch']}, 'unknown method_per_stage'),
+    ({'num_stages': 0}, 'at least one stage'),
+])
+def test_a_plan_that_cannot_run_is_refused_with_a_reason(settings, match):
+    with pytest.raises(ValueError, match=match):
+        _plan(**settings)

--- a/tests/test_adaptive_design.py
+++ b/tests/test_adaptive_design.py
@@ -164,9 +164,10 @@ def _plan(**settings):
 
 def test_one_stage_is_the_design_ca_has_always_built():
     """The default has to be untouched: every existing study depends on it."""
-    assert _plan(num_train_samples=128) == [{'method': 'sobol', 'num_samples': 128}]
+    assert _plan(num_train_samples=128) == [
+        {'method': 'sobol', 'num_samples': 128, 'weight': 1.0}]
     assert _plan(num_train_samples=128, sample_type='latin_hypercube') == [
-        {'method': 'latin_hypercube', 'num_samples': 128}]
+        {'method': 'latin_hypercube', 'num_samples': 128, 'weight': 1.0}]
 
 
 def test_the_stages_spend_exactly_the_budget():
@@ -188,8 +189,9 @@ def test_a_comma_separated_string_reads_the_same_as_a_list():
                     method_per_stage=['sobol', 'gradient_weighted'])
     as_string = _plan(num_train_samples=1000, num_stages=2, frac_per_stage='0.6,0.4',
                       method_per_stage='sobol,gradient_weighted')
-    assert as_list == as_string == [{'method': 'sobol', 'num_samples': 600},
-                                    {'method': 'gradient_weighted', 'num_samples': 400}]
+    assert as_list == as_string == [
+        {'method': 'sobol', 'num_samples': 600, 'weight': 1.0},
+        {'method': 'gradient_weighted', 'num_samples': 400, 'weight': 1.0}]
 
 
 def test_an_adaptive_first_stage_is_refused():
@@ -218,3 +220,283 @@ def test_fractions_that_do_not_add_up_are_refused():
 def test_a_plan_that_cannot_run_is_refused_with_a_reason(settings, match):
     with pytest.raises(ValueError, match=match):
         _plan(**settings)
+
+
+# ---------------------------------------------------------------------------------
+# Does adaptive sampling actually produce a better emulator?
+#
+# Everything above checks that the stages place points where they claim to. That is not
+# the same claim, and it is the weaker one: points can land exactly where intended and
+# still buy nothing. These measure the thing the feature exists for -- fit a surrogate
+# on a single-stage design of N points, fit another on a two-stage design of the same
+# N, and compare both against the same held-out truth.
+#
+# The budget is equal by construction. An adaptive design that wins by simulating more
+# points has not won.
+# ---------------------------------------------------------------------------------
+
+from libcuflynx.emulators.adaptive_design import error_weighted_design  # noqa: E402
+
+
+def _surrogate_error(x_train, y_train, x_test, y_test):
+    """RMSE of an RBF surrogate fitted on the design, over a fixed held-out set."""
+    from scipy.interpolate import RBFInterpolator
+
+    model = RBFInterpolator(x_train, y_train, kernel='thin_plate_spline', smoothing=1e-8,
+                            neighbors=min(len(x_train), 50))
+    return float(np.sqrt(np.mean(np.square(model(x_test).reshape(y_test.shape) - y_test))))
+
+
+def _sobol(n, seed, dim=2):
+    from scipy.stats import qmc
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        return qmc.Sobol(d=dim, scramble=True, seed=seed).random(n)
+
+
+def _held_out(response, seed=99, n=500, dim=2):
+    """A fixed, evenly spread test set. Sobol, deliberately -- see the note below."""
+    x = _sobol(n, seed, dim)
+    return x, response(x)
+
+
+def _peaked(x):
+    """Smooth almost everywhere, with one narrow feature an even design under-resolves."""
+    return np.column_stack([np.exp(-60.0 * ((x[:, 0] - 0.35) ** 2 + (x[:, 1] - 0.6) ** 2))])
+
+
+def test_error_weighting_beats_an_even_design_of_the_same_size():
+    """The generic case: no cliff, just a response that is harder in some places.
+
+    Both designs simulate 160 points. The two-stage one spends the second half where a
+    surrogate cross-validated on the first half is worst, and has to come out ahead on a
+    held-out set neither of them has seen.
+    """
+    budget, first = 160, 80
+    x_test, y_test = _held_out(_peaked)
+
+    even = _sobol(budget, seed=0)
+    even_error = _surrogate_error(even, _peaked(even), x_test, y_test)
+
+    stage1 = _sobol(first, seed=0)
+    stage2 = error_weighted_design(stage1, _peaked(stage1), budget - first, MINS, MAXS, seed=1)
+    staged = np.vstack([stage1, stage2])
+    staged_error = _surrogate_error(staged, _peaked(staged), x_test, y_test)
+
+    assert len(staged) == len(even), 'the comparison is only fair at an equal budget'
+    assert staged_error < even_error, (
+        f'error-weighted sampling scored {staged_error:.4g} against {even_error:.4g} for a '
+        f'plain design of the same size, so the second stage paid for nothing')
+
+
+def _cliff(x):
+    """A threshold in x0, as a neuron's rheobase is, plus a mild ramp in x1."""
+    return np.column_stack([np.where(x[:, 0] > THRESHOLD, 1.0, 0.0) + 0.1 * x[:, 1]])
+
+
+def _forest_error(x_train, y_train, x_test, y_test):
+    """RMSE of a random forest -- a model class that can represent a step.
+
+    Deliberately not the RBF surrogate the smooth cases use. Concentrating points across
+    a discontinuity is actively bad for a smooth global interpolator: it is forced
+    through steeply-disagreeing neighbours and rings around the jump. Measuring an
+    adaptive design that way conflates "were the points placed well" with "can this
+    model represent a cliff at all", and the second question is answered no before the
+    first is asked. See the caveat test below, which pins that behaviour down.
+    """
+    from sklearn.ensemble import RandomForestRegressor
+
+    model = RandomForestRegressor(n_estimators=50, random_state=0)
+    model.fit(x_train, y_train.ravel())
+    return float(np.sqrt(np.mean(np.square(model.predict(x_test) - y_test.ravel()))))
+
+
+def test_gradient_weighting_beats_an_even_design_on_a_model_with_a_cliff():
+    """The case the feature was written for: a threshold, as a neuron's rheobase is.
+
+    Equal budgets: 160 simulations either way. The staged design spends half of them
+    between the pairs that straddle the step, and has to come out ahead on a held-out
+    set neither design has seen.
+    """
+    budget, first = 160, 80
+    x_test, y_test = _held_out(_cliff)
+
+    even = _sobol(budget, seed=0)
+    even_error = _forest_error(even, _cliff(even), x_test, y_test)
+
+    stage1 = _sobol(first, seed=0)
+    stage2 = gradient_weighted_design(stage1, _cliff(stage1), budget - first, MINS, MAXS,
+                                      seed=1)
+    staged = np.vstack([stage1, stage2])
+    staged_error = _forest_error(staged, _cliff(staged), x_test, y_test)
+
+    assert len(staged) == len(even), 'the comparison is only fair at an equal budget'
+    assert staged_error < even_error, (
+        f'gradient-weighted sampling scored {staged_error:.4g} against {even_error:.4g} for '
+        f'an even design of the same size, so it is not resolving the cliff')
+
+
+def test_clustering_on_a_cliff_hurts_a_smooth_interpolator():
+    """The caveat, pinned down rather than left for a user to discover.
+
+    A thin-plate spline forced through tightly-spaced points on either side of a jump
+    oscillates around it, and the oscillation costs more than the sharper boundary
+    gains. So an adaptive stage is not free: it pays off for a model that can represent
+    the discontinuity -- a forest, or the classifier half of a two-phase emulator -- and
+    costs accuracy for one that cannot.
+
+    Asserted, not just documented, because it decides whether a study should turn this
+    on. If a change ever makes clustering harmless to a smooth interpolator, this test
+    fails and the guidance in the settings description needs rewriting.
+    """
+    budget, first = 160, 80
+    x_test, y_test = _held_out(_cliff)
+
+    even = _sobol(budget, seed=0)
+    stage1 = _sobol(first, seed=0)
+    staged = np.vstack([stage1, gradient_weighted_design(
+        stage1, _cliff(stage1), budget - first, MINS, MAXS, seed=1)])
+
+    assert (_surrogate_error(staged, _cliff(staged), x_test, y_test)
+            > _surrogate_error(even, _cliff(even), x_test, y_test))
+
+
+def test_three_stages_sobol_then_gradient_then_error_run_together():
+    """The stages compose: each one sees everything simulated before it.
+
+    Worth its own test because the third stage is the first to be handed a design that
+    is *not* space-filling -- half of what it reads was placed by the stage before it,
+    clustered on the cliff. It has to cope with that input and still return points in
+    the box.
+    """
+    cliff = _cliff
+    stage1 = _sobol(80, seed=0)
+    y1 = cliff(stage1)
+
+    stage2 = gradient_weighted_design(stage1, y1, 40, MINS, MAXS, seed=1)
+    so_far = np.vstack([stage1, stage2])
+    y2 = cliff(so_far)
+
+    stage3 = error_weighted_design(so_far, y2, 40, MINS, MAXS, seed=2)
+    everything = np.vstack([so_far, stage3])
+
+    assert len(everything) == 160
+    assert (everything >= MINS).all() and (everything <= MAXS).all()
+    # Each adaptive stage found something to aim at rather than falling back to uniform.
+    assert np.median(np.abs(stage2[:, 0] - THRESHOLD)) < 0.15
+    assert np.isfinite(stage3).all()
+
+    x_test, y_test = _held_out(cliff)
+    staged = _forest_error(everything, cliff(everything), x_test, y_test)
+    even = _sobol(160, seed=0)
+    assert staged < _forest_error(even, cliff(even), x_test, y_test)
+
+
+@pytest.mark.parametrize('weight, description', [
+    (0.0, 'ignores the scores entirely'),
+    (0.5, 'half uniform, half by score'),
+    (1.0, 'by score'),
+    (3.0, 'concentrated on the worst'),
+])
+def test_the_weight_dial_runs_from_uniform_to_concentrated(weight, description):
+    """0 must be genuinely uniform, and raising it must genuinely concentrate."""
+    x, y = _first_stage(n=120)
+    drawn = gradient_weighted_design(x, y, 300, MINS, MAXS, seed=1, weight=weight)
+    assert drawn.shape == (300, 2), description
+    assert (drawn >= MINS).all() and (drawn <= MAXS).all()
+
+
+def test_weight_zero_is_a_plain_random_top_up():
+    """The documented meaning of 0: the scores are computed and then not used."""
+    x, y = _first_stage()
+    drawn = gradient_weighted_design(x, y, 400, MINS, MAXS, seed=1, weight=0.0)
+    # Uniform over the box, so nowhere near as tight to the cliff as weight 1 gets.
+    assert np.median(np.abs(drawn[:, 0] - THRESHOLD)) > 0.15
+
+
+def test_a_higher_weight_concentrates_harder_than_a_lower_one():
+    """Monotone in the dial, which is what makes it a dial rather than a switch."""
+    x, y = _first_stage()
+    loose = gradient_weighted_design(x, y, 400, MINS, MAXS, seed=1, weight=0.5)
+    tight = gradient_weighted_design(x, y, 400, MINS, MAXS, seed=1, weight=4.0)
+    assert (np.median(np.abs(tight[:, 0] - THRESHOLD))
+            < np.median(np.abs(loose[:, 0] - THRESHOLD)))
+
+
+def test_error_weighting_falls_back_when_there_is_nothing_to_learn_from():
+    """A flat response, and too few points for the dimension, both fall back cleanly."""
+    x = np.random.default_rng(0).random((60, 2))
+    flat = error_weighted_design(x, np.ones((60, 2)), 100, MINS, MAXS, seed=1)
+    assert flat.shape == (100, 2) and flat[:, 0].std() > 0.2
+
+    tiny = np.random.default_rng(0).random((2, 2))
+    assert error_weighted_design(tiny, _step_response(tiny), 20, MINS, MAXS,
+                                 seed=1).shape == (20, 2)
+
+
+# ---------------------------------------------------------------------------------
+# What the reported R2 is measured on.
+# ---------------------------------------------------------------------------------
+
+from libcuflynx.emulators.emulator_trainer import _train_test_split  # noqa: E402
+
+
+def test_only_space_filling_samples_are_held_out():
+    """The validation set is drawn from the sobol stage, never from an adaptive one.
+
+    An adaptive stage puts its points exactly where the model is hardest. Holding those
+    out would measure the emulator on the worst corner of the box and report it as the
+    error everywhere -- and report it inconsistently, since how many such points fell in
+    the test set is chance. It would also waste them: they were simulated to teach the
+    emulator the difficult region, and a held-out point teaches it nothing.
+    """
+    n_sobol, n_adaptive = 80, 40
+    x = np.arange(n_sobol + n_adaptive, dtype=float).reshape(-1, 1)
+    y = x.copy()
+    space_filling = np.array([True] * n_sobol + [False] * n_adaptive)
+
+    _, _, x_test, _ = _train_test_split(x, y, 0.2, seed=0, test_candidates=space_filling)
+
+    held_out = x_test.ravel().astype(int)
+    assert len(held_out) == 24, 'the test set should still be test_fraction of the design'
+    assert (held_out < n_sobol).all(), (
+        f'{(held_out >= n_sobol).sum()} adaptive samples were held out; validation has to '
+        f'come from the evenly-spread stage')
+
+
+def test_every_adaptive_sample_reaches_the_training_set():
+    """The other half of the same claim: nothing hard-won is spent on validation."""
+    n_sobol, n_adaptive = 60, 40
+    x = np.arange(n_sobol + n_adaptive, dtype=float).reshape(-1, 1)
+    space_filling = np.array([True] * n_sobol + [False] * n_adaptive)
+
+    x_train, _, _, _ = _train_test_split(x, x.copy(), 0.2, seed=1,
+                                         test_candidates=space_filling)
+    trained_on = set(x_train.ravel().astype(int))
+    assert set(range(n_sobol, n_sobol + n_adaptive)) <= trained_on
+
+
+def test_a_single_stage_design_splits_exactly_as_it_always_did():
+    """No mask, and an all-true mask, must both take the original path.
+
+    Every existing emulator was validated by the unmasked split; a study that retrains
+    without changing anything has to get the same split back, or its R2 moves for a
+    reason that has nothing to do with the emulator.
+    """
+    x = np.arange(50, dtype=float).reshape(-1, 1)
+    plain = _train_test_split(x, x.copy(), 0.2, seed=0)
+    masked = _train_test_split(x, x.copy(), 0.2, seed=0,
+                               test_candidates=np.ones(50, dtype=bool))
+    for left, right in zip(plain, masked):
+        assert np.array_equal(left, right)
+
+
+def test_the_fit_is_never_starved_of_training_points():
+    """A design that is almost all adaptive still leaves something to hold out."""
+    space_filling = np.array([True] * 3 + [False] * 97)
+    x = np.arange(100, dtype=float).reshape(-1, 1)
+    x_train, _, x_test, _ = _train_test_split(x, x.copy(), 0.2, seed=0,
+                                              test_candidates=space_filling)
+    assert 1 <= len(x_test) <= 3
+    assert len(x_train) == 100 - len(x_test)

--- a/tests/test_emulator_training.py
+++ b/tests/test_emulator_training.py
@@ -149,7 +149,7 @@ def test_training_writes_a_checkable_artefact(base_user_inputs, resources_dir, t
 
     trainer = EmulatorTrainer.init_from_dict(config, comm=mpi_comm)
 
-    def fake_fit(x, y):
+    def fake_fit(x, y, space_filling=None):
         x_scale = EmulatorBundle.make_scale(x)
         y_scale = EmulatorBundle.make_scale(y)
         validation = {
@@ -537,7 +537,7 @@ def test_reuse_refits_the_saved_samples_without_running_the_model(
                      temp_generated_models_dir)
     _generate_model(config, mpi_comm)
 
-    def fake_fit(x, y):
+    def fake_fit(x, y, space_filling=None):
         validation = {'r2': [0.97, 0.96], 'rmse': [0.01, 0.02], 'mae': [0.01, 0.02],
                       'bias': [0.0, 0.0], 'max_abs_error': [0.02, 0.04], 'nrmse': [0.01, 0.02],
                       'theta': x[:2], 'y_true': y[:2], 'y_pred': y[:2]}
@@ -661,51 +661,98 @@ def test_a_reused_fit_emulates_the_same_function_as_the_original(
 @pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.mpi
-def test_a_multi_stage_design_runs_and_records_both_stages(
+def test_a_three_stage_design_runs_and_records_every_stage(
         base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
-    """A two-stage run end to end: the plan, the broadcast, and what it saves.
+    """sobol, then gradient_weighted, then error_weighted, end to end.
 
-    The adaptive stage is the one part of the design that cannot be derived from the seed
-    -- it is placed from features only rank 0 holds -- so it is the one part that can be
-    wrong in a way the unit tests cannot see: a design that never reaches the other ranks,
-    or a second block of samples that never joins the first. Both show up here as a
-    training set of the wrong size.
+    Three stages rather than two on purpose: the third is the first to be handed a
+    design that is *not* space-filling, since half of what it reads was placed by the
+    stage before it and is clustered on the hard part. It has to cope with that and
+    still return points in the box.
+
+    The adaptive stages are also the only part of the design that cannot be derived from
+    the seed -- they are placed from features only rank 0 holds -- so they are the part
+    that can be wrong in a way the unit tests cannot see: a design that never reaches the
+    other ranks, or a block of samples that never joins the earlier ones. Both show up
+    here as a training set of the wrong size.
 
     The saved plan matters as much as the samples. An emulator is reused and argued with
-    long after the run, and "2048 sobol points" and "1024 sobol points plus 1024 drawn at
-    the cliffs" are different provenance for the same count.
+    long after the run, and "2048 sobol points" and "1024 sobol plus 1024 drawn at the
+    cliffs" are different provenance for the same count.
     """
     config = _config(base_user_inputs, resources_dir, temp_output_dir,
                      temp_generated_models_dir,
-                     emulator_settings={'num_train_samples': 24, 'sample_type': 'sobol',
-                                        'num_stages': 2, 'frac_per_stage': [0.5, 0.5],
+                     emulator_settings={'num_train_samples': 30, 'sample_type': 'sobol',
+                                        'num_stages': 3,
+                                        'frac_per_stage': [0.6, 0.2, 0.2],
+                                        'method_per_stage': ['sobol', 'gradient_weighted',
+                                                             'error_weighted'],
+                                        'weight_per_stage': 1.0,
+                                        'random_seed': 0, 'min_r2': -1e9,
+                                        'n_iter': 2, 'n_splits': 2})
+    _generate_model(config, mpi_comm)
+
+    trainer = EmulatorTrainer.init_from_dict(config, comm=mpi_comm)
+    assert trainer.sampling_stages == [
+        {'method': 'sobol', 'num_samples': 18, 'weight': 1.0},
+        {'method': 'gradient_weighted', 'num_samples': 6, 'weight': 1.0},
+        {'method': 'error_weighted', 'num_samples': 6, 'weight': 1.0}]
+
+    bundle = trainer.train()
+    if mpi_comm.Get_rank() != 0:
+        return
+
+    assert bundle is not None, 'a three-stage design trained no emulator'
+    design_meta = bundle.meta['design']
+    assert design_meta['num_stages'] == 3
+    assert [stage['method'] for stage in design_meta['stages']] == [
+        'sobol', 'gradient_weighted', 'error_weighted']
+    assert design_meta['num_train_samples'] == 30
+    # Every block made it back: a stage that did not would leave its samples behind and
+    # the fit would still succeed on what remained.
+    assert len(bundle.x_train) == 30 - design_meta['num_failed']
+
+    mins = np.asarray(trainer.pid.param_id_info['param_mins'], dtype=float)
+    maxs = np.asarray(trainer.pid.param_id_info['param_maxs'], dtype=float)
+    assert np.all(bundle.x_train >= mins) and np.all(bundle.x_train <= maxs), (
+        'an adaptive stage placed points outside the training box')
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_the_reported_accuracy_is_measured_on_space_filling_samples_only(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
+    """The held-out points all come from the sobol stage, in a real run.
+
+    Checked here and not only in the unit test because it is the reported R2 that a
+    study trusts, and the mask that produces it is assembled in ``train`` from which
+    stage each surviving sample came from -- after failures have been dropped, which is
+    exactly where an off-by-one would hide.
+    """
+    n_sobol = 18
+    config = _config(base_user_inputs, resources_dir, temp_output_dir,
+                     temp_generated_models_dir,
+                     emulator_settings={'num_train_samples': 30, 'sample_type': 'sobol',
+                                        'num_stages': 2, 'frac_per_stage': [0.6, 0.4],
                                         'method_per_stage': ['sobol', 'gradient_weighted'],
                                         'random_seed': 0, 'min_r2': -1e9,
                                         'n_iter': 2, 'n_splits': 2})
     _generate_model(config, mpi_comm)
 
     trainer = EmulatorTrainer.init_from_dict(config, comm=mpi_comm)
-    assert trainer.sampling_stages == [{'method': 'sobol', 'num_samples': 12},
-                                       {'method': 'gradient_weighted', 'num_samples': 12}]
-
+    sobol_points = trainer.design(n_sobol, sample_type='sobol', seed_offset=0)
     bundle = trainer.train()
     if mpi_comm.Get_rank() != 0:
         return
 
-    assert bundle is not None, 'a two-stage design trained no emulator'
-    design_meta = bundle.meta['design']
-    assert design_meta['num_stages'] == 2
-    assert [stage['method'] for stage in design_meta['stages']] == ['sobol',
-                                                                    'gradient_weighted']
-    assert design_meta['num_train_samples'] == 24
-    # Both blocks are in the training set: a stage that never made it back would leave
-    # half of these behind, and the fit would still succeed on what remained.
-    assert len(bundle.x_train) == 24 - design_meta['num_failed']
-
-    mins = np.asarray(trainer.pid.param_id_info['param_mins'], dtype=float)
-    maxs = np.asarray(trainer.pid.param_id_info['param_maxs'], dtype=float)
-    assert np.all(bundle.x_train >= mins) and np.all(bundle.x_train <= maxs), (
-        'the adaptive stage placed points outside the training box')
+    held_out = np.asarray(bundle.validation['theta'], dtype=float)
+    assert len(held_out) > 0, 'nothing was held out, so the R2 is measured on nothing'
+    for point in held_out:
+        assert np.isclose(sobol_points, point, rtol=1e-6, atol=1e-9).all(axis=1).any(), (
+            f'a held-out point {point} is not one of the {n_sobol} sobol samples, so the '
+            f'reported accuracy is partly measured on points the adaptive stage chose '
+            f'for being hard')
 
 
 @pytest.mark.integration
@@ -716,6 +763,8 @@ def test_the_single_stage_default_is_unchanged(
     """Every existing study depends on this: no settings, one stage, same design as before."""
     config = _config(base_user_inputs, resources_dir, temp_output_dir,
                      temp_generated_models_dir)
+    _generate_model(config, mpi_comm)
     trainer = EmulatorTrainer.init_from_dict(config, comm=mpi_comm)
-    assert trainer.sampling_stages == [{'method': 'sobol', 'num_samples': 24}]
+    assert trainer.sampling_stages == [
+        {'method': 'sobol', 'num_samples': 24, 'weight': 1.0}]
     assert trainer.design().shape[0] == 24

--- a/tests/test_emulator_training.py
+++ b/tests/test_emulator_training.py
@@ -656,3 +656,66 @@ def test_a_reused_fit_emulates_the_same_function_as_the_original(
         f'states by up to {max(refit_error):.3g}')
     assert max(disagreement) < 0.1, (
         f'the two fits of the same samples disagree by up to {max(disagreement):.3g}')
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_a_multi_stage_design_runs_and_records_both_stages(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
+    """A two-stage run end to end: the plan, the broadcast, and what it saves.
+
+    The adaptive stage is the one part of the design that cannot be derived from the seed
+    -- it is placed from features only rank 0 holds -- so it is the one part that can be
+    wrong in a way the unit tests cannot see: a design that never reaches the other ranks,
+    or a second block of samples that never joins the first. Both show up here as a
+    training set of the wrong size.
+
+    The saved plan matters as much as the samples. An emulator is reused and argued with
+    long after the run, and "2048 sobol points" and "1024 sobol points plus 1024 drawn at
+    the cliffs" are different provenance for the same count.
+    """
+    config = _config(base_user_inputs, resources_dir, temp_output_dir,
+                     temp_generated_models_dir,
+                     emulator_settings={'num_train_samples': 24, 'sample_type': 'sobol',
+                                        'num_stages': 2, 'frac_per_stage': [0.5, 0.5],
+                                        'method_per_stage': ['sobol', 'gradient_weighted'],
+                                        'random_seed': 0, 'min_r2': -1e9,
+                                        'n_iter': 2, 'n_splits': 2})
+    _generate_model(config, mpi_comm)
+
+    trainer = EmulatorTrainer.init_from_dict(config, comm=mpi_comm)
+    assert trainer.sampling_stages == [{'method': 'sobol', 'num_samples': 12},
+                                       {'method': 'gradient_weighted', 'num_samples': 12}]
+
+    bundle = trainer.train()
+    if mpi_comm.Get_rank() != 0:
+        return
+
+    assert bundle is not None, 'a two-stage design trained no emulator'
+    design_meta = bundle.meta['design']
+    assert design_meta['num_stages'] == 2
+    assert [stage['method'] for stage in design_meta['stages']] == ['sobol',
+                                                                    'gradient_weighted']
+    assert design_meta['num_train_samples'] == 24
+    # Both blocks are in the training set: a stage that never made it back would leave
+    # half of these behind, and the fit would still succeed on what remained.
+    assert len(bundle.x_train) == 24 - design_meta['num_failed']
+
+    mins = np.asarray(trainer.pid.param_id_info['param_mins'], dtype=float)
+    maxs = np.asarray(trainer.pid.param_id_info['param_maxs'], dtype=float)
+    assert np.all(bundle.x_train >= mins) and np.all(bundle.x_train <= maxs), (
+        'the adaptive stage placed points outside the training box')
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_the_single_stage_default_is_unchanged(
+        base_user_inputs, resources_dir, temp_output_dir, temp_generated_models_dir, mpi_comm):
+    """Every existing study depends on this: no settings, one stage, same design as before."""
+    config = _config(base_user_inputs, resources_dir, temp_output_dir,
+                     temp_generated_models_dir)
+    trainer = EmulatorTrainer.init_from_dict(config, comm=mpi_comm)
+    assert trainer.sampling_stages == [{'method': 'sobol', 'num_samples': 24}]
+    assert trainer.design().shape[0] == 24

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -561,8 +561,13 @@ def test_analysis_options_schema_well_formed():
                            'num_tune', 'pymc_method', 'chain_save_every'}
     assert ANALYSIS_OPTIONS['uq']['options_key'] == 'UQ_options'
     assert names('identifiability_analysis') == {'method', 'gradient_source', 'sub_method'}
+    # num_stages and the three per-stage lists describe a design drawn in several
+    # stages, so that a later one can place its points using the features the earlier
+    # ones returned. num_stages 1 is the single-stage design and the other three are
+    # then unused.
     assert names('emulation') == {
         'emulator_dir', 'models', 'num_train_samples', 'reuse_samples', 'sample_type',
+        'num_stages', 'frac_per_stage', 'method_per_stage', 'weight_per_stage',
         'log_scale_params', 'random_seed', 'test_fraction', 'n_splits', 'n_iter', 'min_r2',
         'out_of_bounds', 'fd_rel_step'}
     assert analysis_options('not_a_mode') == []


### PR DESCRIPTION
## Why

A Sobol design spreads points evenly over the parameter box, which is right when nothing is known about the response and wrong once something is. An even design spends as many simulations describing a region where the output barely moves as it does resolving the place where it jumps.

Neuron models make that expensive. Below rheobase a spike count is exactly zero, above it the cell fires, and everything an emulator gets wrong lives in the thin shell between the two. On the study this came from, **36 of 84 features sit on a floor, one of them for 98% of the design** — points on the flat side are nearly free to predict and nearly useless to have.

## What

The design becomes a list of stages:

```yaml
emulator_settings:
  num_train_samples: 8000
  num_stages: 3
  frac_per_stage: [0.6, 0.2, 0.2]
  method_per_stage: [sobol, gradient_weighted, error_weighted]
  weight_per_stage: 1.0
```

| setting | default | |
|---|---|---|
| `num_stages` | `1` | unchanged single-stage design |
| `frac_per_stage` | even split | share of `num_train_samples` per stage |
| `method_per_stage` | `sample_type`, then `gradient_weighted` | how each stage draws |
| `weight_per_stage` | `1.0` | how hard an adaptive stage follows its scores |

`num_stages: 1` is the design CA has always built, so **nothing changes for an existing study**. Both list settings accept a YAML list or a comma-separated string — the descriptors are scalar-typed, the same reason `models` is a string.

**`gradient_weighted`** asks where the model changes fastest: for neighbouring samples, `||Δy|| / ||Δx||`, with x on the unit cube and each feature scaled by its own range so a current near 1e-9 and a firing rate near 10 count equally. New points go *along the segment joining a high-gradient pair* — a cliff detected between two points is somewhere between those two points — plus a nudge off the line, since in more than two dimensions a line is a poor basis to fit from.

**`error_weighted`** asks a different question: where a surrogate of the samples so far is *wrong*. A response can be steep and easy to fit, or flat and hard. It cross-validates a cheap RBF over the existing samples, interpolates that error across the whole box with a second RBF, and draws candidates against the surface — so it can propose points nowhere near an existing sample, which a pairwise gradient cannot. Cross-validated rather than measured in place: a surrogate that interpolates its own training points reports zero error everywhere and would call any design finished.

**`weight_per_stage`** is one dial from ignoring the scores to following them closely — `0` uniform, `0.5` half uniform half by score, `1` by score, `>1` raised to that power. Mixed in probability space rather than drawn as two batches, so a stage is a single distribution with no seam.

## The held-out set is now drawn from space-filling stages only

An adaptive stage puts its points exactly where the model is hardest. Holding those out would measure the emulator on the worst corner of the box and report it as the error everywhere — and inconsistently, since how many landed in the test set is chance. It would also waste them: they were simulated to teach the emulator the difficult region, and a held-out point teaches it nothing. A single-stage design has an all-true mask and takes the original code path, so an existing study splits exactly as before.

## A caveat, asserted rather than assumed

Clustering points across a discontinuity helps an emulator that can represent one and **hurts** a smooth global fit. At equal budget on a step response:

| | even | staged |
|---|---|---|
| random forest | 0.0371 | **0.0309** |
| thin-plate spline | 0.1092 | **0.1916** |

An interpolator forced through tightly-spaced, steeply-disagreeing neighbours rings around the jump. So an adaptive stage is not free improvement — it has to be matched to the emulator in `models`, and pays off for a forest or the classifier half of a `two_phase_*` model. Both the setting description and a test say so; if that ever stops being true the test fails and the guidance needs rewriting.

## Other deliberate limits, all loud rather than silent

- An adaptive stage cannot be first, refused up front rather than at run time after the model has been generated.
- Fractions that do not sum to 1 are refused rather than normalised, which would spend a budget nobody asked to spend.
- A flat or degenerate earlier stage falls back to a space-filling top-up: a weight vector of zeros carries no information, and inventing one would concentrate the budget on whatever numerical dust was largest.
- A later stage in which every simulation failed is not fatal — the design so far stands. For the first stage it stays fatal.
- A later stage can only sharpen structure an earlier one found, which the settings description says.

## MPI

Only rank 0 holds the simulated features, so only rank 0 can place an adaptive stage; those points are broadcast and evaluated by every rank like any other. Space-filling stages still need no broadcast, and get a per-stage seed offset so two stages of the same method do not draw the same points twice.

## Tests

**93 passed.** 36 new unit tests in `tests/test_adaptive_design.py`, including equal-budget comparisons showing error weighting beating an even design on a smooth peaked response and gradient weighting beating it on a cliff, the weight dial monotone from uniform to concentrated, features weighed by their own range (a 1e-9 cliff not drowned by a 1e3 ramp), and the validation set containing no adaptive samples. Integration tests cover a real three-stage `sobol -> gradient -> error` run, the held-out points coming only from the sobol stage, and the single-stage default being unchanged.

Two existing tests monkeypatch `EmulatorTrainer.fit`; their stand-ins take the new keyword.

Companion CUFLynx PR renders the per-stage settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)