### PR TITLE
release: libcuflynx 0.5.0, cut from current master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ next release; add to that section as you land a change.
 
 ## Unreleased
 
+## 0.5.0 — 2026-08-24
+
+### Changed — the flat-import shims now go away in 0.6.0, not 0.5.0
+
+They were promised for removal in this release. They survive it instead. This release already
+asks users to migrate their obs_data files (below), and removing the `libcuflynx.` namespace
+shims at the same time would make one upgrade demand two unrelated migrations — one touching
+data, one touching imports. `REMOVAL_VERSION` now reads `0.6.0`, and every shim's warning, the
+README, CONTRIBUTING, CLAUDE.md and the tutorial say so.
+
+The tests that check those docs agree now read `REMOVAL_VERSION` rather than restating it: the
+literal `"0.5.0"` in three test files would have passed happily while every document said
+something else.
+
+
 ### Changed — the scaling benchmark now reports how much work it did (#344)
 
 The 3compartment core-scaling sweep reported CMA-ES speeding up **22.8x on 8 cores**, past the
@@ -109,7 +124,7 @@ Also fixed: the mean of `heart/u_la` in `resources/3compartment_obs_data.json` w
 `u_{AR}`, so it plotted as an aortic-root pressure. It is now `u_{LA}`.
 
 Reading `obs_info` from python: `names_for_plotting` remains as a deprecated alias of
-`item_names_for_plotting` and is removed in 0.5.0. Prefer `data_item_names`,
+`item_names_for_plotting` and is removed in 0.6.0. Prefer `data_item_names`,
 `trace_names_for_plotting` or `item_names_for_plotting`.
 
 ## 0.4.1 — 2026-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ next release; add to that section as you land a change.
 
 ## 0.5.0 — 2026-08-24
 
+### Added — check a posterior against the data it was fitted to (#478, #473)
+
+A chain says what the parameters could be. It does not say whether the model, at those
+parameters, reproduces what was measured — a calibration that fits badly can still produce a
+tidy posterior. `libcuflynx.param_id.posterior_predictive` draws from the chain, simulates each
+draw and scores the result: predictions in units of each measurement's own std, so observables on
+different scales share one axis, plus coverage against its nominal level. The draws are spread
+across MPI ranks, and both engines honour `use_emulator`, without which a check against the
+solver is only affordable on a chain that was.
+
+### Added — the plotting scripts ship with the engine (#479)
+
+`plot_utilities.py` and `plot_outputs.py` are written into every generated bundle, so a folder
+that reproduces a study can also draw it. Three panels nothing drew before: the pairwise
+posterior (`plot_corner`), the posterior predictive against the measurements, and coverage
+against its nominal level. All three read what `posterior_predictive` writes and return quietly
+when it is absent, so they are safe on a calibration-only run.
+
+### Added — emulator designs can be drawn in stages (#488)
+
+A Sobol design spreads points evenly over the parameter box, which is right when nothing is known
+about the response and wasteful once something is. `emulator_settings` now accepts staged
+designs: a first stage explores, and a later one aims at where the model is hard — by output
+gradient (`gradient_weighted`) or by the emulator's own held-out error (`error_weighted`), with a
+weight dial between "follow the signal" and "keep exploring". Validation stays on a Sobol-only
+subset, so the score is not measured on the points the design deliberately clustered.
+
+### Added — two-phase emulators for observables that sit on a floor (#486)
+
+autoemulate's emulators are regressors, and a regressor is the wrong shape for an observable
+pinned at one value over most of its range: a smooth fit splits the difference across the flat
+region and undershoots beyond it. A two-phase emulator classifies which side of the cliff a point
+is on, then regresses only on the side that varies. One rule now decides which non-scalar
+observables an emulator must refuse, rather than several places each deciding differently.
+
+### Added — draw the recorded trace behind the posterior draws (#485)
+
+A recorded trace carried in an obs_data purely to be plotted is now drawn behind the model's own
+draws, the trace panels say which line is which (simulation, data trace, data max, sim max), and
+the model's own value of each statistic travels in the plot metadata rather than only the
+scalars.
+
+### Fixed — sensitivity analysis on an obs_data holding a recorded trace (#487)
+
+`generate_outputs_mpi` looked up an operation func for every data_item, and a trace carried for
+plotting has none, so a Sobol run died on `KeyError: None` before the first sample finished. A
+series observable's weight is now checked before it is interpolated, not after, so a
+zero-weighted trace costs nothing and asks the model for nothing.
+
+### Changed — tested on 3.12, and 3.9 is dropped (#459, #480)
+
+The declared dependencies have required >= 3.10 since 0.4.0; the test matrix now says so.
+
 ### Changed — the flat-import shims now go away in 0.6.0, not 0.5.0
 
 They were promised for removal in this release. They survive it instead. This release already

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ literal `"0.5.0"` in three test files would have passed happily while every docu
 something else.
 
 
+### Added — a whole study in one call, shipped for readers outside this repo (#478)
+
+`libcuflynx.external_testing.full_pipeline_run.build_full_pipeline_run()` runs sensitivity, an
+emulator, a calibration, a chain and a posterior predictive check into one directory, small
+enough for a test. Every stage already had its own test; nothing tested the combination, which
+is what the readers downstream depend on — the generated `plot_outputs.py` and CUFLynx's
+outputs-directory loader both find files by CA's naming rule. Those readers were checked against
+fixtures written by hand, which agree with the reader by construction and cannot notice CA
+renaming a file.
+
+It ships in the package rather than living in `tests/` because the wheel carries no `tests/`:
+CUFLynx resolves CA through whatever `libcuflynx` is installed, so a builder it cannot import is
+a builder it cannot use. It sits in `external_testing` — shipped code whose only callers are
+tests outside this repository — and deliberately not in `checks`, which validates a *user's*
+model during generation. Nothing an ordinary run reaches imports it.
+
 ### Changed — the scaling benchmark now reports how much work it did (#344)
 
 The 3compartment core-scaling sweep reported CMA-ES speeding up **22.8x on 8 cores**, past the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Other useful scripts in `src/libcuflynx/scripts/`: `generate_obs_json.py`, `exam
 
 ## Calling from Python (programmatic API)
 
-The whole pipeline can be driven directly from Python instead of the shell scripts — this is how the interactive tutorials work (`tutorial/interactive/generation_and_calibration.ipynb`). **Import from the `libcuflynx` namespace and put nothing on `sys.path`**: an installed package (`pip install libcuflynx`, or `pip install -e .` on a checkout) is importable from any directory. The flat names (`import solver_wrappers`, `from param_id.paramID import ...`) still resolve in 0.4.0 as deprecation shims that warn, and are **removed in 0.5.0** — don't write new code or docs against them. Nothing here needs OpenCOR: the default solver is `CVODE_myokit`.
+The whole pipeline can be driven directly from Python instead of the shell scripts — this is how the interactive tutorials work (`tutorial/interactive/generation_and_calibration.ipynb`). **Import from the `libcuflynx` namespace and put nothing on `sys.path`**: an installed package (`pip install libcuflynx`, or `pip install -e .` on a checkout) is importable from any directory. The flat names (`import solver_wrappers`, `from param_id.paramID import ...`) still resolve in 0.4.0 as deprecation shims that warn, and are **removed in 0.6.0** — don't write new code or docs against them. Nothing here needs OpenCOR: the default solver is `CVODE_myokit`.
 
 Instead of editing `user_inputs.yaml`, build the config dict in code and mutate it:
 ```python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ The notes for a release must state:
 
 - [ ] **The deprecation shims and when they go.** The flat import names (`import parsers`,
       `from param_id.paramID import ...`) still work in 0.4.0 and emit a `DeprecationWarning`;
-      they are **removed in 0.5.0**. Migrate by prefixing the import with `libcuflynx.`.
+      they are **removed in 0.6.0**. Migrate by prefixing the import with `libcuflynx.`.
 - [ ] **The `funcs_user` migration** (issue #433). The built-in cost / operation / modifier
       functions now live in the package (`libcuflynx.funcs.*`). Anyone who added their own by
       editing `funcs_user/cost_funcs_user.py`, `operation_funcs_user.py` or

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Nothing is ever written inside the installed package.
 
 **Imports without the `libcuflynx.` prefix are deprecated.** `from param_id.paramID import
 CVS0DParamID` still works in 0.4.0 and emits a `DeprecationWarning`; the shims are **removed in
-0.5.0**. See `CHANGELOG.md` for the migration, including the one for anyone who edited
+0.6.0**. See `CHANGELOG.md` for the migration, including the one for anyone who edited
 `funcs_user/*_funcs_user.py` in place.
 
 # Tutorial

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ name = "libcuflynx"
 # the tree reported a version lower than the one already out.
 # 0.4.0 is the release that renames the distribution to libcuflynx and moves every module under
 # the `libcuflynx` namespace. The flat import names (`parsers`, `param_id`, ...) keep working
-# through this release as deprecation shims and are removed in 0.5.0 -- see
+# through this release as deprecation shims and are removed in 0.6.0 -- see
 # libcuflynx/_deprecated_aliases.py::REMOVAL_VERSION, which the shims' warning text quotes.
-version = "0.4.1"
+version = "0.5.0"
 description = "Generation and calibration of CellML circulatory system models from module/vessel arrays"
 readme = "README.md"
 # 3.9 is the real floor, not a conservative label: utilities/package_resources.py needs

--- a/src/checks/__init__.py
+++ b/src/checks/__init__.py
@@ -1,4 +1,4 @@
-"""Deprecated alias for :mod:`libcuflynx.checks`, removed in 0.5.0.
+"""Deprecated alias for :mod:`libcuflynx.checks`, removed in 0.6.0.
 
 Importing this name emits a single ``DeprecationWarning`` and then hands back the real
 ``libcuflynx.checks`` package -- the same module object, not a copy -- so that

--- a/src/emulators/__init__.py
+++ b/src/emulators/__init__.py
@@ -1,4 +1,4 @@
-"""Deprecated alias for :mod:`libcuflynx.emulators`, removed in 0.5.0.
+"""Deprecated alias for :mod:`libcuflynx.emulators`, removed in 0.6.0.
 
 Importing this name emits a single ``DeprecationWarning`` and then hands back the real
 ``libcuflynx.emulators`` package -- the same module object, not a copy -- so that

--- a/src/generators/__init__.py
+++ b/src/generators/__init__.py
@@ -1,4 +1,4 @@
-"""Deprecated alias for :mod:`libcuflynx.generators`, removed in 0.5.0.
+"""Deprecated alias for :mod:`libcuflynx.generators`, removed in 0.6.0.
 
 Importing this name emits a single ``DeprecationWarning`` and then hands back the real
 ``libcuflynx.generators`` package -- the same module object, not a copy -- so that

--- a/src/libcuflynx/_deprecated_aliases.py
+++ b/src/libcuflynx/_deprecated_aliases.py
@@ -4,7 +4,9 @@ Before the rename every module in this project sat at the top level of ``src/`` 
 reached with a ``sys.path.insert(0, 'src')`` followed by ``from param_id.paramID import
 CVS0DParamID``. 0.4.0 moved all of it under :mod:`libcuflynx`. The shim packages in
 ``src/<name>/`` keep the old spellings working for exactly one release; they are removed
-in 0.5.0 (see :data:`REMOVAL_VERSION`).
+in 0.6.0 (see :data:`REMOVAL_VERSION`). Deferred from 0.5.0: that release carries the
+#466 obs_data break, and stacking the namespace removal on top would have made one
+release ask users for two unrelated migrations.
 
 Object identity is the whole difficulty
 ---------------------------------------
@@ -64,7 +66,7 @@ from importlib.machinery import ModuleSpec
 #: Release that deletes these shims. 0.3.0 is already published, the rename ships in
 #: 0.4.0, so users get the whole of 0.4.x to migrate. Stated in the warning text; keep the
 #: release notes saying the same number.
-REMOVAL_VERSION = "0.5.0"
+REMOVAL_VERSION = "0.6.0"
 
 #: The package the flat names now live in.
 PACKAGE = "libcuflynx"

--- a/src/libcuflynx/parsers/PrimitiveParsers.py
+++ b/src/libcuflynx/parsers/PrimitiveParsers.py
@@ -3825,7 +3825,7 @@ class ObsAndParamDataParser(object):
             for II in range(N)]
         # Deprecated alias. `name_for_plotting` named two things; the one nearly every reader
         # wanted was the item's label, so that is what the old key now resolves to. Removed in
-        # 0.5.0 -- read item_names_for_plotting or trace_names_for_plotting instead.
+        # 0.6.0 -- read item_names_for_plotting or trace_names_for_plotting instead.
         obs_info["names_for_plotting"] = obs_info["item_names_for_plotting"]
 
         for II in range(N):

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,4 +1,4 @@
-"""Deprecated alias for :mod:`libcuflynx.models`, removed in 0.5.0.
+"""Deprecated alias for :mod:`libcuflynx.models`, removed in 0.6.0.
 
 Importing this name emits a single ``DeprecationWarning`` and then hands back the real
 ``libcuflynx.models`` package -- the same module object, not a copy -- so that

--- a/src/param_id/__init__.py
+++ b/src/param_id/__init__.py
@@ -1,4 +1,4 @@
-"""Deprecated alias for :mod:`libcuflynx.param_id`, removed in 0.5.0.
+"""Deprecated alias for :mod:`libcuflynx.param_id`, removed in 0.6.0.
 
 Importing this name emits a single ``DeprecationWarning`` and then hands back the real
 ``libcuflynx.param_id`` package -- the same module object, not a copy -- so that

--- a/src/parsers/__init__.py
+++ b/src/parsers/__init__.py
@@ -1,4 +1,4 @@
-"""Deprecated alias for :mod:`libcuflynx.parsers`, removed in 0.5.0.
+"""Deprecated alias for :mod:`libcuflynx.parsers`, removed in 0.6.0.
 
 Importing this name emits a single ``DeprecationWarning`` and then hands back the real
 ``libcuflynx.parsers`` package -- the same module object, not a copy -- so that

--- a/src/protocol_runners/__init__.py
+++ b/src/protocol_runners/__init__.py
@@ -1,4 +1,4 @@
-"""Deprecated alias for :mod:`libcuflynx.protocol_runners`, removed in 0.5.0.
+"""Deprecated alias for :mod:`libcuflynx.protocol_runners`, removed in 0.6.0.
 
 Importing this name emits a single ``DeprecationWarning`` and then hands back the real
 ``libcuflynx.protocol_runners`` package -- the same module object, not a copy -- so that

--- a/src/scripts/__init__.py
+++ b/src/scripts/__init__.py
@@ -1,4 +1,4 @@
-"""Deprecated alias for :mod:`libcuflynx.scripts`, removed in 0.5.0.
+"""Deprecated alias for :mod:`libcuflynx.scripts`, removed in 0.6.0.
 
 Importing this name emits a single ``DeprecationWarning`` and then hands back the real
 ``libcuflynx.scripts`` package -- the same module object, not a copy -- so that

--- a/src/sensitivity_analysis/__init__.py
+++ b/src/sensitivity_analysis/__init__.py
@@ -1,4 +1,4 @@
-"""Deprecated alias for :mod:`libcuflynx.sensitivity_analysis`, removed in 0.5.0.
+"""Deprecated alias for :mod:`libcuflynx.sensitivity_analysis`, removed in 0.6.0.
 
 Importing this name emits a single ``DeprecationWarning`` and then hands back the real
 ``libcuflynx.sensitivity_analysis`` package -- the same module object, not a copy -- so that

--- a/src/solver_wrappers/__init__.py
+++ b/src/solver_wrappers/__init__.py
@@ -1,4 +1,4 @@
-"""Deprecated alias for :mod:`libcuflynx.solver_wrappers`, removed in 0.5.0.
+"""Deprecated alias for :mod:`libcuflynx.solver_wrappers`, removed in 0.6.0.
 
 Importing this name emits a single ``DeprecationWarning`` and then hands back the real
 ``libcuflynx.solver_wrappers`` package -- the same module object, not a copy -- so that

--- a/src/utilities/__init__.py
+++ b/src/utilities/__init__.py
@@ -1,4 +1,4 @@
-"""Deprecated alias for :mod:`libcuflynx.utilities`, removed in 0.5.0.
+"""Deprecated alias for :mod:`libcuflynx.utilities`, removed in 0.6.0.
 
 Importing this name emits a single ``DeprecationWarning`` and then hands back the real
 ``libcuflynx.utilities`` package -- the same module object, not a copy -- so that

--- a/tests/test_deprecated_flat_imports.py
+++ b/tests/test_deprecated_flat_imports.py
@@ -71,7 +71,9 @@ def test_shim_warns_once_naming_the_new_path_and_the_removal_version(fresh_shim)
     assert REMOVAL_VERSION in messages[0]
     # 0.3.0 is already published, so it could never have been the removal version; the
     # rename ships in 0.4.0 and the shims go in the release after it.
-    assert REMOVAL_VERSION == "0.5.0"
+    # Deferred from 0.5.0, which carries the #466 obs_data break: stacking the namespace
+    # removal on top would make one release ask for two unrelated migrations.
+    assert REMOVAL_VERSION == "0.6.0"
 
 
 @pytest.mark.unit
@@ -259,7 +261,7 @@ def test_a_shim_import_does_not_hijack_someone_elses_top_level_module(tmp_path):
 def test_the_package_never_imports_its_own_deprecated_names():
     """A shim reached from inside libcuflynx would warn users about their own dependency.
 
-    It would also mean the package depends on the shims surviving past 0.5.0.
+    It would also mean the package depends on the shims surviving past their removal.
     """
     offenders = []
     for path in sorted((_SRC / PACKAGE).rglob("*.py")):

--- a/tests/test_docs_consistency.py
+++ b/tests/test_docs_consistency.py
@@ -5,7 +5,8 @@ Two things in the docs rot silently, because nothing imports them and nothing ru
 1. **Import instructions.** Before the package existed, every documented snippet appended
    ``src/`` to the interpreter's import path and imported flat module names (``import
    parsers``). Both stopped being true when the code moved under ``libcuflynx/``: the flat
-   names survive only as deprecation shims that warn now and are gone in 0.5.0, and there is
+   names survive only as deprecation shims that warn now and are gone in a later release,
+   and there is
    nothing to add to the import path at all. A doc that still teaches the old way sends every
    new reader down it.
 
@@ -98,7 +99,7 @@ def test_no_import_path_manipulation_in_tutorial_or_readme():
 
 @pytest.mark.unit
 def test_documented_imports_use_the_libcuflynx_namespace():
-    """No documented snippet may import a flat name (they warn now, and vanish in 0.5.0)."""
+    """No documented snippet may import a flat name (they warn now, and vanish later)."""
     offenders = []
     for path in _doc_files():
         text = path.read_text(encoding="utf-8", errors="replace")
@@ -108,7 +109,7 @@ def test_documented_imports_use_the_libcuflynx_namespace():
             offenders.append("%s:%d: %s" % (_rel(path), lineno, line))
     assert not offenders, (
         "documented imports must be prefixed with `libcuflynx.` -- the flat names are "
-        "deprecation shims removed in 0.5.0:\n" + "\n".join(offenders)
+        "deprecation shims scheduled for removal:\n" + "\n".join(offenders)
     )
 
 
@@ -174,8 +175,15 @@ def test_readme_names_both_the_repository_and_the_package():
 
 @pytest.mark.unit
 def test_deprecation_removal_version_is_stated_consistently():
-    """0.5.0 is the removal version; the docs a migrator reads must all say so."""
-    removal = "0.5.0"
+    """The docs a migrator reads must all name the release that removes the shims.
+
+    Read from ``REMOVAL_VERSION`` rather than restated: the version was deferred once
+    (0.5.0 -> 0.6.0) and a literal here would have passed while every doc said the
+    other thing.
+    """
+    from libcuflynx._deprecated_aliases import REMOVAL_VERSION
+
+    removal = REMOVAL_VERSION
     for path in (README, CLAUDE_MD, REPO_ROOT / "CHANGELOG.md",
                  TUTORIAL / "docs" / "api" / "index.md"):
         text = path.read_text(encoding="utf-8")

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -198,8 +198,10 @@ def test_release_procedure_is_documented():
     """Somewhere findable, and naming the parts that cannot be undone."""
     text = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
     assert "Making a release" in text
+    from libcuflynx._deprecated_aliases import REMOVAL_VERSION
+
     for needle in ("release.yml", PYPI_ENVIRONMENT, "trusted publishing", "pyproject.toml",
-                   "0.5.0", "funcs_user"):
+                   REMOVAL_VERSION, "funcs_user"):
         assert needle in text, "CONTRIBUTING.md should mention %r in the release section" % needle
     assert re.search(r"never be (replaced|re-uploaded)", text), (
         "the docs must say a published PyPI version cannot be re-uploaded"

--- a/tutorial/docs/api/index.md
+++ b/tutorial/docs/api/index.md
@@ -22,10 +22,10 @@ pip install libcuflynx
 from libcuflynx.utilities.utility_funcs import get_default_inp_data_dict
 ```
 
-!!! note "The old flat imports still work in 0.4.0, and are removed in 0.5.0"
+!!! note "The old flat imports still work in 0.4.0, and are removed in 0.6.0"
     `from param_id.paramID import CVS0DParamID` (no `libcuflynx.` prefix) still resolves
     in 0.4.0 but emits a `DeprecationWarning`. Prefix your imports now; the shims go away
-    in 0.5.0. See `CHANGELOG.md`.
+    in 0.6.0. See `CHANGELOG.md`.
 
 ## Public API at a glance
 

--- a/tutorial/docs/getting-started.md
+++ b/tutorial/docs/getting-started.md
@@ -32,7 +32,7 @@ pip install "libcuflynx[emulation]"  # surrogate models (pulls in torch; big)
 
 !!! note "The flat imports are deprecated"
     `from param_id.paramID import CVS0DParamID` still works in 0.4.0 with a
-    `DeprecationWarning`, and is **removed in 0.5.0**. Use
+    `DeprecationWarning`, and is **removed in 0.6.0**. Use
     `from libcuflynx.param_id.paramID import CVS0DParamID`.
 
 ### Where an installed libcuflynx reads and writes: `CUFLYNX_USER_DIR`


### PR DESCRIPTION
Cuts 0.5.0 from **current `master`**, rather than reviving the branch behind #482.

## Why a new branch

#482 was based on `integration/next`, and it merged ~40 seconds *after* #481 had already taken that branch to `master`. So the release commits landed on `integration/next` and never reached `master`: `master` has read `version = "0.4.1"` ever since, and has since taken #485, #486, #487 and #488. Tagging `v0.5.0` from `master` would have published 0.4.1's metadata.

The two commits worth keeping from that branch are cherry-picked here — the version bump with the shim-promise move, and the `external_testing` changelog entry. What is not kept is the old changelog's *scope*: it was written before four PRs landed.

## What is in it

| | |
|---|---|
| `release: 0.5.0` | `pyproject.toml` → `0.5.0`, and the flat-import shims move from "removed in 0.5.0" to 0.6.0 — `REMOVAL_VERSION`, eleven shim docstrings, README, CONTRIBUTING, CLAUDE.md, tutorial. Cherry-picked; one auto-merge, in `PrimitiveParsers.py`. |
| `changelog: the full-run builder…` | Cherry-picked. `libcuflynx.external_testing.full_pipeline_run` is what CUFLynx pins by string through `ca_from()`, so it has to be stated in the notes. |
| `changelog: what landed after the release branch was first cut` | New. Entries for #478/#473, #479, #488, #486, #485, #487 and #480/#459 — **none of which added one as it landed**. |

**0.5.0, not 0.4.2**, for the reason the original bump gave: #466 separates an obs_data item's name from its labels, which is a breaking change for users' data files. `cuflynx-migrate-obs-data` converts them, and the notes say so.

## Why the shims survive this release

They were promised for removal *in* 0.5.0, in six places. Removing them here makes one upgrade demand two unrelated migrations — one touching users' data (#466), one touching their imports. The promise moves to 0.6.0 and every place that stated it is updated, rather than being quietly broken. The three tests that pinned the literal `"0.5.0"` now read `REMOVAL_VERSION`, so a document and a test can no longer disagree.

## Verified

`test_docs_consistency`, `test_release_workflow`, `test_deprecated_flat_imports` — 51 passed. These are the ones that check the tag against `pyproject.toml`, and that no document still promises removal in this release. The unit tier is running; I will report it here.

## After merging

Tag `v0.5.0` **on the merge commit** — that is what `release.yml` fires on, and it re-checks the tag against `pyproject.toml` before publishing to PyPI by trusted publishing. Nothing is tagged yet.

The stranded `release/0.5.0` branch and its merge on `integration/next` can be left alone or deleted; nothing needs them now.
