### PR TITLE
release: libcuflynx 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ next release; add to that section as you land a change.
 
 ## Unreleased
 
+## 0.5.1 — 2026-08-25
+
+### Changed — the MCMC ensemble is evaluated in one emulator call (#490)
+
+An ensemble sampler asks for its whole walker population at every step, and a fitted surrogate
+costs almost the same at sixty-four points as at one: per-call overhead dominates. Measured on a
+two-phase RBF emulator with 84 outputs, one parameter vector took 84.8 ms and sixty-four took
+355 ms — 5.6 ms each. The emulator-backed sampler now asks once per step instead of once per
+walker.
+
+### Changed — `OpencorParamID` is now `ParamID`, and `OpencorMCMC` is `MCMC` (#491)
+
+They are the parameter-identification and MCMC engines, and they run against myokit/CVODE,
+casadi and trained emulators as readily as against OpenCOR — the name came from the only backend
+that existed when they were written. **The old names still work**: `OpencorParamID` and
+`OpencorMCMC` remain as aliases, so nothing importing them has to change.
+
+
 ## 0.5.0 — 2026-08-24
 
 ### Added — check a posterior against the data it was fitted to (#478, #473)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "libcuflynx"
 # the `libcuflynx` namespace. The flat import names (`parsers`, `param_id`, ...) keep working
 # through this release as deprecation shims and are removed in 0.6.0 -- see
 # libcuflynx/_deprecated_aliases.py::REMOVAL_VERSION, which the shims' warning text quotes.
-version = "0.5.0"
+version = "0.5.1"
 description = "Generation and calibration of CellML circulatory system models from module/vessel arrays"
 readme = "README.md"
 # 3.9 is the real floor, not a conservative label: utilities/package_resources.py needs


### PR DESCRIPTION
Version bump and changelog only — no behaviour changes. Tagging `v0.5.1` after this merges triggers `release.yml`, which checks the tag against `pyproject.toml` and publishes to PyPI by trusted publishing.

## What is in 0.5.1

Two PRs landed after v0.5.0, neither with a changelog entry:

- **#490 — the MCMC ensemble is evaluated in one emulator call.** An ensemble sampler asks for its whole walker population at every step, and a surrogate costs almost the same at sixty-four points as at one. Measured on a two-phase RBF emulator with 84 outputs: 84.8 ms for one vector, 355 ms for sixty-four — 5.6 ms each.
- **#491 — `OpencorParamID` is now `ParamID`, `OpencorMCMC` is `MCMC`.** They run against myokit/CVODE, casadi and emulators as readily as against OpenCOR; the name came from the only backend that existed when they were written.

## Why 0.5.1 and not 0.6.0

The rename keeps `OpencorParamID` and `OpencorMCMC` as aliases, so nothing importing them has to change — CUFLynx #312 relies on exactly that while it supports both spellings. Nothing else here is breaking, and the flat-import shims still go away in 0.6.0, unchanged by this release.

## Verified

`test_docs_consistency`, `test_release_workflow`, `test_deprecated_flat_imports` — 51 passed. Those are the ones that check the tag against `pyproject.toml` and that no document disagrees about when the shims go.

Cut from current `master` (`6a8d04f`), so this cannot repeat what happened to 0.5.0, where the release commits landed on `integration/next` and never reached `master`.