### PR TITLE
Move fill_protocol_info to obs_data_helpers, where its vocabulary lives

### DIFF
--- a/src/libcuflynx/parsers/MyokitParsers.py
+++ b/src/libcuflynx/parsers/MyokitParsers.py
@@ -28,6 +28,10 @@ The two formats say the same thing in different shapes:
              fields under those same names, which CA expands into the point
              table its solvers want.
 
+Putting the result *into* an obs_data document is
+:func:`libcuflynx.utilities.obs_data_helpers.fill_protocol_info`, which is
+where obs_data's own vocabulary lives.
+
 So the events copy across unchanged -- see
 :mod:`libcuflynx.utilities.protocol_shapes`, whose field vocabulary is Myokit's
 on purpose and which this module validates against rather than restating. The
@@ -378,33 +382,3 @@ def protocol_info_from_events(
         },
         notes,
     )
-
-
-def fill_protocol_info(
-    obs_data: dict[str, Any] | list | None, protocol_info: dict[str, Any]
-) -> dict[str, Any]:
-    """Put ``protocol_info`` into an obs_data document, returning a new dict.
-
-    An existing document's labels and colours are kept when they still fit the
-    new schedule: those are the parts a user writes for themselves ("1 Hz
-    pacing" reads better than "pacing, period 1000"), and re-deriving the timings
-    is no reason to throw them away.
-
-    A bare array of data_items -- CA's other accepted shape, and what the
-    3compartment / heat_fenics studies ship -- becomes the object form carrying
-    those same items, which is the only shape that can hold a protocol_info at
-    all. ``dict(obs_data or {})`` used to raise on one, so a data-only file died
-    rather than being updated.
-    """
-    if isinstance(obs_data, list):
-        obs_data = {"data_items": obs_data}
-    out = dict(obs_data or {})
-    existing = out.get("protocol_info") or {}
-    merged = dict(protocol_info)
-    n = len(protocol_info.get("sim_times", []))
-    for key in ("experiment_labels", "experiment_colors"):
-        kept = existing.get(key)
-        if isinstance(kept, list) and len(kept) == n:
-            merged[key] = kept
-    out["protocol_info"] = merged
-    return out

--- a/src/libcuflynx/utilities/obs_data_helpers.py
+++ b/src/libcuflynx/utilities/obs_data_helpers.py
@@ -8,6 +8,7 @@ import json
 import os, sys
 import re
 import warnings
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # obs_data.json schema vocabularies
@@ -381,3 +382,42 @@ class ObsDataCreator:
         self.obs_data_dict = data
         print(f"Observation data loaded from {input_path}")
         return data
+
+
+def fill_protocol_info(
+    obs_data: dict[str, Any] | list | None, protocol_info: dict[str, Any]
+) -> dict[str, Any]:
+    """Put ``protocol_info`` into an obs_data document, returning a new dict.
+
+    An existing document's labels and colours are kept when they still fit the
+    new schedule: those are the parts a user writes for themselves ("1 Hz
+    pacing" reads better than "pacing, period 1000"), and re-deriving the timings
+    is no reason to throw them away.
+
+    A bare array of data_items -- the other accepted shape, and what the
+    3compartment / heat_fenics studies ship -- becomes the object form carrying
+    those same items, which is the only shape that can hold a protocol_info at
+    all. ``dict(obs_data or {})`` used to raise on one, so a data-only file died
+    rather than being updated.
+
+    Here rather than beside the ``.mmt`` reader that first needed it: every key
+    it writes -- ``protocol_info``, ``data_items``, ``experiment_labels``,
+    ``experiment_colors`` -- is this module's vocabulary, and this is the module
+    that migrates those names when they change (see
+    :func:`migrate_legacy_obs_item_keys`). A copy of this living beside one
+    *producer* of a protocol_info would be a second place to update and a
+    second thing to forget; the EasyML reader produces one too, and so could
+    anything else.
+    """
+    if isinstance(obs_data, list):
+        obs_data = {"data_items": obs_data}
+    out = dict(obs_data or {})
+    existing = out.get("protocol_info") or {}
+    merged = dict(protocol_info)
+    n = len(protocol_info.get("sim_times", []))
+    for key in ("experiment_labels", "experiment_colors"):
+        kept = existing.get(key)
+        if isinstance(kept, list) and len(kept) == n:
+            merged[key] = kept
+    out["protocol_info"] = merged
+    return out

--- a/tests/test_myokit_parser.py
+++ b/tests/test_myokit_parser.py
@@ -19,7 +19,6 @@ from libcuflynx.parsers.MyokitParsers import (
     MyokitImportError,
     cellml_from_model,
     cellml_from_myokit,
-    fill_protocol_info,
     is_myokit_filename,
     looks_like_myokit,
     pace_variable,
@@ -227,36 +226,3 @@ def test_events_can_come_from_somewhere_other_than_a_protocol_object():
 def test_no_events_at_all_is_refused():
     with pytest.raises(MmtProtocolError, match="no protocol events"):
         protocol_info_from_events([], name="a/b", duration=1.0)
-
-
-# ---------------------------------------------------------------------------
-# Putting it into an obs_data document
-# ---------------------------------------------------------------------------
-def test_a_bare_list_of_data_items_becomes_the_object_form():
-    """CA's other accepted obs_data shape, and what several studies ship."""
-    info, _ = protocol_info_from_mmt(MMT, filename="tiny.mmt")
-    out = fill_protocol_info([{"data_item_name": "x"}], info)
-    assert out["data_items"] == [{"data_item_name": "x"}]
-    assert out["protocol_info"] == info
-
-
-def test_hand_written_labels_survive_a_reconversion():
-    info, _ = protocol_info_from_mmt(MMT, filename="tiny.mmt")
-    existing = {"protocol_info": {"experiment_labels": ["1 Hz pacing"],
-                                  "experiment_colors": ["b"]}}
-    out = fill_protocol_info(existing, info)
-    assert out["protocol_info"]["experiment_labels"] == ["1 Hz pacing"]
-    assert out["protocol_info"]["experiment_colors"] == ["b"]
-    assert out["protocol_info"]["sim_times"] == info["sim_times"]
-
-
-def test_labels_that_no_longer_fit_the_schedule_are_replaced():
-    info, _ = protocol_info_from_mmt(MMT, filename="tiny.mmt")
-    existing = {"protocol_info": {"experiment_labels": ["a", "b"]}}
-    out = fill_protocol_info(existing, info)
-    assert out["protocol_info"]["experiment_labels"] == info["experiment_labels"]
-
-
-def test_the_result_is_json_serialisable():
-    info, _ = protocol_info_from_mmt(MMT, filename="tiny.mmt")
-    assert json.loads(json.dumps(fill_protocol_info(None, info)))

--- a/tests/test_obs_data_protocol_info.py
+++ b/tests/test_obs_data_protocol_info.py
@@ -1,0 +1,54 @@
+"""Putting a protocol_info into an obs_data document.
+
+``fill_protocol_info`` lives in ``utilities.obs_data_helpers`` rather than beside
+the ``.mmt`` reader that first needed it, because every key it writes is that
+module's vocabulary -- and that module is where those names get migrated when
+they change. These tests go with it.
+"""
+
+import json
+
+import pytest
+
+from libcuflynx.parsers.MyokitParsers import protocol_info_from_events
+from libcuflynx.utilities.obs_data_helpers import fill_protocol_info
+
+
+def _protocol_info():
+    info, _notes = protocol_info_from_events(
+        [{"level": 1.0, "start": 100.0, "length": 2.0,
+          "period": 1000.0, "multiplier": 0}],
+        name="engine/pace",
+        duration=2000.0,
+    )
+    return info
+
+
+def test_a_bare_list_of_data_items_becomes_the_object_form():
+    """CA's other accepted obs_data shape, and what several studies ship."""
+    info = _protocol_info()
+    out = fill_protocol_info([{"data_item_name": "x"}], info)
+    assert out["data_items"] == [{"data_item_name": "x"}]
+    assert out["protocol_info"] == info
+
+
+def test_hand_written_labels_survive_a_reconversion():
+    info = _protocol_info()
+    existing = {"protocol_info": {"experiment_labels": ["1 Hz pacing"],
+                                  "experiment_colors": ["b"]}}
+    out = fill_protocol_info(existing, info)
+    assert out["protocol_info"]["experiment_labels"] == ["1 Hz pacing"]
+    assert out["protocol_info"]["experiment_colors"] == ["b"]
+    assert out["protocol_info"]["sim_times"] == info["sim_times"]
+
+
+def test_labels_that_no_longer_fit_the_schedule_are_replaced():
+    info = _protocol_info()
+    existing = {"protocol_info": {"experiment_labels": ["a", "b"]}}
+    out = fill_protocol_info(existing, info)
+    assert out["protocol_info"]["experiment_labels"] == info["experiment_labels"]
+
+
+def test_the_result_is_json_serialisable():
+    info = _protocol_info()
+    assert json.loads(json.dumps(fill_protocol_info(None, info)))

--- a/tutorial/docs/model-formats.md
+++ b/tutorial/docs/model-formats.md
@@ -15,9 +15,11 @@ these formats exist.
 
 ```python
 from libcuflynx.parsers.MyokitParsers import cellml_from_myokit, protocol_info_from_mmt
+from libcuflynx.utilities.obs_data_helpers import fill_protocol_info
 
 cellml, saved = cellml_from_myokit(data, filename="lr-1991.mmt", out_dir=outputs)
 info, notes = protocol_info_from_mmt(data, filename="lr-1991.mmt")
+obs_data = fill_protocol_info(obs_data, info)   # obs_data's own vocabulary
 ```
 
 The two halves of a `.mmt` are read separately and deliberately. The `[[model]]`


### PR DESCRIPTION
Follow-up to #495, correcting a placement I got wrong twice.

## Where it was, and why both places were wrong

`fill_protocol_info` puts a `protocol_info` into an obs_data document. It landed in `parsers/MyokitParsers.py` because the `.mmt` reader was the first thing that needed one. Then, when CUFLynx's unit tier failed on it, I moved it out of this package entirely and gave CUFLynx a local copy.

That second move was a fix for the wrong cause. The tier was pinned at a CA commit *predating* the reader, so nothing engine-side could answer at all — the pin has since been bumped past #495. Nothing about the function itself required it to leave.

## Why it belongs here

Every key it writes — `protocol_info`, `data_items`, `experiment_labels`, `experiment_colors` — is `obs_data_helpers`' vocabulary. That module declares itself the "single source of truth for the value sets used by obs_data data_items", and it is where those names get migrated when they change: `migrate_legacy_obs_item_keys` is the #466 rename. A copy of this function in a downstream repo keeps writing the old spelling with nothing to catch it.

It is also not Myokit-specific. The EasyML reader produces a `protocol_info` too, and so could anything else — living beside one *producer* of them was the original mistake.

## Changes

- `fill_protocol_info` moves `parsers/MyokitParsers.py` → `utilities/obs_data_helpers.py`.
- Its tests move to `tests/test_obs_data_protocol_info.py`, and are rewritten to build their `protocol_info` through `protocol_info_from_events` rather than by parsing a `.mmt` — the function has nothing to do with Myokit.
- `MyokitParsers`' docstring points at the new home; the tutorial page shows it in the worked example.

159 passed across the obs_data and parser suites.

## Paired with

A CUFLynx PR that drops its local copy and delegates here. Merge this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)