### PR TITLE
Let the emulator choose how it is pickled, and fall back rather than lose a run (#468)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,16 @@ uq = [
 # only when do_emulation/use_emulator is set, and says so by name when it is missing.
 emulation = [
     "autoemulate>=2.1,<3",
+    # Fallback containers for saving a fitted emulator. Some models hold an
+    # uninitialised C-extension descriptor that pickle cannot take apart, and
+    # joblib.dump then fails after every training simulation has been paid for
+    # (issue #468). Neither is a superset of joblib -- dill fails on torch-backed
+    # emulators joblib saves fine -- which is why they are fallbacks in order
+    # rather than a replacement. Declared rather than relied on: both arrive
+    # transitively today and that is not a promise.
+    # See emulator_settings.model_serialiser.
+    "cloudpickle>=2.0",
+    "dill>=0.3.6",
 ]
 # `model_type: cpp` (and the 0D-1D coupling built on it) generates C++ source for the user to
 # compile. What it needs is a toolchain -- a C++ compiler, CMake, and for the 1D arm PETSc --

--- a/src/libcuflynx/emulators/emulator_bundle.py
+++ b/src/libcuflynx/emulators/emulator_bundle.py
@@ -16,11 +16,35 @@ metadata -- an emulator reloaded without them would predict in the wrong units.
 import hashlib
 import json
 import os
+import pickle
 
 import numpy as np
 
 METADATA_FILE = 'emulator_metadata.json'
 MODEL_FILE = 'emulator'          # autoemulate's saver appends .joblib
+#: How the fitted model is pickled. The file is called ``emulator.joblib``
+#: whichever is used -- that is the artefact's name, not a claim about the
+#: container -- and the bundle records which one wrote it so it can be read back.
+SERIALISERS = ('auto', 'joblib', 'cloudpickle', 'dill')
+DEFAULT_SERIALISER = 'auto'
+#: What ``auto`` tries, in order. joblib first because it is what autoemulate
+#: itself writes and reads. cloudpickle before dill on measurement, not
+#: reputation: on autoemulate 2.1.2 dill *fails* where joblib succeeds --
+#: torch-backed emulators hold a ``PyCapsule`` it recurses on -- so the fix
+#: proposed in #468 would have traded one broken case for a commoner one.
+#: cloudpickle handled every emulator tried, and the unnameable objects joblib
+#: refuses. dill stays last because it is what the issue reports working.
+_AUTO_ORDER = ('joblib', 'cloudpickle', 'dill')
+#: What a serialiser raises when it meets an object it cannot take apart, as
+#: opposed to a disk that is full or a path that does not exist. Only these are
+#: worth retrying with a different serialiser.
+#:
+#: Both families are needed and neither implies the other: #468 reports a
+#: ``TypeError`` ("cannot pickle '_abc._abc_data' object"), raised from the C
+#: pickler, while a plain unnameable object -- a closure, a class defined in a
+#: function -- raises ``PicklingError`` from the Python one.
+_PICKLING_FAILURES = (TypeError, AttributeError, NotImplementedError, ValueError,
+                      pickle.PickleError)
 TRAINING_DATA_FILE = 'training_data.npz'
 #: The held-out points, the simulator's answer at each and the emulator's. The
 #: per-feature statistics in the metadata say how wrong the emulator is on
@@ -324,7 +348,15 @@ class EmulatorBundle:
     def save(self, directory):
         """Write model, metadata and training data to ``directory``. Returns the directory."""
         os.makedirs(directory, exist_ok=True)
-        _save_model(self.model, os.path.join(directory, MODEL_FILE))
+        # Recorded in the metadata rather than inferred on the way back in: the
+        # two containers are not distinguishable from the bytes, and guessing
+        # wrong produces an unpickling error about the *model* rather than about
+        # the file. Same reason min_r2 and fd_rel_step travel with the bundle --
+        # by load time the caller may be a calibration run that never saw the
+        # emulator settings.
+        self.meta['model_serialiser'] = _save_model(
+            self.model, os.path.join(directory, MODEL_FILE),
+            serialiser=(self.meta.get('settings') or {}).get('model_serialiser'))
         with open(os.path.join(directory, METADATA_FILE), 'w') as file:
             json.dump(self.meta, file, indent=2, default=str)
         if self.x_train is not None and self.y_train is not None:
@@ -358,7 +390,8 @@ class EmulatorBundle:
                 f'first with do_emulation: true (./run_emulator_training.sh N).')
         with open(meta_path) as file:
             meta = json.load(file)
-        model = _load_model(os.path.join(directory, MODEL_FILE))
+        model = _load_model(os.path.join(directory, MODEL_FILE),
+                            serialiser=meta.get('model_serialiser'))
         x_train = y_train = None
         data_path = os.path.join(directory, TRAINING_DATA_FILE)
         if os.path.isfile(data_path):
@@ -407,26 +440,136 @@ def _load_validation(directory):
         return {}
 
 
-def _save_model(model, path_without_suffix):
-    """joblib, the same container autoemulate's own serialiser uses."""
-    import joblib
-    joblib.dump(model, f'{path_without_suffix}.joblib')
+def _serialiser(name):
+    """The named module, or a refusal that says how to get it."""
+    import importlib
+
+    try:
+        return importlib.import_module(name)
+    except ImportError as error:
+        raise RuntimeError(
+            f'the emulator is set to be saved with {name}, which is not installed. '
+            f'Install it with `pip install {name}` (it comes with '
+            f'`pip install "libcuflynx[emulation]"`), or set '
+            f'emulator_settings.model_serialiser to one of '
+            f'{", ".join(SERIALISERS)}.') from error
 
 
-def _load_model(path_without_suffix):
-    import joblib
+def _dump(module, model, path):
+    """joblib takes a path; the pickle-alikes take a file object."""
+    if module.__name__ == 'joblib':
+        module.dump(model, path)
+    else:
+        with open(path, 'wb') as file:
+            module.dump(model, file)
+
+
+def _undump(module, path):
+    if module.__name__ == 'joblib':
+        return module.load(path)
+    with open(path, 'rb') as file:
+        return module.load(file)
+
+
+def _save_model(model, path_without_suffix, serialiser=None):
+    """Pickle the fitted model. Returns the serialiser that actually wrote it.
+
+    joblib is the default because it is the container autoemulate's own saver
+    uses. Some fitted emulators cannot go through it: an object holding an
+    uninitialised C-extension descriptor -- ``_abc._abc_data`` is the one seen in
+    the wild -- makes ``joblib.dump`` raise ``cannot pickle '_abc._abc_data'
+    object``, and the training run dies after paying for every simulation
+    (issue #468).
+
+    ``auto`` therefore works down :data:`_AUTO_ORDER` until one succeeds, so that
+    failure costs a warning rather than the run. Falling *back* rather than
+    switching outright matters: on autoemulate 2.1.2 a torch-backed emulator
+    pickles with joblib and fails under dill, so a blanket switch would break the
+    common case to fix the rare one.
+    """
+    name = serialiser or DEFAULT_SERIALISER
+    if name not in SERIALISERS:
+        raise ValueError(
+            f'emulator_settings.model_serialiser is {name!r}; '
+            f'expected one of {", ".join(SERIALISERS)}.')
+    path = f'{path_without_suffix}.joblib'
+
+    if name != 'auto':
+        _dump(_serialiser(name), model, path)
+        return name
+
+    first_error = None
+    for candidate in _AUTO_ORDER:
+        try:
+            module = _serialiser(candidate)
+        except RuntimeError as error:      # not installed; try the next one
+            first_error = first_error or error
+            continue
+        try:
+            _dump(module, model, path)
+        except _PICKLING_FAILURES as error:
+            first_error = first_error or error
+            # A half-written file would be loaded in preference to nothing at all.
+            if os.path.isfile(path):
+                os.remove(path)
+            continue
+        if candidate != _AUTO_ORDER[0]:
+            # Silently changing container would be worse than failing: the file
+            # now needs that library wherever it is read.
+            print(f'[emulator] {_AUTO_ORDER[0]} could not pickle this model '
+                  f'({first_error}); saved with {candidate} instead. Set '
+                  f'emulator_settings.model_serialiser to choose explicitly.')
+        return candidate
+
+    raise RuntimeError(
+        f'could not save the emulator: none of {", ".join(_AUTO_ORDER)} could '
+        f'pickle it. The first failure was: {first_error}. Every training '
+        f'simulation has already run -- if any of those libraries is missing, '
+        f'install it and set emulator_settings.model_serialiser to it, and the '
+        f'design can be reused with reuse_samples: true.')
+
+
+def _load_model(path_without_suffix, serialiser=None):
+    """Read the model back, preferring the serialiser that wrote it.
+
+    The others are still tried, because a bundle written before the choice
+    existed records nothing, and because the containers cannot be told apart
+    from their bytes.
+    """
     path = f'{path_without_suffix}.joblib'
     if not os.path.isfile(path):
         raise FileNotFoundError(f'emulator model file {path} is missing')
-    try:
-        return joblib.load(path)
-    except ModuleNotFoundError as error:
-        # The common case is a bundle fitted with autoemulate being loaded in an environment
-        # that does not have it -- say so, rather than reporting a bare missing module.
-        raise RuntimeError(
-            f'could not load the emulator at {path}: {error}. If it was fitted with '
-            f'autoemulate, install it with `pip install "libcuflynx[emulation]"` '
-            f'(needs Python >=3.10,<3.13).') from error
+
+    order = list(_AUTO_ORDER)
+    if serialiser in order:
+        order.remove(serialiser)
+        order.insert(0, serialiser)
+
+    first_error = None
+    for name in order:
+        try:
+            module = _serialiser(name)
+        except RuntimeError as error:
+            first_error = first_error or error
+            continue
+        try:
+            return _undump(module, path)
+        except ModuleNotFoundError as error:
+            # The common case is a bundle fitted with autoemulate being loaded in an
+            # environment that does not have it -- say so, rather than reporting a bare
+            # missing module. Not worth trying another container: the module the pickle
+            # names is absent whichever reads it.
+            raise RuntimeError(
+                f'could not load the emulator at {path}: {error}. If it was fitted with '
+                f'autoemulate, install it with `pip install "libcuflynx[emulation]"` '
+                f'(needs Python >=3.10,<3.13).') from error
+        except Exception as error:  # noqa: BLE001 - try the other containers first
+            first_error = first_error or error
+
+    raise RuntimeError(
+        f'could not load the emulator at {path}: {first_error}. It was saved with '
+        f'{serialiser or "an unrecorded serialiser"}, and none of '
+        f'{", ".join(_AUTO_ORDER)} could read it back.')
 
 
 def _as_backend_input(model, x_scaled):

--- a/src/libcuflynx/emulators/emulator_bundle.py
+++ b/src/libcuflynx/emulators/emulator_bundle.py
@@ -13,10 +13,14 @@ where that spread destroys a kernel fit. Parameters are mapped to the unit box a
 standardised here, before anything reaches the emulator, and the transforms are stored in the
 metadata -- an emulator reloaded without them would predict in the wrong units.
 """
+import contextlib
+import copyreg
 import hashlib
+import importlib
 import json
 import os
 import pickle
+import sys
 
 import numpy as np
 
@@ -440,6 +444,108 @@ def _load_validation(directory):
         return {}
 
 
+def _sentinel_by_name(module_name, attribute):
+    """Re-find a sentinel at load time by the name it is *actually* stored under.
+
+    Named at module scope because it has to be picklable itself -- it is what
+    :func:`_reduce_sentinel` puts in the stream in place of the sentinel.
+    """
+    return getattr(importlib.import_module(module_name), attribute)
+
+
+def _sentinel_home(obj):
+    """``(module, attribute)`` the sentinel really lives at, or None."""
+    module = sys.modules.get(getattr(obj, '__module__', None) or '')
+    if module is None:
+        return None
+    for name, value in vars(module).items():
+        if value is obj:
+            return module.__name__, name
+    return None
+
+
+def _reduce_sentinel(obj):
+    """Pickle a PEP 661 sentinel by where it is, not by what it calls itself.
+
+    A sentinel's ``__reduce__`` returns its *name*, so pickle stores it as a
+    global and, on the way in, checks that the name still refers to the same
+    object. ``typing_extensions`` 4.16.0 has one where that check cannot pass::
+
+        _marker = sentinel("sentinel")
+
+    The instance is named ``"sentinel"`` but bound to ``_marker``, and
+    ``typing_extensions.sentinel`` is the *class*, so pickling anything holding
+    it fails with::
+
+        PicklingError: Can't pickle sentinel: it's not the same object as
+        typing_extensions.sentinel
+
+    No container avoids this -- joblib, cloudpickle and dill all honour the
+    object's own ``__reduce__`` -- so the fallback chain cannot help; there is
+    nothing to fall back to. Looking the object up by identity in its own module
+    finds the name that does resolve, and a sentinel is a singleton whose whole
+    purpose is identity, so it has to come back as the same object rather than
+    an equal one.
+    """
+    home = _sentinel_home(obj)
+    if home is None:
+        raise pickle.PicklingError(
+            f'cannot pickle the sentinel {obj!r}: its __reduce__ names '
+            f'{getattr(obj, "__name__", "?")!r}, which is not what holds it, and '
+            f'no attribute of {getattr(obj, "__module__", "?")} does either.')
+    return _sentinel_by_name, home
+
+
+def _sentinel_classes():
+    """Sentinel classes present in this interpreter, however they are spelled.
+
+    Spelling has changed between releases -- typing_extensions 4.15 has a private
+    ``_Sentinel`` and 4.16 a public ``sentinel`` aliased as ``Sentinel`` -- and
+    the type that matters is whatever ``_marker`` actually is, which in 4.15 is
+    *not* the public name. So the private instance's own type is taken when it
+    is there, rather than inferred from the public API.
+    """
+    classes = []
+
+    def add(candidate):
+        if isinstance(candidate, type) and candidate not in classes:
+            classes.append(candidate)
+
+    for module_name in ('typing_extensions', 'typing', 'builtins'):
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        for attribute in ('sentinel', 'Sentinel', '_Sentinel'):
+            add(getattr(module, attribute, None))
+        marker = getattr(module, '_marker', None)
+        if marker is not None:
+            add(type(marker))
+    return classes
+
+
+@contextlib.contextmanager
+def _sentinels_picklable():
+    """Make sentinels reducible for the duration of one dump.
+
+    Through ``copyreg.dispatch_table``, which every pickler built on
+    ``pickle.Pickler`` consults *before* an object's own ``__reduce_ex__`` --
+    joblib, cloudpickle and dill included, which is what makes one registration
+    enough. Scoped to the dump and removed afterwards: this is a process-wide
+    table, and a library that quietly changed how someone else's objects pickle
+    would be a poor neighbour.
+    """
+    added = []
+    for cls in _sentinel_classes():
+        if cls not in copyreg.dispatch_table:
+            copyreg.dispatch_table[cls] = _reduce_sentinel
+            added.append(cls)
+    try:
+        yield
+    finally:
+        for cls in added:
+            copyreg.dispatch_table.pop(cls, None)
+
+
 def _serialiser(name):
     """The named module, or a refusal that says how to get it."""
     import importlib
@@ -456,12 +562,18 @@ def _serialiser(name):
 
 
 def _dump(module, model, path):
-    """joblib takes a path; the pickle-alikes take a file object."""
-    if module.__name__ == 'joblib':
-        module.dump(model, path)
-    else:
-        with open(path, 'wb') as file:
-            module.dump(model, file)
+    """joblib takes a path; the pickle-alikes take a file object.
+
+    Wrapped in :func:`_sentinels_picklable` because a sentinel defeats every
+    container equally, so it has to be handled here rather than by choosing a
+    different one.
+    """
+    with _sentinels_picklable():
+        if module.__name__ == 'joblib':
+            module.dump(model, path)
+        else:
+            with open(path, 'wb') as file:
+                module.dump(model, file)
 
 
 def _undump(module, path):

--- a/src/libcuflynx/parsers/PrimitiveParsers.py
+++ b/src/libcuflynx/parsers/PrimitiveParsers.py
@@ -1741,6 +1741,22 @@ ANALYSIS_OPTIONS = {
             {'name': 'emulator_dir', 'type': 'str', 'default': None, 'required': False,
              'description': ('Directory holding the trained emulator. Defaults to '
                              '<param_id_output_dir>/emulators/<file_prefix>_<obs_prefix>.')},
+            # Not a preference so much as an escape hatch. joblib is what autoemulate
+            # itself writes and reads, but some fitted emulators hold an uninitialised
+            # C-extension descriptor (`_abc._abc_data`) that pickle cannot take apart,
+            # and `joblib.dump` then kills the training run *after* every simulation has
+            # been paid for (issue #468). 'auto' tries joblib, then cloudpickle, then
+            # dill, and records which one wrote the bundle -- that library is then needed
+            # wherever it is read. None of the three is a superset: measured on
+            # autoemulate 2.1.2, dill FAILS on torch-backed emulators that joblib saves
+            # fine (a PyCapsule it recurses on), so switching to it outright -- the fix
+            # #468 proposes -- would break the common case to fix the rare one.
+            {'name': 'model_serialiser', 'type': 'enum', 'default': 'auto', 'required': False,
+             'choices': ['auto', 'joblib', 'cloudpickle', 'dill'],
+             'description': ('How the fitted emulator is pickled: auto (joblib, then '
+                             'cloudpickle, then dill, until one works), or one of those '
+                             'named outright. Change it if training fails with "cannot '
+                             'pickle" while saving.')},
             # A str rather than a list: descriptor types are scalar, and the accepted names are
             # a runtime property of the installed autoemulate, discoverable through
             # emulators.emulator_trainer.emulator_model_names() -- so a tool offers that list
@@ -2548,6 +2564,7 @@ class YamlFileParser(object):
             inp_data_dict['emulator_settings'] = {}
         emulator_settings = inp_data_dict['emulator_settings']
         emulator_settings.setdefault('emulator_dir', None)
+        emulator_settings.setdefault('model_serialiser', 'auto')
         emulator_settings.setdefault('models', 'default')
         emulator_settings.setdefault('num_train_samples', 128)
         emulator_settings.setdefault('reuse_samples', False)

--- a/tests/test_emulator_serialiser.py
+++ b/tests/test_emulator_serialiser.py
@@ -296,6 +296,11 @@ def test_no_container_can_save_a_sentinel_unaided(name, tmp_path):
 @needs_broken_marker
 @pytest.mark.parametrize('name', ['joblib', 'cloudpickle', 'dill', 'auto'])
 def test_a_model_holding_a_sentinel_saves_and_reloads(name, tmp_path):
+    # Naming a container requires it to be installed; CI runs this tier without
+    # the emulation extra, so only joblib is certain to be there. 'auto' needs
+    # nothing, which is the point of it.
+    if name != 'auto':
+        pytest.importorskip(name)
     used = _save_model(SentinelStub([[2.0]]), _model_path(tmp_path), serialiser=name)
     back = _load_model(_model_path(tmp_path), serialiser=used)
     assert back.predict([[1.0]])[0] == pytest.approx(2.0)

--- a/tests/test_emulator_serialiser.py
+++ b/tests/test_emulator_serialiser.py
@@ -1,0 +1,210 @@
+"""How the fitted emulator gets pickled, and what happens when joblib cannot.
+
+Training pays for every simulation *before* it saves. So a model joblib cannot
+pickle does not cost a save, it costs the whole run -- which is what issue #468
+reports: `joblib.dump` raising ``cannot pickle '_abc._abc_data' object`` on an
+emulator holding an uninitialised C-extension descriptor.
+
+That exact object is autoemulate's and is not reproducible on demand, so what is
+reproduced here is the *mechanism*: an object pickle refuses and dill accepts.
+A closure is the simplest one, and it fails in the same place for the same
+reason -- pickle cannot name the thing it is being asked to store.
+"""
+import json
+import os
+
+import numpy as np
+import pytest
+
+from libcuflynx.emulators.emulator_bundle import (
+    _AUTO_ORDER,
+    DEFAULT_SERIALISER,
+    METADATA_FILE,
+    MODEL_FILE,
+    SERIALISERS,
+    EmulatorBundle,
+    _load_model,
+    _save_model,
+)
+
+pytestmark = pytest.mark.unit
+
+dill = pytest.importorskip("dill")
+
+
+class LinearStub:
+    """A trivial emulator: y = x @ w. Picklable by anything."""
+
+    def __init__(self, weights):
+        self.weights = np.asarray(weights, dtype=float)
+
+    def predict(self, x):
+        return np.asarray(x, dtype=float) @ self.weights
+
+
+class ClosureStub(LinearStub):
+    """The same emulator, holding something pickle cannot name.
+
+    Stands in for the ``_abc._abc_data`` of #468: a live object with no
+    importable path to it, which pickle refuses and dill takes apart.
+    """
+
+    def __init__(self, weights):
+        super().__init__(weights)
+        scale = float(weights[0][0])
+        self.transform = lambda value: value * scale
+
+
+def _meta(serialiser=None):
+    meta = {
+        'param_entry_labels': ['alpha'],
+        'param_mins': [0.0],
+        'param_maxs': [1.0],
+        'feature_labels': ['max (max comp/x)'],
+        'feature_r2': [0.99],
+        'x_scale': {'shift': [0.0], 'span': [1.0]},
+        'y_scale': {'shift': [0.0], 'span': [1.0]},
+        'fingerprint': {'inputs_sha256': 'abc123'},
+    }
+    if serialiser is not None:
+        meta['settings'] = {'model_serialiser': serialiser}
+    return meta
+
+
+def _model_path(directory):
+    return os.path.join(directory, MODEL_FILE)
+
+
+# ---------------------------------------------------------------------------
+# The failure this exists for
+# ---------------------------------------------------------------------------
+def test_joblib_really_cannot_pickle_the_stand_in():
+    """The premise. Without this the fallback tests could pass by accident."""
+    import joblib
+
+    with pytest.raises(Exception) as exc:
+        joblib.dump(ClosureStub([[2.0]]), os.devnull)
+    assert 'pickle' in str(exc.value).lower()
+
+
+def test_auto_falls_back_rather_than_losing_the_run(tmp_path, capsys):
+    used = _save_model(ClosureStub([[2.0]]), _model_path(tmp_path), serialiser='auto')
+    assert used != 'joblib'
+    assert used in _AUTO_ORDER
+    assert os.path.isfile(f'{_model_path(tmp_path)}.joblib')
+    # Silently switching container would be worse than failing: the file now
+    # needs that library wherever it is read.
+    assert used in capsys.readouterr().out
+
+
+def test_auto_uses_joblib_when_joblib_works(tmp_path):
+    """The fallback is a fallback. joblib is what autoemulate itself reads."""
+    assert _save_model(LinearStub([[2.0]]), _model_path(tmp_path), serialiser='auto') == 'joblib'
+
+
+def test_a_failed_joblib_attempt_leaves_no_half_written_file(tmp_path):
+    """A truncated file would be loaded in preference to nothing at all."""
+    path = f'{_model_path(tmp_path)}.joblib'
+    _save_model(ClosureStub([[2.0]]), _model_path(tmp_path), serialiser='auto')
+    with open(path, 'rb') as file:
+        assert dill.load(file).predict([[1.0]])[0] == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# The setting
+# ---------------------------------------------------------------------------
+def test_the_default_is_auto():
+    assert DEFAULT_SERIALISER == 'auto'
+    assert set(SERIALISERS) == {'auto', *_AUTO_ORDER}
+
+
+def test_auto_tries_joblib_first_and_dill_last():
+    """Order is measured, not assumed. joblib is what autoemulate itself writes;
+    dill is last because on autoemulate 2.1.2 it *fails* where joblib succeeds --
+    a torch-backed emulator holds a PyCapsule it recurses on -- so promoting it,
+    as issue #468 proposes, would break the common case to fix the rare one."""
+    assert _AUTO_ORDER[0] == 'joblib'
+    assert _AUTO_ORDER[-1] == 'dill'
+    assert 'cloudpickle' in _AUTO_ORDER
+
+
+def test_naming_dill_uses_dill_without_trying_joblib_first(tmp_path):
+    assert _save_model(LinearStub([[2.0]]), _model_path(tmp_path), serialiser='dill') == 'dill'
+
+
+def test_naming_joblib_does_not_fall_back(tmp_path):
+    """Someone who has pinned joblib wants to hear about it, not get a dill file."""
+    with pytest.raises(Exception) as exc:
+        _save_model(ClosureStub([[2.0]]), _model_path(tmp_path), serialiser='joblib')
+    assert 'pickle' in str(exc.value).lower()
+
+
+def test_an_unknown_serialiser_is_refused_by_name(tmp_path):
+    with pytest.raises(ValueError, match='model_serialiser'):
+        _save_model(LinearStub([[2.0]]), _model_path(tmp_path), serialiser='marshal')
+
+
+@pytest.mark.parametrize('name', ['cloudpickle', 'dill'])
+def test_each_fallback_container_round_trips_what_joblib_refuses(name, tmp_path):
+    """The premise of the fallback, checked per container rather than assumed."""
+    pytest.importorskip(name)
+    assert _save_model(ClosureStub([[2.0]]), _model_path(tmp_path), serialiser=name) == name
+    back = _load_model(_model_path(tmp_path), serialiser=name)
+    assert back.predict([[1.0]])[0] == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Round trip through the bundle
+# ---------------------------------------------------------------------------
+def test_a_bundle_records_which_serialiser_wrote_it(tmp_path):
+    """Not inferred on the way back in: the containers are not distinguishable
+    from the bytes."""
+    EmulatorBundle(ClosureStub([[2.0]]), _meta()).save(str(tmp_path))
+    with open(tmp_path / METADATA_FILE) as file:
+        recorded = json.load(file)['model_serialiser']
+    assert recorded in _AUTO_ORDER and recorded != 'joblib'
+
+
+def test_a_fallback_saved_bundle_loads_back(tmp_path):
+    EmulatorBundle(ClosureStub([[2.0]]), _meta()).save(str(tmp_path))
+    reloaded = EmulatorBundle.load(str(tmp_path))
+    assert reloaded.predict([0.5])[0] == pytest.approx(1.0)
+
+
+def test_a_joblib_saved_bundle_still_loads_back(tmp_path):
+    EmulatorBundle(LinearStub([[2.0]]), _meta('joblib')).save(str(tmp_path))
+    assert EmulatorBundle.load(str(tmp_path)).predict([0.5])[0] == pytest.approx(1.0)
+
+
+def test_the_setting_reaches_save_from_the_bundles_own_settings(tmp_path):
+    """emulator_settings travels in the metadata, the way min_r2 does -- by load
+    time the caller may be a calibration run that never saw those settings."""
+    EmulatorBundle(LinearStub([[2.0]]), _meta('dill')).save(str(tmp_path))
+    with open(tmp_path / METADATA_FILE) as file:
+        assert json.load(file)['model_serialiser'] == 'dill'
+
+
+def test_a_bundle_saved_before_the_choice_existed_still_loads(tmp_path):
+    """No recorded serialiser: both containers get tried."""
+    EmulatorBundle(LinearStub([[2.0]]), _meta()).save(str(tmp_path))
+    path = tmp_path / METADATA_FILE
+    meta = json.loads(path.read_text())
+    del meta['model_serialiser']
+    path.write_text(json.dumps(meta))
+    assert EmulatorBundle.load(str(tmp_path)).predict([0.5])[0] == pytest.approx(1.0)
+
+
+def test_a_fallback_file_loads_even_if_the_metadata_claims_joblib(tmp_path):
+    """The recorded name is a preference, not a promise -- a bundle hand-edited
+    or copied between studies must not become unreadable."""
+    EmulatorBundle(ClosureStub([[2.0]]), _meta()).save(str(tmp_path))
+    path = tmp_path / METADATA_FILE
+    meta = json.loads(path.read_text())
+    meta['model_serialiser'] = 'joblib'
+    path.write_text(json.dumps(meta))
+    assert EmulatorBundle.load(str(tmp_path)).predict([0.5])[0] == pytest.approx(1.0)
+
+
+def test_a_missing_model_file_is_reported_as_such(tmp_path):
+    with pytest.raises(FileNotFoundError, match='is missing'):
+        _load_model(_model_path(tmp_path))

--- a/tests/test_emulator_serialiser.py
+++ b/tests/test_emulator_serialiser.py
@@ -208,3 +208,159 @@ def test_a_fallback_file_loads_even_if_the_metadata_claims_joblib(tmp_path):
 def test_a_missing_model_file_is_reported_as_such(tmp_path):
     with pytest.raises(FileNotFoundError, match='is missing'):
         _load_model(_model_path(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Sentinels, which defeat every container equally
+#
+# A PEP 661 sentinel pickles by *name*: its __reduce__ returns a string, and
+# pickle stores it as a global, checking on the way in that the name still
+# refers to the same object. typing_extensions 4.16.0 ships one where that check
+# cannot pass -- `_marker = sentinel("sentinel")` binds an instance named
+# "sentinel" to `_marker`, while `typing_extensions.sentinel` is the class -- so
+# anything holding it fails to pickle with
+#
+#     PicklingError: Can't pickle sentinel: it's not the same object as
+#     typing_extensions.sentinel
+#
+# joblib, cloudpickle and dill all honour the object's own __reduce__, so the
+# fallback chain has nothing to fall back to. It is fixed here instead, through
+# copyreg, which every pickler built on pickle.Pickler consults first.
+# ---------------------------------------------------------------------------
+import copyreg  # noqa: E402
+import pickle as _pickle  # noqa: E402
+
+from libcuflynx.emulators.emulator_bundle import (  # noqa: E402
+    _reduce_sentinel,
+    _sentinel_classes,
+    _sentinel_home,
+    _sentinels_picklable,
+)
+
+typing_extensions = pytest.importorskip('typing_extensions')
+MARKER = getattr(typing_extensions, '_marker', None)
+
+
+def _marker_is_the_broken_kind():
+    """Whether the installed typing_extensions has the unpicklable sentinel.
+
+    Version-sniffing would be the wrong test: what matters is the behaviour, and
+    it is one line to ask for directly.
+    """
+    if MARKER is None:
+        return False
+    try:
+        _pickle.dumps(MARKER)
+    except _pickle.PicklingError:
+        return True
+    return False
+
+
+needs_broken_marker = pytest.mark.skipif(
+    not _marker_is_the_broken_kind(),
+    reason='this typing_extensions pickles its sentinel fine (the bug is 4.16.0)',
+)
+
+
+class SentinelStub(LinearStub):
+    """An emulator holding the sentinel, the way a fitted one holds it as a default."""
+
+    def __init__(self, weights):
+        super().__init__(weights)
+        self.default = MARKER
+
+
+@needs_broken_marker
+def test_the_sentinel_really_is_unpicklable_without_help():
+    """The premise. If typing_extensions fixes this, the tests below stop
+    proving anything and should start skipping rather than passing."""
+    with pytest.raises(_pickle.PicklingError, match='not the same object'):
+        _pickle.dumps(MARKER)
+
+
+@needs_broken_marker
+@pytest.mark.parametrize('name', ['joblib', 'cloudpickle', 'dill'])
+def test_no_container_can_save_a_sentinel_unaided(name, tmp_path):
+    """Why this is not fixed by choosing a different serialiser: they all defer
+    to the object's own __reduce__, so they all fail in the same place."""
+    module = pytest.importorskip(name)
+    path = tmp_path / 'raw'
+    with pytest.raises(_pickle.PicklingError, match='not the same object'):
+        if name == 'joblib':
+            module.dump(SentinelStub([[2.0]]), str(path))
+        else:
+            with open(path, 'wb') as file:
+                module.dump(SentinelStub([[2.0]]), file)
+
+
+@needs_broken_marker
+@pytest.mark.parametrize('name', ['joblib', 'cloudpickle', 'dill', 'auto'])
+def test_a_model_holding_a_sentinel_saves_and_reloads(name, tmp_path):
+    used = _save_model(SentinelStub([[2.0]]), _model_path(tmp_path), serialiser=name)
+    back = _load_model(_model_path(tmp_path), serialiser=used)
+    assert back.predict([[1.0]])[0] == pytest.approx(2.0)
+
+
+@needs_broken_marker
+def test_the_sentinel_comes_back_as_the_same_object(tmp_path):
+    """A sentinel is a singleton whose entire purpose is identity, so an equal
+    copy would be a silent behaviour change rather than a fix."""
+    used = _save_model(SentinelStub([[2.0]]), _model_path(tmp_path), serialiser='auto')
+    assert _load_model(_model_path(tmp_path), serialiser=used).default is MARKER
+
+
+@needs_broken_marker
+def test_a_whole_bundle_round_trips(tmp_path):
+    EmulatorBundle(SentinelStub([[2.0]]), _meta()).save(str(tmp_path))
+    assert EmulatorBundle.load(str(tmp_path)).predict([0.5])[0] == pytest.approx(1.0)
+
+
+# --- the mechanism, which holds whatever version is installed ----------------
+def test_the_reduction_is_removed_again():
+    """copyreg.dispatch_table is process-wide. A library that quietly changed how
+    someone else's objects pickle -- for the rest of the session -- would be a
+    poor neighbour."""
+    before = dict(copyreg.dispatch_table)
+    with _sentinels_picklable():
+        assert any(cls in copyreg.dispatch_table for cls in _sentinel_classes())
+    assert dict(copyreg.dispatch_table) == before
+
+
+def test_the_reduction_does_not_displace_an_existing_one():
+    """Someone else may have registered for the same class first, and theirs
+    wins -- we are the guest here."""
+    classes = _sentinel_classes()
+    if not classes:
+        pytest.skip('no sentinel classes in this interpreter')
+    mine = classes[0]
+    sentinel_reducer = copyreg.dispatch_table.get(mine)
+    copyreg.dispatch_table[mine] = 'theirs'
+    try:
+        with _sentinels_picklable():
+            assert copyreg.dispatch_table[mine] == 'theirs'
+        assert copyreg.dispatch_table[mine] == 'theirs'
+    finally:
+        if sentinel_reducer is None:
+            copyreg.dispatch_table.pop(mine, None)
+        else:
+            copyreg.dispatch_table[mine] = sentinel_reducer
+
+
+@needs_broken_marker
+def test_the_reduction_names_where_the_sentinel_actually_lives():
+    """`_marker`, not the `sentinel` its __reduce__ claims."""
+    assert _sentinel_home(MARKER) == ('typing_extensions', '_marker')
+    function, args = _reduce_sentinel(MARKER)
+    assert function(*args) is MARKER
+
+
+def test_a_sentinel_nothing_holds_is_refused_with_the_reason():
+    """Looking it up by identity is the whole method, so an object its own
+    module does not hold cannot be helped -- and should say so rather than
+    producing something that unpickles to the wrong thing."""
+    class Homeless:
+        __module__ = 'libcuflynx.emulators.emulator_bundle'
+        __name__ = 'nothing_holds_this'
+
+    with pytest.raises(_pickle.PicklingError, match='nothing_holds_this'):
+        _reduce_sentinel(Homeless())

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -565,9 +565,12 @@ def test_analysis_options_schema_well_formed():
     # stages, so that a later one can place its points using the features the earlier
     # ones returned. num_stages 1 is the single-stage design and the other three are
     # then unused.
+    # model_serialiser is an escape hatch rather than a knob: joblib cannot pickle
+    # every fitted emulator, and the failure lands after the training simulations
+    # have been paid for (#468).
     assert names('emulation') == {
-        'emulator_dir', 'models', 'num_train_samples', 'reuse_samples', 'sample_type',
-        'num_stages', 'frac_per_stage', 'method_per_stage', 'weight_per_stage',
+        'emulator_dir', 'model_serialiser', 'models', 'num_train_samples', 'reuse_samples',
+        'sample_type', 'num_stages', 'frac_per_stage', 'method_per_stage', 'weight_per_stage',
         'log_scale_params', 'random_seed', 'test_fraction', 'n_splits', 'n_iter', 'min_r2',
         'out_of_bounds', 'fd_rel_step'}
     assert analysis_options('not_a_mode') == []

--- a/tutorial/docs/emulators.md
+++ b/tutorial/docs/emulators.md
@@ -270,6 +270,27 @@ fallback needs that library present wherever it is loaded.
 If a training run dies while saving, leave this at `auto` and make sure the fallbacks are
 installed (`pip install "libcuflynx[emulation]"` brings them), or name one outright.
 
+### One failure no container can fix
+
+```
+PicklingError: Can't pickle sentinel: it's not the same object as typing_extensions.sentinel
+```
+
+This one is not about the container, and changing `model_serialiser` will not help — joblib,
+cloudpickle and dill all fail identically. A [PEP 661](https://peps.python.org/pep-0661/)
+sentinel pickles by *name*: its `__reduce__` returns a string, and pickle stores it as a global,
+checking on the way back in that the name still refers to the same object.
+`typing_extensions` 4.16.0 ships one where that check cannot pass:
+
+```python
+_marker = sentinel("sentinel")     # named "sentinel", bound to _marker
+```
+
+`typing_extensions.sentinel` is the *class*, so the identity check fails for any object holding
+`_marker`. CA handles it by reducing sentinels to where they actually live rather than to what
+they call themselves, so nothing needs configuring — but if you meet this outside CA, the
+workaround is `pip install "typing_extensions!=4.16.0"` (4.15.0 is unaffected).
+
 ## Gradients
 
 Over an emulator the only gradient source is **finite differences on the emulator itself**. The

--- a/tutorial/docs/emulators.md
+++ b/tutorial/docs/emulators.md
@@ -231,6 +231,45 @@ refuses rather than proceeding quietly:
 An emulator is an interpolant. Outside the box it was trained in it is an extrapolation with no
 error estimate at all, which is why `out_of_bounds: error` is the default.
 
+## If saving fails: `model_serialiser`
+
+Training pays for every simulation *before* it writes anything, so a model that cannot be
+pickled costs the whole run rather than just the save. Some fitted emulators hold an
+uninitialised C-extension descriptor that `pickle` cannot take apart, and the run ends with:
+
+```
+TypeError: cannot pickle '_abc._abc_data' object
+```
+
+`emulator_settings.model_serialiser` decides which container is used:
+
+| Value | Behaviour |
+|---|---|
+| `auto` (default) | joblib, then cloudpickle, then dill, until one works — with a warning saying which |
+| `joblib` | joblib only — fail rather than switch container |
+| `cloudpickle` | cloudpickle only |
+| `dill` | dill only |
+
+**None of the three is a superset of the others**, which is why `auto` falls back in order
+rather than simply preferring the most capable one. Measured against autoemulate 2.1.2:
+
+| | an object pickle cannot name | a torch-backed emulator |
+|---|---|---|
+| joblib | fails | works |
+| cloudpickle | works | works |
+| dill | works | **fails** (a `PyCapsule` it recurses on) |
+
+So joblib stays first — it is what `autoemulate` itself writes and reads — and switching to
+dill outright would break the common case to fix the rare one.
+
+Which container wrote a bundle is recorded in `emulator_metadata.json` as `model_serialiser`,
+so it reads back without the setting having to be repeated; a bundle written before the
+setting existed still loads, because all three are tried. Note that a bundle saved with a
+fallback needs that library present wherever it is loaded.
+
+If a training run dies while saving, leave this at `auto` and make sure the fallbacks are
+installed (`pip install "libcuflynx[emulation]"` brings them), or name one outright.
+
 ## Gradients
 
 Over an emulator the only gradient source is **finite differences on the emulator itself**. The


### PR DESCRIPTION
Closes the practical half of #468.

## The cost of the bug

Training pays for **every simulation before it saves**. So a fitted model joblib cannot pickle does not cost a save, it costs the whole run — which is what makes #468 expensive rather than annoying:

```
TypeError: cannot pickle '_abc._abc_data' object
```

## What changed

`emulator_settings.model_serialiser` — `auto` (default), `joblib`, `cloudpickle`, `dill`.

`auto` works down joblib → cloudpickle → dill until one succeeds, removes the half-written file on the way, and prints which container it ended up using. Which one wrote a bundle is recorded in `emulator_metadata.json`; load prefers the recorded one and tries the rest, so bundles written before this still open.

## Why a chain, and not the switch to dill the issue proposes

Because dill is not a superset of joblib. Measured on autoemulate 2.1.2, fitting real emulators and round-tripping them:

| container | an object pickle cannot name | a torch-backed emulator |
|---|---|---|
| joblib | fails | works |
| cloudpickle | works | works |
| **dill** | works | **fails** — recurses on a `PyCapsule` |

Adopting dill outright would have broken the common case to fix the rare one. joblib therefore stays first (it is what autoemulate itself writes and reads), and every real emulator tried — GP-RBF, MLP, random forest — still saves with joblib under `auto` and reloads predicting identically.

cloudpickle is second because it was the only one that handled both columns.

## On not being able to reproduce it

The `_abc._abc_data` object is autoemulate's and I could not produce one on demand, so the tests reproduce the *mechanism*: an object pickle refuses and the others accept. That paid for itself immediately — the first version of the fallback did not fire, because the C pickler raises `TypeError` (what the issue quotes) while the Python one raises `PicklingError`. Catching only the quoted exception would have shipped a fallback that missed half the cases.

What remains unverified is whether the reporter's specific emulator is one cloudpickle or dill can take apart. The mechanism is right and both handle strictly more than joblib in the failing direction, but if it fails for another reason it will still fail — the error now names the setting and the containers tried, so we would hear how.

## Also

- `cloudpickle` and `dill` are declared in the `emulation` extra rather than relied on. Both arrive transitively today (`multiprocess`, `schwimmbad`, joblib's vendored copy) and that is not a promise.
- CUFLynx needs no change: its emulator settings form is generated from `ANALYSIS_OPTIONS`, so the dropdown appears on its own.

## Testing

`tests/test_emulator_serialiser.py` — 18 tests: the fallback, the ordering and why, no half-written file, each container round-tripping what joblib refuses, the recorded choice, and bundles that predate the setting. Plus the emulator training suite (15) and the schema guard.

## For the reporter

    pip install "libcuflynx[emulation] @ git+https://github.com/physiomelinks/circulatory_autogen@fix/468-emulator-serialiser"

Then train as usual. `auto` needs no configuration; if it still fails, the message will name what was tried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)