### PR TITLE
Robust and under-dispersed likelihoods, a 25x emulator fix, and spiking observables

### DIFF
--- a/src/libcuflynx/emulators/emulator_trainer.py
+++ b/src/libcuflynx/emulators/emulator_trainer.py
@@ -81,8 +81,9 @@ def emulator_model_names():
     # The two-phase variants are offered here so a settings form can list them, but
     # they are not part of `all` -- see _parse_models. Two stages cost more to fit
     # than one and only pay off when the features really do have a floor.
-    from libcuflynx.emulators.internal_emulators import two_phase_model_names
-    return base + two_phase_model_names(base)
+    from libcuflynx.emulators.internal_emulators import (
+        multi_phase_model_names, two_phase_model_names)
+    return base + two_phase_model_names(base) + multi_phase_model_names(base)
 
 
 def base_emulator_model_names():
@@ -429,7 +430,31 @@ class EmulatorTrainer:
         # for the emulator list when it builds its two_phase_<name> helpers, so a
         # top-level import either way closes the cycle.
         from libcuflynx.emulators.internal_emulators import (  # noqa: PLC0415
-            base_emulator_name, fit_two_phase, is_two_phase, two_phase_name)
+            base_emulator_name, classify_features, fit_multi_phase, fit_two_phase,
+            is_multi_phase, is_two_phase, multi_phase_name, two_phase_name)
+
+        multi_phase = [name for name in (models or []) if is_multi_phase(name)]
+        if multi_phase:
+            if len(models) > 1:
+                raise ValueError(
+                    f'a multi-phase emulator is fitted on its own, but models is {models!r}. '
+                    f'Ask for exactly one, e.g. models: {multi_phase[0]}.')
+            base_name = base_emulator_name(multi_phase[0])
+            kwargs.pop('models', None)
+            # Classified from the *unscaled* targets: y_scaled is affine-mapped, and an
+            # integer count is not an integer any more once it has been.
+            kinds = classify_features(y)
+            if self.rank == 0:
+                counts = {kind: int(np.sum(kinds == kind))
+                          for kind in ('count', 'jump', 'smooth')}
+                print(f'[emulator] multi-phase over {len(kinds)} features: '
+                      f'{counts["count"]} count, {counts["jump"]} jump, '
+                      f'{counts["smooth"]} smooth')
+            model, result = fit_multi_phase(
+                x_train, y_train, x_test, y_test, base_name,
+                _load_autoemulate(), kwargs, kinds)
+            validation = _validation_report(model, x_test, y_test, x_scale, y_scale)
+            return (model, validation, multi_phase_name(base_name), x_scale, y_scale)
 
         two_phase = [name for name in (models or []) if is_two_phase(name)]
         if two_phase:

--- a/src/libcuflynx/emulators/internal_emulators.py
+++ b/src/libcuflynx/emulators/internal_emulators.py
@@ -512,8 +512,13 @@ def _fit_expected_count(x, column):
         return _ExpectedCount(None, values if values.size else np.array([0.0]))
     # Fitted on indices into `values`, not on the values themselves -- see _ExpectedCount.
     labels = np.searchsorted(values, column)
-    model = GradientBoostingClassifier(random_state=0)
-    model.fit(x, labels)
+    try:
+        model = GradientBoostingClassifier(random_state=0)
+        model.fit(x, labels)
+    except Exception as error:  # noqa: BLE001 - one column must not end the run
+        print(f'[emulator] a count classifier could not be fitted '
+              f'({type(error).__name__}: {error}); predicting its mean instead')
+        return _ExpectedCount(None, np.array([float(np.mean(column))]))
     return _ExpectedCount(model, values)
 
 
@@ -556,17 +561,34 @@ def _fit_side(x_train, y_train, x_test, y_test, rows, base_name, autoemulate_cls
               fit_kwargs, fallback_model):
     """A regressor of the base family fitted on one side of a jump.
 
-    Falls back to the model fitted on everything when a side is too thin to fit on --
-    a worse answer for those rows than a dedicated regressor, and a much better one
-    than a constant.
+    Falls back to the model fitted on everything when a side cannot be fitted -- a
+    worse answer for those rows than a dedicated regressor, and a much better one than
+    the constant ``two_phase_`` would put there.
+
+    Two ways a side fails. It can be too thin: autoemulate cross-validates with
+    ``n_splits`` folds, so a side needs enough rows to *fold*, not merely enough to
+    fit, and eight rows across five folds leaves one point per fold. And it can fail
+    anyway -- every candidate erroring leaves autoemulate with no results at all and
+    ``best_result()`` raising, which would take a whole training run down over one
+    branch of one observable.
     """
-    if int(np.sum(rows)) < MIN_SIDE_ROWS:
+    n_splits = int(fit_kwargs.get('n_splits', 5) or 5)
+    needed = max(MIN_SIDE_ROWS, 2 * n_splits)
+    available = int(np.sum(rows))
+    if available < needed:
+        print(f'[emulator] a jump side has {available} row(s), fewer than the {needed} '
+              f'a {n_splits}-fold fit needs; using the all-rows regressor there')
         return fallback_model
     kwargs = dict(fit_kwargs)
     kwargs['models'] = [base_name]
-    side = autoemulate_cls(x_train[rows], y_train[rows], test_data=(x_test, y_test),
-                           **kwargs)
-    return side.best_result().model
+    try:
+        side = autoemulate_cls(x_train[rows], y_train[rows], test_data=(x_test, y_test),
+                               **kwargs)
+        return side.best_result().model
+    except Exception as error:  # noqa: BLE001 - any fit failure degrades, never fatal
+        print(f'[emulator] a jump side ({available} rows) could not be fitted '
+              f'({type(error).__name__}: {error}); using the all-rows regressor there')
+        return fallback_model
 
 
 class _SingleOutputBinary:

--- a/src/libcuflynx/emulators/internal_emulators.py
+++ b/src/libcuflynx/emulators/internal_emulators.py
@@ -32,6 +32,10 @@ import numpy as np
 #: Prefix that marks a two-phase variant of an autoemulate emulator.
 TWO_PHASE_PREFIX = 'two_phase_'
 
+#: Prefix that marks a multi-phase variant: one emulator that treats counts, jumps
+#: and smooth observables each in the way their own shape asks for.
+MULTI_PHASE_PREFIX = 'multi_phase_'
+
 #: A feature is treated as having a floor when at least this share of the design
 #: returns one single value. Well below the 82% seen on real spike-frequency
 #: features, and well above the repetition a genuinely continuous feature shows.
@@ -48,8 +52,11 @@ def is_two_phase(name):
 
 
 def base_emulator_name(name):
-    """``two_phase_MLP`` -> ``MLP``. Returns ``name`` unchanged if not two-phase."""
-    return name[len(TWO_PHASE_PREFIX):] if is_two_phase(name) else name
+    """``two_phase_MLP`` / ``multi_phase_MLP`` -> ``MLP``; anything else unchanged."""
+    for prefix in (TWO_PHASE_PREFIX, MULTI_PHASE_PREFIX):
+        if isinstance(name, str) and name.startswith(prefix):
+            return name[len(prefix):]
+    return name
 
 
 def two_phase_name(name):
@@ -253,6 +260,323 @@ def _as_array(raw, n_rows):
     except Exception:  # noqa: BLE001
         values = np.asarray(raw, dtype=float)
     return np.asarray(values, dtype=float).reshape(n_rows, -1)
+
+
+
+# ================================================================================
+# multi-phase: one emulator, three kinds of observable
+#
+# A study's observables are not all the same shape, and fitting them as though they
+# were is what the two-phase emulator was a first answer to. This is the second.
+# Three kinds are recognised, each from the training data rather than from a name:
+#
+#   count   an integer-valued observable -- a spike count in a window. The forward
+#           model is deterministic and returns one integer, so what is learned is a
+#           *classifier* over the integers it returns, and what is predicted is the
+#           expected count under that classifier. Never negative (so a Poisson cost
+#           never meets its clip), and smooth in theta because the class
+#           probabilities are, so an optimiser still has a gradient to follow.
+#
+#   jump    a continuous observable that lives on two separated branches -- the peak
+#           voltage of a trace that either spikes or does not. A classifier picks the
+#           branch and **a regressor of the base family is fitted on each side**, so
+#           the quiet branch is predicted rather than pinned to a constant. That is
+#           the difference from ``two_phase_``, which substitutes the floor value on
+#           the inactive side and so cannot follow it at all.
+#
+#   smooth  everything else, straight from the base regressor.
+#
+# One base family per emulator: ``multi_phase_MLP`` uses an MLP for every regressor
+# it fits, ``multi_phase_RadialBasisFunctions`` an RBF. Mixing families inside one
+# emulator would make the comparison between them meaningless.
+# ================================================================================
+
+#: A column is a count when every finite value is a non-negative integer and it takes
+#: at least this many distinct values -- one value is a constant, not a count.
+COUNT_MIN_CLASSES = 2
+
+#: ...and at most this many. A count with hundreds of levels is a continuous quantity
+#: for every practical purpose, and a classifier over it would be all variance.
+COUNT_MAX_CLASSES = 24
+
+#: A column is a jump when the largest gap between consecutive sorted values is at
+#: least this share of its full range. Chosen well above the gap a smooth sample
+#: produces and well below a true branch separation.
+JUMP_GAP_FRAC = 0.20
+
+#: Both sides of a jump need at least this many rows to fit a regressor on.
+MIN_SIDE_ROWS = 8
+
+
+def is_multi_phase(name):
+    """Whether ``name`` asks for a multi-phase variant."""
+    return isinstance(name, str) and name.startswith(MULTI_PHASE_PREFIX)
+
+
+def multi_phase_name(name):
+    """``MLP`` -> ``multi_phase_MLP``."""
+    return name if is_multi_phase(name) else MULTI_PHASE_PREFIX + name
+
+
+def multi_phase_model_names(base_names):
+    """A ``multi_phase_`` variant for each name in ``base_names``."""
+    return [multi_phase_name(name) for name in base_names]
+
+
+def is_count_column(column):
+    """Whether a column is an integer count.
+
+    Tested on the **unscaled** values: the trainer maps y onto a well-conditioned
+    range before fitting, and an affine map turns integers into a grid that no
+    integer test recognises. So the caller has to classify before scaling.
+    """
+    finite = np.asarray(column, dtype=float)
+    finite = finite[np.isfinite(finite)]
+    if finite.size == 0:
+        return False
+    if np.any(finite < 0):
+        return False
+    if not np.allclose(finite, np.round(finite), atol=1e-9, rtol=0):
+        return False
+    return COUNT_MIN_CLASSES <= len(np.unique(np.round(finite))) <= COUNT_MAX_CLASSES
+
+
+def jump_threshold(column, gap_frac=JUMP_GAP_FRAC, min_side=MIN_SIDE_ROWS):
+    """Where a column separates into two branches, or ``None`` if it does not.
+
+    The split is the midpoint of the widest gap between consecutive observed values,
+    accepted only when that gap is a large share of the column's range and both sides
+    carry enough rows to fit on. Deliberately not "the value repeated most often"
+    (:func:`floor_mask`): a peak voltage that either spikes or does not has two
+    *populations*, not a repeated constant, and the floor test does not see it.
+    """
+    finite = np.asarray(column, dtype=float)
+    finite = finite[np.isfinite(finite)]
+    if finite.size < 2 * min_side:
+        return None
+    values = np.unique(finite)
+    if values.size < 2:
+        return None
+    spread = values[-1] - values[0]
+    if spread <= 0:
+        return None
+    gaps = np.diff(values)
+    widest = int(np.argmax(gaps))
+    if gaps[widest] / spread < gap_frac:
+        return None
+    threshold = 0.5 * (values[widest] + values[widest + 1])
+    low = int(np.sum(finite <= threshold))
+    if low < min_side or (finite.size - low) < min_side:
+        return None
+    return float(threshold)
+
+
+def classify_features(y):
+    """Label every column ``'count'``, ``'jump'`` or ``'smooth'``.
+
+    Call this on the **unscaled** training targets; see :func:`is_count_column`.
+    """
+    y = np.asarray(y, dtype=float)
+    kinds = []
+    for index in range(y.shape[1]):
+        column = y[:, index]
+        if is_count_column(column):
+            kinds.append('count')
+        elif jump_threshold(column) is not None:
+            kinds.append('jump')
+        else:
+            kinds.append('smooth')
+    return np.asarray(kinds, dtype=object)
+
+
+class _ExpectedCount:
+    """A classifier over the values a count observable takes, read as its mean.
+
+    The forward model is deterministic -- one theta gives one integer -- so the
+    distribution here is the emulator's uncertainty about which integer, not
+    variability in the model. Reading it as an expectation is a plug-in estimate of
+    that integer, and it is the useful one: non-negative by construction, and
+    continuous in theta where an argmax would be a staircase with no gradient.
+
+    Where the emulator is unsure the expectation sits between classes, which costs
+    slightly *more* than the true integer would under a Poisson likelihood. That bias
+    is the safe direction: the alternative failure -- scoring zero cost for a
+    confidently wrong silence -- is the one that pulls a chain somewhere the model
+    never goes.
+    """
+
+    def __init__(self, model, classes):
+        self.model = model
+        #: The values the observable actually takes, in ascending order. The classifier
+        #: is fitted on their *indices*: sklearn refuses float labels as "continuous",
+        #: and after the trainer's affine scaling the counts are floats.
+        self.classes = np.asarray(classes, dtype=float)
+
+    def predict(self, x):
+        if self.model is None:
+            return np.full(len(x), float(self.classes[0]))
+        probabilities = np.asarray(self.model.predict_proba(x), dtype=float)
+        indices = np.asarray(getattr(self.model, 'classes_', range(probabilities.shape[1])),
+                             dtype=int)
+        return probabilities @ self.classes[indices]
+
+
+class MultiPhaseEmulator:
+    """Counts, jumps and smooth observables, each predicted the way its shape asks.
+
+    Presents ``predict`` and nothing else, which is all ``EmulatorBundle`` asks of a
+    model, and pickles through joblib like autoemulate's own.
+    """
+
+    def __init__(self, base_model, kinds, count_models, jump_groups, base_name):
+        self.base_model = base_model
+        self.kinds = np.asarray(kinds, dtype=object)
+        #: column index -> _ExpectedCount
+        self.count_models = dict(count_models)
+        #: list of {'columns', 'classifier', 'low', 'high'}
+        self.jump_groups = list(jump_groups)
+        self.base_name = base_name
+
+    @property
+    def model_name(self):
+        return multi_phase_name(self.base_name)
+
+    def predict(self, x):
+        x = np.asarray(x, dtype=float)
+        if x.ndim == 1:
+            x = x.reshape(1, -1)
+        out = _as_array(self.base_model.predict(_backend_input(self.base_model, x)), len(x))
+
+        for column, model in self.count_models.items():
+            if column < out.shape[1]:
+                out[:, column] = model.predict(x)
+
+        for group in self.jump_groups:
+            side = np.asarray(group['classifier'].predict(x)).astype(bool).reshape(len(x))
+            for which, model in (('low', group['low']), ('high', group['high'])):
+                if model is None:
+                    continue
+                rows = ~side if which == 'low' else side
+                if not rows.any():
+                    continue
+                values = _as_array(model.predict(_backend_input(model, x[rows])),
+                                   int(rows.sum()))
+                for column in group['columns']:
+                    if column < out.shape[1] and column < values.shape[1]:
+                        out[rows, column] = values[:, column]
+        return out
+
+
+def fit_multi_phase(x_train, y_train, x_test, y_test, base_name, autoemulate_cls,
+                    fit_kwargs, kinds):
+    """Fit the base regressor, the count classifiers and the per-branch regressors.
+
+    ``kinds`` comes from :func:`classify_features` on the *unscaled* targets; ``y_train``
+    here is scaled, as everything the trainer fits is. That is fine for both extra
+    stages: a classifier only needs the classes to be distinct, and an expectation
+    commutes with the affine scaling, so the mean of the scaled classes is the scaled
+    mean of the counts.
+
+    Jump columns are grouped by the rows they put on each side, and one pair of
+    regressors is fitted per group. Columns that jump together -- which is what
+    observables of one trace do -- then cost one pair between them rather than one
+    pair each.
+    """
+    y_train = np.asarray(y_train, dtype=float)
+    kinds = np.asarray(kinds, dtype=object)
+
+    kwargs = dict(fit_kwargs)
+    kwargs['models'] = [base_name]
+    base = autoemulate_cls(x_train, y_train, test_data=(x_test, y_test), **kwargs)
+    base_result = base.best_result()
+
+    count_models = {}
+    for column in np.flatnonzero(kinds == 'count'):
+        count_models[int(column)] = _fit_expected_count(x_train, y_train[:, column])
+
+    jump_groups = _fit_jump_groups(x_train, y_train, y_test, x_test, kinds,
+                                   base_name, autoemulate_cls, fit_kwargs,
+                                   base_result.model)
+
+    return (MultiPhaseEmulator(base_result.model, kinds, count_models, jump_groups,
+                               base_name),
+            base_result)
+
+
+def _fit_expected_count(x, column):
+    """One multiclass classifier over the values this count takes."""
+    from sklearn.ensemble import GradientBoostingClassifier
+
+    values = np.unique(column[np.isfinite(column)])
+    if values.size < 2:
+        return _ExpectedCount(None, values if values.size else np.array([0.0]))
+    # Fitted on indices into `values`, not on the values themselves -- see _ExpectedCount.
+    labels = np.searchsorted(values, column)
+    model = GradientBoostingClassifier(random_state=0)
+    model.fit(x, labels)
+    return _ExpectedCount(model, values)
+
+
+def _fit_jump_groups(x_train, y_train, y_test, x_test, kinds, base_name,
+                     autoemulate_cls, fit_kwargs, fallback_model):
+    """A classifier and a regressor per side, for each set of columns that jump together."""
+    columns = [int(c) for c in np.flatnonzero(kinds == 'jump')]
+    if not columns:
+        return []
+
+    # Split each jump column on the *scaled* values: the threshold is recomputed here
+    # rather than carried from the unscaled pass, because an affine map moves it.
+    sides = {}
+    for column in columns:
+        threshold = jump_threshold(y_train[:, column])
+        if threshold is None:
+            continue
+        sides[column] = y_train[:, column] > threshold
+
+    groups = {}
+    for column, mask in sides.items():
+        groups.setdefault(mask.tobytes(), []).append(column)
+
+    from sklearn.ensemble import GradientBoostingClassifier
+
+    fitted = []
+    for members in groups.values():
+        mask = sides[members[0]]
+        classifier = _fit_column(GradientBoostingClassifier, x_train, mask)
+        low = _fit_side(x_train, y_train, x_test, y_test, ~mask, base_name,
+                        autoemulate_cls, fit_kwargs, fallback_model)
+        high = _fit_side(x_train, y_train, x_test, y_test, mask, base_name,
+                         autoemulate_cls, fit_kwargs, fallback_model)
+        fitted.append({'columns': members, 'classifier': _SingleOutputBinary(classifier),
+                       'low': low, 'high': high})
+    return fitted
+
+
+def _fit_side(x_train, y_train, x_test, y_test, rows, base_name, autoemulate_cls,
+              fit_kwargs, fallback_model):
+    """A regressor of the base family fitted on one side of a jump.
+
+    Falls back to the model fitted on everything when a side is too thin to fit on --
+    a worse answer for those rows than a dedicated regressor, and a much better one
+    than a constant.
+    """
+    if int(np.sum(rows)) < MIN_SIDE_ROWS:
+        return fallback_model
+    kwargs = dict(fit_kwargs)
+    kwargs['models'] = [base_name]
+    side = autoemulate_cls(x_train[rows], y_train[rows], test_data=(x_test, y_test),
+                           **kwargs)
+    return side.best_result().model
+
+
+class _SingleOutputBinary:
+    """One binary classifier, answered as a flat boolean vector."""
+
+    def __init__(self, model):
+        self.model = model
+
+    def predict(self, x):
+        return np.asarray(self.model.predict(x)).astype(bool).reshape(len(x))
 
 
 # --------------------------------------------------------------------------------

--- a/src/libcuflynx/emulators/internal_emulators.py
+++ b/src/libcuflynx/emulators/internal_emulators.py
@@ -295,8 +295,16 @@ def _as_array(raw, n_rows):
 #: at least this many distinct values -- one value is a constant, not a count.
 COUNT_MIN_CLASSES = 2
 
-#: ...and at most this many. A count with hundreds of levels is a continuous quantity
-#: for every practical purpose, and a classifier over it would be all variance.
+#: ...and at most this many. A count with hundreds of levels is a continuous quantity for
+#: every practical purpose, and a classifier over it would be all variance.
+#:
+#: Left at 24 deliberately. Raising it to 64 (so that counts with 26-53 levels became
+#: _ExpectedCount models rather than falling through to the regressor) does remove the
+#: negative predictions of #498 -- but it roughly doubles the error on exactly those
+#: features (RMSE +107% on ox1, +81% on cpvt, measured on 12000-sample bundles) and makes
+#: the whole emulator worse: std(dcost) 2.675 -> 3.097 on ox1 and 3.385 -> 4.343 on cpvt.
+#: The warning above is correct; a 42-class classifier really is all variance. The negatives
+#: are handled by clamping in MultiPhaseEmulator.predict instead, which costs nothing.
 COUNT_MAX_CLASSES = 24
 
 #: A column is a jump when the largest gap between consecutive sorted values is at
@@ -341,6 +349,22 @@ def is_count_column(column):
     return COUNT_MIN_CLASSES <= len(np.unique(np.round(finite))) <= COUNT_MAX_CLASSES
 
 
+def is_count_like(column):
+    """A non-negative integer quantity, however many levels it happens to show.
+
+    :func:`is_count_column` additionally caps the number of levels, because that is what
+    decides whether a *classifier* over them is sensible. This one asks only what the
+    quantity is, which is what decides whether a negative prediction is meaningful (#498).
+    """
+    finite = np.asarray(column, dtype=float)
+    finite = finite[np.isfinite(finite)]
+    if finite.size == 0 or np.any(finite < 0):
+        return False
+    if not np.allclose(finite, np.round(finite), atol=1e-9, rtol=0):
+        return False
+    return len(np.unique(np.round(finite))) >= COUNT_MIN_CLASSES
+
+
 def jump_threshold(column, gap_frac=JUMP_GAP_FRAC, min_side=MIN_SIDE_ROWS):
     """Where a column separates into two branches, or ``None`` if it does not.
 
@@ -372,16 +396,28 @@ def jump_threshold(column, gap_frac=JUMP_GAP_FRAC, min_side=MIN_SIDE_ROWS):
 
 
 def classify_features(y):
-    """Label every column ``'count'``, ``'jump'`` or ``'smooth'``.
+    """Label every column ``'count'``, ``'floored_count'``, ``'jump'`` or ``'smooth'``.
 
     Call this on the **unscaled** training targets; see :func:`is_count_column`.
+
+    ``floored_count`` is a count with more levels than a classifier should be asked to
+    separate, but which still spends much of the design sitting on one value -- a spike
+    count that is zero until the cell starts firing. Before #498 those fell through to the
+    plain regressor, which rippled below the floor and returned negative counts: on the
+    12000-sample SN_full bundles, 46-49% of predictions for such a column were negative and
+    ~100% of those sat where the true count was exactly zero. They get the floor treatment
+    instead -- a *binary* classifier, which is cheap and low-variance, plus a regressor for
+    the magnitude above it.
     """
     y = np.asarray(y, dtype=float)
+    has_floor, _ = floor_mask(y)
     kinds = []
     for index in range(y.shape[1]):
         column = y[:, index]
         if is_count_column(column):
             kinds.append('count')
+        elif is_count_like(column) and has_floor[index]:
+            kinds.append('floored_count')
         elif jump_threshold(column) is not None:
             kinds.append('jump')
         else:
@@ -428,18 +464,41 @@ class MultiPhaseEmulator:
     model, and pickles through joblib like autoemulate's own.
     """
 
-    def __init__(self, base_model, kinds, count_models, jump_groups, base_name):
+    def __init__(self, base_model, kinds, count_models, jump_groups, base_name,
+                 count_columns=None, floor_groups=None):
         self.base_model = base_model
         self.kinds = np.asarray(kinds, dtype=object)
+        #: Every column that is a count, including any the classifier declined to model.
+        self._count_columns = list(count_columns) if count_columns is not None \
+            else list(count_models)
         #: column index -> _ExpectedCount
         self.count_models = dict(count_models)
         #: list of {'columns', 'classifier', 'low', 'high'}
         self.jump_groups = list(jump_groups)
+        #: list of {'columns', 'classifier', 'floor_value', 'magnitude'} -- counts whose
+        #: level count is past what a classifier should separate, but which still have a
+        #: floor to put exactly where it belongs rather than smoothing through it (#498).
+        self._floor_groups = list(floor_groups) if floor_groups is not None else []
         self.base_name = base_name
 
     @property
     def model_name(self):
         return multi_phase_name(self.base_name)
+
+    @property
+    def floor_groups(self):
+        """Floor groups, empty for a bundle pickled before #498."""
+        return getattr(self, '_floor_groups', []) or []
+
+    @property
+    def count_columns(self):
+        """Count columns, falling back to the modelled ones.
+
+        A property rather than a plain attribute because joblib restores ``__dict__``
+        directly and never calls ``__init__``: a bundle pickled before #498 has no such
+        attribute at all, and unpickling one must not raise.
+        """
+        return getattr(self, '_count_columns', None) or list(self.count_models)
 
     def predict(self, x):
         x = np.asarray(x, dtype=float)
@@ -450,6 +509,29 @@ class MultiPhaseEmulator:
         for column, model in self.count_models.items():
             if column < out.shape[1]:
                 out[:, column] = model.predict(x)
+
+        # A count is non-negative whatever produced it. _ExpectedCount is non-negative by
+        # construction, but a column that failed is_count_column -- too many levels, or an
+        # integrality test the design broke -- is left on the plain regressor, which is not.
+        # Clamping here covers every path rather than only the classified one (#498).
+        if self.count_columns:
+            idx = [c for c in self.count_columns if c < out.shape[1]]
+            if idx:
+                out[:, idx] = np.clip(out[:, idx], 0.0, None)
+
+        for group in self.floor_groups:
+            active = np.asarray(group['classifier'].predict(x)).astype(bool).reshape(len(x))
+            values = None
+            if group['magnitude'] is not None and active.any():
+                values = _as_array(
+                    group['magnitude'].predict(_backend_input(group['magnitude'], x[active])),
+                    int(active.sum()))
+            for column in group['columns']:
+                if column >= out.shape[1]:
+                    continue
+                out[~active, column] = group['floor_value'][column]
+                if values is not None and column < values.shape[1]:
+                    out[active, column] = values[:, column]
 
         for group in self.jump_groups:
             side = np.asarray(group['classifier'].predict(x)).astype(bool).reshape(len(x))
@@ -490,16 +572,23 @@ def fit_multi_phase(x_train, y_train, x_test, y_test, base_name, autoemulate_cls
     base = autoemulate_cls(x_train, y_train, test_data=(x_test, y_test), **kwargs)
     base_result = base.best_result()
 
+    count_columns = [int(c) for c in np.flatnonzero(kinds == 'count')]
     count_models = {}
-    for column in np.flatnonzero(kinds == 'count'):
-        count_models[int(column)] = _fit_expected_count(x_train, y_train[:, column])
+    for column in count_columns:
+        count_models[column] = _fit_expected_count(x_train, y_train[:, column])
 
     jump_groups = _fit_jump_groups(x_train, y_train, y_test, x_test, kinds,
                                    base_name, autoemulate_cls, fit_kwargs,
                                    base_result.model)
 
+    floor_groups = _fit_floor_groups(x_train, y_train, y_test, x_test, kinds,
+                                     base_name, autoemulate_cls, fit_kwargs,
+                                     base_result.model)
+    count_columns += [int(c) for c in np.flatnonzero(kinds == 'floored_count')]
+
     return (MultiPhaseEmulator(base_result.model, kinds, count_models, jump_groups,
-                               base_name),
+                               base_name, count_columns=count_columns,
+                               floor_groups=floor_groups),
             base_result)
 
 
@@ -520,6 +609,47 @@ def _fit_expected_count(x, column):
               f'({type(error).__name__}: {error}); predicting its mean instead')
         return _ExpectedCount(None, np.array([float(np.mean(column))]))
     return _ExpectedCount(model, values)
+
+
+def _fit_floor_groups(x_train, y_train, y_test, x_test, kinds, base_name,
+                      autoemulate_cls, fit_kwargs, fallback_model):
+    """On-floor/active classifier plus a magnitude regressor, for each floored count.
+
+    The same two-stage shape :class:`TwoPhaseEmulator` uses, applied inside multi_phase to
+    the counts that have too many levels for :class:`_ExpectedCount`. The classifier is
+    binary -- which is the whole point, since a classifier over their 26-53 levels is all
+    variance and measurably worse than a regressor (#498).
+
+    The floor is recomputed on the *scaled* targets, as the jump split is: an affine map
+    moves the value but not which rows sit on it.
+    """
+    columns = [int(c) for c in np.flatnonzero(kinds == 'floored_count')]
+    if not columns:
+        return []
+
+    has_floor, floor_value = floor_mask(y_train)
+    from sklearn.ensemble import GradientBoostingClassifier
+
+    groups = {}
+    for column in columns:
+        if not has_floor[column]:
+            continue
+        active = y_train[:, column] != floor_value[column]
+        groups.setdefault(active.tobytes(), []).append(column)
+
+    fitted = []
+    for members in groups.values():
+        active = y_train[:, members[0]] != floor_value[members[0]]
+        if int(active.sum()) < MIN_ACTIVE_ROWS:
+            continue
+        classifier = _fit_column(GradientBoostingClassifier, x_train, active)
+        magnitude = _fit_side(x_train, y_train, x_test, y_test, active, base_name,
+                              autoemulate_cls, fit_kwargs, fallback_model)
+        fitted.append({'columns': members,
+                       'classifier': _SingleOutputBinary(classifier),
+                       'floor_value': {c: float(floor_value[c]) for c in members},
+                       'magnitude': magnitude})
+    return fitted
 
 
 def _fit_jump_groups(x_train, y_train, y_test, x_test, kinds, base_name,

--- a/src/libcuflynx/funcs/cost_funcs_user.py
+++ b/src/libcuflynx/funcs/cost_funcs_user.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.special import gammaln
 
 from libcuflynx.param_id.differentiable import differentiable
 from libcuflynx.param_id.math_backend import make_math_backend, bind_backend
@@ -44,6 +45,13 @@ def cost_combiner(func):
 
 mb = make_math_backend("numpy")
 
+#: log(sqrt(2*pi)), the Gaussian normalising constant. gaussian_MLE drops it -- it is the same
+#: for every evaluation, so it changes no optimum. A *mixture* cannot drop it: the weight the
+#: mixture gives each component depends on the ratio of their densities, so both have to be
+#: normalised. See gaussian_MLE_robust.
+_LOG_SQRT_2PI = 0.5 * float(np.log(2.0 * np.pi))
+_SQRT_2PI = float(np.sqrt(2.0 * np.pi))
+
 
 @differentiable
 @is_MLE
@@ -55,6 +63,231 @@ def gaussian_MLE(output, desired_mean, std, weight):
     """
     per = mb.power((output - desired_mean) / std, 2) * weight
     return 0.5 * mb.sum(per) / mb.numel(per)
+
+
+#: How many terms of the Conway-Maxwell-Poisson series to sum. The distribution is
+#: under-dispersed for nu > 1, so its tail is shorter than a Poisson of the same mean; 256
+#: terms is far past the point where a term contributes at double precision for any count
+#: this pipeline sees (spike counts in the tens).
+COM_POISSON_TERMS = 256
+
+
+#: ``j`` and ``log(j!)`` for the series, built once. Recomputing ``gammaln`` on every call
+#: cost 1.1 ms per evaluation, which at eighteen count observables and sixty-four walkers is
+#: 3.5 hours added to a 10000-step chain.
+_COM_POISSON_J = np.arange(COM_POISSON_TERMS, dtype=float)
+_COM_POISSON_LOG_FACT = gammaln(_COM_POISSON_J + 1.0)
+
+
+def _com_poisson_log_terms(log_lam, nu, n_terms=COM_POISSON_TERMS):
+    """log of the unnormalised weight of each count j: j*log(lambda) - nu*log(j!)."""
+    if n_terms == COM_POISSON_TERMS:
+        j, log_fact = _COM_POISSON_J, _COM_POISSON_LOG_FACT
+    else:
+        j = np.arange(n_terms, dtype=float)
+        log_fact = gammaln(j + 1.0)
+    return j * log_lam - nu * log_fact, j
+
+
+def _com_poisson_log_Z(log_lam, nu, n_terms=COM_POISSON_TERMS):
+    """log of the normalising constant Z(lambda, nu), by log-sum-exp."""
+    terms, _ = _com_poisson_log_terms(log_lam, nu, n_terms)
+    top = terms.max()
+    return top + np.log(np.exp(terms - top).sum())
+
+
+def _com_poisson_mean(log_lam, nu, n_terms=COM_POISSON_TERMS):
+    """E[Y] under COM-Poisson. Monotone increasing in log_lam, which is what inverts it."""
+    terms, j = _com_poisson_log_terms(log_lam, nu, n_terms)
+    top = terms.max()
+    w = np.exp(terms - top)
+    return float((w * j).sum() / w.sum())
+
+
+def _com_poisson_log_lam_for_mean(target, nu, n_terms=COM_POISSON_TERMS):
+    """The log(lambda) whose COM-Poisson mean is ``target``.
+
+    lambda is *not* the mean unless nu == 1, so a model that predicts an expected count has
+    to be mapped onto it. The mean is strictly increasing in lambda, so a bisection on
+    log(lambda) is exact to machine tolerance in ~60 iterations and cannot diverge -- which
+    a Newton step on a distribution this flat-tailed can. The asymptotic
+    ``lambda ~= (m + (nu-1)/(2nu))**nu`` is not used: it is poor for exactly the small means
+    this pipeline has (spike counts of 0-3).
+    """
+    if target <= 0.0:
+        return -np.inf
+    # bracket around the Poisson answer (log lambda = log(mean) at nu == 1); the true value
+    # moves monotonically with nu, so a wide but finite bracket around it is safe.
+    guess = np.log(target)
+    lo, hi = guess - 40.0, guess + 40.0
+    for _ in range(60):
+        mid = 0.5 * (lo + hi)
+        if _com_poisson_mean(mid, nu, n_terms) < target:
+            lo = mid
+        else:
+            hi = mid
+    return 0.5 * (lo + hi)
+
+
+#: Cached (log lambda, log mean, log Z) grids, one per nu. Built on first use.
+_COM_POISSON_TABLES = {}
+
+#: Grid resolution for those tables. 20000 points over log lambda in [-50, 60] puts the
+#: interpolation error below 1e-9 in the cost, against a 60-step bisection plus a 256-term
+#: log-sum-exp *per call* -- which added two hours to a 10000-step chain.
+_COM_POISSON_GRID = 20000
+
+
+def _com_poisson_table(nu, n_terms=COM_POISSON_TERMS):
+    """``(log_lam, log_mean, log_Z)`` on a grid, so a cost evaluation is two interpolations."""
+    key = (float(nu), int(n_terms))
+    cached = _COM_POISSON_TABLES.get(key)
+    if cached is not None:
+        return cached
+    log_lam = np.linspace(-50.0, 60.0, _COM_POISSON_GRID)
+    j = _COM_POISSON_J if n_terms == COM_POISSON_TERMS else np.arange(n_terms, dtype=float)
+    log_fact = (_COM_POISSON_LOG_FACT if n_terms == COM_POISSON_TERMS
+                else gammaln(j + 1.0))
+    terms = log_lam[:, None] * j[None, :] - nu * log_fact[None, :]
+    top = terms.max(axis=1, keepdims=True)
+    w = np.exp(terms - top)
+    total = w.sum(axis=1)
+    log_Z = top[:, 0] + np.log(total)
+    mean = (w * j[None, :]).sum(axis=1) / total
+    keep = mean > 0                      # the smallest lambdas underflow to a zero mean
+    log_lam, log_Z, log_mean = log_lam[keep], log_Z[keep], np.log(mean[keep])
+    # Interpolate the residual from the analytic trend rather than the quantity itself.
+    # mean ~ lambda**(1/nu), so log_lam ~ nu*log_mean and the leftover is small and flat --
+    # which drops the linear-interpolation error from 7e-5 to below 1e-9 on the same grid.
+    cached = (log_lam, log_mean, log_Z, log_lam - nu * log_mean)
+    _COM_POISSON_TABLES[key] = cached
+    return cached
+
+
+@is_MLE
+def com_poisson_MLE(output, prob_dist_params, weight, nu=1.0, background_rate=0.0):
+    """Conway-Maxwell-Poisson NLL for a count whose spread is narrower than Poisson's.
+
+    A Poisson cannot be told how tight it is: its variance equals its mean, so at an observed
+    count of 0 or 1 it barely distinguishes a model that fires once from one that fires three
+    times. COM-Poisson adds the one parameter that fixes this::
+
+        P(Y=y) = lambda**y / ((y!)**nu * Z(lambda, nu)),   Z = sum_j lambda**j / (j!)**nu
+
+    ``nu`` is the dispersion: 1 is exactly Poisson, ``nu > 1`` is under-dispersed (tighter),
+    ``nu < 1`` over-dispersed. Unlike raising a data_item's ``weight``, this stays a proper
+    probability model -- weighting tempers the likelihood by a power and is not a distribution
+    over counts at all, so a posterior built from it is not a posterior for any model.
+
+    **``output`` is the expected count, not lambda.** lambda is only the mean when nu == 1, so
+    the model's prediction is mapped through :func:`_com_poisson_log_lam_for_mean` first. That
+    keeps the optimum at ``E[Y] == k`` for every nu, which is what makes nu a pure
+    tightness knob rather than something that also moves the fit.
+
+    ``background_rate`` matches :func:`poisson_MLE`: a rate the model does not claim to
+    explain, added to its prediction before scoring.
+
+    The ``log(k!)`` term is kept rather than dropped (it carries ``nu``, so unlike the Poisson
+    case it is not a constant across candidate nu), which means costs are comparable between
+    nu values but not with ``poisson_MLE``'s.
+    """
+    if not isinstance(prob_dist_params, dict) or "k" not in prob_dist_params:
+        raise ValueError(
+            "prob_dist_params for com_poisson_MLE in obs_data.json must be a dict with a 'k' "
+            "entry (the observed count)")
+    if nu <= 0.0:
+        raise ValueError(f"nu for com_poisson_MLE must be > 0, got {nu}")
+    if background_rate < 0.0:
+        raise ValueError(
+            f"background_rate for com_poisson_MLE must be >= 0, got {background_rate}")
+
+    k = float(prob_dist_params["k"])
+    mean = float(np.clip(np.clip(output, 0.0, None) + background_rate, 1e-12, None))
+
+    # The expensive half was inverting the mean -- sixty bisection steps, each a full
+    # log-sum-exp. That is what the table replaces. log Z is then a single 256-term
+    # log-sum-exp at the answer, so it stays exact rather than interpolated.
+    _, grid_log_mean, _, grid_resid = _com_poisson_table(nu)
+    log_mean = np.log(mean)
+    log_lam = float(nu * log_mean + np.interp(log_mean, grid_log_mean, grid_resid))
+    log_Z = float(_com_poisson_log_Z(log_lam, nu))
+    cost = (nu * gammaln(k + 1.0) + log_Z - k * log_lam) * weight
+    return float(cost)
+
+
+@differentiable
+@is_MLE
+def gaussian_MLE_robust(output, desired_mean, std, weight,
+                        p_outlier=0.0, outlier_width=170.0):
+    """Gaussian NLL with an outlier component, for an observable the model can miss outright.
+
+    ``gaussian_MLE`` assumes the model is always trying to hit the observation and is only ever
+    off by measurement noise. That is false for an observable with a discontinuity in it. The
+    maximum membrane voltage of a spiking cell is the spike peak when the cell fires and the
+    subthreshold maximum when it does not, so the model produces one of two values ~110 mV apart
+    and nothing in between. Against a measurement sigma of a few mV the gap is 25-30 sigma, and
+    landing on the wrong side of it costs hundreds of nats -- more than every other observable in
+    the study put together. That number is arithmetic on a category error: the branch mismatch is
+    a *model discrepancy* event and sigma is a *measurement* scale.
+
+    So score it as a two-component mixture::
+
+        p(y | theta) = (1 - eps) * N(y ; m(theta), std**2)  +  eps * q(y)
+
+    ``eps`` (``p_outlier``) is the probability the model's prediction is wrong for reasons outside
+    theta -- for a jump observable, the probability it takes the wrong branch. ``q`` is what is
+    believed about ``y`` when that happens: uniform over ``outlier_width``, the physiological span
+    of the observable, so ``q(y) = 1/outlier_width``.
+
+    Because ``y`` is data, ``q(y)`` is a constant, and the whole thing closes to::
+
+        NLL = weight * [ log(W/eps) - log(1 + K * exp(-z**2 / 2)) ],
+              z = (output - desired_mean)/std,   K = (1-eps)*W / (eps*std*sqrt(2*pi))
+
+    ``K`` is constant, so ``K*exp(-z**2/2)`` is bounded above by ``K`` -- no overflow, no log of
+    zero, and no log-sum-exp needed. It is smooth in theta, hence ``@differentiable``.
+
+    What the two knobs do is worth keeping straight, because only one of them is a real dial:
+
+    * ``p_outlier`` and ``outlier_width`` set the *height* of the cap, ``log(W/eps)``: the most
+      this observable can ever cost, however wrong the model is.
+    * ``std`` sets *where* the cap starts, at ``z_c = sqrt(2*ln((1-eps)*W/(eps*std*sqrt(2*pi))))``.
+      Because eps and W enter through a logarithm, ``z_c`` is ~3.2-3.4 for any sensible pair --
+      halving eps moves it by a few hundredths. ``std`` moves the crossover linearly, so it is
+      ``std``, not eps, that decides which observables still inform the fit and which are written
+      off as outliers.
+
+    Set ``std`` accordingly: it has to cover the discrepancy you expect to *fit* (a systematically
+    over-large spike amplitude, say) while leaving the discrepancy you want *capped* (the branch
+    flip) outside. That makes it measurement error and model discrepancy in quadrature, not an
+    instrument specification.
+
+    ``p_outlier=0`` reduces to the ordinary Gaussian NLL **including** the normalising constant,
+    so it differs from ``gaussian_MLE`` by ``log(std*sqrt(2*pi))``. Per-item constants cancel in a
+    Metropolis ratio and move no optimum, but they do shift the reported cost, so numbers from a
+    study using this cost are not comparable with numbers from one using ``gaussian_MLE``.
+    """
+    if not 0.0 <= p_outlier < 1.0:
+        raise ValueError(
+            f"p_outlier for gaussian_MLE_robust must be in [0, 1), got {p_outlier}. It is the "
+            f"probability that the model's prediction is wrong for reasons outside the "
+            f"parameters; 1 would mean the model is never informative.")
+    if outlier_width <= 0.0:
+        raise ValueError(
+            f"outlier_width for gaussian_MLE_robust must be positive, got {outlier_width}. It is "
+            f"the span of values this observable can plausibly take when the model is wrong, in "
+            f"the observable's own units.")
+
+    z = (output - desired_mean) / std
+    if p_outlier == 0.0:
+        # The eps -> 0 limit, written out rather than reached by dividing by zero.
+        per = 0.5 * mb.power(z, 2) + mb.log(std) + _LOG_SQRT_2PI
+    else:
+        log_cap = float(np.log(outlier_width / p_outlier))
+        gain = ((1.0 - p_outlier) / p_outlier) * outlier_width / (std * _SQRT_2PI)
+        per = log_cap - mb.log(1.0 + gain * mb.exp(-0.5 * mb.power(z, 2)))
+    per = per * weight
+    return mb.sum(per) / mb.numel(per)
 
 
 @differentiable
@@ -145,7 +378,7 @@ def kernel_density_estimation(output, prob_dist_params, weight, bandwidth="scott
 
 
 @is_MLE
-def poisson_MLE(output, prob_dist_params, weight):
+def poisson_MLE(output, prob_dist_params, weight, background_rate=0.0):
     """Poisson negative log-likelihood contribution, for count data.
 
     The model output is the rate (lambda); ``prob_dist_params['k']`` is the observed count.
@@ -155,15 +388,31 @@ def poisson_MLE(output, prob_dist_params, weight):
     NLL = lambda - k*log(lambda), so it is minimised at lambda == k. (#367 had the sign the
     other way round, i.e. the log-likelihood, which an optimiser would have driven *away*
     from the data.)
+
+    ``background_rate`` is a rate the model does not claim to explain -- spontaneous activity, or
+    a detection artefact -- added to the model's own rate before scoring. It defaults to 0, which
+    reproduces the behaviour below exactly, and exists because the clip is otherwise doing work
+    it was never meant to do. A model that is silent where the recording fired k times pays
+    ``-k*log(lambda)``, and with lambda pinned at the 1e-12 clip that is ``k * 27.6`` -- a number
+    set by a numerical guard rather than by any belief about the cell. State it instead: at
+    ``background_rate=0.01`` the same miss costs ``k * 4.6``.
+
+    It is a strong dial, not a formality. Anywhere a jump observable has been capped (see
+    ``gaussian_MLE_robust``) the counts are the only thing left pushing the model towards firing,
+    so this value sets almost the whole of that push. It also moves the optimum to
+    ``output == k - background_rate``, which is negligible at 0.01 but is a bias, not a rounding.
     """
     if not isinstance(prob_dist_params, dict) or "k" not in prob_dist_params:
         raise ValueError(
             "prob_dist_params for poisson_MLE in obs_data.json must be a dict with a 'k' "
             "entry (the observed count)")
 
-    # A Poisson rate is positive; clip so a parameter set that drives it to zero costs a lot
-    # rather than producing -inf/nan and poisoning the whole cost.
-    lam = np.clip(output, 1e-12, None)
+    if background_rate < 0.0:
+        raise ValueError(
+            f"background_rate for poisson_MLE must be >= 0, got {background_rate}")
+    # A Poisson rate is positive. background_rate is the stated floor; the 1e-12 clip stays
+    # underneath it as the last-resort guard against -inf/nan when no floor was given.
+    lam = np.clip(np.clip(output, 0.0, None) + background_rate, 1e-12, None)
     k = prob_dist_params["k"]
 
     cost = (lam - k * np.log(lam)) * weight

--- a/src/libcuflynx/funcs/operation_funcs_user.py
+++ b/src/libcuflynx/funcs/operation_funcs_user.py
@@ -266,6 +266,68 @@ def calc_min_peak(t, V, series_output=False, spike_min_thresh=None):
     return min_peak
 
 @series_to_constant
+def min_between_first_two_spikes(t, V, series_output=False, spike_min_thresh=None):
+    """The afterhyperpolarisation trough: the minimum between a trace's first two spikes.
+
+    Locates the spikes in *this* trace rather than taking a fixed window, so the recording
+    and the model are each measured over their own first interspike interval. A window fixed
+    from the recording would make the feature partly a spike-timing measurement: on one
+    SN_full experiment the model had a spike inside the recording's window in only 10 of 40
+    posterior draws, because it fires more slowly than the cell, and the "trough" was then a
+    rising subthreshold ramp. Timing belongs in ``first_peak_time``; this is depth alone.
+
+    With fewer than two spikes there is no interspike interval, and the maximum of the trace
+    is returned -- the same sentinel :func:`calc_min_peak` uses. It is deliberately far from
+    any real trough: paired with ``gaussian_MLE_robust`` the cost is then capped, rather than
+    the subthreshold minimum being compared against a real AHP, which would duplicate what a
+    steady-state minimum already measures.
+    """
+    if series_output:
+        return V
+    peak_idxs, _ = find_peaks(V, height=spike_min_thresh)
+    if len(peak_idxs) < 2:
+        return mb.max(V)
+    return mb.min(V[peak_idxs[0]:peak_idxs[1] + 1])
+
+
+@series_to_constant
+def AHP_minus_steady_state_min(t, V, series_output=False, spike_min_thresh=None):
+    """How much deeper the *first* afterhyperpolarisation is than the steady-state minimum.
+
+    ``min_between_first_two_spikes(V) - steady_state_min(V)``, i.e. the trough after the first
+    spike measured against the trough the trace settles to. Two reasons to score the
+    difference rather than the trough itself:
+
+    * **It is not redundant.** ``steady_state_min`` is the minimum of the second half, which
+      during repetitive firing *is* a later AHP trough. On the SN_full recordings the first
+      trough and the steady-state minimum sit 0.5-2.8 mV apart, well inside a 4 mV sigma, so
+      an absolute AHP observable mostly repeats what ``steady_state_min`` already says.
+      The difference is what is left over: spike-frequency accommodation of the trough.
+    * **It barely charges the firing decision again.** A trace that never fires has its
+      firing already scored by the spike counts and by any jump observable; a difference that
+      is near zero whenever the model is silent does not charge it a third time. See #498's
+      sibling discussion -- the same binary is otherwise asserted by ~22 observables that are
+      all deterministic functions of it.
+
+    A trace with fewer than two spikes has no first interspike interval and so no measurable
+    accommodation: **zero** is returned, not the trace maximum that
+    :func:`min_between_first_two_spikes` uses. That difference is deliberate. An absolute
+    trough needs a sentinel far from any real value so a silent model is obviously wrong; a
+    *difference* wants the opposite, because "the model did not fire" is already asserted by
+    the spike counts and by every jump observable. Measured on ox1: with a far sentinel this
+    observable would add ~24 raw nats to the silence penalty, against ~0.6 with zero -- and
+    the counts alone already contribute 219.
+    """
+    if series_output:
+        return V
+    peak_idxs, _ = find_peaks(V, height=spike_min_thresh)
+    if len(peak_idxs) < 2:
+        return 0.0 * mb.max(V)          # zero, keeping the backend's type
+    return (min_between_first_two_spikes(t, V, spike_min_thresh=spike_min_thresh)
+            - steady_state_min(V))
+
+
+@series_to_constant
 def min_period(t, V, series_output=False, spike_min_thresh=None, distance=None):
     if series_output:
         return V
@@ -417,6 +479,86 @@ def max_first_half(x, series_output=False, start_frac=0.0, end_frac=0.5):
         return mb.min(range_values)
 
 @series_to_constant
+def V_plateau(t, V, series_output=False, spike_min_thresh=None, distance=None,
+              dV_dt_thresh=10e3):
+    """Mean voltage of the interspike plateau, after the AHP has recovered.
+
+    For each action potential, take its peak and the trough that follows it. The plateau is
+    taken to begin one peak-to-trough duration *after* the trough -- ``t_trough +
+    (t_trough - t_peak)`` -- which skips the AHP and its recovery, and to end at the firing
+    threshold of the next action potential, or at the end of the trace when there is none.
+    The value is the mean over that window for the **last** action potential whose plateau
+    start still falls inside it.
+
+    This replaces a "steady state minimum". ``steady_state_min`` takes the minimum of the
+    second half of the window, which on a repetitively firing trace is not a steady state at
+    all -- it is simply a later AHP trough. Averaging between the AHP and the next threshold
+    measures the interspike membrane potential the cell actually sits at, which is what a
+    plateau is meant to be, and it is no longer a trough measurement in disguise.
+
+    Thresholds come from :func:`_ap_thresholds`, the same walk :func:`mean_AP_threshold`
+    reports, so the two observables are consistent by construction.
+
+    With no action potentials there is no interspike interval; the mean of the second half of
+    the trace is returned, which is the plateau of a silent trace.
+    """
+    if series_output:
+        return V
+    peak_idxs, _ = find_peaks(V, height=spike_min_thresh, distance=distance)
+    fallback = mb.mean(V[len(V) // 2:])
+    if len(peak_idxs) < 1:
+        return fallback
+
+    thresholds = _ap_thresholds(t, V, peak_idxs, dV_dt_thresh)
+    window = None
+    for i, peak_idx in enumerate(peak_idxs):
+        next_peak = peak_idxs[i + 1] if i + 1 < len(peak_idxs) else len(V)
+        trough_idx = peak_idx + int(np.argmin(V[peak_idx:next_peak]))
+        start = t[trough_idx] + (t[trough_idx] - t[peak_idx])
+        if i + 1 < len(peak_idxs) and thresholds[i + 1][0] is not None:
+            end = t[thresholds[i + 1][0]]
+        else:
+            end = t[-1]
+        if start < end:
+            window = (start, end)          # keep the last AP that still has room
+    if window is None:
+        return fallback
+    selected = (t >= window[0]) & (t <= window[1])
+    if not np.any(selected):
+        return fallback
+    return mb.mean(V[selected])
+
+
+def _ap_thresholds(t, V, peak_idxs, dV_dt_thresh):
+    """``(index, voltage)`` where dV/dt first exceeds ``dV_dt_thresh`` ahead of each peak.
+
+    The walk is the one :func:`mean_AP_threshold` has always used -- start three quarters of
+    the way from the previous peak to this one, step forward until dV/dt crosses, then
+    interpolate the voltage -- factored out so the plateau window can start and end at the
+    same thresholds the threshold observable reports. ``(None, None)`` for a peak whose
+    threshold runs off the end of the trace.
+    """
+    out = []
+    prev_idx = 0
+    for peak_idx in peak_idxs:
+        current_idx = int((peak_idx + prev_idx) * 3 / 4)
+        dV_dt = 0
+        dV_dt_prev = 0
+        while dV_dt < dV_dt_thresh and current_idx < len(t) - 1:
+            dV_dt_prev = dV_dt
+            dV_dt = (V[current_idx + 1] - V[current_idx]) / (t[current_idx + 1] - t[current_idx])
+            current_idx += 1
+        if current_idx < len(t) - 1:
+            out.append((current_idx,
+                        np.interp(dV_dt_thresh, [dV_dt_prev, dV_dt],
+                                  [V[current_idx - 1], V[current_idx]])))
+            prev_idx = peak_idx
+        else:
+            out.append((None, None))
+    return out
+
+
+@series_to_constant
 def mean_AP_threshold(t, V, series_output=False, spike_min_thresh=None, distance=None, dV_dt_thresh=10e3):
     """
     This function calculates the mean action potential threshold
@@ -437,25 +579,9 @@ def mean_AP_threshold(t, V, series_output=False, spike_min_thresh=None, distance
         # there are no peaks, so set value to mean of the voltage
         threshold = mb.mean(V)
     else:
-        prev_idx = 0
-        thresholds = []
-        for peak_idx in peak_idxs:
-            t_peak = t[peak_idx]
-            current_idx = int((peak_idx + prev_idx) *3/ 4)
-            dV_dt = 0
-            dV_dt_prev = 0
-            while dV_dt < dV_dt_thresh and current_idx < len(t) - 1:
-                dV_dt_prev = dV_dt
-                dV_dt = (V[current_idx + 1] - V[current_idx]) / (t[current_idx + 1] - t[current_idx])
-                current_idx += 1
-            if current_idx < len(t) - 1:
-                interp_thresh = np.interp(dV_dt_thresh, [dV_dt_prev, dV_dt], [V[current_idx-1], V[current_idx]])
-                thresholds.append(interp_thresh) 
-                prev_idx = peak_idx
-            else:
-                # threshold not found for this peak, ignore it.
-                pass
-            
+        thresholds = [v for _, v in _ap_thresholds(t, V, peak_idxs, dV_dt_thresh)
+                      if v is not None]
+
         if len(thresholds) == 0:
             # no thresholds found, exit
             print("no thresholds found, setting cost to large")

--- a/src/libcuflynx/funcs/operation_funcs_user.py
+++ b/src/libcuflynx/funcs/operation_funcs_user.py
@@ -147,6 +147,31 @@ def calc_spike_frequency_windowed(t, V, series_output=False, spike_min_thresh=-1
     return spikes_per_s
 
 @series_to_constant
+def calc_spike_count_windowed(t, V, series_output=False, spike_min_thresh=-10,
+                              start_frac=0.0, end_frac=1.0):
+    """The number of spikes in the window -- the count itself, not a rate.
+
+    Same peak detection as :func:`calc_spike_frequency_windowed`; that one divides by
+    the window length and this one does not. The distinction matters to the cost: a
+    count is what a Poisson likelihood scores (``poisson_MLE`` takes the observed count
+    as ``prob_dist_params['k']`` and the model's count as lambda), and dividing by the
+    window turns an integer into a rate whose Poisson variance is wrong by the window
+    length squared.
+
+    It also matters to an emulator. An integer-valued observable can be learned as a
+    classifier over the values it takes rather than regressed as a continuous quantity
+    -- see ``multi_phase_<name>`` -- and that is only visible if the observable is
+    still an integer by the time the emulator sees it.
+    """
+    if series_output:
+        return V
+    start_idx = int(start_frac*(len(t)-1))
+    end_idx = int(end_frac*(len(t)-1))
+    peak_idxs, peak_properties = find_peaks(V[start_idx:end_idx], height=spike_min_thresh)
+    return float(len(peak_idxs))
+
+
+@series_to_constant
 def first_peak_time(t, V, series_output=False, spike_min_thresh=None):
     """ 
     returns the time value (time from start of pre_time, NOT the start of 

--- a/src/libcuflynx/param_id/paramID.py
+++ b/src/libcuflynx/param_id/paramID.py
@@ -168,9 +168,10 @@ def ensure_mle_cost_type_for_bayesian_inner(inner, inp_data_dict):
     outlier component and went back to paying hundreds of nats for a wrong branch. Both are
     MLE costs; neither needed replacing.
 
-    The consequence for the legacy spelling: ``UQ_options['cost_type']`` no longer forces a
-    cost onto observables that already name a valid one. It is the fallback for those that do
-    not, which is what the key is for now that ``cost_type`` lives per data_item.
+    The consequence for the legacy spelling: a ``cost_type`` named in ``UQ_options`` no
+    longer forces a cost onto observables that already name a valid one. It is the fallback
+    for those that do not, which is what the key is for now that ``cost_type`` lives per
+    data_item.
     """
     if inner is None or getattr(inner, "obs_info", None) is None:
         return

--- a/src/libcuflynx/param_id/paramID.py
+++ b/src/libcuflynx/param_id/paramID.py
@@ -153,12 +153,24 @@ def _resolve_UQ_options(UQ_options, mcmc_options):
 
 def ensure_mle_cost_type_for_bayesian_inner(inner, inp_data_dict):
     """
-    Set ``obs_info['cost_type']`` on an ParamID / MCMC instance so every
-    observable uses an ``@is_MLE`` cost (required for ``ln L = -cost`` in MCMC / Laplace).
+    Make sure every observable uses an ``@is_MLE`` cost (required for ``ln L = -cost`` in
+    MCMC / Laplace), **without discarding the ones that already do**.
 
-    Chooses the first ``cost_type`` string found in optimiser / mcmc option dicts in
-    ``inp_data_dict`` that names an ``@is_MLE`` cost in ``inner.cost_funcs_dict``;
-    otherwise ``gaussian_MLE``.
+    An observable whose own ``cost_type`` is already an MLE cost keeps it. Only the rest are
+    replaced, with the first ``cost_type`` found in the optimiser / UQ option dicts of
+    ``inp_data_dict`` that names an ``@is_MLE`` cost, or ``gaussian_MLE``.
+
+    It used to overwrite the whole vector with that one name, which quietly undid every
+    per-data_item choice the obs_data made -- and worse than quietly. A ``poisson_MLE`` count
+    is scored against ``prob_dist_params`` and deliberately carries no ``value``, so rewriting
+    it to ``gaussian_MLE`` compared the model against a ground truth of ``nan`` and every
+    sample in the chain came back ``nan``. A ``gaussian_MLE_robust`` item simply lost its
+    outlier component and went back to paying hundreds of nats for a wrong branch. Both are
+    MLE costs; neither needed replacing.
+
+    The consequence for the legacy spelling: ``UQ_options['cost_type']`` no longer forces a
+    cost onto observables that already name a valid one. It is the fallback for those that do
+    not, which is what the key is for now that ``cost_type`` lives per data_item.
     """
     if inner is None or getattr(inner, "obs_info", None) is None:
         return
@@ -185,8 +197,15 @@ def ensure_mle_cost_type_for_bayesian_inner(inner, inp_data_dict):
     if chosen is None:
         chosen = "gaussian_MLE"
     n = inner.obs_info["num_obs"]
-    inner.obs_info["cost_type"] = [chosen] * n
-    inner.cost_type = inner.obs_info["cost_type"]
+    existing = list(inner.obs_info.get("cost_type") or [])
+    resolved = []
+    for idx in range(n):
+        current = existing[idx] if idx < len(existing) else None
+        func = costs.get(current) if current else None
+        keep = func is not None and getattr(func, "is_MLE", False)
+        resolved.append(current if keep else chosen)
+    inner.obs_info["cost_type"] = resolved
+    inner.cost_type = resolved
 
 
 # Re-exported for backwards compatibility; the canonical definition is in param_id.aadc_backend.

--- a/src/libcuflynx/solver_wrappers/emulator_solver_helper.py
+++ b/src/libcuflynx/solver_wrappers/emulator_solver_helper.py
@@ -313,7 +313,23 @@ class SimulationHelper:
         return None
 
     def reset_and_clear(self, only_one_exp=-1):
-        self._features = None
+        """No solver state to reset, and the prediction has to survive this.
+
+        The protocol executor calls this after the last sub-experiment of *every* experiment,
+        because a real solver must not carry integrator state across them. An emulator has no
+        such state, and ``_features`` is a pure function of theta -- the same full feature
+        vector serves every segment, which is why :meth:`run` predicts once and indexes it.
+
+        Clearing it here made an eight-experiment study predict **eight times per cost
+        evaluation** instead of once, and worse, it discarded the batched prediction that
+        :meth:`predict_ensemble` had just computed for the whole walker population -- so the
+        vectorised MCMC path paid the batching cost and then re-predicted per walker anyway.
+        Measured on the SN_full ox1 study: 205 ms per cost evaluation against 26 ms, and an
+        MCMC step of 64 walkers 5.6 s against 0.4 s.
+
+        ``set_theta`` already drops the cache when theta actually changes, which is the only
+        thing that can invalidate it.
+        """
         return None
 
     def close_simulation(self):

--- a/tests/test_ahp_operation.py
+++ b/tests/test_ahp_operation.py
@@ -1,0 +1,184 @@
+"""``min_between_first_two_spikes``: the afterhyperpolarisation trough as an observable.
+
+The point of locating the spikes in each trace, rather than taking a window fixed from the
+recording, is that the model spikes at its own times. On one SN_full experiment the model had
+a spike inside the recording's window in only 10 of 40 posterior draws, so the "trough" was
+often a rising subthreshold ramp -- a spike-timing measurement wearing a trough's name.
+"""
+import numpy as np
+import pytest
+
+from libcuflynx.funcs.operation_funcs_user import min_between_first_two_spikes as ahp
+
+pytestmark = pytest.mark.unit
+
+
+def trace(spike_times, trough=-70.0, rest=-60.0, n=2001):
+    t = np.linspace(0, 1, n)
+    V = np.full_like(t, rest)
+    for a, b in zip(spike_times[:-1], spike_times[1:]):
+        V[(t > a + .02) & (t < b - .02)] = trough
+    for s in spike_times:
+        V[(t > s - .005) & (t < s + .005)] = 30.0
+    return t, V
+
+
+def test_it_returns_the_trough_between_the_first_two_spikes():
+    t, V = trace([0.2, 0.6])
+    assert ahp(t, V, spike_min_thresh=-10) == pytest.approx(-70.0)
+
+
+def test_a_deeper_trough_later_is_ignored():
+    """Only the *first* interspike interval counts, however the trace evolves after it."""
+    t, V = trace([0.2, 0.5, 0.8])
+    V[(t > 0.55) & (t < 0.75)] = -95.0          # much deeper, but after the second spike
+    assert ahp(t, V, spike_min_thresh=-10) == pytest.approx(-70.0)
+
+
+def test_timing_does_not_change_the_answer():
+    """The whole reason for locating spikes per-trace: shift them and the depth is unchanged."""
+    a = ahp(*trace([0.10, 0.30]), spike_min_thresh=-10)
+    b = ahp(*trace([0.55, 0.85]), spike_min_thresh=-10)
+    assert a == pytest.approx(b)
+
+
+@pytest.mark.parametrize('spikes', [[], [0.3]])
+def test_fewer_than_two_spikes_returns_the_maximum(spikes):
+    """A sentinel far from any trough, so gaussian_MLE_robust caps it rather than the
+    subthreshold minimum being scored against a real AHP."""
+    t, V = trace(spikes) if spikes else (np.linspace(0, 1, 501), np.full(501, -60.0))
+    got = ahp(t, V, spike_min_thresh=-10)
+    assert got == pytest.approx(np.max(V))
+    assert got > -60.0 or not spikes
+
+
+def test_series_output_passes_the_trace_through():
+    t, V = trace([0.2, 0.6])
+    assert np.array_equal(ahp(t, V, series_output=True, spike_min_thresh=-10), V)
+
+
+def test_it_is_registered_as_an_operation():
+    import libcuflynx.funcs.operation_funcs_user as ofu
+    assert callable(getattr(ofu, 'min_between_first_two_spikes'))
+
+
+# ------------------------------------------- the difference form, AHP minus steady state
+
+from libcuflynx.funcs.operation_funcs_user import AHP_minus_steady_state_min as ahp_diff
+
+
+def two_trough_trace(first_trough, late_trough, spikes=(0.10, 0.30), n=2001):
+    """Spikes early, a first trough between them, then a different steady-state trough."""
+    t = np.linspace(0, 1, n)
+    V = np.full_like(t, -60.0)
+    if len(spikes) >= 2:
+        V[(t > spikes[0] + .02) & (t < spikes[1] - .02)] = first_trough
+    V[t > 0.55] = late_trough
+    for s in spikes:
+        V[(t > s - .005) & (t < s + .005)] = 30.0
+    return t, V
+
+
+def test_it_measures_accommodation_of_the_trough():
+    t, V = two_trough_trace(first_trough=-70.0, late_trough=-65.0)
+    assert ahp_diff(t, V, spike_min_thresh=-10) == pytest.approx(-5.0)
+
+
+def test_no_accommodation_gives_zero():
+    t, V = two_trough_trace(first_trough=-65.0, late_trough=-65.0)
+    assert ahp_diff(t, V, spike_min_thresh=-10) == pytest.approx(0.0)
+
+
+def test_a_common_offset_cancels():
+    """The point of a difference: anything shared by both minima drops out."""
+    t, V = two_trough_trace(-70.0, -65.0)
+    a = ahp_diff(t, V, spike_min_thresh=-10)
+    b = ahp_diff(t, V - 12.0, spike_min_thresh=-10)      # whole trace shifted
+    assert a == pytest.approx(b)
+
+
+def test_a_silent_trace_returns_zero_not_a_far_sentinel():
+    """A silent model must not be charged for its silence a third time.
+
+    ``min_between_first_two_spikes`` deliberately returns the trace maximum when there is no
+    interspike interval, because an absolute trough needs an obviously-wrong sentinel. A
+    difference wants the opposite: the counts and the jump observables already assert that the
+    model did not fire, so this one should stay quiet. Measured on ox1, a far sentinel would
+    add ~24 raw nats to the silence penalty against ~0.6 with zero.
+    """
+    t, V = two_trough_trace(-70.0, -65.0, spikes=())
+    assert ahp_diff(t, V, spike_min_thresh=-10) == pytest.approx(0.0)
+    t, V = two_trough_trace(-70.0, -65.0, spikes=(0.10,))       # a single spike
+    assert ahp_diff(t, V, spike_min_thresh=-10) == pytest.approx(0.0)
+
+
+def test_the_silent_sentinel_costs_far_less_than_a_far_one():
+    from libcuflynx.funcs.cost_funcs_user import gaussian_MLE_robust
+    kw = dict(p_outlier=0.04, outlier_width=60.0)
+    observed, sigma = -1.6, 1.5
+    best = gaussian_MLE_robust(observed, observed, sigma, 1.0, **kw)
+    quiet = gaussian_MLE_robust(0.0, observed, sigma, 1.0, **kw)
+    far = gaussian_MLE_robust(5.0, observed, sigma, 1.0, **kw)
+    assert quiet - best < 0.15 * (far - best)
+
+
+def test_series_output_passes_through():
+    t, V = two_trough_trace(-70.0, -65.0)
+    assert np.array_equal(ahp_diff(t, V, series_output=True, spike_min_thresh=-10), V)
+
+
+# ------------------------------------------------------ V_plateau, the interspike plateau
+
+from libcuflynx.funcs.operation_funcs_user import V_plateau, steady_state_min
+
+
+def firing_trace(plateau=-55.0, ahp=-75.0, spikes=(0.2, 0.5, 0.8), n=4001):
+    """A trace with a distinct AHP trough and a distinct interspike plateau."""
+    t = np.linspace(0, 1, n)
+    V = np.full_like(t, plateau)
+    for s in spikes:
+        up = (t > s - .004) & (t < s + .004)
+        V[up] = np.linspace(plateau, 30.0, up.sum())
+        dn = (t > s + .004) & (t < s + .02)
+        V[dn] = np.linspace(30.0, ahp, dn.sum())
+        rec = (t > s + .02) & (t < s + .06)
+        V[rec] = np.linspace(ahp, plateau, rec.sum())
+    return t, V
+
+
+def test_it_finds_the_plateau_not_the_trough():
+    """The whole point: steady_state_min returns the AHP on a firing trace, this does not."""
+    t, V = firing_trace(plateau=-55.0, ahp=-75.0)
+    assert V_plateau(t, V, spike_min_thresh=-10) == pytest.approx(-55.0, abs=1.5)
+    assert steady_state_min(V) == pytest.approx(-75.0, abs=0.5)
+
+
+def test_it_tracks_the_plateau_when_the_trough_is_unchanged():
+    """Move the plateau, hold the AHP: the plateau observable must follow the plateau."""
+    a = V_plateau(*firing_trace(plateau=-55.0, ahp=-75.0), spike_min_thresh=-10)
+    b = V_plateau(*firing_trace(plateau=-45.0, ahp=-75.0), spike_min_thresh=-10)
+    assert b - a == pytest.approx(10.0, abs=1.5)
+
+
+def test_it_ignores_the_trough_depth():
+    """Move the AHP, hold the plateau: the plateau observable must barely move."""
+    a = V_plateau(*firing_trace(plateau=-55.0, ahp=-75.0), spike_min_thresh=-10)
+    b = V_plateau(*firing_trace(plateau=-55.0, ahp=-90.0), spike_min_thresh=-10)
+    assert abs(b - a) < 2.0
+
+
+def test_a_silent_trace_falls_back_to_the_second_half_mean():
+    t = np.linspace(0, 1, 1001)
+    V = np.full_like(t, -62.0)
+    assert V_plateau(t, V, spike_min_thresh=-10) == pytest.approx(-62.0)
+
+
+def test_a_single_spike_still_gives_a_plateau():
+    """One AP has no next threshold, so the window runs to the end of the trace."""
+    t, V = firing_trace(plateau=-55.0, ahp=-75.0, spikes=(0.2,))
+    assert V_plateau(t, V, spike_min_thresh=-10) == pytest.approx(-55.0, abs=1.5)
+
+
+def test_series_output_passes_through():
+    t, V = firing_trace()
+    assert np.array_equal(V_plateau(t, V, series_output=True, spike_min_thresh=-10), V)

--- a/tests/test_ahp_operation.py
+++ b/tests/test_ahp_operation.py
@@ -113,7 +113,11 @@ def test_a_silent_trace_returns_zero_not_a_far_sentinel():
 
 
 def test_the_silent_sentinel_costs_far_less_than_a_far_one():
-    from libcuflynx.funcs.cost_funcs_user import gaussian_MLE_robust
+    # Through the registry, not the bare module function: the funcs dispatch on a module-level
+    # ``mb`` that each register_* hook rebinds, so a bare call inherits whichever backend the
+    # last-built registry left behind (casadi's ``numel`` needs a casadi type, #315).
+    from libcuflynx.funcs.cost_funcs_user import get_cost_funcs_dict_for_mode
+    gaussian_MLE_robust = get_cost_funcs_dict_for_mode("numpy")["gaussian_MLE_robust"]
     kw = dict(p_outlier=0.04, outlier_width=60.0)
     observed, sigma = -1.6, 1.5
     best = gaussian_MLE_robust(observed, observed, sigma, 1.0, **kw)

--- a/tests/test_emulator_solver_helper.py
+++ b/tests/test_emulator_solver_helper.py
@@ -605,3 +605,72 @@ def test_the_old_class_names_still_import():
 
     assert paramID.OpencorParamID is paramID.ParamID
     assert paramID.OpencorMCMC is paramID.MCMC
+
+# ------------------------------------------------- the prediction survives a protocol reset
+
+class PredictCounter(LinearStub):
+    """A LinearStub that records how many times the bundle was asked to predict."""
+
+    def __init__(self, weights):
+        super().__init__(weights)
+        self.calls = 0
+
+    def predict(self, x):
+        self.calls += 1
+        return super().predict(x)
+
+
+def _helper_over(bundle):
+    from libcuflynx.solver_wrappers.emulator_solver_helper import SimulationHelper
+    return SimulationHelper('unused/dir', bundle=bundle, out_of_bounds='clip')
+
+
+def test_reset_and_clear_keeps_the_prediction(base_user_inputs, resources_dir, tmp_path):
+    """``reset_and_clear`` must not throw away features an emulator already predicted.
+
+    The protocol executor calls it after the last sub-experiment of *every* experiment,
+    because a solver must not carry integrator state between them. An emulator has none, and
+    its features are a pure function of theta -- so clearing here made an N-experiment study
+    predict N times per cost evaluation instead of once. Measured at 205 ms against 21 ms on
+    an eight-experiment study, and it also discarded the batched ``predict_ensemble`` result
+    that the vectorised MCMC path had just computed for the whole walker population.
+    """
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    bundle, _, _ = _write_bundle(config)
+    counting = PredictCounter(bundle.model.weights)
+    bundle.model = counting
+    helper = _helper_over(bundle)
+
+    theta = np.full(len(bundle.param_entry_labels), 0.5)
+    helper.set_theta(theta)
+    helper.run()
+    assert counting.calls == 1
+
+    # eight experiments' worth of resets, with theta unchanged throughout
+    for _ in range(8):
+        helper.reset_and_clear()
+        helper.run()
+    assert counting.calls == 1, ('reset_and_clear re-predicted; the features are a pure '
+                                 'function of theta and nothing about theta changed')
+
+
+def test_a_changed_theta_still_invalidates_the_prediction(base_user_inputs, resources_dir,
+                                                          tmp_path):
+    """The one thing that *must* still drop the cache is theta actually moving."""
+    config = _config(base_user_inputs, resources_dir, tmp_path)
+    bundle, _, _ = _write_bundle(config)
+    counting = PredictCounter(bundle.model.weights)
+    bundle.model = counting
+    helper = _helper_over(bundle)
+
+    n = len(bundle.param_entry_labels)
+    helper.set_theta(np.full(n, 0.5)); helper.run()
+    first = np.array(helper._features, dtype=float)
+    helper.reset_and_clear()
+    helper.set_theta(np.full(n, 0.25)); helper.run()
+    assert counting.calls == 2
+    assert not np.allclose(first, np.array(helper._features, dtype=float))
+
+    # and setting the same theta again does not re-predict
+    helper.set_theta(np.full(n, 0.25)); helper.run()
+    assert counting.calls == 2

--- a/tests/test_internal_emulators.py
+++ b/tests/test_internal_emulators.py
@@ -162,9 +162,9 @@ def _autoemulate_or_skip():
         pytest.skip('autoemulate is not installed')
 
 
-def test_a_settings_form_is_offered_both_kinds():
-    """CUFLynx reads this list at runtime rather than hardcoding one, so the
-    two-phase variants reach its emulator settings without a change on its side."""
+def test_a_settings_form_is_offered_every_kind():
+    """CUFLynx reads this list at runtime rather than hardcoding one, so a new
+    variant reaches its emulator settings without a change on its side."""
     _autoemulate_or_skip()
     from libcuflynx.emulators.emulator_trainer import (
         base_emulator_model_names, emulator_model_names)
@@ -172,9 +172,11 @@ def test_a_settings_form_is_offered_both_kinds():
     offered = emulator_model_names()
     base = base_emulator_model_names()
 
-    assert len(offered) == 2 * len(base)
+    # plain, two-phase and multi-phase
+    assert len(offered) == 3 * len(base)
     for name in base:
         assert ie.two_phase_name(name) in offered
+        assert ie.multi_phase_name(name) in offered
 
 
 def test_all_does_not_sweep_up_the_two_phase_variants():
@@ -185,6 +187,7 @@ def test_all_does_not_sweep_up_the_two_phase_variants():
     from libcuflynx.emulators.emulator_trainer import _parse_models
 
     assert not any(ie.is_two_phase(name) for name in _parse_models('all'))
+    assert not any(ie.is_multi_phase(name) for name in _parse_models('all'))
 
 
 def test_asking_for_one_by_name_reaches_the_trainer():
@@ -214,3 +217,185 @@ def test_a_two_phase_name_cannot_be_mixed_with_others():
     trainer.pid = None
     with pytest.raises(ValueError, match='fitted on its own'):
         trainer.fit(np.zeros((10, 2)), np.zeros((10, 2)))
+
+
+# ---------------------------------------------------------------------------
+# multi-phase: counts, jumps and smooth observables in one emulator
+# ---------------------------------------------------------------------------
+def _multi_phase_design(seed=0, n=400):
+    """One column of each kind, with a quiet branch that genuinely varies.
+
+    The quiet branch varying is the point: a constant one is representable by the
+    two-phase emulator, so it would not distinguish the two.
+    """
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(0, 1, size=(n, 3))
+    count = np.where(x[:, 0] < 0.4, 0, np.round(1 + 4 * (x[:, 0] - 0.4) / 0.6)).astype(float)
+    jump = np.where(x[:, 1] < 0.5, -60 + 18 * x[:, 2], 20 + 25 * x[:, 2])
+    smooth = 3.0 + 2.0 * x[:, 0] - 1.5 * x[:, 1] ** 2
+    return x, np.column_stack([count, jump, smooth])
+
+
+def test_the_three_kinds_are_found_from_the_data_not_from_a_name():
+    from libcuflynx.emulators.internal_emulators import classify_features
+
+    _, y = _multi_phase_design()
+    assert list(classify_features(y)) == ["count", "jump", "smooth"]
+
+
+def test_a_count_is_only_a_count_when_it_is_a_small_set_of_non_negative_integers():
+    import numpy as np
+
+    from libcuflynx.emulators.internal_emulators import is_count_column
+
+    assert is_count_column(np.array([0.0, 1, 2, 3, 1, 0, 2]))
+    # negative -> not a count
+    assert not is_count_column(np.array([0.0, -1, 2, 3]))
+    # non-integer -> not a count
+    assert not is_count_column(np.array([0.0, 1.5, 2, 3]))
+    # a single value is a constant, not a count
+    assert not is_count_column(np.zeros(20))
+    # too many levels is a continuous quantity for every practical purpose
+    assert not is_count_column(np.arange(200.0))
+
+
+def test_a_jump_is_two_populations_not_a_repeated_value():
+    """``floor_mask`` cannot see this shape, which is why it needed its own test.
+
+    A peak voltage that either spikes or does not has two *branches*, each varying;
+    no single value repeats, so the floor test finds nothing.
+    """
+    import numpy as np
+
+    from libcuflynx.emulators.internal_emulators import floor_mask, jump_threshold
+
+    rng = np.random.default_rng(3)
+    x = rng.uniform(0, 1, 400)
+    column = np.where(x < 0.5, -60 + 18 * x, 20 + 25 * x)
+
+    assert jump_threshold(column) is not None
+    has_floor, _ = floor_mask(column.reshape(-1, 1))
+    assert not has_floor.any()
+
+
+def test_a_smooth_column_has_no_jump():
+    import numpy as np
+
+    from libcuflynx.emulators.internal_emulators import jump_threshold
+
+    rng = np.random.default_rng(4)
+    assert jump_threshold(np.sort(rng.uniform(0, 1, 400))) is None
+
+
+@pytest.mark.parametrize("family", ["RadialBasisFunctions", "MLP"])
+def test_multi_phase_predicts_each_kind_the_way_its_shape_asks(family):
+    """Counts stay non-negative, and every kind is recovered."""
+    import numpy as np
+
+    from libcuflynx.emulators.emulator_trainer import _load_autoemulate
+    from libcuflynx.emulators.internal_emulators import classify_features, fit_multi_phase
+
+    pytest.importorskip("autoemulate")
+    x, y = _multi_phase_design()
+    kinds = classify_features(y)
+    shift, span = y.min(0), np.ptp(y, 0)
+    scaled = (y - shift) / span
+    train, test = slice(0, 320), slice(320, None)
+
+    model, _ = fit_multi_phase(
+        x[train], scaled[train], x[test], scaled[test], family,
+        _load_autoemulate(), dict(n_iter=3, n_splits=3, random_seed=0), kinds)
+
+    assert model.model_name == f"multi_phase_{family}"
+    predicted = model.predict(x[test]) * span + shift
+
+    # A count is never negative -- a Poisson cost clips a negative lambda to 1e-12 and
+    # charges k*log(1e12) for it, with no gradient to climb back out.
+    assert predicted[:, 0].min() >= -1e-9
+
+    for column in range(3):
+        truth = y[test][:, column]
+        residual = ((truth - predicted[:, column]) ** 2).sum()
+        total = ((truth - truth.mean()) ** 2).sum()
+        assert 1 - residual / total > 0.9, f"column {column} fitted poorly"
+
+
+def test_both_sides_of_a_jump_get_their_own_regressor():
+    """The difference from two-phase, stated as the number it changes.
+
+    Two-phase substitutes one constant on the inactive side, so a quiet branch that
+    varies is not merely approximated badly -- it cannot be represented at all.
+    """
+    import numpy as np
+
+    from libcuflynx.emulators.emulator_trainer import _load_autoemulate
+    from libcuflynx.emulators.internal_emulators import (
+        classify_features, fit_multi_phase, fit_two_phase)
+
+    pytest.importorskip("autoemulate")
+    rng = np.random.default_rng(1)
+    x = rng.uniform(0, 1, size=(500, 3))
+    y = np.where(x[:, 1] < 0.5, -60 + 18 * x[:, 2], 20 + 25 * x[:, 2]).reshape(-1, 1)
+    shift, span = y.min(0), np.ptp(y, 0)
+    scaled = (y - shift) / span
+    train, test = slice(0, 400), slice(400, None)
+    autoemulate, kwargs = _load_autoemulate(), dict(n_iter=3, n_splits=3, random_seed=0)
+
+    multi, _ = fit_multi_phase(x[train], scaled[train], x[test], scaled[test],
+                               "RadialBasisFunctions", autoemulate, kwargs,
+                               classify_features(y))
+    two, _ = fit_two_phase(x[train], scaled[train], x[test], scaled[test],
+                           "RadialBasisFunctions", autoemulate, kwargs)
+
+    quiet = x[test][:, 1] < 0.5
+    truth = y[test].ravel()[quiet]
+
+    def quiet_r2(model):
+        predicted = (model.predict(x[test]) * span + shift).ravel()[quiet]
+        return 1 - ((truth - predicted) ** 2).sum() / ((truth - truth.mean()) ** 2).sum()
+
+    assert quiet_r2(multi) > 0.9
+    assert quiet_r2(multi) > quiet_r2(two) + 0.5
+    assert len(multi.jump_groups) == 1
+    assert multi.jump_groups[0]["low"] is not None
+    assert multi.jump_groups[0]["high"] is not None
+
+
+def test_columns_that_jump_together_share_one_pair_of_regressors():
+    """Otherwise every observable of one trace pays for its own pair."""
+    import numpy as np
+
+    from libcuflynx.emulators.emulator_trainer import _load_autoemulate
+    from libcuflynx.emulators.internal_emulators import classify_features, fit_multi_phase
+
+    pytest.importorskip("autoemulate")
+    rng = np.random.default_rng(2)
+    x = rng.uniform(0, 1, size=(400, 3))
+    spiking = x[:, 1] < 0.5
+    y = np.column_stack([
+        np.where(spiking, -60 + 18 * x[:, 2], 20 + 25 * x[:, 2]),
+        np.where(spiking, -40 + 9 * x[:, 0], 35 + 12 * x[:, 0]),
+    ])
+    shift, span = y.min(0), np.ptp(y, 0)
+    scaled = (y - shift) / span
+    model, _ = fit_multi_phase(x[:320], scaled[:320], x[320:], scaled[320:],
+                               "RadialBasisFunctions", _load_autoemulate(),
+                               dict(n_iter=3, n_splits=3, random_seed=0),
+                               classify_features(y))
+    assert len(model.jump_groups) == 1
+    assert sorted(model.jump_groups[0]["columns"]) == [0, 1]
+
+
+def test_a_multi_phase_name_is_refused_alongside_another_model():
+    from libcuflynx.emulators.internal_emulators import (
+        base_emulator_name, is_multi_phase, multi_phase_name)
+
+    assert is_multi_phase("multi_phase_MLP")
+    assert not is_multi_phase("two_phase_MLP")
+    assert base_emulator_name("multi_phase_MLP") == "MLP"
+    assert base_emulator_name("two_phase_MLP") == "MLP"
+    assert base_emulator_name("MLP") == "MLP"
+    assert multi_phase_name("MLP") == "multi_phase_MLP"
+    assert multi_phase_name("multi_phase_MLP") == "multi_phase_MLP"

--- a/tests/test_internal_emulators.py
+++ b/tests/test_internal_emulators.py
@@ -438,3 +438,136 @@ def test_a_jump_side_that_fails_to_fit_falls_back_rather_than_raising():
     got = _fit_side(np.zeros((200, 2)), np.zeros((200, 1)), None, None, rows,
                     "RadialBasisFunctions", fails, {"n_splits": 5}, sentinel)
     assert got is sentinel
+
+
+# ----------------------------------------------------- counts never come back negative (#498)
+
+def test_the_class_cap_is_left_where_it_performs_best():
+    """The cap stays at 24, and that is a measured choice rather than an oversight.
+
+    Raising it so that counts with 26-53 levels became classifiers removed the negative
+    predictions of #498, but roughly doubled the error on those very features (RMSE +107%
+    on ox1, +81% on cpvt) and made the emulator worse overall -- std(dcost) 2.675 -> 3.097
+    and 3.385 -> 4.343 on the two 12000-sample studies. Negatives are clamped in predict
+    instead, which costs nothing. If this number is ever raised, re-measure both.
+    """
+    from libcuflynx.emulators.internal_emulators import is_count_column, COUNT_MAX_CLASSES
+    import numpy as np
+    rng = np.random.default_rng(0)
+    assert COUNT_MAX_CLASSES == 24
+    assert is_count_column(rng.integers(0, 20, size=4000).astype(float))
+    # beyond the cap a count is handled by the regressor, and the clamp below keeps it sane
+    assert not is_count_column(rng.integers(0, 40, size=4000).astype(float))
+    assert not is_count_column(rng.normal(size=500))
+    assert not is_count_column(rng.integers(0, 5, size=500).astype(float) - 3.0)
+
+
+def test_multi_phase_never_predicts_a_negative_count():
+    """Whatever produced the value, a count column is clamped at zero on the way out."""
+    from libcuflynx.emulators.internal_emulators import MultiPhaseEmulator
+
+    class Negative:
+        """Stands in for the plain regressor a demoted count would fall through to."""
+        def predict(self, x):
+            return np.full((len(x), 3), -2.5)
+
+    kinds = np.array(['count', 'smooth', 'count'], dtype=object)
+    # count_models deliberately empty: this is the fall-through path that produced the bug
+    model = MultiPhaseEmulator(Negative(), kinds, {}, [], 'RadialBasisFunctions',
+                               count_columns=[0, 2])
+    out = model.predict(np.zeros((7, 4)))
+    assert (out[:, [0, 2]] >= 0).all(), 'a count came back negative'
+    assert (out[:, 1] == -2.5).all(), 'a smooth column must not be clamped'
+
+
+def test_an_older_pickle_without_count_columns_still_loads():
+    """count_columns defaults to the modelled counts, so an existing bundle keeps working."""
+    from libcuflynx.emulators.internal_emulators import MultiPhaseEmulator
+
+    class Zero:
+        def predict(self, x):
+            return np.zeros((len(x), 2))
+
+    model = MultiPhaseEmulator(Zero(), np.array(['count', 'smooth'], dtype=object),
+                               {0: None}, [], 'MLP')
+    assert model.count_columns == [0]
+
+
+# ------------------------------------ floored counts get the floor treatment (#498)
+
+def test_a_count_past_the_class_cap_is_a_floored_count_not_smooth():
+    """The demoted counts of #498 are recognised rather than dropped to the regressor.
+
+    They are integer, non-negative, and spend most of the design on zero -- 31-92% on the
+    SN_full bundles -- so they have a floor to put exactly where it belongs.
+    """
+    from libcuflynx.emulators.internal_emulators import classify_features
+    rng = np.random.default_rng(0)
+    n = 600
+    few = rng.integers(0, 10, size=n).astype(float)             # under the cap
+    many = np.where(rng.random(n) < 0.7, 0.0,
+                    rng.integers(1, 45, size=n).astype(float))  # over the cap, floored at 0
+    smooth = rng.normal(size=n)
+    kinds = list(classify_features(np.column_stack([few, many, smooth])))
+    assert kinds[0] == 'count'
+    assert kinds[1] == 'floored_count'
+    assert kinds[2] == 'smooth'
+
+
+def test_a_floored_count_never_predicts_below_its_floor():
+    """The floor is assigned, not smoothed through -- so no clamping is needed for it."""
+    from libcuflynx.emulators.internal_emulators import MultiPhaseEmulator
+
+    class Rippling:
+        """A regressor that dips below zero the way a smooth fit does at a floor."""
+        def predict(self, x):
+            return np.full((len(x), 2), -0.4)
+
+    class SaysFloor:
+        def predict(self, x):
+            return np.zeros(len(x), dtype=bool)      # every row is on the floor
+
+    model = MultiPhaseEmulator(
+        Rippling(), np.array(['floored_count', 'smooth'], dtype=object), {}, [],
+        'RadialBasisFunctions', count_columns=[0],
+        floor_groups=[{'columns': [0], 'classifier': SaysFloor(),
+                       'floor_value': {0: 0.0}, 'magnitude': None}])
+    out = model.predict(np.zeros((5, 3)))
+    assert (out[:, 0] == 0.0).all(), 'the floor should be assigned exactly'
+    assert (out[:, 1] == -0.4).all(), 'a smooth column must be left alone'
+
+
+def test_the_magnitude_regressor_is_used_off_the_floor():
+    from libcuflynx.emulators.internal_emulators import MultiPhaseEmulator
+
+    class Base:
+        def predict(self, x):
+            return np.full((len(x), 1), -99.0)
+
+    class Magnitude:
+        def predict(self, x):
+            return np.full((len(x), 1), 7.0)
+
+    class Alternating:
+        def predict(self, x):
+            return np.arange(len(x)) % 2 == 1
+
+    model = MultiPhaseEmulator(
+        Base(), np.array(['floored_count'], dtype=object), {}, [], 'MLP',
+        count_columns=[0],
+        floor_groups=[{'columns': [0], 'classifier': Alternating(),
+                       'floor_value': {0: 0.0}, 'magnitude': Magnitude()}])
+    out = model.predict(np.zeros((4, 2)))[:, 0]
+    assert list(out) == [0.0, 7.0, 0.0, 7.0]
+
+
+def test_an_older_bundle_without_floor_groups_still_predicts():
+    from libcuflynx.emulators.internal_emulators import MultiPhaseEmulator
+
+    class Zero:
+        def predict(self, x):
+            return np.zeros((len(x), 1))
+
+    model = MultiPhaseEmulator(Zero(), np.array(['smooth'], dtype=object), {}, [], 'MLP')
+    assert model.floor_groups == []
+    assert model.predict(np.zeros((3, 2))).shape == (3, 1)

--- a/tests/test_internal_emulators.py
+++ b/tests/test_internal_emulators.py
@@ -399,3 +399,42 @@ def test_a_multi_phase_name_is_refused_alongside_another_model():
     assert base_emulator_name("MLP") == "MLP"
     assert multi_phase_name("MLP") == "multi_phase_MLP"
     assert multi_phase_name("multi_phase_MLP") == "multi_phase_MLP"
+
+
+def test_a_jump_side_too_thin_to_fold_falls_back_rather_than_raising():
+    """A side needs enough rows to *fold*, not merely to fit.
+
+    autoemulate cross-validates with n_splits folds and, when every candidate errors,
+    keeps no results at all -- so ``best_result()`` raises and one branch of one
+    observable would take the whole training run with it.
+    """
+    import numpy as np
+
+    from libcuflynx.emulators.internal_emulators import _fit_side
+
+    sentinel = object()
+
+    def explode(*_args, **_kwargs):  # pragma: no cover - must never be reached
+        raise AssertionError("a side this thin should not have been fitted")
+
+    rows = np.zeros(200, dtype=bool)
+    rows[:9] = True  # over MIN_SIDE_ROWS, under 2 * n_splits
+    got = _fit_side(np.zeros((200, 2)), np.zeros((200, 1)), None, None, rows,
+                    "RadialBasisFunctions", explode, {"n_splits": 5}, sentinel)
+    assert got is sentinel
+
+
+def test_a_jump_side_that_fails_to_fit_falls_back_rather_than_raising():
+    import numpy as np
+
+    from libcuflynx.emulators.internal_emulators import _fit_side
+
+    sentinel = object()
+
+    def fails(*_args, **_kwargs):
+        raise ValueError("No results available. Please run AutoEmulate.compare() first.")
+
+    rows = np.ones(200, dtype=bool)
+    got = _fit_side(np.zeros((200, 2)), np.zeros((200, 1)), None, None, rows,
+                    "RadialBasisFunctions", fails, {"n_splits": 5}, sentinel)
+    assert got is sentinel

--- a/tests/test_robust_cost_funcs.py
+++ b/tests/test_robust_cost_funcs.py
@@ -1,0 +1,317 @@
+"""``gaussian_MLE_robust`` and ``poisson_MLE``'s background rate.
+
+Both exist for observables with a discontinuity in them: a maximum membrane voltage is the
+spike peak when the cell fires and the subthreshold maximum when it does not, so the model
+produces one of two values ~110 mV apart and nothing between. Under a plain Gaussian that gap
+is 25-30 sigma and one wrong branch costs more than every other observable put together --
+which is arithmetic on a category error, because a branch flip is model discrepancy and sigma
+is measurement noise.
+
+The properties asserted here are the ones that make the mixture usable rather than merely
+smaller: a *stated* ceiling, a crossover in a known place, exact reduction to the Gaussian at
+eps = 0, and no overflow anywhere in between.
+"""
+import math
+
+import numpy as np
+import pytest
+
+from libcuflynx.funcs.cost_funcs_user import (
+    cost_func_metadata,
+    gaussian_MLE,
+    gaussian_MLE_robust,
+    get_cost_funcs_dict_for_mode,
+    poisson_MLE,
+)
+from libcuflynx.param_id.cost_kwargs import call_cost_func, check_cost_kwargs
+
+EPS = 0.04
+WIDTH = 170.0
+STD = 6.0
+TRUTH = 20.0
+
+
+def _cost(z, **over):
+    kwargs = dict(p_outlier=EPS, outlier_width=WIDTH)
+    kwargs.update(over)
+    std = kwargs.pop("std", STD)
+    return gaussian_MLE_robust(TRUTH + z * std, TRUTH, std, 1.0, **kwargs)
+
+
+def _crossover_z(eps=EPS, width=WIDTH, std=STD):
+    """Where the outlier component overtakes the Gaussian one."""
+    return math.sqrt(2.0 * math.log((1.0 - eps) * width / (eps * std * math.sqrt(2.0 * math.pi))))
+
+
+@pytest.mark.unit
+def test_the_cost_is_capped_at_log_width_over_epsilon():
+    """However wrong the model is, one observable can never cost more than log(W/eps).
+
+    This is the whole point: the ceiling is a number the modeller chose, not a number the
+    scale of the discontinuity chose for them.
+    """
+    cap = math.log(WIDTH / EPS)
+    assert _cost(6.0) == pytest.approx(cap, rel=1e-6)
+    assert _cost(50.0) == pytest.approx(cap, rel=1e-12)
+    assert _cost(1e4) == pytest.approx(cap, rel=1e-12)
+    assert _cost(-1e4) == pytest.approx(cap, rel=1e-12)
+    assert _cost(0.0) < cap
+
+
+@pytest.mark.unit
+def test_at_the_crossover_the_cost_is_exactly_the_cap_minus_log_two():
+    """The two components are equal there, so their sum is twice either one.
+
+    Pinning the crossover matters because it, not the cap, decides which observables still
+    inform the fit: anything whose *best achievable* error is beyond it is written off.
+    """
+    for eps, width, std in ((0.04, 170.0, 6.0), (0.05, 170.0, 4.0), (0.01, 40.0, 1.5)):
+        z_c = _crossover_z(eps, width, std)
+        cap = math.log(width / eps)
+        got = _cost(z_c, p_outlier=eps, outlier_width=width, std=std)
+        assert got == pytest.approx(cap - math.log(2.0), rel=1e-9)
+
+
+@pytest.mark.unit
+def test_the_crossover_barely_moves_with_epsilon_but_scales_with_std():
+    """eps and the width enter through a logarithm; std multiplies.
+
+    So std is the dial that decides what is fitted and what is capped, and eps only sets how
+    much a capped observable costs. Getting this backwards is the easy mistake.
+    """
+    base = _crossover_z(0.05, WIDTH, STD)
+    # a 25% change in eps -- the size of decision a modeller actually makes here
+    assert _crossover_z(0.04, WIDTH, STD) == pytest.approx(base, abs=0.1)
+    # and even a tenfold change moves it by less than one sigma, in either direction
+    assert abs(_crossover_z(0.005, WIDTH, STD) - base) < 1.0
+    assert abs(_crossover_z(0.5, WIDTH, STD) - base) < 1.6
+    # in the observable's own units, though, it tracks std almost exactly
+    assert _crossover_z(EPS, WIDTH, 12.0) * 12.0 > 1.8 * _crossover_z(EPS, WIDTH, 6.0) * 6.0
+
+
+@pytest.mark.unit
+def test_zero_p_outlier_is_the_normalised_gaussian():
+    """The eps -> 0 limit, and the documented offset from gaussian_MLE.
+
+    A mixture cannot drop the normalising constant -- the weight each component gets depends on
+    the ratio of their densities -- so this cost keeps it and gaussian_MLE does not.
+    """
+    offset = math.log(STD * math.sqrt(2.0 * math.pi))
+    for z in (0.0, 0.5, 2.0, 7.5):
+        plain = gaussian_MLE(TRUTH + z * STD, TRUTH, STD, 1.0)
+        assert _cost(z, p_outlier=0.0) == pytest.approx(plain + offset, rel=1e-12)
+
+
+@pytest.mark.unit
+def test_it_is_monotone_in_the_error_and_finite_everywhere():
+    zs = np.concatenate([np.linspace(0.0, 12.0, 400), [1e3, 1e6]])
+    costs = np.array([_cost(z) for z in zs])
+    assert np.all(np.isfinite(costs))
+    assert np.all(np.diff(costs) >= -1e-12)
+    assert costs[0] == pytest.approx(_cost(-0.0))
+    # symmetric in the sign of the error
+    assert _cost(-2.7) == pytest.approx(_cost(2.7), rel=1e-12)
+
+
+@pytest.mark.unit
+def test_a_tiny_p_outlier_does_not_overflow():
+    """gain = (1-eps)W/(eps*std*sqrt(2pi)) grows as eps shrinks, but only ever multiplies
+    exp(-z^2/2) <= 1, so nothing exponentiates a large number."""
+    for eps in (1e-3, 1e-6, 1e-12):
+        assert np.isfinite(_cost(0.0, p_outlier=eps))
+        assert _cost(40.0, p_outlier=eps) == pytest.approx(math.log(WIDTH / eps), rel=1e-9)
+
+
+@pytest.mark.unit
+def test_weight_and_series_behave_like_gaussian_MLE():
+    assert _cost(1.3, ) * 3.0 == pytest.approx(
+        gaussian_MLE_robust(TRUTH + 1.3 * STD, TRUTH, STD, 3.0,
+                            p_outlier=EPS, outlier_width=WIDTH))
+    series = np.array([TRUTH, TRUTH + STD, TRUTH + 40.0 * STD])
+    got = gaussian_MLE_robust(series, TRUTH, STD, 1.0, p_outlier=EPS, outlier_width=WIDTH)
+    expected = np.mean([_cost(0.0), _cost(1.0), math.log(WIDTH / EPS)])
+    assert got == pytest.approx(expected, rel=1e-9)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", [-0.01, 1.0, 1.5])
+def test_an_impossible_p_outlier_is_refused(bad):
+    with pytest.raises(ValueError, match="p_outlier"):
+        _cost(0.0, p_outlier=bad)
+
+
+@pytest.mark.unit
+def test_a_non_positive_outlier_width_is_refused():
+    with pytest.raises(ValueError, match="outlier_width"):
+        _cost(0.0, outlier_width=0.0)
+
+
+@pytest.mark.unit
+def test_it_is_registered_and_reaches_the_cost_call_path():
+    """Registration is automatic, and cost_kwargs is the route the knobs travel by."""
+    registry = get_cost_funcs_dict_for_mode("numpy")
+    assert "gaussian_MLE_robust" in registry
+    meta = cost_func_metadata()["gaussian_MLE_robust"]
+    assert meta["is_MLE"] and meta["differentiable"] and not meta["is_combiner"]
+
+    got = call_cost_func(registry["gaussian_MLE_robust"], TRUTH + 200.0, TRUTH,
+                         std=STD, weight=1.0,
+                         cost_kwargs={"p_outlier": EPS, "outlier_width": WIDTH})
+    assert got == pytest.approx(math.log(WIDTH / EPS), rel=1e-6)
+
+    # a mistyped knob is caught at setup, not after the first forward solve
+    with pytest.raises(ValueError):
+        check_cost_kwargs({"p_outlyer": EPS}, registry["gaussian_MLE_robust"],
+                          "gaussian_MLE_robust", "V_max")
+
+
+@pytest.mark.unit
+def test_poisson_background_rate_defaults_to_the_previous_behaviour():
+    for output, k in ((0.0, 4), (3.0, 3), (7.5, 2), (-1.0, 1)):
+        lam = np.clip(output, 1e-12, None)
+        assert poisson_MLE(output, {"k": k}, 1.0) == pytest.approx(lam - k * np.log(lam))
+
+
+@pytest.mark.unit
+def test_poisson_background_rate_bounds_the_silent_model():
+    """A model that never fires is what the clip was silently pricing; now the price is stated."""
+    k = 4
+    clipped = poisson_MLE(0.0, {"k": k}, 1.0)
+    assert clipped == pytest.approx(k * math.log(1e12), rel=1e-6)
+    for lam0 in (0.001, 0.01, 0.1):
+        got = poisson_MLE(0.0, {"k": k}, 1.0, background_rate=lam0)
+        assert got == pytest.approx(lam0 - k * math.log(lam0), rel=1e-12)
+        assert got < clipped
+    # and the optimum moves to k - background_rate, which is a bias and not a rounding
+    lam0 = 0.01
+    at_shifted = poisson_MLE(k - lam0, {"k": k}, 1.0, background_rate=lam0)
+    assert at_shifted <= poisson_MLE(float(k), {"k": k}, 1.0, background_rate=lam0)
+
+
+@pytest.mark.unit
+def test_a_negative_background_rate_is_refused():
+    with pytest.raises(ValueError, match="background_rate"):
+        poisson_MLE(1.0, {"k": 1}, 1.0, background_rate=-0.1)
+
+
+class _Inner:
+    """The surface ``ensure_mle_cost_type_for_bayesian_inner`` touches."""
+
+    def __init__(self, cost_types):
+        self.obs_info = {"num_obs": len(cost_types), "cost_type": list(cost_types)}
+        self.cost_type = self.obs_info["cost_type"]
+        self.cost_funcs_dict = get_cost_funcs_dict_for_mode("numpy")
+
+
+@pytest.mark.unit
+def test_bayesian_setup_keeps_an_observable_that_already_names_an_mle_cost():
+    """The MCMC path must not undo the obs_data's per-item choices.
+
+    It used to replace the whole vector with one name, which turned a ``poisson_MLE`` count --
+    scored against ``prob_dist_params`` and deliberately carrying no ``value`` -- into a
+    ``gaussian_MLE`` against a ground truth of nan, and stripped the outlier component off
+    every ``gaussian_MLE_robust`` item. Both are MLE costs and neither needed touching.
+    """
+    from libcuflynx.param_id.paramID import ensure_mle_cost_type_for_bayesian_inner
+
+    inner = _Inner(["gaussian_MLE", "poisson_MLE", "gaussian_MLE_robust", "poisson_MLE"])
+    ensure_mle_cost_type_for_bayesian_inner(
+        inner, {"UQ_options": {"cost_type": "gaussian_MLE"}})
+    assert inner.cost_type == ["gaussian_MLE", "poisson_MLE",
+                               "gaussian_MLE_robust", "poisson_MLE"]
+    assert inner.obs_info["cost_type"] is inner.cost_type
+
+
+@pytest.mark.unit
+def test_bayesian_setup_still_replaces_a_cost_that_is_not_an_mle():
+    """The rule it exists to enforce is unchanged: ln L = -cost needs an MLE everywhere."""
+    from libcuflynx.param_id.paramID import ensure_mle_cost_type_for_bayesian_inner
+
+    inner = _Inner(["MSE", "AE", "poisson_MLE"])
+    ensure_mle_cost_type_for_bayesian_inner(
+        inner, {"UQ_options": {"cost_type": "gaussian_MLE"}})
+    assert inner.cost_type == ["gaussian_MLE", "gaussian_MLE", "poisson_MLE"]
+
+    # and with no usable option it falls back to gaussian_MLE, as before
+    inner = _Inner(["MSE", None])
+    ensure_mle_cost_type_for_bayesian_inner(inner, {})
+    assert inner.cost_type == ["gaussian_MLE", "gaussian_MLE"]
+
+
+# ------------------------------------------------- Conway-Maxwell-Poisson (under-dispersed)
+
+class TestComPoisson:
+    """``com_poisson_MLE``: a count likelihood whose tightness is a parameter.
+
+    A Poisson's variance is its mean, so at an observed count of 0 or 1 it barely separates a
+    model that fires once from one that fires three times. COM-Poisson adds ``nu``: 1 is
+    Poisson, above 1 is under-dispersed. This is the proper-model alternative to raising a
+    data_item's ``weight``, which tempers the likelihood by a power and is not a distribution.
+    """
+
+    def test_nu_one_is_exactly_poisson(self):
+        from libcuflynx.funcs.cost_funcs_user import com_poisson_MLE, poisson_MLE
+        from scipy.special import gammaln
+        for k in (0, 1, 4, 8):
+            for mean in (0.5, 1.0, 3.0, 8.0):
+                com = com_poisson_MLE(mean, {'k': k}, 1.0, nu=1.0)
+                # poisson_MLE drops log(k!); com_poisson_MLE keeps it because it carries nu
+                assert com == pytest.approx(poisson_MLE(mean, {'k': k}, 1.0) + gammaln(k + 1),
+                                            abs=1e-8)
+
+    def test_output_is_the_expected_count_for_every_nu(self):
+        """The optimum stays at E[Y] == k, so nu is tightness alone and does not move the fit."""
+        from libcuflynx.funcs.cost_funcs_user import com_poisson_MLE
+        for nu in (1.0, 2.0, 3.0, 5.0):
+            for k in (1, 4, 8):
+                at_k = com_poisson_MLE(float(k), {'k': k}, 1.0, nu=nu)
+                for off in (0.5, -0.5, 2.0, -0.9):
+                    if k + off <= 0:
+                        continue
+                    assert com_poisson_MLE(k + off, {'k': k}, 1.0, nu=nu) > at_k
+
+    def test_larger_nu_is_under_dispersed(self):
+        from libcuflynx.funcs.cost_funcs_user import (
+            _com_poisson_log_lam_for_mean, _com_poisson_log_terms)
+        import numpy as np
+
+        def variance(mean, nu):
+            terms, j = _com_poisson_log_terms(_com_poisson_log_lam_for_mean(mean, nu), nu)
+            w = np.exp(terms - terms.max()); w /= w.sum()
+            m = (w * j).sum()
+            return float((w * (j - m) ** 2).sum())
+
+        for mean in (1.0, 3.0, 8.0):
+            assert variance(mean, 1.0) == pytest.approx(mean, rel=1e-6)   # Poisson: var == mean
+            assert variance(mean, 2.0) < variance(mean, 1.0)
+            assert variance(mean, 5.0) < variance(mean, 2.0)
+
+    def test_larger_nu_punishes_over_firing_harder(self):
+        """The whole point: at k=1 a model firing three times should cost more as nu rises."""
+        from libcuflynx.funcs.cost_funcs_user import com_poisson_MLE
+        excess = [com_poisson_MLE(3.0, {'k': 1}, 1.0, nu=nu)
+                  - com_poisson_MLE(1.0, {'k': 1}, 1.0, nu=nu) for nu in (1.0, 2.0, 3.0, 5.0)]
+        assert excess == sorted(excess)
+        assert excess[2] > 2 * excess[0]        # nu=3 more than doubles the Poisson penalty
+
+    def test_the_silence_penalty_is_left_alone(self):
+        """nu must sharpen over-firing without inflating 'the cell fired and the model did not'.
+
+        After ``gaussian_MLE_robust`` caps the jump observables the counts are the only thing
+        pushing the model towards firing, so that direction must not move much with nu.
+        """
+        from libcuflynx.funcs.cost_funcs_user import com_poisson_MLE
+        silent = [com_poisson_MLE(0.0, {'k': 1}, 1.0, nu=nu, background_rate=0.01)
+                  - com_poisson_MLE(1.0, {'k': 1}, 1.0, nu=nu) for nu in (1.0, 3.0)]
+        assert silent[1] / silent[0] < 1.2
+
+    def test_it_is_registered_and_rejects_bad_arguments(self):
+        from libcuflynx.funcs.cost_funcs_user import com_poisson_MLE, cost_func_metadata
+        meta = cost_func_metadata()
+        assert meta['com_poisson_MLE']['is_MLE'] is True
+        with pytest.raises(ValueError):
+            com_poisson_MLE(1.0, {'k': 1}, 1.0, nu=0.0)
+        with pytest.raises(ValueError):
+            com_poisson_MLE(1.0, {'k': 1}, 1.0, background_rate=-1.0)
+        with pytest.raises(ValueError):
+            com_poisson_MLE(1.0, {'no_k': 1}, 1.0)

--- a/tests/test_sn_firing_threshold_recovery.py
+++ b/tests/test_sn_firing_threshold_recovery.py
@@ -1,0 +1,396 @@
+"""Can a calibration find a sodium conductance across the threshold where the cell starts firing?
+
+This is the SN_full V_max problem reproduced small enough to run in a test. In the real study
+each ``V_max`` observable is the spike peak when the cell fires and the subthreshold maximum
+when it does not, so it takes one of two values ~110 mV apart and nothing in between. Scored by
+a plain Gaussian against a measurement sigma of a few mV, that gap is 25-30 sigma and one wrong
+branch costs more than every other observable in the study put together -- a number that comes
+from pricing a *model discrepancy* event on a *measurement* scale.
+
+``SN_simple`` shows the same thing on one parameter. Sweeping ``soma_SN/g_Na1_6`` (the transient
+Nav1.6 current, the spike generator) under a weak stimulus:
+
+    g_Na1_6   0.00   0.02   0.04   0.05  |  0.06   0.07   0.10   0.20   0.30   0.45   0.60
+    V_max    -55.0  -54.4  -53.5  -52.7  | +51.6  +52.7  +52.8  +56.1  +57.1  +57.0  +58.2
+    spikes       0      0      0      0  |     1      1      1      2      4      5      5
+
+A 105 mV step between 0.05 and 0.06, and a count that is exactly zero on one side. So the test
+covers both regimes by construction, and it exercises every piece the real study leans on:
+``gaussian_MLE_robust`` for the jump, ``poisson_MLE`` with a background rate for the count, the
+``multi_phase_`` emulator that classifies a jump column instead of regressing across it, and
+MCMC recovery of the parameter that generated the data.
+
+**dt matters more than it looks.** At ``dt=0.005`` -- fine for the smooth observables -- V_max
+scatters anywhere between -55 and +57 with no visible branch structure, because a 5 ms sample
+grid lands wherever it likes on a ~1 ms action potential. The bimodality above only appears at
+``dt=2e-4``. A test that used the coarse grid would be measuring the sampler, not the cell.
+"""
+import json
+import os
+import shutil
+
+import numpy as np
+import pytest
+
+from libcuflynx.param_id.paramID import CVS0DParamID
+from libcuflynx.parsers.PrimitiveParsers import YamlFileParser
+from libcuflynx.scripts.script_generate_with_new_architecture import generate_with_new_architecture
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    MPI = None
+
+#: The stimulus. Weak on purpose: at the -0.12 nA of the other SN_simple fixtures the cell
+#: fires for every g_Na1_6 in range, so there is no threshold to cross.
+I_IN = -0.02
+PARAM = "soma_SN/g_Na1_6"
+PARAM_MIN, PARAM_MAX = 0.0, 0.6
+
+#: Straddling the threshold at ~0.055: one firing, one silent.
+G_FIRING = 0.30
+G_SILENT = 0.02
+
+#: The knobs under test, matching what SN_full's ProcessData.py now writes.
+V_MAX_STD = 6.0
+V_MAX_P_OUTLIER = 0.04
+V_MAX_OUTLIER_WIDTH = 170.0
+COUNT_BACKGROUND_RATE = 0.01
+
+
+@pytest.fixture
+def mpi_comm():
+    if MPI is None:
+        pytest.skip("mpi4py is required for this test")
+    return MPI.COMM_WORLD
+
+
+def _obs_document(v_max, n_spikes):
+    """One current step, scored by the two costs this test exists for."""
+    return {
+        "protocol_info": {
+            "pre_times": [0.1],
+            "sim_times": [[0.35, 0.85]],
+            "params_to_change": {"soma_SN/I_in": [[0.0, I_IN]]},
+            "experiment_colors": ["r"],
+            "experiment_labels": ["threshold"],
+            "protocol_traces": {},
+        },
+        "prediction_items": [],
+        "data_items": [
+            {
+                "data_item_name": "V_max", "trace_name_for_plotting": "V_{max}",
+                "data_type": "constant", "operation": "max",
+                "operands": ["soma_SN/V"], "unit": "milliV", "weight": 1.0,
+                "value": float(v_max), "std": V_MAX_STD,
+                "cost_type": "gaussian_MLE_robust",
+                "cost_kwargs": {"p_outlier": V_MAX_P_OUTLIER,
+                                "outlier_width": V_MAX_OUTLIER_WIDTH},
+                "experiment_idx": 0, "subexperiment_idx": 1, "plot_type": "horizontal",
+            },
+            {
+                "data_item_name": "n_spikes", "trace_name_for_plotting": "n_{spikes}",
+                "data_type": "constant", "operation": "calc_spike_count_windowed",
+                "operands": ["time", "soma_SN/V"],
+                "operation_kwargs": {"spike_min_thresh": -10},
+                "unit": "dimensionless", "weight": 1.0,
+                "cost_type": "poisson_MLE",
+                "prob_dist_params": {"k": float(n_spikes)},
+                "cost_kwargs": {"background_rate": COUNT_BACKGROUND_RATE},
+                "experiment_idx": 0, "subexperiment_idx": 1, "plot_type": "None",
+            },
+        ],
+    }
+
+
+def _resources(resources_dir, work_dir):
+    """A resources directory holding just this test's one-parameter params_for_id.
+
+    Copied rather than pointed at the real one because ``params_for_id_path`` is always
+    re-derived from ``resources_dir`` by the parser -- setting the key in the config has no
+    effect at all, which is a trap worth not falling into twice.
+    """
+    out = os.path.join(work_dir, "resources")
+    os.makedirs(out, exist_ok=True)
+    for name in ("SN_simple_vessel_array.csv", "SN_simple_parameters.csv"):
+        shutil.copy(os.path.join(resources_dir, name), out)
+    with open(os.path.join(out, "SN_simple_params_for_id.csv"), "w") as handle:
+        handle.write("vessel_name, param_name, min, max, name_for_plotting\n")
+        handle.write(f"soma_SN, g_Na1_6, {PARAM_MIN}, {PARAM_MAX}, g_{{Na1.6}}\n")
+    return out
+
+
+def _config(base_user_inputs, work_dir, resources, obs_path, **overrides):
+    config = base_user_inputs.copy()
+    config.update({
+        "file_prefix": "SN_simple",
+        "input_param_file": "SN_simple_parameters.csv",
+        "params_for_id_file": "SN_simple_params_for_id.csv",
+        "model_type": "cellml",
+        "solver": "CVODE_myokit",
+        "param_id_method": "genetic_algorithm",
+        "pre_time": 0.1, "sim_time": 1.2,
+        # see the module docstring: the branch structure is invisible at 5 ms
+        "dt": 2e-4,
+        "DEBUG": True, "do_uq": False, "do_ia": False, "do_ad": False,
+        "plot_predictions": False,
+        "solver_info": {"solver": "CVODE_myokit", "MaximumStep": 2e-4},
+        "resources_dir": resources,
+        "generated_models_dir": os.path.join(work_dir, "generated_models"),
+        "param_id_output_dir": os.path.join(work_dir, "out"),
+        "param_id_obs_path": obs_path,
+        "optimiser_options": {"num_calls_to_function": 4},
+        "debug_optimiser_options": {"num_calls_to_function": 4},
+    })
+    config.update(overrides)
+    return YamlFileParser().parse_user_inputs_file(
+        config, obs_path_needed=True, do_generation_with_fit_parameters=False)
+
+
+def _features(pid, theta):
+    """The (V_max, n_spikes) the solver produces at one parameter value."""
+    mapping = list(pid.obs_info["const_idx_to_obs_idx"])
+    _, operands, _ = pid.get_cost_obs_and_pred_from_params(np.asarray([theta], dtype=float))
+    values = np.full(len(mapping), np.nan)
+    with pid.accumulating_temp_results():
+        index = 0
+        for exp_idx in range(pid.protocol_info["num_experiments"]):
+            for sub_idx in range(pid.protocol_info["num_sub_per_exp"][exp_idx]):
+                operand = operands[index] if index < len(operands) else None
+                index += 1
+                if operand is None:
+                    continue
+                with pid.evaluating_segment(exp_idx, sub_idx):
+                    obs_dict = pid.get_obs_output_dict(operand)
+                if obs_dict is None:
+                    continue
+                const = np.asarray(obs_dict["const"], dtype=float).reshape(-1)
+                for const_idx in range(len(const)):
+                    if pid._item_belongs_to_segment(mapping[const_idx], exp_idx, sub_idx):
+                        values[const_idx] = const[const_idx]
+    return values
+
+
+def _posterior(output_dir, burn_in=0.5):
+    """The chain, burnt in and flattened. ``mcmc_chain.npy`` is (steps, walkers, params)."""
+    chain = np.load(os.path.join(output_dir, "mcmc_chain.npy"))
+    start = int(burn_in * chain.shape[0])
+    return chain[start:].reshape(-1, chain.shape[2])[:, 0]
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_the_firing_threshold_is_a_jump_the_plain_gaussian_cannot_afford(
+        base_user_inputs, resources_dir, temp_output_dir, mpi_comm):
+    """The cliff exists, and the mixture is what makes it affordable.
+
+    Two things are asserted that no unit test can: that the *simulator* really does produce two
+    branches with nothing between them, and that the difference between the two costs at a
+    wrong-branch parameter is the difference between a bounded penalty and a dominating one.
+    """
+    pytest.importorskip("myokit")
+    if mpi_comm.Get_size() > 1:
+        pytest.skip("this test drives the solver directly and is single-rank")
+
+    work = temp_output_dir
+    resources = _resources(resources_dir, work)
+    obs_path = os.path.join(work, "obs_probe.json")
+    with open(obs_path, "w") as handle:
+        json.dump(_obs_document(0.0, 0.0), handle)
+
+    config = _config(base_user_inputs, work, resources, obs_path)
+    assert generate_with_new_architecture(False, config), "SN_simple generation failed"
+    config = _config(base_user_inputs, work, resources, obs_path)
+    pid = CVS0DParamID.init_from_dict(config).param_id
+
+    ladder = [0.0, 0.02, 0.04, 0.05, 0.06, 0.08, 0.20, 0.30, 0.60]
+    seen = np.array([_features(pid, g) for g in ladder])
+    v_max, spikes = seen[:, 0], seen[:, 1]
+
+    silent = spikes == 0
+    assert silent.any() and (~silent).any(), (
+        f"the design must cover both regimes; got spike counts {spikes.tolist()}")
+    # the two branches, and the empty space between them
+    assert v_max[silent].max() < -40.0, f"silent branch is not subthreshold: {v_max[silent]}"
+    assert v_max[~silent].min() > 40.0, f"firing branch is not a spike peak: {v_max[~silent]}"
+    assert v_max[~silent].min() - v_max[silent].max() > 80.0, "no gap between the branches"
+    # V_max carries no information the count does not: it is the same binary, restated
+    assert np.array_equal(v_max > 0.0, ~silent)
+
+    from libcuflynx.funcs.cost_funcs_user import gaussian_MLE, gaussian_MLE_robust
+
+    observed = float(v_max[~silent][0])          # the cell fired
+    wrong_branch = float(v_max[silent][-1])      # the model did not
+    plain = gaussian_MLE(wrong_branch, observed, V_MAX_STD, 1.0)
+    robust = gaussian_MLE_robust(wrong_branch, observed, V_MAX_STD, 1.0,
+                                 p_outlier=V_MAX_P_OUTLIER,
+                                 outlier_width=V_MAX_OUTLIER_WIDTH)
+    assert plain > 100.0, f"expected the plain Gaussian to be ruinous here, got {plain}"
+    assert robust <= np.log(V_MAX_OUTLIER_WIDTH / V_MAX_P_OUTLIER) + 1e-9
+    assert robust < plain / 10.0
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.mpi
+def test_mcmc_over_an_emulator_recovers_the_conductance_that_made_the_data(
+        base_user_inputs, resources_dir, temp_output_dir, mpi_comm):
+    """Train on the jump, then infer through it, and check the answer against the truth.
+
+    The data is the solver's own output at a known ``g_Na1_6``, so "was the inference right" has
+    an answer that does not depend on the emulator's opinion of itself. Two truths are used, one
+    each side of the threshold, because they fail in different ways: a firing observation
+    identifies the parameter from both sides, and a silent one only bounds it from above -- every
+    conductance below threshold produces exactly the same silence. A posterior that claims to
+    have pinned down a silent cell is wrong, and that is worth asserting as much as recovery is.
+
+    One emulator serves both, deliberately: ``value``, ``cost_type`` and ``cost_kwargs`` are
+    outside the emulator fingerprint, so changing what the data says needs no retrain. Only the
+    operations would.
+    """
+    pytest.importorskip("myokit")
+    pytest.importorskip("autoemulate")
+    pytest.importorskip("emcee")
+
+    from libcuflynx.emulators.emulator_bundle import EmulatorBundle
+    from libcuflynx.emulators.emulator_trainer import EmulatorTrainer, resolve_emulator_dir
+    from libcuflynx.emulators.internal_emulators import classify_features
+
+    work = temp_output_dir
+    rank = mpi_comm.Get_rank()
+    resources = _resources(resources_dir, work) if rank == 0 else os.path.join(work, "resources")
+    mpi_comm.Barrier()
+
+    probe_path = os.path.join(work, "obs_probe.json")
+    if rank == 0:
+        with open(probe_path, "w") as handle:
+            json.dump(_obs_document(0.0, 0.0), handle)
+        assert generate_with_new_architecture(
+            False, _config(base_user_inputs, work, resources, probe_path)), "generation failed"
+    mpi_comm.Barrier()
+
+    emulator_settings = {
+        "models": "multi_phase_RadialBasisFunctions",
+        # MIN_SIDE_ROWS is 8, and the silent branch is only g <= ~0.055, i.e. 9% of the box.
+        # At 40 samples the low side has 3 rows and classify_features calls the column smooth,
+        # which is how the whole point of the test gets silently skipped. 160 puts ~12 silent
+        # rows in the training split, and the two adaptive stages add more near the threshold.
+        "num_train_samples": 160,
+        "sample_type": "sobol",
+        "random_seed": 0,
+        "test_fraction": 0.2,
+        "n_iter": 2,
+        "n_splits": 2,
+        # this is the tool for finding out whether an emulator is good enough, so it must be
+        # able to load one that is not
+        "min_r2": -1e30,
+        "out_of_bounds": "clip",
+    }
+    train_config = _config(base_user_inputs, work, resources, probe_path,
+                           do_emulation=True, emulator_settings=emulator_settings)
+    trainer = EmulatorTrainer.init_from_dict(train_config, comm=mpi_comm)
+    bundle = trainer.train()
+    mpi_comm.Barrier()
+    if rank != 0:
+        return
+
+    emulator_dir = resolve_emulator_dir(train_config)
+    saved = EmulatorBundle.load(emulator_dir)
+    labels = list(saved.feature_labels)
+    v_idx, n_idx = labels.index("V_max"), labels.index("n_spikes")
+
+    # Classified rather than regressed across, the jump column is nearly exact; regressed
+    # across it (what happens when the design is too small to see the branches) it scored
+    # R2 -30.9 on this same fixture.
+    r2 = dict(zip(labels, np.asarray(saved.meta["feature_r2"], dtype=float)))
+    assert r2["V_max"] > 0.9, f"held-out R2 for the jump column is {r2['V_max']:.4f}"
+    assert r2["n_spikes"] > 0.9, f"held-out R2 for the count column is {r2['n_spikes']:.4f}"
+
+    y_train = np.asarray(saved.y_train, dtype=float)
+    kinds = classify_features(y_train)
+    assert kinds[n_idx] == "count", (
+        f"an integer spike count must be recognised as one, got {kinds[n_idx]}")
+    assert kinds[v_idx] == "jump", (
+        f"V_max must be recognised as a jump so it is classified rather than regressed "
+        f"across, got {kinds[v_idx]}")
+    assert (y_train[:, n_idx] == 0).any() and (y_train[:, n_idx] > 0).any(), (
+        "the design must contain both silent and firing points")
+
+    # The emulator must land on a branch, never between them -- a value the simulator cannot
+    # produce is not a small error, it is a different answer.
+    grid = np.linspace(PARAM_MIN, PARAM_MAX, 61).reshape(-1, 1)
+    predicted = np.asarray(saved.predict(grid, out_of_bounds="clip"), dtype=float)
+    low = y_train[y_train[:, v_idx] < 0.0, v_idx].max()
+    high = y_train[y_train[:, v_idx] > 0.0, v_idx].min()
+    in_the_gap = ((predicted[:, v_idx] > low + 0.1 * (high - low))
+                  & (predicted[:, v_idx] < high - 0.1 * (high - low)))
+    assert in_the_gap.mean() < 0.15, (
+        f"{in_the_gap.sum()} of {len(grid)} sweep points predict a V_max the model never "
+        f"produces (between {low:.1f} and {high:.1f} mV)")
+    assert (predicted[:, n_idx] >= 0.0).all(), "a spike count cannot be negative"
+
+    solver_config = _config(base_user_inputs, work, resources, probe_path)
+    solver = CVS0DParamID.init_from_dict(solver_config).param_id
+
+    for name, truth, identified_from_both_sides in (("firing", G_FIRING, True),
+                                                    ("silent", G_SILENT, False)):
+        v_max, spikes = _features(solver, truth)
+        obs_path = os.path.join(work, f"obs_{name}.json")
+        with open(obs_path, "w") as handle:
+            json.dump(_obs_document(v_max, spikes), handle)
+
+        out_dir = os.path.join(work, f"mcmc_{name}")
+        config = _config(base_user_inputs, work, resources, obs_path,
+                         param_id_output_dir=out_dir,
+                         use_emulator=True,
+                         emulator_settings=dict(emulator_settings,
+                                                emulator_dir=emulator_dir),
+                         do_uq=True,
+                         UQ_options={"method": "mcmc", "library": "emcee",
+                                     "num_steps": 400, "num_walkers": 16,
+                                     "burn_in": 0.5, "cost_type": "gaussian_MLE"},
+                         debug_UQ_options={"method": "mcmc", "library": "emcee",
+                                           "num_steps": 400, "num_walkers": 16,
+                                           "burn_in": 0.5, "cost_type": "gaussian_MLE"})
+        runner = CVS0DParamID.init_from_dict(config)
+        runner.set_best_param_vals(np.array([truth]))
+        runner.run_UQ()
+
+        samples = _posterior(runner.output_dir)
+        assert samples.size > 1000, f"{name}: chain is too short to say anything"
+        lower, upper = np.percentile(samples, [5.0, 95.0])
+        median = float(np.median(samples))
+        # printed because the interesting output of a recovery test is the interval, not the
+        # pass: a tolerance chosen to be safe hides how well it actually did.
+        print(f"[recovery] {name}: true g_Na1_6 {truth:.3f} -> posterior median "
+              f"{median:.4f}, 5-95% [{lower:.4f}, {upper:.4f}], "
+              f"P(silent) {np.mean(samples < 0.06):.2f}")
+
+        if identified_from_both_sides:
+            assert lower <= truth <= upper, (
+                f"{name}: true g_Na1_6 {truth} outside the 5-95% interval "
+                f"[{lower:.4f}, {upper:.4f}] (median {median:.4f})")
+            # The substantive claim is the branch, and it should be certain: a firing cell
+            # rules out the silent region outright. Within the firing branch the parameter is
+            # only weakly identified -- V_max moves 6 mV against a 6 mV sigma over the whole
+            # range and the count carries the rest -- so the interval is wide on purpose and
+            # the median tolerance is loose on purpose.
+            assert np.mean(samples < 0.06) < 0.05, (
+                f"{name}: {100 * np.mean(samples < 0.06):.0f}% of the posterior says the cell "
+                f"was silent, but it fired")
+            assert abs(median - truth) < 0.2, (
+                f"{name}: posterior median {median:.4f} is nowhere near {truth}")
+        else:
+            # Every conductance below threshold gives exactly the same silence, so the data
+            # bounds the parameter from above and says nothing at all below. Asserting
+            # concentration here would be asserting a claim the data cannot support -- what
+            # can be asserted is that the bound lands on the threshold.
+            assert np.mean(samples < 0.06) > 0.9, (
+                f"{name}: only {100 * np.mean(samples < 0.06):.0f}% of the posterior is in the "
+                f"silent region")
+            assert upper < 0.12, (
+                f"{name}: the posterior should be cut off near the ~0.055 threshold, but its "
+                f"95th percentile is {upper:.4f}")
+            assert lower < truth < upper, (
+                f"{name}: true g_Na1_6 {truth} outside [{lower:.4f}, {upper:.4f}]")

--- a/tests/test_solver_info_validation.py
+++ b/tests/test_solver_info_validation.py
@@ -612,6 +612,34 @@ def test_reuse_samples_is_a_tickbox_that_says_what_it_does_not_do():
     assert "'reuse_samples'" in trainer_src
 
 
+def _without_docstrings(source):
+    """``source`` with every docstring blanked, so a scan reads code and not prose about it.
+
+    Documentation naturally quotes the very expression it is documenting -- writing out
+    ``UQ_options['cost_type']`` to explain how that key is treated does not make the module
+    read it. Left in, such a sentence is indistinguishable from a real access and reports a
+    setting as read that nothing reads.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return source
+    lines = source.splitlines(keepends=True)
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = getattr(node, 'body', None)
+        if not body:
+            continue
+        doc = body[0]
+        if not (isinstance(doc, ast.Expr) and isinstance(doc.value, ast.Constant)
+                and isinstance(doc.value.value, str)):
+            continue
+        for i in range(doc.lineno - 1, doc.end_lineno):
+            lines[i] = '\n'
+    return ''.join(lines)
+
+
 def test_every_uq_option_the_code_reads_is_advertised():
     """A UQ setting CA reads but does not declare cannot be reached from a front-end at all.
 
@@ -633,7 +661,7 @@ def test_every_uq_option_the_code_reads_is_advertised():
     for path in src_dir.rglob('*.py'):
         if 'obsolete' in path.parts:
             continue
-        read.update(pattern.findall(path.read_text(encoding='utf-8')))
+        read.update(pattern.findall(_without_docstrings(path.read_text(encoding='utf-8'))))
 
     advertised = {o['name'] for o in analysis_options('uq')}
     assert read, 'found no UQ_options reads at all -- the pattern has stopped matching'


### PR DESCRIPTION
Six commits: two that were already on this branch (`multi_phase_<name>` and its jump-side
fallback), and four new ones. Rebased onto `master` at d0f6f563. **207 tests pass** across the
emulator, cost, operation, UQ and MCMC suites.

All of it came out of calibrating the SN_full sympathetic-neuron model to two patch-clamp
datasets, where several observables were being scored by likelihoods that did not describe
them and the emulator was 25x slower than it needed to be.

## Cost functions

**`gaussian_MLE_robust`** — a two-component contamination mixture, for an observable with a
discontinuity in it. `V_max` is the spike peak when the cell fires and the subthreshold maximum
when it does not, so a plain Gaussian charges a wrong branch **27 sigma** — more than the whole
rest of the fit — for a binary the spike counts already carry. Because the observation is data
the outlier density is a constant, so it closes to
`w*[log(W/eps) - log(1 + K exp(-z^2/2))]` with `K` constant: no log-sum-exp, no overflow,
differentiable, and it needs the same single scalar prediction `gaussian_MLE` does.

**`com_poisson_MLE`** — a Conway-Maxwell-Poisson. A Poisson cannot be told how tight it is
(its variance *is* its mean), so where the cell fired 0 or 1 times it barely separated a model
firing once from one firing three times: all nine such terms came to 0.12 of a total cost near
8. `nu` is the dispersion, `nu = 1` reduces to `poisson_MLE` exactly. Note `lambda` is the mean
only at `nu = 1`, so the model's expected count is inverted onto it — the optimum stays at
`E[Y] = k` for every `nu`, making `nu` a pure tightness knob. A cached inversion table takes a
call from 1.1 ms to 0.015 ms, which is two hours off a 10000-step chain.

This is the proper-model alternative to raising a data_item's `weight`, which tempers the
likelihood by a power and is not a distribution over counts.

**`poisson_MLE` gains `background_rate`** (default 0, exactly today's behaviour): a rate the
model does not claim to explain. It replaces an implicit constant — `lambda` was clipped at
1e-12, so a silent model against `k` paid `k*27.6`, a number set by a numerical guard rather
than by any belief.

**A bug that would have discarded all of it.** `ensure_mle_cost_type_for_bayesian_inner`, on the
path of every MCMC and Laplace run, replaced *every* observable's `cost_type` with one name.
Verified: it collapsed `{gaussian_MLE: 18, poisson_MLE: 18, gaussian_MLE_robust: 8}` to
`{gaussian_MLE: 44}` — and the Poisson items carry no `value`, so every chain sample came back
`nan`. It now keeps an observable whose cost is already an MLE.

## Emulator

**`reset_and_clear` no longer throws away the prediction.** The protocol executor calls it after
every experiment because a solver must not carry integrator state; the emulator helper
implemented that by clearing its cached features. But an emulator has no such state and
`_features` is a pure function of theta. Clearing it made an eight-experiment study predict
eight times per cost evaluation instead of once — and threw away the batched
`predict_ensemble` result the vectorised MCMC path had just computed, so it paid the batching
cost and re-predicted per walker anyway.

> 205 ms -> 21 ms per cost evaluation; an MCMC step of 64 walkers **5.6 s -> 0.23 s (24.8x)**.
> Costs are bit-identical before and after (max difference 0.000e+00 over 12 theta).

**Floored counts get the floor treatment (#498).** A count column with more levels than
`COUNT_MAX_CLASSES` fails `is_count_column`, is typed `smooth`, and lands on the plain regressor,
which has no non-negativity constraint — 3746 of 43200 predictions negative on ox1, 6307 on
cpvt, and ~100% of them where the true count was exactly zero.

Raising the cap is the wrong fix and is measured as such in the commit: at 64 the negatives go
but the error on those features roughly doubles (RMSE +107% / +81%) and the emulator gets worse
overall (std(dcost) 2.675 -> 3.097 and 3.385 -> 4.343). The existing comment on
`COUNT_MAX_CLASSES` is right. Instead there is a fourth kind, `floored_count`, which gets a
**binary** on-floor/active classifier plus a magnitude regressor — the shape `TwoPhaseEmulator`
already uses. The floor is assigned exactly, so no negatives by construction and gradient is
preserved above it. Older pickles keep working; both new attributes are properties with
fallbacks.

## Observables

**`V_plateau`** — the mean voltage of the interspike plateau, from one peak-to-trough duration
after the trough to the next AP's firing threshold. It exists because `steady_state_min` (min of
the second half) is *not* a steady state on a repetitively firing trace — it is simply a later
AHP trough. On these recordings the two differ by 14-19 mV (ox1) and 2.5-10 mV (cpvt), so an
observable named and weighted as a plateau was measuring a trough.

**`min_between_first_two_spikes`** — the AHP trough, locating spikes in whichever trace it is
given rather than using a window fixed from the recording. A fixed window makes the feature
partly a spike-timing measurement: on one experiment the model had a spike inside the
recording's window in only 10 of 40 posterior draws.

**`AHP_minus_steady_state_min`** — that trough against the steady-state one, i.e. accommodation.
A difference, because the absolute trough was collinear with `steady_state_min`, and because it
is ~0 whenever the model is silent — which matters, since "does it fire" is already asserted by
~22 observables that are all deterministic functions of that one binary.

The AP threshold walk is factored out of `mean_AP_threshold` into `_ap_thresholds`, so
`V_plateau` starts and ends at the same thresholds that observable reports.
`mean_AP_threshold`'s behaviour is unchanged.

## Tests

New: `tests/test_ahp_operation.py`, `tests/test_robust_cost_funcs.py`,
`tests/test_sn_firing_threshold_recovery.py` (an end-to-end recovery test: sweeping
`soma_SN/g_Na1_6` gives a 105 mV step and a count that is exactly zero on one side; the posterior
recovers the firing case and, in the silent case, puts its 95th percentile on the physical
threshold without being told it). Plus additions to `test_internal_emulators.py` and
`test_emulator_solver_helper.py`.

Closes #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
