### PR TITLE
Resolve parameter names a model hoisted under another convention

### DIFF
--- a/src/libcuflynx/solver_wrappers/myokit_helper.py
+++ b/src/libcuflynx/solver_wrappers/myokit_helper.py
@@ -366,6 +366,9 @@ class SimulationHelper:
         # Map Myokit state qnames to their variables for fast lookup
         # Myokit states are named like "<component>_module.<var>" after CellML import.
         states = list(model.states())
+        # Built once: the qnames Myokit ended up with, which is not the same set
+        # the CellML declared (connected variables are merged into one).
+        qname_to_var = {v.qname(): v for v in model.variables(deep=True)}
         for s in states:
             qn = s.qname()
             # Translate Myokit component name back to CellML component name used in init_map
@@ -387,14 +390,39 @@ class SimulationHelper:
             except Exception:
                 pass
 
-            # If init_val is an unqualified identifier, qualify it within the same component
-            # so Myokit parsing works (requires fully qualified names).
+            # If init_val is an unqualified identifier, qualify it so Myokit can
+            # parse it (fully qualified names are required). Its own component is
+            # only the first guess: Myokit's importer *merges* connected
+            # variables, so a constant the CellML declared in this component but
+            # defined in `parameters` no longer has a qname here -- it survives
+            # only as `parameters.<whatever that model calls it>`. Fall back to
+            # the resolver, which knows the naming conventions (CUFLynx #300);
+            # an unresolvable name is left alone so the numeric initial value
+            # stands rather than the whole step being abandoned for this model.
             expr = init_val
             if re.fullmatch(r"[A-Za-z_]\w*", init_val):
-                expr = f"{comp_mod}.{init_val}"
+                expr = self._qualify_initial_reference(qname_to_var, comp, comp_mod, init_val)
+                if expr is None:
+                    continue
 
             # Set initial value as expression string (Myokit will parse it)
             s.set_initial_value(expr)
+
+    @staticmethod
+    def _qualify_initial_reference(qname_to_var, comp, comp_mod, name):
+        """The qname of *name* as seen from CellML component *comp*, or None.
+
+        Its own component wins when the variable is still there. Otherwise the
+        shared resolver is asked, which covers both the CA parameter convention
+        and the hoisted forms other generators write.
+        """
+        for own in (f"{comp_mod}.{name}", f"{comp}.{name}"):
+            if own in qname_to_var:
+                return own
+        _, qname = VariableNameResolver.resolve_key(
+            f"{comp}/{name}", [("var", qname_to_var)], separator="."
+        )
+        return qname
 
     def _prepare_cellml_for_myokit_libcellml(self, path):
         """

--- a/src/libcuflynx/solver_wrappers/name_resolver.py
+++ b/src/libcuflynx/solver_wrappers/name_resolver.py
@@ -22,7 +22,18 @@ Canonical alias patterns tried (in order):
   'parameters/Var_bare'   same, _module stripped
   'parameters_Comp/Var'   global-prefix convention     (global/x → parameters_global/x)
   'Comp_module/Var'       add _module to component
+  'parameters/Comp_Var'   hoisted parameter, component first (soma_SN/c_ER → parameters/soma_SN_c_ER)
+  'parameters/Var'        hoisted parameter, name kept as-is (soma_SN/g_Na → parameters/g_Na)
+  'parameters_global/Var' hoisted global constant       (soma_SN/R → parameters_global/R)
   'Var'                   bare variable name (unambiguous only in index mode)
+
+The last three exist because a CellML model does not have to name its hoisted
+parameters the way circulatory_autogen names them. PhLynx writes 'soma_SN_c_ER'
+where CA writes 'c_ER_soma_SN', and drops the prefix entirely for a name that is
+already unique in the model -- and Myokit's importer *merges* connected variables,
+so after import only the defining copy in 'parameters' survives and 'soma_SN.c_ER'
+is not a qname any more. Without these aliases a study built in PhLynx resolves
+none of its own parameters (CUFLynx #300).
 
 For key mode with separator='.', every '/'-candidate is also tried with '/' → '.'
 (so Myokit qnames like 'Lotka_Volterra_module.x' are matched automatically).
@@ -180,5 +191,13 @@ class VariableNameResolver:
             f"parameters_{comp}{sep}{var}", # global-prefix convention
             f"parameters_{comp_bare}{sep}{var}",
             f"{comp_mod}{sep}{var}",        # add _module
+            # Hoisted-parameter conventions other generators use. Tried after the
+            # CA-shaped ones above so a model that follows both is read the CA way,
+            # and before the bare name so 'soma_SN/g_Na' cannot be answered by an
+            # unrelated 'g_Na' in some other component.
+            f"parameters{sep}{comp}_{var}", # component first (PhLynx)
+            f"parameters{sep}{comp_bare}_{var}",
+            f"parameters{sep}{var}",        # hoisted without a prefix
+            f"parameters_global{sep}{var}", # hoisted global constant
             var,                            # bare variable name
         ]

--- a/tests/test_hoisted_parameter_names.py
+++ b/tests/test_hoisted_parameter_names.py
@@ -1,0 +1,201 @@
+"""A model whose parameters are hoisted the way another generator hoists them.
+
+circulatory_autogen builds its flat CellML with the parameters collected into a
+``parameters`` component and named ``<param>_<vessel>`` -- ``C_aortic_root``.
+Nothing about CellML requires that, and PhLynx does not do it: it writes
+``<component>_<param>`` (``soma_SN_c_ER``), and drops the prefix entirely for a
+name that is already unique in the model (``g_Na``). Globals go to
+``parameters_global``.
+
+That difference is invisible until the model is loaded, because Myokit's CellML
+importer **merges connected variables**: the copy in ``soma_SN`` and the copy in
+``parameters`` become one variable, and the one that survives is the one holding
+the definition. So after import ``soma_SN.g_Na`` is not a qname -- only
+``parameters.g_Na`` is -- and every name the user wrote in their obs_data and
+params_for_id resolves to nothing.
+
+What that looked like from CUFLynx (#300): a study built in PhLynx loaded, its
+sliders appeared, and the run failed with "Pacing parameter soma_SN/I_in must
+resolve to a valid variable", the valid list being 500 names none of which the
+user had ever typed.
+"""
+
+import numpy as np
+import pytest
+
+from libcuflynx.solver_wrappers.myokit_helper import SimulationHelper
+from libcuflynx.solver_wrappers.name_resolver import VariableNameResolver
+
+#: A two-parameter model in PhLynx's shape: one parameter hoisted with its
+#: component as a prefix, one hoisted bare, one global, and a state whose initial
+#: value is a *reference* to a hoisted parameter rather than a number.
+HOISTED_CELLML = """<?xml version="1.0" encoding="UTF-8"?>
+<model xmlns="http://www.cellml.org/cellml/2.0#"
+       xmlns:cellml="http://www.cellml.org/cellml/2.0#"
+       name="HoistedParameters">
+  <units name="per_second"><unit exponent="-1" units="second"/></units>
+  <units name="mV"><unit prefix="milli" units="volt"/></units>
+
+  <component name="environment">
+    <variable name="t" units="second" interface="public"/>
+  </component>
+
+  <component name="parameters_global">
+    <variable name="R" units="dimensionless" initial_value="2" interface="public"/>
+  </component>
+
+  <component name="parameters">
+    <variable name="soma_k" units="per_second" initial_value="3" interface="public"/>
+    <variable name="g" units="dimensionless" initial_value="5" interface="public"/>
+    <variable name="soma_V_rest" units="mV" initial_value="-70" interface="public"/>
+  </component>
+
+  <component name="soma">
+    <variable name="t" units="second" interface="public"/>
+    <variable name="R" units="dimensionless" interface="public"/>
+    <variable name="k" units="per_second" interface="public"/>
+    <variable name="g" units="dimensionless" interface="public"/>
+    <variable name="V_rest" units="mV" interface="public"/>
+    <variable name="V" units="mV" initial_value="V_rest"/>
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+      <apply><eq/>
+        <apply><diff/><bvar><ci>t</ci></bvar><ci>V</ci></apply>
+        <apply><times/>
+          <apply><times/><ci>k</ci><ci>g</ci></apply>
+          <apply><divide/>
+            <apply><minus/><cn cellml:units="mV">0</cn><ci>V</ci></apply>
+            <ci>R</ci>
+          </apply>
+        </apply>
+      </apply>
+    </math>
+  </component>
+
+  <connection component_1="environment" component_2="soma">
+    <map_variables variable_1="t" variable_2="t"/>
+  </connection>
+  <connection component_1="parameters_global" component_2="soma">
+    <map_variables variable_1="R" variable_2="R"/>
+  </connection>
+  <connection component_1="parameters" component_2="soma">
+    <map_variables variable_1="soma_k" variable_2="k"/>
+    <map_variables variable_1="g" variable_2="g"/>
+    <map_variables variable_1="soma_V_rest" variable_2="V_rest"/>
+  </connection>
+</model>
+"""
+
+
+@pytest.fixture(scope="module")
+def hoisted_helper(tmp_path_factory):
+    path = tmp_path_factory.mktemp("hoisted") / "hoisted.cellml"
+    path.write_text(HOISTED_CELLML)
+    return SimulationHelper(str(path), 0.01, 1.0, pre_time=0.0)
+
+
+# ---------------------------------------------------------------------------
+# The alias table
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "written,qname",
+    [
+        ("soma/k", "parameters.soma_k"),           # component-first prefix
+        ("soma/g", "parameters.g"),                # hoisted with no prefix
+        ("soma/R", "parameters_global.R"),         # hoisted global constant
+    ],
+)
+def test_a_hoisted_parameter_resolves_to_where_the_model_kept_it(written, qname):
+    """The three forms this repository did not previously know about."""
+    qnames = {"parameters.soma_k": 1, "parameters.g": 1, "parameters_global.R": 1}
+    assert VariableNameResolver.resolve_key(
+        written, [("var", qnames)], separator="."
+    ) == ("var", qname)
+
+
+@pytest.mark.unit
+def test_this_repositorys_own_convention_still_wins():
+    """Ordering, not coverage, is what keeps the CA models reading the CA way.
+
+    A model that happens to satisfy both conventions -- ``C_aortic_root`` and
+    ``aortic_root_C`` both present -- must still be read as circulatory_autogen
+    writes it, because that is the one this repository generated.
+    """
+    qnames = {"parameters.C_aortic_root": 1, "parameters.aortic_root_C": 1}
+    assert VariableNameResolver.resolve_key(
+        "aortic_root/C", [("var", qnames)], separator="."
+    ) == ("var", "parameters.C_aortic_root")
+
+
+@pytest.mark.unit
+def test_a_bare_name_elsewhere_does_not_answer_for_a_hoisted_one():
+    """``parameters/Var`` is tried before the bare name, and only then.
+
+    Without the ordering, ``soma/g`` in a model with a ``membrane.g`` and no
+    hoisted ``g`` would silently resolve to the membrane's -- a wrong answer is
+    worse here than no answer, because it calibrates the wrong variable.
+    """
+    qnames = {"membrane.g": 1}
+    kind, qname = VariableNameResolver.resolve_key(
+        "soma/g", [("var", qnames)], separator="."
+    )
+    assert (kind, qname) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# The same names through a loaded model
+# ---------------------------------------------------------------------------
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "written,qname",
+    [
+        ("soma/k", "parameters.soma_k"),
+        ("soma/g", "parameters.g"),
+        ("soma/R", "parameters_global.R"),
+        ("soma/V_rest", "parameters.soma_V_rest"),
+    ],
+)
+def test_the_loaded_model_answers_to_the_names_the_user_wrote(
+    hoisted_helper, written, qname
+):
+    """The end the user meets: names from their params_for_id, against the model.
+
+    ``soma.k`` does not exist after import -- Myokit merged it away -- so this is
+    the assertion that a study written against the CellML resolves against the
+    Myokit model it became.
+    """
+    assert hoisted_helper._resolve_name(written) == ("var", qname)
+
+
+@pytest.mark.integration
+def test_an_initial_value_that_names_a_hoisted_parameter_survives_import(
+    hoisted_helper,
+):
+    """``initial_value="V_rest"`` must keep pointing at the parameter.
+
+    The importer's own component is the wrong place to look for it once the
+    variables are merged, and the old code looked only there: the reference came
+    out as ``soma.V_rest``, Myokit could not resolve it, and the step was
+    abandoned with a printed warning. The state then kept a *numeric* initial
+    value, so calibrating ``V_rest`` moved nothing.
+    """
+    state = next(s for s in hoisted_helper.model.states() if s.qname() == "soma.V")
+    assert str(state.initial_value()) == "parameters.soma_V_rest"
+
+
+@pytest.mark.integration
+def test_the_model_runs_and_the_hoisted_parameters_reach_the_solver(hoisted_helper):
+    """Resolution is not the point on its own -- setting the value is."""
+    def final_V(g):
+        hoisted_helper.reset_and_clear()
+        hoisted_helper.set_param_vals(["soma/g"], [g])
+        assert hoisted_helper.run()
+        # (variable, sub-experiment, time) -- one of each here.
+        return np.asarray(hoisted_helper.get_results(["soma/V"])).ravel()[-1]
+
+    fast, frozen = final_V(5.0), final_V(0.0)
+
+    # g scales the whole right-hand side, so g=0 holds V at its initial value
+    # and g=5 decays it towards zero. Anything else means the write did not land.
+    assert abs(frozen - (-70.0)) < 1e-6
+    assert fast > frozen + 1.0


### PR DESCRIPTION
A study built in PhLynx and loaded into CUFLynx would not run. Every name in the user's obs_data and params_for_id resolved to nothing, and the run failed with

    Pacing parameter soma_SN/I_in must resolve to a valid variable

followed by five hundred names the user had never typed. Reported on CUFLynx #300.

## Why

`VariableNameResolver` knew one hoisting convention: this repository's. CA collects a module's constants into a `parameters` component and names them `<param>_<vessel>` — `C_aortic_root`. PhLynx collects them too, but names them the other way round (`soma_SN_c_ER`), and drops the prefix entirely for a name that is already unique in the model (`g_Na`); globals go to `parameters_global`.

That difference is invisible in the CellML — both components still declare `soma_SN.c_ER` — but Myokit's importer **merges connected variables**, and the copy that survives is the one holding the definition. After import `soma_SN.c_ER` is not a qname at all. Only `parameters.soma_SN_c_ER` is. So a model this repository did not generate is unaddressable by the names its own author wrote.

Three alias forms are added:

| written | found |
|---|---|
| `soma_SN/c_ER` | `parameters.soma_SN_c_ER` |
| `soma_SN/g_Na` | `parameters.g_Na` |
| `soma_SN/R` | `parameters_global.R` |

They are tried **after** the existing CA-shaped aliases, so a model satisfying both conventions is still read the way CA writes it, and **before** the bare-name fallback, so a same-named variable in an unrelated component cannot answer for a hoisted one. A wrong answer is worse than no answer here: it calibrates the wrong variable.

## The same merge, a second bug

`_apply_post_import_initial_expressions` turns `initial_value="V_rest"` into a Myokit expression by qualifying the bare name with its own component — `soma_SN.V_rest`, which after the merge does not exist. Myokit could not resolve it, the whole step was abandoned with a printed warning, and the state kept a *numeric* initial value. Calibrating that parameter then moved nothing, silently. It now goes through the resolver; an unresolvable name leaves the numeric value standing rather than abandoning the step for the whole model.

## Tests

`tests/test_hoisted_parameter_names.py` — the alias table, the ordering that keeps CA's convention winning, and a PhLynx-shaped model loaded end to end: the names resolve, the initial-value reference survives import, and writing a parameter changes the trace. 8 of the 11 fail without this change.

CUFLynx-side coverage is on CUFLynx #300, which runs PhLynx's own exported archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)