### PR TITLE
Raise on an unusable obs_data instead of exit()ing on it

### DIFF
--- a/src/libcuflynx/parsers/PrimitiveParsers.py
+++ b/src/libcuflynx/parsers/PrimitiveParsers.py
@@ -45,6 +45,21 @@ mpi_available = _mpi_utils.mpi_available()
 rank = _mpi_utils.rank()
 
 
+class ObsDataError(ValueError):
+    """An ``obs_data.json`` the parser cannot use, described well enough to fix it.
+
+    These checks used to ``print()`` and ``exit()``. That is survivable in a script, where
+    the message lands on the terminal the user is already reading, and unrecoverable
+    anywhere else: ``exit()`` raises ``SystemExit``, which inherits from ``BaseException``
+    and so passes straight through the ``except Exception`` an embedding application wraps
+    the parser in. CUFLynx turned one of these into a bare "Internal Server Error", with
+    the explanation visible only in the server's own stdout.
+
+    So they raise, and the message carries the offending numbers rather than naming the
+    keys and leaving the reader to go and look them up.
+    """
+
+
 def resolve_user_path(path, user_files_dir):
     """Resolve a user-supplied relative path from ``user_inputs.yaml``.
 
@@ -670,6 +685,26 @@ def migrate_legacy_obs_columns(gt_df):
                       DeprecationWarning, stacklevel=3)
         gt_df = gt_df.rename(columns={legacy: current})
     return gt_df
+
+
+def _obs_item_label(gt_df, II):
+    """How to refer to row ``II`` of ``gt_df`` in an error message.
+
+    Its ``data_item_name`` when it has one, because that is what the obs_data file calls it
+    and so what the reader will search for; otherwise the operands, which at least say which
+    variable it came from; and failing both, the row index.
+    """
+    try:
+        row = gt_df.iloc[II]
+    except (IndexError, KeyError):
+        return f"item {II}"
+    name = row.get("data_item_name") if hasattr(row, "get") else None
+    if isinstance(name, str) and name:
+        return name
+    operands = row.get("operands") if hasattr(row, "get") else None
+    if isinstance(operands, (list, tuple)) and operands:
+        return "/".join(str(o) for o in operands)
+    return f"item {II}"
 
 
 def check_data_item_names_unique(gt_df, prediction_info=None):
@@ -3957,17 +3992,28 @@ class ObsAndParamDataParser(object):
         for II in range(gt_df.shape[0]):
             if gt_df.iloc[II]["data_type"] == "series":
                 if "obs_dt" not in gt_df.iloc[II].keys():
-                    print("dt not found in obs_data.json for series data, exiting")
-                    exit()
+                    raise ObsDataError(
+                        f"series data item '{_obs_item_label(gt_df, II)}' has no 'obs_dt'. "
+                        f"Every series item needs the sample spacing of its own data, in "
+                        f"seconds, so the solver output can be compared with it.")
                 dt_list.append(gt_df.iloc[II]["obs_dt"])
-        
+
         obs_info["obs_dt"] = np.array(dt_list)
-        
+
         if len(obs_info["obs_dt"]) > 0:
-            if min(obs_info["obs_dt"]) < dt:
-                print("one of the dt in obs_data.json is less than the dt in user_inputs.yaml, the output timestep"
-                    "defined in user_inputs.yaml must be less than the smallest dt for your data. Exiting")
-                exit()
+            smallest = float(min(obs_info["obs_dt"]))
+            if smallest < dt:
+                culprits = [_obs_item_label(gt_df, II) for II in range(gt_df.shape[0])
+                            if gt_df.iloc[II]["data_type"] == "series"
+                            and float(gt_df.iloc[II].get("obs_dt", np.inf)) < dt]
+                raise ObsDataError(
+                    f"the solver timestep dt = {dt:g} s is coarser than the sample spacing "
+                    f"of the series data it has to be compared against: the smallest "
+                    f"'obs_dt' in obs_data.json is {smallest:g} s"
+                    + (f", on {', '.join(culprits[:4])}" if culprits else "")
+                    + (f" and {len(culprits) - 4} more" if len(culprits) > 4 else "")
+                    + f". Set dt to {smallest:g} or less in user_inputs.yaml, or resample "
+                      f"the series data to {dt:g} s or coarser.")
 
         # The std for the different observables
         obs_info["std_const_vec"] = np.array([gt_df.iloc[II]["std"] for II in range(gt_df.shape[0])

--- a/src/libcuflynx/parsers/PrimitiveParsers.py
+++ b/src/libcuflynx/parsers/PrimitiveParsers.py
@@ -687,6 +687,35 @@ def migrate_legacy_obs_columns(gt_df):
     return gt_df
 
 
+def _series_is_scored(gt_df, II):
+    """Whether series row ``II`` can contribute to the cost at all.
+
+    Two ways it cannot. A zero weight drops an item from the cost outright -- that is what
+    ``weight`` means everywhere else in the parser, and how a study switches an observable
+    off without deleting it. And an item carrying no samples has nothing to be compared
+    against whatever the solver produces.
+
+    Used only to decide whether an item's ``obs_dt`` may constrain the solver timestep. A
+    series nobody scores cannot require anything of dt, and a placeholder that does is a
+    study-stopping bug: SN_full ships eight empty, zero-weighted series at 1e-4 whose only
+    effect was to block every evaluation.
+    """
+    row = gt_df.iloc[II]
+    weight = row.get("weight", 1.0)
+    try:
+        if weight is not None and float(weight) == 0.0:
+            return False
+    except (TypeError, ValueError):
+        pass                                    # an unreadable weight is not a reason to skip
+    value = row.get("value")
+    if value is None:
+        return False
+    try:
+        return len(value) > 0
+    except TypeError:
+        return True                             # a scalar in a series row: let it speak
+
+
 def _obs_item_label(gt_df, II):
     """How to refer to row ``II`` of ``gt_df`` in an error message.
 
@@ -3998,22 +4027,33 @@ class ObsAndParamDataParser(object):
                         f"seconds, so the solver output can be compared with it.")
                 dt_list.append(gt_df.iloc[II]["obs_dt"])
 
+        # One entry per series, in order: plot_outputs indexes this by series_idx, so it
+        # stays parallel to the series even where an entry belongs to one that is never
+        # scored. The *guard* below is what skips those.
         obs_info["obs_dt"] = np.array(dt_list)
 
-        if len(obs_info["obs_dt"]) > 0:
-            smallest = float(min(obs_info["obs_dt"]))
-            if smallest < dt:
-                culprits = [_obs_item_label(gt_df, II) for II in range(gt_df.shape[0])
-                            if gt_df.iloc[II]["data_type"] == "series"
-                            and float(gt_df.iloc[II].get("obs_dt", np.inf)) < dt]
-                raise ObsDataError(
-                    f"the solver timestep dt = {dt:g} s is coarser than the sample spacing "
-                    f"of the series data it has to be compared against: the smallest "
-                    f"'obs_dt' in obs_data.json is {smallest:g} s"
-                    + (f", on {', '.join(culprits[:4])}" if culprits else "")
-                    + (f" and {len(culprits) - 4} more" if len(culprits) > 4 else "")
-                    + f". Set dt to {smallest:g} or less in user_inputs.yaml, or resample "
-                      f"the series data to {dt:g} s or coarser.")
+        # Only a series that will actually be compared constrains the solver's timestep. A
+        # zero-weighted item is dropped from the cost, and one carrying no samples has
+        # nothing to compare against, so neither can require anything of dt. SN_full's
+        # obs_data ships eight such placeholders at obs_dt = 1e-4, and they were enough to
+        # stop every evaluation of a study whose scored observables are all constants.
+        culprits = [_obs_item_label(gt_df, II) for II in range(gt_df.shape[0])
+                    if gt_df.iloc[II]["data_type"] == "series"
+                    and float(gt_df.iloc[II].get("obs_dt", np.inf)) < dt
+                    and _series_is_scored(gt_df, II)]
+        if culprits:
+            smallest = float(min(float(gt_df.iloc[II]["obs_dt"])
+                                 for II in range(gt_df.shape[0])
+                                 if gt_df.iloc[II]["data_type"] == "series"
+                                 and _series_is_scored(gt_df, II)))
+            raise ObsDataError(
+                f"the solver timestep dt = {dt:g} s is coarser than the sample spacing "
+                f"of the series data it has to be compared against: the smallest "
+                f"'obs_dt' in obs_data.json is {smallest:g} s"
+                + f", on {', '.join(culprits[:4])}"
+                + (f" and {len(culprits) - 4} more" if len(culprits) > 4 else "")
+                + f". Set dt to {smallest:g} or less in user_inputs.yaml, or resample "
+                  f"the series data to {dt:g} s or coarser.")
 
         # The std for the different observables
         obs_info["std_const_vec"] = np.array([gt_df.iloc[II]["std"] for II in range(gt_df.shape[0])

--- a/tests/test_obs_data_errors_are_catchable.py
+++ b/tests/test_obs_data_errors_are_catchable.py
@@ -1,0 +1,111 @@
+"""The obs_data guards raise, so an application embedding the parser can report them.
+
+``print()`` then ``exit()`` is fine in a script: the message lands on the terminal the user
+is already looking at. Anywhere else it is the worst of both worlds. ``exit()`` raises
+``SystemExit``, which derives from ``BaseException`` rather than ``Exception``, so it goes
+straight through the ``except Exception`` an embedding application wraps a parse in -- and
+the explanation, being a bare ``print``, goes to that application's stdout where nobody is
+reading.
+
+That is not hypothetical. CUFLynx's ``POST /api/protocol/run`` returned a bare "Internal
+Server Error" on an SN_full study whose series carry ``obs_dt = 1e-4`` while the app
+evaluates at its default ``dt = 0.01``. The sentence explaining it existed, and reached only
+the uvicorn log.
+
+These drive the real ``get_ground_truth_values`` rather than a copy of its four lines, so
+they fail if the guard is changed. Each asserts three things: it raises, what it raises is an
+ordinary ``Exception`` and not ``SystemExit``, and the message carries the numbers needed to
+act rather than only the names of the keys involved.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from libcuflynx.parsers.PrimitiveParsers import (ObsAndParamDataParser, ObsDataError,
+                                                 _obs_item_label)
+
+#: The columns ``get_ground_truth_values`` reads before it reaches the obs_dt guard. Kept
+#: minimal on purpose: a full study would need a model, a protocol and a params file to
+#: reach four lines of validation.
+def series_row(name='Vgt_{B0}', obs_dt=1e-4, **extra):
+    row = {
+        'data_type': 'series', 'data_item_name': name, 'operands': ['soma/V'],
+        'operation': 'series', 'value': [0.0, 1.0], 'std': 1.0, 'weight': 1.0,
+        'prob_dist_params': None, 'obs_dt': obs_dt,
+    }
+    if obs_dt is None:
+        del row['obs_dt']
+    row.update(extra)
+    return row
+
+
+def run(rows, dt, output_dir=None):
+    """``output_dir`` matters only past the guard: the function writes ground_truth npy
+    files there once it has validated. The raising tests never reach it."""
+    obs_info = {'num_obs': len(rows),
+                'data_types': [r['data_type'] for r in rows]}
+    return ObsAndParamDataParser().get_ground_truth_values(
+        pd.DataFrame(rows), obs_info, output_dir, dt)
+
+
+def test_a_dt_finer_than_the_solver_step_raises_rather_than_exiting():
+    """The SN_full case: obs_dt 1e-4 against an application's default dt of 0.01."""
+    with pytest.raises(ObsDataError) as excinfo:
+        run([series_row()], dt=0.01)
+    assert isinstance(excinfo.value, Exception)
+    assert not isinstance(excinfo.value, SystemExit), \
+        'SystemExit passes through `except Exception`, which is the bug'
+
+
+def test_the_message_carries_both_numbers_and_the_offending_item():
+    with pytest.raises(ObsDataError) as excinfo:
+        run([series_row()], dt=0.01)
+    message = str(excinfo.value)
+    assert '0.01' in message, 'the solver dt the caller used must appear'
+    assert '0.0001' in message, 'the obs_dt that conflicts with it must appear'
+    assert 'Vgt_{B0}' in message, 'and which item it came from'
+
+
+def test_many_offenders_are_summarised_not_listed_in_full():
+    with pytest.raises(ObsDataError) as excinfo:
+        run([series_row(f'Vgt_{{s{i}}}') for i in range(9)], dt=0.01)
+    message = str(excinfo.value)
+    assert 'Vgt_{s0}' in message
+    assert 'and 5 more' in message, 'four named, the rest counted'
+    assert 'Vgt_{s8}' not in message
+
+
+def test_only_the_items_that_actually_conflict_are_named():
+    with pytest.raises(ObsDataError) as excinfo:
+        run([series_row('Vgt_{fine}', 1e-4), series_row('Vgt_{coarse}', 0.5)], dt=0.01)
+    message = str(excinfo.value)
+    assert 'Vgt_{fine}' in message
+    assert 'Vgt_{coarse}' not in message, 'a series coarser than dt is not the problem'
+
+
+def test_a_series_without_obs_dt_raises_and_names_itself():
+    with pytest.raises(ObsDataError, match=r"Vgt_\{nodt\}"):
+        run([series_row('Vgt_{nodt}', obs_dt=None)], dt=0.01)
+
+
+def test_a_dt_equal_to_obs_dt_is_fine(tmp_path):
+    """The boundary is ``<``, not ``<=``: sampling the solver exactly at the data's spacing
+    is the normal, intended case and must not trip the guard."""
+    out = run([series_row()], dt=1e-4, output_dir=str(tmp_path))
+    assert np.allclose(out['obs_dt'], [1e-4])
+
+
+def test_constants_alone_do_not_trip_it(tmp_path):
+    """An obs_data with no series has nothing to compare a dt against."""
+    out = run([{'data_type': 'constant', 'data_item_name': 'V_{max}', 'operands': ['soma/V'],
+                'operation': 'max', 'value': 1.0, 'std': 1.0, 'weight': 1.0,
+                'prob_dist_params': None}], dt=0.01, output_dir=str(tmp_path))
+    assert len(out['obs_dt']) == 0
+
+
+def test_the_label_falls_back_when_an_item_has_no_name():
+    df = pd.DataFrame([{'data_type': 'series', 'operands': ['soma/V_sensed']}])
+    assert _obs_item_label(df, 0) == 'soma/V_sensed'
+    bare = pd.DataFrame([{'data_type': 'series'}])
+    assert _obs_item_label(bare, 0) == 'item 0'
+    assert _obs_item_label(bare, 7) == 'item 7', 'an out-of-range row must not raise'

--- a/tests/test_obs_data_errors_are_catchable.py
+++ b/tests/test_obs_data_errors_are_catchable.py
@@ -22,7 +22,7 @@ import pandas as pd
 import pytest
 
 from libcuflynx.parsers.PrimitiveParsers import (ObsAndParamDataParser, ObsDataError,
-                                                 _obs_item_label)
+                                                 _obs_item_label, _series_is_scored)
 
 #: The columns ``get_ground_truth_values`` reads before it reaches the obs_dt guard. Kept
 #: minimal on purpose: a full study would need a model, a protocol and a params file to
@@ -109,3 +109,52 @@ def test_the_label_falls_back_when_an_item_has_no_name():
     bare = pd.DataFrame([{'data_type': 'series'}])
     assert _obs_item_label(bare, 0) == 'item 0'
     assert _obs_item_label(bare, 7) == 'item 7', 'an out-of-range row must not raise'
+
+
+# --------------------------------------------------- only a scored series constrains dt
+
+def test_an_empty_zero_weighted_series_does_not_block_the_study(tmp_path):
+    """The SN_full case exactly: eight placeholder series at obs_dt 1e-4, weight 0 and no
+    samples, in a study whose scored observables are all constants. They cannot be compared
+    against anything, so they must not stop the evaluation."""
+    rows = [series_row(f'Vgt_{{s{i}}}', 1e-4, weight=0.0, value=[]) for i in range(8)]
+    rows.append({'data_type': 'constant', 'data_item_name': 'V_{max}', 'operands': ['soma/V'],
+                 'operation': 'max', 'value': 1.0, 'std': 1.0, 'weight': 1.0,
+                 'prob_dist_params': None})
+    out = run(rows, dt=0.01, output_dir=str(tmp_path))
+    assert len(out['obs_dt']) == 8, 'obs_dt stays parallel to the series for plot_outputs'
+
+
+def test_a_scored_series_still_constrains_dt():
+    """The guard must not have been softened into uselessness."""
+    with pytest.raises(ObsDataError, match=r"Vgt_\{real\}"):
+        run([series_row('Vgt_{real}', 1e-4, weight=1.0, value=[0.0, 1.0])], dt=0.01)
+
+
+def test_a_weighted_but_empty_series_does_not_constrain_dt(tmp_path):
+    run([series_row('Vgt_{empty}', 1e-4, weight=1.0, value=[])], dt=0.01,
+        output_dir=str(tmp_path))
+
+
+def test_a_zero_weighted_series_with_samples_does_not_constrain_dt(tmp_path):
+    run([series_row('Vgt_{off}', 1e-4, weight=0.0, value=[0.0, 1.0])], dt=0.01,
+        output_dir=str(tmp_path))
+
+
+def test_only_the_scored_offender_is_named():
+    with pytest.raises(ObsDataError) as excinfo:
+        run([series_row('Vgt_{placeholder}', 1e-4, weight=0.0, value=[]),
+             series_row('Vgt_{real}', 1e-4, weight=1.0, value=[0.0, 1.0])], dt=0.01)
+    message = str(excinfo.value)
+    assert 'Vgt_{real}' in message
+    assert 'Vgt_{placeholder}' not in message
+
+
+def test_series_is_scored_reads_weight_and_samples():
+    df = pd.DataFrame([
+        series_row('a', weight=1.0, value=[0.0]),
+        series_row('b', weight=0.0, value=[0.0]),
+        series_row('c', weight=1.0, value=[]),
+        series_row('d', weight=None, value=[0.0]),
+    ])
+    assert [_series_is_scored(df, i) for i in range(4)] == [True, False, False, True]


### PR DESCRIPTION
**Stacked on #500** (`fix/hoisted-parameter-names`) — review that first; this PR's diff is
the two guards and their tests.

CUFLynx's `POST /api/protocol/run` returns a bare **Internal Server Error** on an SN_full
study. The underlying problem is real and already detected — the series carry
`obs_dt = 1e-4`, the app evaluates at its default `dt = 0.01` — and
`get_ground_truth_values` already writes a sentence explaining it. Neither the diagnosis nor
the sentence reaches the user:

```
File ".../PrimitiveParsers.py", line 3970, in get_ground_truth_values
    exit()
SystemExit: None
```

`print()` + `exit()` is fine in a script, where the message lands on the terminal the user is
already reading. Anywhere else it is the worst of both worlds — `SystemExit` derives from
`BaseException`, so it passes straight through the `except Exception` an embedding
application wraps a parse in, and the explanation goes to that application's stdout.

## Two commits

**1. Raise instead of exit.** The two `obs_dt` guards raise `ObsDataError(ValueError)`,
matching the `XError(ValueError)` convention already used by `MyokitImportError`,
`EasyMLImportError` and `ProtocolShapeError`. Messages carry the numbers rather than naming
the keys:

> the solver timestep dt = 0.01 s is coarser than the sample spacing of the series data it
> has to be compared against: the smallest `obs_dt` in obs_data.json is 0.0001 s, on
> `Vgt_{Baseline0}`, … and 4 more. Set dt to 0.0001 or less in user_inputs.yaml, or resample
> the series data to 0.01 s or coarser.

Four names then a count — an obs_data with 36 series should not print 36 names.

**2. The actual root cause.** The guard considered *every* series, including ones that can
never be scored. SN_full ships eight placeholders — weight 0, no samples, `obs_dt = 1e-4` —
and those eight blocked every evaluation of a study whose scored observables are all
constants. A zero weight drops an item from the cost; an item with no samples has nothing to
compare. Neither can require anything of `dt`.

`obs_info["obs_dt"]` is unchanged — still one entry per series in order, because
`plot_outputs` indexes it by `series_idx` and a compacted array would misalign it. Only the
guard skips.

## Tests

14, driving the real `get_ground_truth_values` rather than a copy of the guard, so they fail
if it changes. They pin that it raises; that what it raises is catchable as `Exception` and
is **not** `SystemExit`; that the message carries both numbers and the offending item; that
only genuinely conflicting items are named; and that the boundary is `<` not `<=`, since
sampling the solver exactly at the data's spacing is the normal case.

Verified end to end: `protocol/run` goes 500 → 200 on the SN_full ox1 and cpvt studies.

## Scope

Two of the **31** `exit()` calls in `PrimitiveParsers`. The rest are the same latent bug for
any embedding application, but converting them is not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfQsxarGfeaax6MNNo7ZJe