### PR TITLE
Save the posterior median as a parameter set, not only as a report

### DIFF
--- a/src/libcuflynx/param_id/paramID.py
+++ b/src/libcuflynx/param_id/paramID.py
@@ -4548,7 +4548,65 @@ class MCMC(ParamID):
         with open(path, 'w') as write_file:
             json.dump(document, write_file, indent=2)
         print(f'mcmc statistics saved in {path}')
+
+        self.save_posterior_point_estimates(medians, means)
         return document
+
+    def save_posterior_point_estimates(self, medians, means):
+        """Write the posterior median and mean as *loadable parameter sets*.
+
+        ``mcmc_statistics.json`` already records both, but keyed by display name
+        (``g_{Na}``) and buried in a per-parameter summary alongside quartiles. That is a
+        report, not a parameter set: nothing can feed it back into a model, because the
+        display names are not the model's and the file's shape is not one any parameter
+        loader reads.
+
+        The consequence is that ``save_mcmc_statistics`` promises "both are now on disk to
+        choose from" while only one of the two -- ``best_param_vals.npy`` -- is actually in
+        a form anything can load. Choosing the median meant reading the JSON and retyping
+        fourteen numbers, and that matters, because a calibration best is an argmin found by
+        whatever surrogate drove it and can sit somewhere the model behaves quite
+        differently. One SN_full cpvt run put its "best fit" at a resting potential of
+        -19 mV against data at -75; the posterior median from the same chain sat at -80.
+
+        So, beside the JSON:
+
+        * ``posterior_median_params.csv`` -- ``vessel_name,param_name,value``, the format
+          CUFLynx's parameter loader reads. Self-describing, so it does not depend on
+          column order matching the model that loads it.
+        * ``posterior_median_param_vals.npy`` -- the bare array in optimiser order, the
+          same shape as ``best_param_vals.npy``, for anything that reads that.
+
+        And the same pair for the mean, because the two costs are reported side by side and
+        a reader invited to compare them should be able to load either.
+
+        A modifier slot names several model parameters and holds one value, so every member
+        is written with that value -- matching how ``best_param_vals.npy`` is read back.
+        """
+        if getattr(self, "rank", 0) != 0:
+            return
+        members_per_slot = self.param_id_info["param_names"]
+        for label, values in (("median", medians), ("mean", means)):
+            values = np.asarray(values, dtype=float).ravel()
+
+            npy_path = os.path.join(self.output_dir, f"posterior_{label}_param_vals")
+            np.save(npy_path, values)
+
+            csv_path = os.path.join(self.output_dir, f"posterior_{label}_params.csv")
+            with open(csv_path, "w", newline="") as handle:
+                writer = csv.writer(handle)
+                writer.writerow(["vessel_name", "param_name", "value"])
+                for slot, members in enumerate(members_per_slot):
+                    if slot >= len(values):
+                        break
+                    for qname in members:
+                        vessel, _, param = str(qname).partition("/")
+                        if not param:
+                            # Not a vessel/param name. Write it whole rather than dropping
+                            # it, so the file still accounts for every slot.
+                            vessel, param = "", str(qname)
+                        writer.writerow([vessel, param, repr(float(values[slot]))])
+            print(f"posterior {label} saved as a loadable parameter set in {csv_path}")
 
     def calculate_pred_from_posterior_samples(self, flat_samples, n_sims=100):
         # idxs of output are [exp_idx][sim_idx, pred_idx, time_idx]

--- a/src/libcuflynx/parsers/PrimitiveParsers.py
+++ b/src/libcuflynx/parsers/PrimitiveParsers.py
@@ -45,6 +45,21 @@ mpi_available = _mpi_utils.mpi_available()
 rank = _mpi_utils.rank()
 
 
+class ObsDataError(ValueError):
+    """An ``obs_data.json`` the parser cannot use, described well enough to fix it.
+
+    These checks used to ``print()`` and ``exit()``. That is survivable in a script, where
+    the message lands on the terminal the user is already reading, and unrecoverable
+    anywhere else: ``exit()`` raises ``SystemExit``, which inherits from ``BaseException``
+    and so passes straight through the ``except Exception`` an embedding application wraps
+    the parser in. CUFLynx turned one of these into a bare "Internal Server Error", with
+    the explanation visible only in the server's own stdout.
+
+    So they raise, and the message carries the offending numbers rather than naming the
+    keys and leaving the reader to go and look them up.
+    """
+
+
 def resolve_user_path(path, user_files_dir):
     """Resolve a user-supplied relative path from ``user_inputs.yaml``.
 
@@ -670,6 +685,26 @@ def migrate_legacy_obs_columns(gt_df):
                       DeprecationWarning, stacklevel=3)
         gt_df = gt_df.rename(columns={legacy: current})
     return gt_df
+
+
+def _obs_item_label(gt_df, II):
+    """How to refer to row ``II`` of ``gt_df`` in an error message.
+
+    Its ``data_item_name`` when it has one, because that is what the obs_data file calls it
+    and so what the reader will search for; otherwise the operands, which at least say which
+    variable it came from; and failing both, the row index.
+    """
+    try:
+        row = gt_df.iloc[II]
+    except (IndexError, KeyError):
+        return f"item {II}"
+    name = row.get("data_item_name") if hasattr(row, "get") else None
+    if isinstance(name, str) and name:
+        return name
+    operands = row.get("operands") if hasattr(row, "get") else None
+    if isinstance(operands, (list, tuple)) and operands:
+        return "/".join(str(o) for o in operands)
+    return f"item {II}"
 
 
 def check_data_item_names_unique(gt_df, prediction_info=None):
@@ -3957,17 +3992,28 @@ class ObsAndParamDataParser(object):
         for II in range(gt_df.shape[0]):
             if gt_df.iloc[II]["data_type"] == "series":
                 if "obs_dt" not in gt_df.iloc[II].keys():
-                    print("dt not found in obs_data.json for series data, exiting")
-                    exit()
+                    raise ObsDataError(
+                        f"series data item '{_obs_item_label(gt_df, II)}' has no 'obs_dt'. "
+                        f"Every series item needs the sample spacing of its own data, in "
+                        f"seconds, so the solver output can be compared with it.")
                 dt_list.append(gt_df.iloc[II]["obs_dt"])
-        
+
         obs_info["obs_dt"] = np.array(dt_list)
-        
+
         if len(obs_info["obs_dt"]) > 0:
-            if min(obs_info["obs_dt"]) < dt:
-                print("one of the dt in obs_data.json is less than the dt in user_inputs.yaml, the output timestep"
-                    "defined in user_inputs.yaml must be less than the smallest dt for your data. Exiting")
-                exit()
+            smallest = float(min(obs_info["obs_dt"]))
+            if smallest < dt:
+                culprits = [_obs_item_label(gt_df, II) for II in range(gt_df.shape[0])
+                            if gt_df.iloc[II]["data_type"] == "series"
+                            and float(gt_df.iloc[II].get("obs_dt", np.inf)) < dt]
+                raise ObsDataError(
+                    f"the solver timestep dt = {dt:g} s is coarser than the sample spacing "
+                    f"of the series data it has to be compared against: the smallest "
+                    f"'obs_dt' in obs_data.json is {smallest:g} s"
+                    + (f", on {', '.join(culprits[:4])}" if culprits else "")
+                    + (f" and {len(culprits) - 4} more" if len(culprits) > 4 else "")
+                    + f". Set dt to {smallest:g} or less in user_inputs.yaml, or resample "
+                      f"the series data to {dt:g} s or coarser.")
 
         # The std for the different observables
         obs_info["std_const_vec"] = np.array([gt_df.iloc[II]["std"] for II in range(gt_df.shape[0])

--- a/src/libcuflynx/parsers/PrimitiveParsers.py
+++ b/src/libcuflynx/parsers/PrimitiveParsers.py
@@ -687,6 +687,35 @@ def migrate_legacy_obs_columns(gt_df):
     return gt_df
 
 
+def _series_is_scored(gt_df, II):
+    """Whether series row ``II`` can contribute to the cost at all.
+
+    Two ways it cannot. A zero weight drops an item from the cost outright -- that is what
+    ``weight`` means everywhere else in the parser, and how a study switches an observable
+    off without deleting it. And an item carrying no samples has nothing to be compared
+    against whatever the solver produces.
+
+    Used only to decide whether an item's ``obs_dt`` may constrain the solver timestep. A
+    series nobody scores cannot require anything of dt, and a placeholder that does is a
+    study-stopping bug: SN_full ships eight empty, zero-weighted series at 1e-4 whose only
+    effect was to block every evaluation.
+    """
+    row = gt_df.iloc[II]
+    weight = row.get("weight", 1.0)
+    try:
+        if weight is not None and float(weight) == 0.0:
+            return False
+    except (TypeError, ValueError):
+        pass                                    # an unreadable weight is not a reason to skip
+    value = row.get("value")
+    if value is None:
+        return False
+    try:
+        return len(value) > 0
+    except TypeError:
+        return True                             # a scalar in a series row: let it speak
+
+
 def _obs_item_label(gt_df, II):
     """How to refer to row ``II`` of ``gt_df`` in an error message.
 
@@ -3998,22 +4027,33 @@ class ObsAndParamDataParser(object):
                         f"seconds, so the solver output can be compared with it.")
                 dt_list.append(gt_df.iloc[II]["obs_dt"])
 
+        # One entry per series, in order: plot_outputs indexes this by series_idx, so it
+        # stays parallel to the series even where an entry belongs to one that is never
+        # scored. The *guard* below is what skips those.
         obs_info["obs_dt"] = np.array(dt_list)
 
-        if len(obs_info["obs_dt"]) > 0:
-            smallest = float(min(obs_info["obs_dt"]))
-            if smallest < dt:
-                culprits = [_obs_item_label(gt_df, II) for II in range(gt_df.shape[0])
-                            if gt_df.iloc[II]["data_type"] == "series"
-                            and float(gt_df.iloc[II].get("obs_dt", np.inf)) < dt]
-                raise ObsDataError(
-                    f"the solver timestep dt = {dt:g} s is coarser than the sample spacing "
-                    f"of the series data it has to be compared against: the smallest "
-                    f"'obs_dt' in obs_data.json is {smallest:g} s"
-                    + (f", on {', '.join(culprits[:4])}" if culprits else "")
-                    + (f" and {len(culprits) - 4} more" if len(culprits) > 4 else "")
-                    + f". Set dt to {smallest:g} or less in user_inputs.yaml, or resample "
-                      f"the series data to {dt:g} s or coarser.")
+        # Only a series that will actually be compared constrains the solver's timestep. A
+        # zero-weighted item is dropped from the cost, and one carrying no samples has
+        # nothing to compare against, so neither can require anything of dt. SN_full's
+        # obs_data ships eight such placeholders at obs_dt = 1e-4, and they were enough to
+        # stop every evaluation of a study whose scored observables are all constants.
+        culprits = [_obs_item_label(gt_df, II) for II in range(gt_df.shape[0])
+                    if gt_df.iloc[II]["data_type"] == "series"
+                    and float(gt_df.iloc[II].get("obs_dt", np.inf)) < dt
+                    and _series_is_scored(gt_df, II)]
+        if culprits:
+            smallest = float(min(float(gt_df.iloc[II]["obs_dt"])
+                                 for II in range(gt_df.shape[0])
+                                 if gt_df.iloc[II]["data_type"] == "series"
+                                 and _series_is_scored(gt_df, II)))
+            raise ObsDataError(
+                f"the solver timestep dt = {dt:g} s is coarser than the sample spacing "
+                f"of the series data it has to be compared against: the smallest "
+                f"'obs_dt' in obs_data.json is {smallest:g} s"
+                + f", on {', '.join(culprits[:4])}"
+                + (f" and {len(culprits) - 4} more" if len(culprits) > 4 else "")
+                + f". Set dt to {smallest:g} or less in user_inputs.yaml, or resample "
+                  f"the series data to {dt:g} s or coarser.")
 
         # The std for the different observables
         obs_info["std_const_vec"] = np.array([gt_df.iloc[II]["std"] for II in range(gt_df.shape[0])

--- a/tests/test_mcmc_statistics.py
+++ b/tests/test_mcmc_statistics.py
@@ -30,8 +30,15 @@ def _engine(tmp_path, num_params=2, best_param_vals=None, best_cost=None,
     obj.best_param_vals = best_param_vals
     obj.best_cost = best_cost
     obj.UQ_options = UQ_options if UQ_options is not None else {}
-    obj.param_id_info = {'param_names_for_plotting': names
-                         or [f'p_{i}' for i in range(num_params)]}
+    # Both lists, as a real run has them: `param_names` is what the parser always
+    # builds (one entry per slot, each a list of the model qnames that slot sets --
+    # a grouped or modifier row names several), and `param_names_for_plotting` is
+    # the display form beside it. A stub carrying only the latter is not an MCMC
+    # that could have run: there is no sampling without parameters to sample.
+    obj.param_id_info = {
+        'param_names_for_plotting': names or [f'p_{i}' for i in range(num_params)],
+        'param_names': [[f'vessel_{i}/p_{i}'] for i in range(num_params)],
+    }
     obj._costs = list(costs)
     obj.get_cost_and_obs_from_params = lambda vals, reset=True: (obj._costs.pop(0), None)
     return obj

--- a/tests/test_obs_data_errors_are_catchable.py
+++ b/tests/test_obs_data_errors_are_catchable.py
@@ -1,0 +1,111 @@
+"""The obs_data guards raise, so an application embedding the parser can report them.
+
+``print()`` then ``exit()`` is fine in a script: the message lands on the terminal the user
+is already looking at. Anywhere else it is the worst of both worlds. ``exit()`` raises
+``SystemExit``, which derives from ``BaseException`` rather than ``Exception``, so it goes
+straight through the ``except Exception`` an embedding application wraps a parse in -- and
+the explanation, being a bare ``print``, goes to that application's stdout where nobody is
+reading.
+
+That is not hypothetical. CUFLynx's ``POST /api/protocol/run`` returned a bare "Internal
+Server Error" on an SN_full study whose series carry ``obs_dt = 1e-4`` while the app
+evaluates at its default ``dt = 0.01``. The sentence explaining it existed, and reached only
+the uvicorn log.
+
+These drive the real ``get_ground_truth_values`` rather than a copy of its four lines, so
+they fail if the guard is changed. Each asserts three things: it raises, what it raises is an
+ordinary ``Exception`` and not ``SystemExit``, and the message carries the numbers needed to
+act rather than only the names of the keys involved.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from libcuflynx.parsers.PrimitiveParsers import (ObsAndParamDataParser, ObsDataError,
+                                                 _obs_item_label)
+
+#: The columns ``get_ground_truth_values`` reads before it reaches the obs_dt guard. Kept
+#: minimal on purpose: a full study would need a model, a protocol and a params file to
+#: reach four lines of validation.
+def series_row(name='Vgt_{B0}', obs_dt=1e-4, **extra):
+    row = {
+        'data_type': 'series', 'data_item_name': name, 'operands': ['soma/V'],
+        'operation': 'series', 'value': [0.0, 1.0], 'std': 1.0, 'weight': 1.0,
+        'prob_dist_params': None, 'obs_dt': obs_dt,
+    }
+    if obs_dt is None:
+        del row['obs_dt']
+    row.update(extra)
+    return row
+
+
+def run(rows, dt, output_dir=None):
+    """``output_dir`` matters only past the guard: the function writes ground_truth npy
+    files there once it has validated. The raising tests never reach it."""
+    obs_info = {'num_obs': len(rows),
+                'data_types': [r['data_type'] for r in rows]}
+    return ObsAndParamDataParser().get_ground_truth_values(
+        pd.DataFrame(rows), obs_info, output_dir, dt)
+
+
+def test_a_dt_finer_than_the_solver_step_raises_rather_than_exiting():
+    """The SN_full case: obs_dt 1e-4 against an application's default dt of 0.01."""
+    with pytest.raises(ObsDataError) as excinfo:
+        run([series_row()], dt=0.01)
+    assert isinstance(excinfo.value, Exception)
+    assert not isinstance(excinfo.value, SystemExit), \
+        'SystemExit passes through `except Exception`, which is the bug'
+
+
+def test_the_message_carries_both_numbers_and_the_offending_item():
+    with pytest.raises(ObsDataError) as excinfo:
+        run([series_row()], dt=0.01)
+    message = str(excinfo.value)
+    assert '0.01' in message, 'the solver dt the caller used must appear'
+    assert '0.0001' in message, 'the obs_dt that conflicts with it must appear'
+    assert 'Vgt_{B0}' in message, 'and which item it came from'
+
+
+def test_many_offenders_are_summarised_not_listed_in_full():
+    with pytest.raises(ObsDataError) as excinfo:
+        run([series_row(f'Vgt_{{s{i}}}') for i in range(9)], dt=0.01)
+    message = str(excinfo.value)
+    assert 'Vgt_{s0}' in message
+    assert 'and 5 more' in message, 'four named, the rest counted'
+    assert 'Vgt_{s8}' not in message
+
+
+def test_only_the_items_that_actually_conflict_are_named():
+    with pytest.raises(ObsDataError) as excinfo:
+        run([series_row('Vgt_{fine}', 1e-4), series_row('Vgt_{coarse}', 0.5)], dt=0.01)
+    message = str(excinfo.value)
+    assert 'Vgt_{fine}' in message
+    assert 'Vgt_{coarse}' not in message, 'a series coarser than dt is not the problem'
+
+
+def test_a_series_without_obs_dt_raises_and_names_itself():
+    with pytest.raises(ObsDataError, match=r"Vgt_\{nodt\}"):
+        run([series_row('Vgt_{nodt}', obs_dt=None)], dt=0.01)
+
+
+def test_a_dt_equal_to_obs_dt_is_fine(tmp_path):
+    """The boundary is ``<``, not ``<=``: sampling the solver exactly at the data's spacing
+    is the normal, intended case and must not trip the guard."""
+    out = run([series_row()], dt=1e-4, output_dir=str(tmp_path))
+    assert np.allclose(out['obs_dt'], [1e-4])
+
+
+def test_constants_alone_do_not_trip_it(tmp_path):
+    """An obs_data with no series has nothing to compare a dt against."""
+    out = run([{'data_type': 'constant', 'data_item_name': 'V_{max}', 'operands': ['soma/V'],
+                'operation': 'max', 'value': 1.0, 'std': 1.0, 'weight': 1.0,
+                'prob_dist_params': None}], dt=0.01, output_dir=str(tmp_path))
+    assert len(out['obs_dt']) == 0
+
+
+def test_the_label_falls_back_when_an_item_has_no_name():
+    df = pd.DataFrame([{'data_type': 'series', 'operands': ['soma/V_sensed']}])
+    assert _obs_item_label(df, 0) == 'soma/V_sensed'
+    bare = pd.DataFrame([{'data_type': 'series'}])
+    assert _obs_item_label(bare, 0) == 'item 0'
+    assert _obs_item_label(bare, 7) == 'item 7', 'an out-of-range row must not raise'

--- a/tests/test_obs_data_errors_are_catchable.py
+++ b/tests/test_obs_data_errors_are_catchable.py
@@ -22,7 +22,7 @@ import pandas as pd
 import pytest
 
 from libcuflynx.parsers.PrimitiveParsers import (ObsAndParamDataParser, ObsDataError,
-                                                 _obs_item_label)
+                                                 _obs_item_label, _series_is_scored)
 
 #: The columns ``get_ground_truth_values`` reads before it reaches the obs_dt guard. Kept
 #: minimal on purpose: a full study would need a model, a protocol and a params file to
@@ -109,3 +109,52 @@ def test_the_label_falls_back_when_an_item_has_no_name():
     bare = pd.DataFrame([{'data_type': 'series'}])
     assert _obs_item_label(bare, 0) == 'item 0'
     assert _obs_item_label(bare, 7) == 'item 7', 'an out-of-range row must not raise'
+
+
+# --------------------------------------------------- only a scored series constrains dt
+
+def test_an_empty_zero_weighted_series_does_not_block_the_study(tmp_path):
+    """The SN_full case exactly: eight placeholder series at obs_dt 1e-4, weight 0 and no
+    samples, in a study whose scored observables are all constants. They cannot be compared
+    against anything, so they must not stop the evaluation."""
+    rows = [series_row(f'Vgt_{{s{i}}}', 1e-4, weight=0.0, value=[]) for i in range(8)]
+    rows.append({'data_type': 'constant', 'data_item_name': 'V_{max}', 'operands': ['soma/V'],
+                 'operation': 'max', 'value': 1.0, 'std': 1.0, 'weight': 1.0,
+                 'prob_dist_params': None})
+    out = run(rows, dt=0.01, output_dir=str(tmp_path))
+    assert len(out['obs_dt']) == 8, 'obs_dt stays parallel to the series for plot_outputs'
+
+
+def test_a_scored_series_still_constrains_dt():
+    """The guard must not have been softened into uselessness."""
+    with pytest.raises(ObsDataError, match=r"Vgt_\{real\}"):
+        run([series_row('Vgt_{real}', 1e-4, weight=1.0, value=[0.0, 1.0])], dt=0.01)
+
+
+def test_a_weighted_but_empty_series_does_not_constrain_dt(tmp_path):
+    run([series_row('Vgt_{empty}', 1e-4, weight=1.0, value=[])], dt=0.01,
+        output_dir=str(tmp_path))
+
+
+def test_a_zero_weighted_series_with_samples_does_not_constrain_dt(tmp_path):
+    run([series_row('Vgt_{off}', 1e-4, weight=0.0, value=[0.0, 1.0])], dt=0.01,
+        output_dir=str(tmp_path))
+
+
+def test_only_the_scored_offender_is_named():
+    with pytest.raises(ObsDataError) as excinfo:
+        run([series_row('Vgt_{placeholder}', 1e-4, weight=0.0, value=[]),
+             series_row('Vgt_{real}', 1e-4, weight=1.0, value=[0.0, 1.0])], dt=0.01)
+    message = str(excinfo.value)
+    assert 'Vgt_{real}' in message
+    assert 'Vgt_{placeholder}' not in message
+
+
+def test_series_is_scored_reads_weight_and_samples():
+    df = pd.DataFrame([
+        series_row('a', weight=1.0, value=[0.0]),
+        series_row('b', weight=0.0, value=[0.0]),
+        series_row('c', weight=1.0, value=[]),
+        series_row('d', weight=None, value=[0.0]),
+    ])
+    assert [_series_is_scored(df, i) for i in range(4)] == [True, False, False, True]

--- a/tests/test_posterior_point_estimates_are_loadable.py
+++ b/tests/test_posterior_point_estimates_are_loadable.py
@@ -1,0 +1,126 @@
+"""The posterior median is written as something that can be loaded, not just reported.
+
+``mcmc_statistics.json`` has always carried the median, keyed by *display* name
+(``g_{Na}``) inside a per-parameter summary next to quartiles and a 95% interval. That is a
+report. Nothing can feed it back into a model: the display names are not the model's, and
+the shape is not one any parameter loader reads.
+
+So ``save_mcmc_statistics`` could promise "both are now on disk to choose from" while only
+one of the two -- ``best_param_vals.npy`` -- was in a loadable form, and choosing the median
+meant reading JSON and retyping fourteen numbers.
+
+That is not a cosmetic gap. A calibration best is an argmin found by whatever drove the
+search, and when a surrogate drove it the argmin can sit where the surrogate is wrong: one
+SN_full cpvt run reported a best fit whose resting potential was -19 mV against data at -75,
+while the posterior median from the same chain sat at -80.
+"""
+import csv
+import json
+import os
+
+import numpy as np
+import pytest
+
+from libcuflynx.param_id.paramID import MCMC
+
+
+class _Writer:
+    """The parts of MCMC ``save_posterior_point_estimates`` touches, and nothing else.
+
+    Bound off the real class rather than reimplemented, so the test exercises the shipped
+    method: driving a whole MCMC would need a model, a protocol and a chain to reach four
+    lines of file writing.
+    """
+
+    def __init__(self, output_dir, members_per_slot, rank=0):
+        self.output_dir = output_dir
+        self.param_id_info = {"param_names": members_per_slot}
+        self.rank = rank
+
+    save_posterior_point_estimates = MCMC.save_posterior_point_estimates
+
+
+def read_csv(path):
+    with open(path, newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+@pytest.fixture
+def writer(tmp_path):
+    return _Writer(str(tmp_path), [["soma_SN/g_Na"], ["soma_SN/g_leak_K"],
+                                   ["soma_SN/V_mid_w"]])
+
+
+def test_both_estimates_are_written_in_both_formats(writer, tmp_path):
+    writer.save_posterior_point_estimates([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+    for label in ("median", "mean"):
+        assert os.path.isfile(tmp_path / f"posterior_{label}_params.csv")
+        assert os.path.isfile(tmp_path / f"posterior_{label}_param_vals.npy")
+
+
+def test_the_csv_carries_names_so_it_does_not_depend_on_order(writer, tmp_path):
+    """The columns a parameter loader reads: vessel_name, param_name, value. Self-describing,
+    so loading it into a model does not require the columns to line up positionally."""
+    writer.save_posterior_point_estimates([1.5, 2.5, 3.5], [0.0, 0.0, 0.0])
+    rows = read_csv(tmp_path / "posterior_median_params.csv")
+    assert [r["vessel_name"] for r in rows] == ["soma_SN"] * 3
+    assert [r["param_name"] for r in rows] == ["g_Na", "g_leak_K", "V_mid_w"]
+    assert [float(r["value"]) for r in rows] == [1.5, 2.5, 3.5]
+
+
+def test_the_npy_matches_best_param_vals_in_shape_and_order(writer, tmp_path):
+    """A bare array in optimiser order, so anything reading best_param_vals.npy reads this."""
+    writer.save_posterior_point_estimates([1.5, 2.5, 3.5], [4.5, 5.5, 6.5])
+    assert np.allclose(np.load(tmp_path / "posterior_median_param_vals.npy"), [1.5, 2.5, 3.5])
+    assert np.allclose(np.load(tmp_path / "posterior_mean_param_vals.npy"), [4.5, 5.5, 6.5])
+
+
+def test_the_median_and_the_mean_do_not_overwrite_each_other(writer, tmp_path):
+    writer.save_posterior_point_estimates([1.0, 1.0, 1.0], [9.0, 9.0, 9.0])
+    med = [float(r["value"]) for r in read_csv(tmp_path / "posterior_median_params.csv")]
+    mean = [float(r["value"]) for r in read_csv(tmp_path / "posterior_mean_params.csv")]
+    assert med == [1.0, 1.0, 1.0] and mean == [9.0, 9.0, 9.0]
+
+
+def test_a_modifier_slot_writes_every_member_at_the_slot_value(tmp_path):
+    """One slot, several model parameters, one value -- matching how best_param_vals.npy is
+    read back, where each member qname takes the slot's value."""
+    w = _Writer(str(tmp_path), [["a/g_x", "b/g_x", "c/g_x"], ["soma_SN/g_Na"]])
+    w.save_posterior_point_estimates([2.0, 7.0], [0.0, 0.0])
+    rows = read_csv(tmp_path / "posterior_median_params.csv")
+    assert len(rows) == 4
+    assert [float(r["value"]) for r in rows] == [2.0, 2.0, 2.0, 7.0]
+    assert [r["vessel_name"] for r in rows] == ["a", "b", "c", "soma_SN"]
+
+
+def test_a_name_without_a_vessel_is_kept_whole(tmp_path):
+    """Rather than dropped, so the file still accounts for every slot."""
+    w = _Writer(str(tmp_path), [["bare_name"]])
+    w.save_posterior_point_estimates([3.0], [3.0])
+    rows = read_csv(tmp_path / "posterior_median_params.csv")
+    assert rows[0]["vessel_name"] == "" and rows[0]["param_name"] == "bare_name"
+
+
+def test_full_precision_is_kept(writer, tmp_path):
+    """A parameter set rounded on the way to disk is a different parameter set. Spans and
+    conductances here run to 1e-5, where %.6g would lose real digits."""
+    values = [1.2345678901234567e-05, 2.0, 3.0]
+    writer.save_posterior_point_estimates(values, values)
+    rows = read_csv(tmp_path / "posterior_median_params.csv")
+    assert float(rows[0]["value"]) == values[0]
+
+
+def test_only_rank_zero_writes(tmp_path):
+    """Every rank runs this; one file, written once."""
+    w = _Writer(str(tmp_path), [["soma_SN/g_Na"]], rank=1)
+    w.save_posterior_point_estimates([1.0], [1.0])
+    assert not os.path.isfile(tmp_path / "posterior_median_params.csv")
+
+
+def test_more_slots_than_values_stops_rather_than_raising(tmp_path):
+    """A truncated array should give what it can, not an IndexError in the last step of a
+    run that has already spent hours sampling."""
+    w = _Writer(str(tmp_path), [["a/x"], ["b/y"], ["c/z"]])
+    w.save_posterior_point_estimates([1.0, 2.0], [1.0, 2.0])
+    rows = read_csv(tmp_path / "posterior_median_params.csv")
+    assert [r["param_name"] for r in rows] == ["x", "y"]


### PR DESCRIPTION
**Stacked on #501**, which is stacked on #500.

## The gap

`save_mcmc_statistics` says *"both are now on disk to choose from"* — but only one of the two
is in a form anything can load:

| estimator | on disk as | loadable? |
|---|---|---|
| calibration best | `best_param_vals.npy` (bare array, optimiser order) | **yes** |
| posterior median | a `median` field inside `mcmc_statistics.json`, keyed by **display name** (`g_{Na}`) | **no** |

Those display names are not the model's, and that shape is not one any parameter loader
reads. Choosing the median meant opening the JSON and retyping fourteen numbers.

## Why it matters

A calibration best is an argmin found by whatever drove the search, and when a surrogate
drove it, the argmin can sit exactly where the surrogate is wrong. Measured on an SN_full
cpvt run:

| | reported cost | solver cost | V rest | fires? |
|---|---|---|---|---|
| GA best fit | 1.76 | **68.87** | **−19.78 mV** | no |
| posterior median | — | **9.81** | −80.35 mV | no |

Data says −75.14 mV. The emulator predicted −73.8 for the same observable the solver puts at
−18.8, so the optimiser walked into a region where the surrogate is ~55 mV wrong. The
estimator the user actually wants was the one they could not load.

## What is written

Beside `mcmc_statistics.json`, on rank 0:

- **`posterior_median_params.csv`** — `vessel_name,param_name,value`. Self-describing, so
  loading it does not depend on column order matching the model.
- **`posterior_median_param_vals.npy`** — the bare array in optimiser order, same shape as
  `best_param_vals.npy`, for anything reading that.

And the same pair for the mean, since the two costs are already reported side by side and a
reader invited to compare them should be able to load either.

A modifier slot names several model parameters and holds one value, so every member is
written at that value — matching how `best_param_vals.npy` is read back. Values go out
through `repr()` rather than a format string: SN_full conductances run to 1e-5, where
`%.6g` drops real digits, and a rounded parameter set is a different parameter set.

## Verified

Against CUFLynx's own loader — `POST /api/params/load` on the generated CSV returns 200 and
all 14 parameters, correctly named as `soma_SN/g_Na` etc. No CUFLynx change is required; its
existing load-parameters-from-file path reads this format already.

9 tests, driving the shipped method: both formats written, names carried, npy order matching
`best_param_vals.npy`, median and mean not overwriting each other, modifier slots expanding
to every member, full precision kept, rank-0 only, and a truncated array stopping rather
than raising in the last step of a run that has already sampled for hours.

## Backfilling finished runs

No re-run needed — recompute the medians from `mcmc_chain.npy` and call the same method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfQsxarGfeaax6MNNo7ZJe