### PR TITLE
Create the GitHub release when a tag publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,3 +90,58 @@ jobs:
 
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
+
+  # A tag publishes to PyPI, and used to stop there -- so v0.4.1, v0.5.0 and v0.5.1 are on
+  # PyPI with nothing on the releases page, and v0.4.0's entry was written by hand. The
+  # releases page is where someone looks to find out what changed between two versions they
+  # have installed, so leaving it to memory means it is right only when someone remembers.
+  #
+  # Gated on `publish`, not on `build`: a release that announces a version PyPI rejected
+  # points at something nobody can install. Notes only, no attached files -- PyPI is the
+  # distribution channel, and a wheel on the releases page is a second copy that can drift
+  # from it.
+  github-release:
+    name: Create the GitHub release
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      # To create the release. Deliberately narrower than the workflow default, and not
+      # `id-token`, which only the PyPI upload needs.
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Take the notes from CHANGELOG.md
+      id: notes
+      run: |
+        version="${GITHUB_REF_NAME#v}"
+        # The section for this version, from its heading to the next `## ` heading. Written
+        # to a file rather than an output: release notes are long and contain everything
+        # awkward for a shell variable.
+        awk -v v="$version" '
+          $0 ~ "^## "v"( |$|—)" {found=1; next}
+          found && /^## / {exit}
+          found {print}
+        ' CHANGELOG.md > notes.md
+        if [ ! -s notes.md ]; then
+          echo "::warning::no CHANGELOG.md section for $version; publishing a stub"
+          printf 'See CHANGELOG.md.\n' > notes.md
+        fi
+        printf '\n---\n\nInstall: `pip install libcuflynx==%s`\nPyPI: https://pypi.org/project/libcuflynx/%s/\n' \
+          "$version" "$version" >> notes.md
+
+    - name: Create it
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # `--verify-tag` so a typo'd ref cannot invent a release against a tag that is not
+        # there. Idempotent on re-run: editing beats failing when the publish is fine and
+        # only this step was retried.
+        if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+          gh release edit "$GITHUB_REF_NAME" --notes-file notes.md
+        else
+          gh release create "$GITHUB_REF_NAME" --verify-tag \
+            --title "libcuflynx ${GITHUB_REF_NAME#v}" --notes-file notes.md
+        fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,16 @@ can publish.
 - **`publish`** — downloads that artifact and publishes it with
   `pypa/gh-action-pypi-publish`, in the GitHub environment named **`pypi`**, with
   `permissions: id-token: write`.
+- **`github-release`** — creates the entry on the
+  [releases page](https://github.com/physiomelinks/circulatory_autogen/releases), taking its
+  notes from the `CHANGELOG.md` section for the version. Gated on `publish`, so a release
+  never announces a version PyPI rejected. Notes only: PyPI is the distribution channel, and
+  a wheel attached here would be a second copy that can drift from it.
+
+  This job was added late. **v0.4.1, v0.5.0 and v0.5.1 are on PyPI with no entry on the
+  releases page** because the workflow used to stop at `publish`, and v0.4.0's and v0.6.0's
+  entries were written by hand. If you want the history complete, they can be backfilled with
+  `gh release create vX.Y.Z --notes-file <section of CHANGELOG.md>`.
 
 A `workflow_dispatch` run builds and checks but does **not** publish, so the build can be
 exercised without cutting a release.

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -194,6 +194,26 @@ def test_the_tag_versus_version_check_reads_this_repository_s_real_version(workf
 
 
 @pytest.mark.unit
+def test_a_tag_also_creates_the_github_release(workflow):
+    """PyPI is not the only place a release has to appear.
+
+    Publishing to PyPI and stopping there is what left v0.4.1, v0.5.0 and v0.5.1 with no
+    entry on the releases page -- the page people read to find out what changed between
+    two versions they have installed.
+    """
+    job = workflow["jobs"]["github-release"]
+    assert job["needs"] == "publish", (
+        "gate it on the upload, not the build: a release announcing a version PyPI "
+        "rejected points at something nobody can install"
+    )
+    assert job["permissions"] == {"contents": "write"}
+    assert "refs/tags/v" in job["if"]
+    run = " ".join(step.get("run", "") for step in job["steps"])
+    assert "CHANGELOG.md" in run, "the notes should come from the changelog, not be invented"
+    assert "--verify-tag" in run, "a typo'd ref must not invent a release"
+
+
+@pytest.mark.unit
 def test_release_procedure_is_documented():
     """Somewhere findable, and naming the parts that cannot be undone."""
     text = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")


### PR DESCRIPTION
A tag publishes to PyPI and stops there. That is why **v0.4.1, v0.5.0 and v0.5.1 are on PyPI with no entry on the [releases page](https://github.com/physiomelinks/circulatory_autogen/releases)** — v0.4.0's and v0.6.0's were written by hand. The releases page is where someone looks to find out what changed between two versions they already have installed, so leaving it to whoever remembers means it is right only sometimes.

## The job

`github-release`, after `publish`:

- **Notes come from `CHANGELOG.md`**, extracted for the tag's version, rather than invented. Verified against the real file: 0.6.0 → 26 lines, 0.5.1 → 17, 0.4.1 → 51, and a version with no section falls back to a stub with a `::warning::` rather than an empty release.
- **Gated on `publish`, not `build`** — a release announcing a version PyPI rejected points at something nobody can install.
- **Notes only, no attached files.** PyPI is the distribution channel; a wheel here is a second copy that can drift from it. Matches what v0.4.0 and v0.6.0 already look like.
- **`gh` with the job's own `github.token`**, not a third-party action, matching this workflow's existing position on not introducing credentials it does not need. `contents: write` and nothing else — not `id-token`, which only the PyPI upload needs.
- **`--verify-tag`** so a typo'd ref cannot invent a release against a tag that is not there, and re-running edits an existing release rather than failing, because the case that actually happens is a good publish whose release step was retried.

## Tests

`test_a_tag_also_creates_the_github_release` pins the gate, the permissions, the tag condition, and that the notes come from the changelog. `tests/test_release_workflow.py` is 11 passing; docs consistency 7.

CONTRIBUTING.md's release section documents the new job, and says plainly which three versions are missing from the page and how to backfill them if you want the history complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mk1rvBawTUN3SP7VwHVGhh