### PR TITLE
One spelling per concept in obs_info and prediction_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ next release; add to that section as you land a change.
 
 ## Unreleased
 
+### Changed — one spelling per concept in `obs_info` and `prediction_info`
+
+The obs_data *file* vocabulary was split by #466; the parsed dicts were not, and kept the old
+spellings as live aliases. `obs_info` held `obs_names` with `data_item_names` aliased to the
+same list, and `names_for_plotting` aliased to `item_names_for_plotting`. `prediction_info`
+was worse: its `names_for_plotting` meant the **trace** label where obs_info's meant the
+**item** label, so one key named two different things depending on which dict you held.
+
+Now: `obs_info` has `data_item_names`, `trace_names_for_plotting` and
+`item_names_for_plotting` and nothing else; `prediction_info` mirrors it exactly, with its
+`names` becoming `operands` (a list per item, as on obs_info) and its `names_for_plotting`
+becoming `trace_names_for_plotting`. `obs_item_names` / `obs_item_labels` /
+`obs_trace_labels` / `obs_operand_lists` now work on either dict.
+
+**If you build one of these dicts by hand**, `ParamID` normalises what it is handed and warns
+once per superseded key; a dict setting both an old key and its replacement is an error.
+Reading the old keys off a parsed dict no longer works, because they are no longer written.
+
+Two bugs fell out. `posterior_predictive` captioned a series panel with the item's *identity*
+where it meant the trace label, and `print_observable_errors` named one of its six branches by
+identity where the other five used the label.
+
+
 ## 0.6.0 — 2026-08-31
 
 ### Removed — the flat-import shims (#428)
@@ -31,6 +54,7 @@ internally (`paramID.py`), so removing it is a change to the parser and its call
 than a deletion, and it does not belong in the same release as the namespace removal for the
 same reason that removal was deferred out of 0.5.0. Prefer `data_item_names`,
 `trace_names_for_plotting` or `item_names_for_plotting`; the alias will go in a later release.
+*(Done in Unreleased — see "one spelling per concept" above.)*
 
 ## 0.5.1 — 2026-08-25
 

--- a/src/libcuflynx/param_id/cost_kwargs.py
+++ b/src/libcuflynx/param_id/cost_kwargs.py
@@ -182,7 +182,7 @@ def validate_cost_kwargs(obs_info, cost_funcs_dict, cost_types):
     raw_list = obs_info.get("cost_kwargs") if obs_info else None
     if not raw_list:
         return
-    names = obs_item_names(obs_info) or obs_info.get("names", [])
+    names = obs_item_names(obs_info)
     for i, raw in enumerate(raw_list):
         if not raw:
             continue

--- a/src/libcuflynx/param_id/paramID.py
+++ b/src/libcuflynx/param_id/paramID.py
@@ -1302,7 +1302,7 @@ class CVS0DParamID():
         to.
         """
         sim_obj = mcmc_object if self.mcmc_instead else self.param_id
-        names = self.obs_info['names_for_plotting']
+        names = obs_item_labels(self.obs_info)
         values = {name: {} for name in names}
 
         flat_samples = np.asarray(flat_samples, dtype=float)
@@ -1353,7 +1353,7 @@ class CVS0DParamID():
 
     def _add_measured_values(self, values):
         """Add the measured data each feature is answerable to, under 'exp_data'."""
-        for obs_idx, name in enumerate(self.obs_info['names_for_plotting']):
+        for obs_idx, name in enumerate(obs_item_labels(self.obs_info)):
             data_type = self.obs_info['data_types'][obs_idx]
             measured = values[name].setdefault('exp_data', [])
             if data_type == 'constant':
@@ -1437,7 +1437,7 @@ class CVS0DParamID():
                     ax.scatter(np.random.normal(idx, 0.04, size=len(vals)), vals,
                                color='black', s=5, alpha=0.2, zorder=2)
 
-            obs_idx = self.obs_info['names_for_plotting'].index(feature)
+            obs_idx = obs_item_labels(self.obs_info).index(feature)
             ax.set_xticks(range(len(labels)))
             ax.set_xticklabels(labels, rotation=15)
             ax.set_ylabel(f"{feature} ({self.obs_info['units'][obs_idx]})")
@@ -1466,7 +1466,7 @@ class CVS0DParamID():
             return None
         import seaborn as sns
 
-        features = list(self.obs_info['names_for_plotting'])
+        features = list(obs_item_labels(self.obs_info))
         if not features:
             return None
         cols = min(3, len(features))

--- a/src/libcuflynx/param_id/paramID.py
+++ b/src/libcuflynx/param_id/paramID.py
@@ -101,7 +101,9 @@ import math
 import scipy.linalg as la
 # from scipy.optimize import curve_fit
 import warnings
-from libcuflynx.utilities.obs_data_helpers import (obs_item_names, obs_item_labels,
+from libcuflynx.utilities.obs_data_helpers import (normalise_obs_info,
+                                                   normalise_prediction_info,
+                                                   obs_item_names, obs_item_labels,
                                                    obs_operand_lists, obs_trace_labels)
 warnings.filterwarnings( "ignore", module = "matplotlib/..*" )
 # TODO maybe remove matplotlib warnings as above
@@ -1870,9 +1872,11 @@ class ParamID():
         self.emulates_features = False
 
         self.solver_info = solver_info
-        self.obs_info = obs_info
+        # The boundary: everything below reads the current vocabulary only, so a dict
+        # assembled by hand elsewhere is brought into it here, once, with a warning.
+        self.obs_info = normalise_obs_info(obs_info)
         self.param_id_info = param_id_info
-        self.prediction_info = prediction_info # currently not used
+        self.prediction_info = normalise_prediction_info(prediction_info)  # currently not used
         self.optimiser_options = optimiser_options
         if self.param_id_info is not None:
             self.num_params = len(self.param_id_info["param_names"])
@@ -2222,10 +2226,12 @@ class ParamID():
         self._refresh_num_weighted_obs_tables()
 
     def set_prediction_info(self, prediction_info):
-        self.prediction_info = prediction_info
+        self.prediction_info = normalise_prediction_info(prediction_info)
     
     def set_obs_info(self, obs_info):
-        self.obs_info = obs_info
+        # Before cost_type is read and before the kwargs validators run, so all three
+        # see one vocabulary.
+        self.obs_info = normalise_obs_info(obs_info)
         self.cost_type = self.obs_info["cost_type"]
         validate_operation_kwargs(self.obs_info, self.operation_funcs_dict)
         validate_cost_kwargs(self.obs_info, self.cost_funcs_dict, self.cost_type)

--- a/src/libcuflynx/param_id/paramID.py
+++ b/src/libcuflynx/param_id/paramID.py
@@ -101,7 +101,8 @@ import math
 import scipy.linalg as la
 # from scipy.optimize import curve_fit
 import warnings
-from libcuflynx.utilities.obs_data_helpers import obs_item_names, obs_item_labels
+from libcuflynx.utilities.obs_data_helpers import (obs_item_names, obs_item_labels,
+                                                   obs_operand_lists, obs_trace_labels)
 warnings.filterwarnings( "ignore", module = "matplotlib/..*" )
 # TODO maybe remove matplotlib warnings as above
 
@@ -1551,7 +1552,8 @@ class CVS0DParamID():
         for exp_idx in self.prediction_info['experiment_idxs']:
             self.param_id.simulate_once(reset=False, only_one_exp=exp_idx)
             tSim = self.param_id.sim_helper.tSim - self.param_id.pre_time
-            pred_names = [name for II, name in enumerate(self.prediction_info['names']) if 
+            pred_qnames = [str(ops[0]) for ops in obs_operand_lists(self.prediction_info)]
+            pred_names = [name for II, name in enumerate(pred_qnames) if
                                   self.prediction_info['experiment_idxs'][II] == exp_idx]
             pred_output = np.array(self.param_id.sim_helper.get_results(pred_names))
                     
@@ -1566,7 +1568,7 @@ class CVS0DParamID():
             print('Prediction variables are not saved when use_emulator is set: they are '
                   'traces, and the emulator predicts the scalar observable features only.')
             return
-        if self.prediction_info['names'] is not None:
+        if obs_operand_lists(self.prediction_info):
             print('Saving prediction data')
             time_and_pred_per_exp_list = self.__get_prediction_data()
 
@@ -1578,8 +1580,10 @@ class CVS0DParamID():
                 
             # also save the prediction variable names to csv
             with open(os.path.join(self.output_dir, 'prediction_variable_names.csv'), 'w') as wf:
-                for name in self.prediction_info['names']:
-                    wf.write(name + '\n')
+                # One qname per line -- the operand list holds one entry per prediction
+                # item, so this writes exactly what it always did.
+                for ops in obs_operand_lists(self.prediction_info):
+                    wf.write(str(ops[0]) + '\n')
             
             print('prediction data saved')
 
@@ -1670,7 +1674,7 @@ class CVS0DParamID():
     def postprocess_predictions(self):
         # TODO redo this for new prediction_info in obs_data.json 
         # TODO This should be straight forward
-        if self.prediction_info['names'] == None:
+        if not obs_operand_lists(self.prediction_info):
             print('no prediction variables, not plotting predictions')
             return 0
         m3_to_cm3 = 1e6
@@ -1689,7 +1693,7 @@ class CVS0DParamID():
         best_param_vals = self.get_best_param_vals()
 
         save_list = []
-        for pred_idx in range(len(self.prediction_info['names'])):
+        for pred_idx in range(len(obs_operand_lists(self.prediction_info))):
             exp_idx = self.prediction_info['experiment_idxs'][pred_idx]
             pred_array = pred_list_of_arrays[pred_idx]
             tSim = self.protocol_info['tSims_per_exp'][exp_idx].flatten()
@@ -1721,7 +1725,7 @@ class CVS0DParamID():
             for sample_idx in range(pred_array.shape[0]):
                 axs.plot(tSim, conversion*pred_array[sample_idx, pred_idx, :], alpha=0.5)
             axs.set_xlabel('Time [$s$]', fontsize=14)
-            axs.set_ylabel(f'${self.prediction_info["names_for_plotting"][pred_idx]}$ [{unit_for_plot}]', fontsize=14)
+            axs.set_ylabel(f'${obs_trace_labels(self.prediction_info)[pred_idx]}$ [{unit_for_plot}]', fontsize=14)
             axs.set_xlim(min(tSim), max(tSim))
             plt.savefig(os.path.join(self.plot_dir,
                                     f'prediction_{self.file_name_prefix}_'
@@ -1743,7 +1747,7 @@ class CVS0DParamID():
                                 np.argmin(np.abs(pred_mean - np.mean(pred_mean)))]
             # TODO put units in prediction file and use it here
             axs.set_xlabel('Time [$s$]', fontsize=14)
-            axs.set_ylabel(f'${self.prediction_info["names_for_plotting"][pred_idx]}$ [{unit_for_plot}]', fontsize=14)
+            axs.set_ylabel(f'${obs_trace_labels(self.prediction_info)[pred_idx]}$ [{unit_for_plot}]', fontsize=14)
             # for sample_idx in range(pred_array.shape[1]):
 
             # axs.plot(tSim, conversion*pred_mean, 'b', label='mean', linewidth=1.5)
@@ -2750,7 +2754,8 @@ class ParamID():
                                           
         pred_operand_outputs = self.get_pred_from_params(param_vals=param_vals, reset=False, 
                                                 only_one_exp=exp_idx, 
-                                                pred_names=self.prediction_info['names'])
+                                                pred_names=[str(ops[0]) for ops in
+                                                            obs_operand_lists(self.prediction_info)])
     
         # The second index of pred_output is the operand idx
         # TODO currently we don't allow operands for prediction outputs.
@@ -3631,7 +3636,7 @@ A caller that steps through the segments in order does so inside
 
     def _observable_label(self, obs_idx):
         """Human-readable, disambiguating label for observable ``obs_idx`` (used as the row key
-        of the local-sensitivity matrices). names_for_plotting can repeat across observables that
+        of the local-sensitivity matrices). item_names_for_plotting can repeat across observables that
         share a variable but differ by operation (e.g. mean vs max of the same trace), so the
         operation and operand are folded in.
 

--- a/src/libcuflynx/param_id/plot_outputs.py
+++ b/src/libcuflynx/param_id/plot_outputs.py
@@ -295,7 +295,8 @@ class ParamIDPlotOutputs:
         obs_stub = self.client.param_id_obs_file_prefix
 
         obs_tuples_unique = []
-        for idx, obs_name in enumerate(obs_info["obs_names"]):
+        item_names = obs_item_names(obs_info)
+        for idx, obs_name in enumerate(item_names):
             tup = (obs_name, obs_info["experiment_idxs"][idx])
             if tup not in obs_tuples_unique:
                 obs_tuples_unique.append(tup)
@@ -330,7 +331,7 @@ class ParamIDPlotOutputs:
                     freq_idx += 1
 
                 if (
-                    obs_info["obs_names"][II],
+                    item_names[II],
                     obs_info["experiment_idxs"][II],
                 ) != obs_tuples_unique[unique_obs_count]:
                     continue
@@ -540,7 +541,7 @@ class ParamIDPlotOutputs:
                         pass
                     else:
                         print(
-                            f'plot_type for {obs_info["obs_names"][II]} '
+                            f'plot_type for {obs_item_names(obs_info)[II]} '
                             f"of {obs_info['plot_type'][II]} is not recognised",
                             "for constants it must be in [None, horizontal, veritical, horizontal_from_min], exiting",
                         )
@@ -1263,7 +1264,8 @@ class ParamIDPlotOutputs:
                     print(f'{obs_item_labels(obs_info)[obs_idx]} series error:')
                 else:
                     print(
-                        f'{obs_info["obs_names"][obs_idx]} {obs_info["data_types"][obs_idx]} error:'
+                        f'{obs_item_labels(obs_info)[obs_idx]} '
+                        f'{obs_info["data_types"][obs_idx]} error:'
                     )
                 print(f"{percent_error_vec[obs_idx]:.2f} %")
             if dt_row == "frequency":

--- a/src/libcuflynx/param_id/posterior_predictive.py
+++ b/src/libcuflynx/param_id/posterior_predictive.py
@@ -38,6 +38,8 @@ Usage::
     result.save(output_dir)
     print(result.summary())
 """
+from libcuflynx.utilities.obs_data_helpers import (obs_item_names,
+                                                   obs_trace_labels)
 import json
 import os
 
@@ -473,10 +475,15 @@ class PosteriorPredictiveResult:
         return samples_path, coverage_path
 
 
-def observable_labels(obs_info):
-    """A readable name per constant observable, in ``ground_truth_const`` order."""
-    names = (obs_info.get('data_item_names') or obs_info.get('names_for_plotting')
-             or obs_info.get('obs_names'))
+def observable_item_names(obs_info):
+    """A data_item's identity per constant observable, in ``ground_truth_const`` order.
+
+    Named for what it returns. It was ``observable_labels``, which is also the name of a
+    function in ``paramID`` that returns display *labels* -- two names for one thing and one
+    name for two things. Identity is the right answer here: it goes into the persisted
+    ``labels=`` array that a reload is checked against, and a label may be reworded.
+    """
+    names = obs_item_names(obs_info)
     return [str(names[obs_idx]) for obs_idx in obs_info['const_idx_to_obs_idx']]
 
 
@@ -553,7 +560,7 @@ def series_metadata(client, series, ground_truth, std, predictions=None):
         time_axes[key] = segment_time_axis(
             protocol_info, exp_idx, sub_idx, block.shape[1]).tolist()
 
-    labels = observable_labels(obs_info)
+    labels = observable_item_names(obs_info)
     plot_types = obs_info.get('plot_type') or []
     observables = []
     for const_idx, obs_idx in enumerate(obs_info['const_idx_to_obs_idx']):
@@ -589,7 +596,9 @@ def series_metadata(client, series, ground_truth, std, predictions=None):
     recorded = obs_info.get('ground_truth_series') or []
     series_map = obs_info.get('series_idx_to_obs_idx') or []
     series_weights = obs_info.get('weight_series_vec')
-    series_names = obs_info.get('data_item_names') or obs_info.get('trace_names_for_plotting') or []
+    # The trace's label: this feeds a display field on a series panel, and the chain it
+    # replaces tried the *identity* first, so a panel was captioned with a data_item_name.
+    series_names = obs_trace_labels(obs_info)
     for series_idx, obs_idx in enumerate(series_map):
         if series_idx >= len(recorded):
             break
@@ -703,7 +712,7 @@ def posterior_predictive(inp_data_dict=None, num_samples=100, burn_in=0.5,
 
     result = PosteriorPredictiveResult(
         thetas=thetas, predictions=predictions, ground_truth=ground_truth,
-        std=std, labels=observable_labels(obs_info),
+        std=std, labels=observable_item_names(obs_info),
         coverage_summary=coverage(predictions, ground_truth, std, levels),
         chain_info=chain_info, failures=failures, used_emulator=bool(use_emulator),
         series=series,

--- a/src/libcuflynx/parsers/PrimitiveParsers.py
+++ b/src/libcuflynx/parsers/PrimitiveParsers.py
@@ -665,6 +665,17 @@ PARAM_MODIFIER_OPERATIONS = PARAM_MODIFIERS
 DEFAULT_PARAM_MODIFIER_OPERATION = DEFAULT_PARAM_MODIFIER
 
 
+def _empty_prediction_info():
+    """The shape ``process_obs_info`` fills for prediction_items.
+
+    One definition rather than three literals: the keys are the same as obs_info's, and three
+    copies is how a fourth comes to differ from the other three.
+    """
+    return {'operands': [], 'units': [], 'data_item_names': [],
+            'trace_names_for_plotting': [], 'item_names_for_plotting': [],
+            'experiment_idxs': []}
+
+
 def migrate_legacy_obs_columns(gt_df):
     """Rename an obs dataframe's superseded columns, warning once per column.
 
@@ -3495,9 +3506,7 @@ class ObsAndParamDataParser(object):
             protocol_info = {"pre_times": [pre_time], 
                              "sim_times": [[sim_time]],
                              "params_to_change": {}}
-            prediction_info = {'names': [], 'units': [], 'data_item_names': [],
-                               'names_for_plotting': [], 'item_names_for_plotting': [],
-                               'experiment_idxs': []}
+            prediction_info = _empty_prediction_info()
             
 
         # --- Case 2: Dictionary structure ---
@@ -3606,9 +3615,7 @@ class ObsAndParamDataParser(object):
                     "experiment_idx": {"types": (int, np.integer), "default": 0},
                 }
 
-                prediction_info = {'names': [], 'units': [], 'data_item_names': [],
-                               'names_for_plotting': [], 'item_names_for_plotting': [],
-                               'experiment_idxs': []}
+                prediction_info = _empty_prediction_info()
                 for entry_idx, raw_entry in enumerate(prediction_items):
                     if not isinstance(raw_entry, dict):
                         raise ValueError(
@@ -3648,18 +3655,16 @@ class ObsAndParamDataParser(object):
                             "Invalid prediction_items value types:\n" + "\n".join(pred_type_errors)
                         )
 
-                    prediction_info['names'].append(str(entry['operands'][0]))
+                    prediction_info['operands'].append(list(entry['operands']))
                     prediction_info['units'].append(entry['unit'])
                     prediction_info['data_item_names'].append(entry['data_item_name'])
-                    prediction_info['names_for_plotting'].append(
+                    prediction_info['trace_names_for_plotting'].append(
                         entry['trace_name_for_plotting'])
                     prediction_info['item_names_for_plotting'].append(
                         entry['item_name_for_plotting'])
                     prediction_info['experiment_idxs'].append(entry['experiment_idx'])
             else:
-                prediction_info = {'names': [], 'units': [], 'data_item_names': [],
-                               'names_for_plotting': [], 'item_names_for_plotting': [],
-                               'experiment_idxs': []}
+                prediction_info = _empty_prediction_info()
             
         else:
             print(f"Error: unknown data type for imported json object of {type(json_obj)}")
@@ -3853,10 +3858,9 @@ class ObsAndParamDataParser(object):
         # --- Simple Array Generation ---
         N = gt_df.shape[0]
         
-        # obs_names is the item identity, and doubles as the key an operation_kwargs
-        # reference to another item resolves against (#466).
-        obs_info["obs_names"] = gt_df["data_item_name"].tolist()
-        obs_info["data_item_names"] = obs_info["obs_names"]
+        # The item identity, which doubles as the key an operation_kwargs reference to
+        # another item resolves against (#466). Spelled as the entry key it comes from.
+        obs_info["data_item_names"] = gt_df["data_item_name"].tolist()
         obs_info["data_types"] = gt_df["data_type"].tolist()
         obs_info["units"] = gt_df["unit"].tolist()
         obs_info["experiment_idxs"] = [gt_df.iloc[II].get("experiment_idx", 0) for II in range(N)]
@@ -3898,16 +3902,12 @@ class ObsAndParamDataParser(object):
         obs_info["cost_kwargs"] = [gt_df.iloc[II].get("cost_kwargs", {}) for II in range(N)]
         obs_info["freqs"] = [gt_df.iloc[II].get("frequencies") for II in range(N)]
         obs_info["trace_names_for_plotting"] = [
-            gt_df.iloc[II].get("trace_name_for_plotting", obs_info["obs_names"][II])
+            gt_df.iloc[II].get("trace_name_for_plotting", obs_info["data_item_names"][II])
             for II in range(N)]
         obs_info["item_names_for_plotting"] = [
             gt_df.iloc[II].get("item_name_for_plotting",
                                obs_info["trace_names_for_plotting"][II])
             for II in range(N)]
-        # Deprecated alias. `name_for_plotting` named two things; the one nearly every reader
-        # wanted was the item's label, so that is what the old key now resolves to. Removed in
-        # 0.6.0 -- read item_names_for_plotting or trace_names_for_plotting instead.
-        obs_info["names_for_plotting"] = obs_info["item_names_for_plotting"]
 
         for II in range(N):
             op = gt_df.iloc[II].get("operation")

--- a/src/libcuflynx/scripts/migrate_obs_data.py
+++ b/src/libcuflynx/scripts/migrate_obs_data.py
@@ -27,11 +27,14 @@ import os
 import re
 import sys
 
+from libcuflynx.utilities.obs_data_helpers import LEGACY_OBS_ITEM_KEYS
+
 #: ``"data_item_name": "..."`` wherever it sits on the line, so a file that puts the key inline
 #: after an opening brace is treated the same as one that gives it a line of its own.
 _NAME = re.compile(r'"data_item_name"(\s*):(\s*)"((?:[^"\\]|\\.)*)"')
-_LEGACY_KEYS = (('variable', 'data_item_name'),
-                ('name_for_plotting', 'trace_name_for_plotting'))
+#: Derived, not restated: a third copy of this mapping is how the rewriter comes to skip a
+#: key the loader migrates. Order matters -- the regex rewrite applies these in sequence.
+_LEGACY_KEYS = tuple(LEGACY_OBS_ITEM_KEYS.items())
 
 
 def _operation_of(item):

--- a/src/libcuflynx/solver_wrappers/myokit_helper.py
+++ b/src/libcuflynx/solver_wrappers/myokit_helper.py
@@ -853,10 +853,39 @@ class SimulationHelper:
         raise RuntimeError("Simulation has not been run yet.")
 
     def _collect_all_results_dict_from_log(self):
-        results = {qname: np.asarray(self.last_log[qname]) for qname in self.last_log.keys()}
-        # Keep a stable project-level time key regardless of importer-specific qnames.
-        if "environment.time" not in results:
-            results["environment.time"] = self._get_log_time_series()
+        """Every logged variable, once, under a key set that does not vary between runs.
+
+        The time series needs care. Myokit merges connected variables on import and keeps one
+        qname for the pair, so which name the model ends up using is the importer's choice --
+        for the 3compartment model it is ``volume_sum_module.t``, because ``environment.time``
+        is connected to it and does not survive as a separate variable. This project publishes
+        the time under one stable name regardless.
+
+        The log sometimes also carries that importer-specific qname, and sometimes does not:
+        ``all_outputs_with_best_param_vals_exp_0.npz`` gained a ``volume_sum_module.t`` key in
+        one run of five, against an identical model and identical code, holding an array
+        bit-identical to ``environment.time``. So the file's key set was not reproducible, and
+        anything diffing two runs saw a change that was not one. Dropping the log's own time
+        key and publishing the series only as ``environment.time`` makes the set the same every
+        time, whichever name the importer picked.
+        """
+        log_time_key = None
+        if hasattr(self.last_log, "time_key"):
+            try:
+                log_time_key = self.last_log.time_key()
+            except Exception:
+                log_time_key = None
+
+        # Time first, always. The log arrives in both shapes -- sometimes keyed
+        # `environment.time`, sometimes the importer's `volume_sum_module.t` -- and putting the
+        # series wherever that key happened to sit would leave the npz's *order* varying even
+        # once its key set was fixed. First is where the `environment.time` shape already put
+        # it, so this reproduces the common case exactly.
+        results = {"environment.time": self._get_log_time_series()}
+        for qname in self.last_log.keys():
+            if qname == log_time_key or qname == "environment.time":
+                continue
+            results[qname] = np.asarray(self.last_log[qname])
         return results
 
     def _get_log_time_series(self):

--- a/src/libcuflynx/utilities/obs_data_helpers.py
+++ b/src/libcuflynx/utilities/obs_data_helpers.py
@@ -101,6 +101,15 @@ def obs_trace_labels(obs_info):
             or obs_info.get("names_for_plotting") or [])
 
 
+def obs_operand_lists(info):
+    """Each item's operands -- the model variables it reduces -- as a list per item.
+
+    Works on an ``obs_info`` and on a ``prediction_info`` alike, which is why
+    ``prediction_info`` stores a list per item rather than the bare qname it used to.
+    """
+    return (info or {}).get("operands") or []
+
+
 def migrate_legacy_obs_item_keys(items, where='data_items', variable_was_the_operand=False):
     """Rewrite an obs_data entry's superseded key names, warning once per key per file.
 

--- a/src/libcuflynx/utilities/obs_data_helpers.py
+++ b/src/libcuflynx/utilities/obs_data_helpers.py
@@ -145,6 +145,95 @@ def migrate_legacy_obs_item_keys(items, where='data_items', variable_was_the_ope
         warnings.warn(f"{where}: {LEGACY_OBS_KEY_ADVICE[old]}", DeprecationWarning, stacklevel=3)
     return migrated
 
+#: Superseded keys of the parsed ``obs_info`` dict. This is a DIFFERENT layer from
+#: :data:`LEGACY_OBS_ITEM_KEYS`, which renames keys of an obs_data *entry* -- the file a user
+#: writes. These rename keys of the dict the parser hands the engine.
+LEGACY_OBS_INFO_KEYS = {
+    'obs_names': 'data_item_names',
+    'names_for_plotting': 'item_names_for_plotting',
+}
+
+#: The same for ``prediction_info`` -- and the targets are deliberately NOT the same.
+#:
+#: ``names_for_plotting`` appears in both tables and means something different in each: the
+#: *item* label in an obs_info, the *trace* label in a prediction_info. Merging the two tables
+#: would silently move a trace label into the item-label slot, which is the kind of mistake that
+#: shows up as a mislabelled axis months later rather than as a failure. ``names`` is worse: it
+#: holds a model qname, so mapping it to ``data_item_names`` by analogy with obs_info's
+#: ``obs_names`` would feed qnames to the uniqueness check while the solver was handed
+#: identities. ``test_the_two_info_tables_disagree_on_purpose`` pins this apart.
+LEGACY_PREDICTION_INFO_KEYS = {
+    'names': 'operands',
+    'names_for_plotting': 'trace_names_for_plotting',
+}
+
+LEGACY_INFO_KEY_ADVICE = {
+    'obs_names': ("obs_info['obs_names'] is deprecated: use 'data_item_names', which is the "
+                  "same list under the name the obs_data entry uses ('data_item_name')."),
+    'names': ("prediction_info['names'] is deprecated: use 'operands', which holds the same "
+              "model qnames as a list per item, matching obs_info['operands']."),
+    'obs_info.names_for_plotting': (
+        "obs_info['names_for_plotting'] is deprecated: it was the *item* label, so use "
+        "'item_names_for_plotting'. The trace's axis label is 'trace_names_for_plotting'."),
+    'prediction_info.names_for_plotting': (
+        "prediction_info['names_for_plotting'] is deprecated: it was the *trace* label, so use "
+        "'trace_names_for_plotting'. The item's own label is 'item_names_for_plotting'."),
+}
+
+
+def _advice(where, old):
+    """The advice for *old*, disambiguated by dict when the key means two things."""
+    return LEGACY_INFO_KEY_ADVICE.get(f'{where}.{old}') or LEGACY_INFO_KEY_ADVICE[old]
+
+
+def _normalise_info(info, table, where):
+    """Rewrite a parsed info dict's superseded keys, warning once per key.
+
+    The obs_info twin of :func:`migrate_legacy_obs_item_keys`, and deliberately the same
+    bargain: a copy rather than a mutation, because a dict handed in by a caller is theirs;
+    an error rather than a precedence rule when both spellings are set, because no reading of
+    that is not a mistake; and one warning per key, not per element.
+
+    ``None`` passes through -- ``prediction_info`` is genuinely optional, and a caller that
+    has none should not have to say so twice.
+    """
+    if info is None or not isinstance(info, dict):
+        return info
+
+    out = dict(info)
+    seen_legacy = []
+    for old, new in table.items():
+        if old not in out:
+            continue
+        if new in out:
+            raise ValueError(
+                f"{where} sets both '{old}' and its replacement '{new}'. "
+                f"Remove '{old}'. {_advice(where, old)}")
+        out[new] = out.pop(old)
+        seen_legacy.append(old)
+
+    # `names` held a flat list of qnames; `operands` is a list *per item*, as it already is on
+    # obs_info. Renaming the key without reshaping would leave one name covering two shapes,
+    # which is the confusion this whole change exists to remove.
+    if 'names' in table and 'names' in seen_legacy:
+        out['operands'] = [list(n) if isinstance(n, (list, tuple)) else [n]
+                           for n in out['operands']]
+
+    for old in seen_legacy:
+        warnings.warn(_advice(where, old), DeprecationWarning, stacklevel=3)
+    return out
+
+
+def normalise_obs_info(obs_info):
+    """An ``obs_info`` in the current vocabulary. See :func:`_normalise_info`."""
+    return _normalise_info(obs_info, LEGACY_OBS_INFO_KEYS, 'obs_info')
+
+
+def normalise_prediction_info(prediction_info):
+    """A ``prediction_info`` in the current vocabulary. See :func:`_normalise_info`."""
+    return _normalise_info(prediction_info, LEGACY_PREDICTION_INFO_KEYS, 'prediction_info')
+
+
 def get_default_cost_type():
     """The ``cost_type`` a data_item gets when it does not specify one."""
     return DEFAULT_COST_TYPE

--- a/src/libcuflynx/utilities/obs_data_helpers.py
+++ b/src/libcuflynx/utilities/obs_data_helpers.py
@@ -81,24 +81,24 @@ LEGACY_OBS_KEY_ADVICE = {
 def obs_item_names(obs_info):
     """Each data_item's identity, i.e. what an operation_kwargs reference resolves against.
 
-    Falls back to the deprecated ``names_for_plotting`` for an ``obs_info`` assembled by hand
-    rather than by the parser. Plenty of code does assemble one -- CUFLynx builds partial ones,
-    and so does every test double -- and it should not have to learn a new key to keep working.
+    One key, not a fallback chain. A dict assembled by hand elsewhere is brought into the
+    current vocabulary by :func:`normalise_obs_info` at the boundary it arrives on, which is
+    also where its author is told to move -- a silent fallback here told nobody anything, and
+    kept the old spelling working indefinitely.
+
+    Works on a ``prediction_info`` too, which is why that dict now spells its keys this way.
     """
-    return (obs_info.get("data_item_names") or obs_info.get("obs_names")
-            or obs_info.get("names_for_plotting") or [])
+    return (obs_info or {}).get("data_item_names") or []
 
 
 def obs_item_labels(obs_info):
     """Each data_item's display label (the scalar feature). See ``obs_item_names``."""
-    return (obs_info.get("item_names_for_plotting")
-            or obs_info.get("names_for_plotting") or [])
+    return (obs_info or {}).get("item_names_for_plotting") or []
 
 
 def obs_trace_labels(obs_info):
     """Each data_item's trace label (the series it is drawn from). See ``obs_item_names``."""
-    return (obs_info.get("trace_names_for_plotting")
-            or obs_info.get("names_for_plotting") or [])
+    return (obs_info or {}).get("trace_names_for_plotting") or []
 
 
 def obs_operand_lists(info):

--- a/tests/test_all_outputs_key_set.py
+++ b/tests/test_all_outputs_key_set.py
@@ -1,0 +1,70 @@
+"""The all-outputs npz must have the same key set every run.
+
+Myokit merges connected variables on import and keeps one qname for the pair, so the model's
+time variable is named by the importer -- `volume_sum_module.t` for the 3compartment model,
+because `environment.time` is connected to it and does not survive separately. This project
+publishes the time under one stable name.
+
+The log sometimes also carried that importer-specific qname and sometimes did not, so the npz
+gained a duplicate of the time series in roughly one run of five and anything diffing two runs
+saw a change that was not one.
+"""
+import numpy as np
+import pytest
+
+from libcuflynx.solver_wrappers.myokit_helper import SimulationHelper
+
+
+class _Log(dict):
+    """A DataLog stand-in: a dict that also knows which of its keys is the time."""
+
+    def __init__(self, mapping, time_key):
+        super().__init__(mapping)
+        self._time_key = time_key
+
+    def time_key(self):
+        return self._time_key
+
+
+def _collect(log):
+    helper = SimulationHelper.__new__(SimulationHelper)
+    helper.last_log = log
+    return SimulationHelper._collect_all_results_dict_from_log(helper)
+
+
+@pytest.mark.unit
+def test_the_importers_time_qname_is_not_published_alongside_environment_time():
+    """Two keys for one series is what made the file's key set vary between runs."""
+    t = np.linspace(0.0, 1.0, 5)
+    results = _collect(_Log({"volume_sum_module.t": t, "heart.v": t * 2},
+                            time_key="volume_sum_module.t"))
+
+    assert "volume_sum_module.t" not in results
+    assert "heart.v" in results
+    np.testing.assert_array_equal(results["environment.time"], t)
+
+
+@pytest.mark.unit
+def test_the_key_set_does_not_depend_on_what_the_importer_named_the_time():
+    """The same model logged under either spelling must produce the same keys.
+
+    This is the invariant the varying npz broke: two runs of one study differed only in
+    whether the importer's time qname came through, and the file's key set followed.
+    """
+    t = np.linspace(0.0, 1.0, 5)
+    importer_named = _collect(_Log({"volume_sum_module.t": t, "heart.v": t},
+                                   time_key="volume_sum_module.t"))
+    already_stable = _collect(_Log({"environment.time": t, "heart.v": t},
+                                   time_key="environment.time"))
+
+    assert set(importer_named) == set(already_stable) == {"environment.time", "heart.v"}
+
+
+@pytest.mark.unit
+def test_a_model_whose_time_is_already_environment_time_is_unchanged():
+    """The common case must not lose its time series to the exclusion above."""
+    t = np.linspace(0.0, 1.0, 5)
+    results = _collect(_Log({"environment.time": t, "heart.v": t}, time_key="environment.time"))
+
+    assert set(results) == {"environment.time", "heart.v"}
+    np.testing.assert_array_equal(results["environment.time"], t)

--- a/tests/test_obs_data_conventions.py
+++ b/tests/test_obs_data_conventions.py
@@ -98,15 +98,44 @@ def test_the_canonical_example_still_shows_the_convention():
 @pytest.mark.parametrize('path', _authored_obs_data_files(),
                          ids=lambda p: os.path.basename(p))
 def test_no_label_restates_its_own_operation(path):
+    # `item_name_for_plotting`, not the retired `name_for_plotting`. The shipped files were
+    # migrated to the #466 vocabulary, so the old key was always absent and this assertion
+    # could never fire whatever the files said. The *item* label is the one that would restate
+    # an operation, since it defaults to "<trace> (<operation>)".
+    #
+    # No shipped file trips this today -- the derived default cannot, so only a hand-written
+    # label could. It is a guard on what someone adds next, which is why
+    # `test_the_operation_check_catches_a_label_that_restates_itself` exists: without it a
+    # clean corpus and a broken check look identical, which is exactly how this rotted.
     offenders = [
-        (item.get('name_for_plotting'), item.get('operation'), (item.get('operands') or [''])[0])
+        (item.get('item_name_for_plotting'), item.get('operation'),
+         (item.get('operands') or [''])[0])
         for item in _data_items(path)
         if item.get('operation') in _REDUCERS
-        and _spells_its_own_operation(item.get('name_for_plotting'), item.get('operation'))
+        and _spells_its_own_operation(item.get('item_name_for_plotting'), item.get('operation'))
     ]
     assert not offenders, (
-        f'{os.path.relpath(path, _ROOT)}: name_for_plotting names the output *before* the '
+        f'{os.path.relpath(path, _ROOT)}: item_name_for_plotting names the output *before* the '
         f'operation (see resources/3compartment_obs_data.json, where mean and max of '
         f'aortic_root/v are both "v_{{AR}}"). These restate their own operation: '
         + '; '.join(f'{label!r} (operation {op!r} on {operand})'
                     for label, op, operand in offenders))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('label,operation,caught', [
+    ('mean(T_p1)', 'mean', True),        # functional application
+    ('v_{max}', 'max', True),            # latex subscript
+    ('v_max', 'max', True),              # plain subscript
+    ('v_{AR}', 'mean', False),           # names the trace, not the operation
+    ('mean_flow', 'mean', False),        # a quantity that merely contains the word
+    (None, 'mean', False),               # absent label -- the state that made this vacuous
+])
+def test_the_operation_check_catches_a_label_that_restates_itself(label, operation, caught):
+    """The sweep above scans a corpus that currently has nothing to find.
+
+    A check with no violations to catch and a check that cannot catch anything look the same
+    from the outside, and this one spent a release in the second state while reading as the
+    first. This asserts the predicate itself still works.
+    """
+    assert _spells_its_own_operation(label, operation) is caught

--- a/tests/test_obs_data_vocabulary.py
+++ b/tests/test_obs_data_vocabulary.py
@@ -201,7 +201,7 @@ def test_a_legacy_prediction_item_gets_its_operand_from_the_variable_it_named():
     out = _parse(_doc([_item()],
                       [{'variable': 'main/y', 'unit': 'dimensionless'}]))
     pred = out['prediction_info']
-    assert pred['names'] == ['main/y']
+    assert pred['operands'] == [['main/y']]
     assert pred['data_item_names'] == ['main/y']
 
 

--- a/tests/test_obs_data_vocabulary.py
+++ b/tests/test_obs_data_vocabulary.py
@@ -21,8 +21,14 @@ import pytest
 from libcuflynx.parsers.PrimitiveParsers import (ObsAndParamDataParser,
                                                  check_data_item_names_unique,
                                                  default_item_name_for_plotting)
-from libcuflynx.utilities.obs_data_helpers import (LEGACY_OBS_ITEM_KEYS,
-                                                   migrate_legacy_obs_item_keys)
+from libcuflynx.utilities.obs_data_helpers import (LEGACY_OBS_INFO_KEYS,
+                                                   LEGACY_OBS_ITEM_KEYS,
+                                                   LEGACY_PREDICTION_INFO_KEYS,
+                                                   migrate_legacy_obs_item_keys,
+                                                   normalise_obs_info,
+                                                   normalise_prediction_info,
+                                                   obs_item_labels, obs_item_names,
+                                                   obs_trace_labels)
 
 _ROOT = os.path.join(os.path.dirname(__file__), '..')
 
@@ -315,3 +321,84 @@ def test_every_shipped_obs_data_item_has_a_unique_name():
         if dupes:
             bad[name] = dupes
     assert not bad, "shipped obs_data files with repeated data_item_name: %s" % bad
+
+
+# ---------------------------------------------------------------------------
+# The parsed obs_info / prediction_info vocabulary -- a different layer from the
+# entry keys above, with its own tables.
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_the_two_info_tables_disagree_on_purpose():
+    """``names_for_plotting`` means the ITEM label in one dict and the TRACE label in the other.
+
+    This is the test to read before merging the two tables into one, which is the tidy-up
+    somebody will eventually attempt. A shared mapping cannot be right for both: whichever
+    target it picked, the other dict's labels would move into the wrong slot, and nothing
+    would fail -- an axis would just be captioned with the wrong text.
+    """
+    assert LEGACY_OBS_INFO_KEYS['names_for_plotting'] == 'item_names_for_plotting'
+    assert LEGACY_PREDICTION_INFO_KEYS['names_for_plotting'] == 'trace_names_for_plotting'
+    assert LEGACY_OBS_INFO_KEYS != LEGACY_PREDICTION_INFO_KEYS
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('legacy,current', sorted(LEGACY_OBS_INFO_KEYS.items()))
+def test_an_obs_info_setting_both_spellings_is_an_error(legacy, current):
+    with pytest.raises(ValueError) as excinfo:
+        normalise_obs_info({legacy: ['a'], current: ['b']})
+    assert legacy in str(excinfo.value) and current in str(excinfo.value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('legacy,current', sorted(LEGACY_PREDICTION_INFO_KEYS.items()))
+def test_a_prediction_info_setting_both_spellings_is_an_error(legacy, current):
+    with pytest.raises(ValueError) as excinfo:
+        normalise_prediction_info({legacy: ['a'], current: ['b']})
+    assert legacy in str(excinfo.value) and current in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_normalising_does_not_mutate_the_caller_s_dict():
+    original = {'obs_names': ['a'], 'names_for_plotting': ['A']}
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        normalise_obs_info(original)
+    assert original == {'obs_names': ['a'], 'names_for_plotting': ['A']}
+
+
+@pytest.mark.unit
+def test_one_warning_per_legacy_key_not_per_item():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        normalise_obs_info({'obs_names': ['a', 'b', 'c'], 'names_for_plotting': ['A', 'B', 'C']})
+    messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(messages) == 2, messages
+
+
+@pytest.mark.unit
+def test_a_prediction_infos_flat_names_become_operand_lists():
+    """The rename carries a shape change no table can express.
+
+    ``operands`` is a list *per item* on obs_info, so a prediction_info that spelled it
+    ``names`` -- flat -- has to be reshaped, or one key would name two shapes.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        out = normalise_prediction_info({'names': ['main/y', 'main/z']})
+    assert out['operands'] == [['main/y'], ['main/z']]
+
+
+@pytest.mark.unit
+def test_none_prediction_info_passes_through():
+    """It is genuinely optional -- CUFLynx hands ParamID `prediction_info=None`."""
+    assert normalise_prediction_info(None) is None
+
+
+@pytest.mark.unit
+def test_the_accessors_read_a_canonical_prediction_info():
+    """One set of accessors for both dicts is the point of mirroring their key names."""
+    pred = {'data_item_names': ['y'], 'item_names_for_plotting': ['Y (max)'],
+            'trace_names_for_plotting': ['Y']}
+    assert obs_item_names(pred) == ['y']
+    assert obs_item_labels(pred) == ['Y (max)']
+    assert obs_trace_labels(pred) == ['Y']

--- a/tests/test_operation_kwargs.py
+++ b/tests/test_operation_kwargs.py
@@ -19,6 +19,7 @@ from libcuflynx.param_id.operation_funcs import (
     resolve_operation_kwargs,
     validate_operation_kwargs,
 )
+from libcuflynx.utilities.obs_data_helpers import obs_item_names
 from libcuflynx.parsers.PrimitiveParsers import ObsAndParamDataParser, scriptFunctionParser
 
 
@@ -393,7 +394,7 @@ def test_external_user_op_receives_operation_kwargs_from_obs_data_json(tmp_path)
         kwargs = resolve_operation_kwargs(
             obs_info["operation_kwargs"][idx], func,
             operation_name=obs_info["operations"][idx],
-            data_item_name=obs_info["names_for_plotting"][idx],
+            data_item_name=obs_item_names(obs_info)[idx],
             temp_results={}, num_operands=1)
         results.append(func(x, **kwargs))
     assert results[0] == pytest.approx(2.0)

--- a/tests/test_posterior_predictive.py
+++ b/tests/test_posterior_predictive.py
@@ -284,7 +284,7 @@ class FakeClient:
             "const_idx_to_obs_idx": [0, 1],
             "experiment_idxs": [0, 0],
             "subexperiment_idxs": [0, 0],
-            "obs_names": ["a", "b"],
+            "data_item_names": ["a", "b"],
         }
         self.protocol_info = {"num_sub_per_exp": [1]}
 
@@ -459,8 +459,11 @@ class SeriesClient:
             # one scalar, then one obs index per recorded trace
             "experiment_idxs": [0] + [0] * n,
             "subexperiment_idxs": [0] + [0] * n,
-            "obs_names": ["a"] + ["gt%d" % i for i in range(n)],
             "data_item_names": ["a"] + ["Vgt_{%d}" % i for i in range(n)],
+            # The parser always populates this, defaulting it to the identity when the
+            # entry names no trace (PrimitiveParsers.process_obs_info). A double that
+            # omits it is not an obs_info the engine could ever be handed.
+            "trace_names_for_plotting": ["a"] + ["Vgt_{%d}" % i for i in range(n)],
             "operands": [["x/v"]] + [["time", "x/v"]] * n,
             "ground_truth_series": [np.linspace(-70.0, -50.0, 40) for _ in range(n)],
             "series_idx_to_obs_idx": list(range(1, n + 1)),

--- a/tests/test_uq_posterior_plots.py
+++ b/tests/test_uq_posterior_plots.py
@@ -58,7 +58,7 @@ def _plotter(tmp_path, engine, names=('x',), data_types=('constant',), units=('d
     obj.plot_dir = str(tmp_path)
     obj.output_dir = str(tmp_path)
     obj.obs_info = {
-        'names_for_plotting': list(names),
+        'item_names_for_plotting': list(names),
         'data_types': list(data_types),
         'units': list(units),
         'experiment_idxs': [0] * len(names),

--- a/tutorial/docs/parameter-identification.md
+++ b/tutorial/docs/parameter-identification.md
@@ -428,12 +428,21 @@ and the `data_item` names it in `operation` with one `operation_kwargs` entry pe
 
 ### prediction items (optional)
 
-You can include a `prediction_items` list in `obs_data.json` to request additional model outputs to plot (not used in the cost function). Each entry includes:
+You can include a `prediction_items` list in `obs_data.json` to request additional model outputs to plot (not used in the cost function). They take the same vocabulary as a `data_item`:
 
-- **variable**
-- **unit**
+- **data_item_name**: This item's identity, unique across every `data_item` and
+  `prediction_item` in the file.
+- **operands**: The model variable to record, as a list — e.g. `["heart/u_lv"]`. This is what
+  the old **variable** entry named; it no longer doubles as the item's name.
+- **unit**: The unit of the recorded variable.
 - **experiment_idx** (optional; defaults to 0)
-- **name_for_plotting** (optional)
+- **trace_name_for_plotting** (optional): The axis label, in latex format. Defaults to the
+  first operand.
+- **item_name_for_plotting** (optional): The item's own label. Defaults to
+  `"<trace_name_for_plotting> (<operation>)"`.
+
+Together the last two replace the old **name_for_plotting**. A file still using `variable` or
+`name_for_plotting` loads with a deprecation warning; `cuflynx-migrate-obs-data` rewrites it.
 
 ## Running external cellml models
 


### PR DESCRIPTION
One spelling per concept in `obs_info` and `prediction_info`.

## The problem

#466 split the obs_data **file** vocabulary — `variable` → `data_item_name` + `operands`, `name_for_plotting` → `trace_name_for_plotting` + `item_name_for_plotting` — and the file layer got a proper rule: rewrite on load, warn once, refuse a document setting both spellings. The **in-memory** dicts never followed, leaving three inconsistencies:

1. **The parser wrote the old name as the real one.** `obs_info["obs_names"]` was the list, with `data_item_names` aliased to the same object — so the key a user writes and the key the engine holds disagreed for no reason.
2. **`names_for_plotting` meant two different things** — the *item* label in `obs_info`, the *trace* label in `prediction_info`. One key, two meanings, and `prediction_info` had no accessors to hide it.
3. **Ten sites read the deprecated spellings directly**, bypassing the accessors that exist to hide them. Two reimplemented the fallback chain with a *different* precedence.

## The shape

`obs_info` now has `data_item_names` / `trace_names_for_plotting` / `item_names_for_plotting` and nothing else. `prediction_info` mirrors it exactly: `names` → `operands` (a list per item, as on obs_info), `names_for_plotting` → `trace_names_for_plotting`. `obs_item_names` / `obs_item_labels` / `obs_trace_labels` / `obs_operand_lists` work on either dict.

A dict handed in from outside is normalised at `ParamID.__init__` and the two setters — warning once per superseded key, erroring if it sets both an old key and its replacement. That is the same bargain `migrate_legacy_obs_item_keys` already strikes for files; the accessors no longer absorb old names silently, because a silent fallback told nobody anything and kept the old spelling alive indefinitely.

**Two legacy tables, deliberately not one.** `names_for_plotting` maps to *different* targets per dict, so a shared mapping would move trace labels into the item-label slot (or the reverse) and nothing would fail — an axis would just be captioned wrongly. `test_the_two_info_tables_disagree_on_purpose` exists to be read before somebody merges them.

## Seven commits, green at each

`b160ad77` reads → accessors · `1f496ab7` tables + normalisers · `ecdedc6b` parser canonical only · `20b1cc18` normaliser at the boundary · `b947c376` accessor fallbacks stripped · `0fb86622` docs + the guard · `e37ce615` the npz key set

## Bugs found on the way

- **`posterior_predictive` captioned a series panel with the item's identity** where it meant the trace label — the fallback chain tried identity first.
- **`print_observable_errors` named one of six branches by identity** where the other five used the label.
- **`test_no_label_restates_its_own_operation` could not fail.** It read `name_for_plotting`, which the migrator renames on load, so it was always handed `None`. Repointing it alone would have been a smaller version of the same mistake — no shipped file sets `item_name_for_plotting` on a reducing item either — so `_spells_its_own_operation` is now tested directly. A clean corpus and a broken check are indistinguishable from outside, which is how this rotted for a release.
- **The tutorial documented the old vocabulary for `prediction_items`** while the schema required the new one; the `data_items` section 300 lines above was updated at the time and this was missed.
- **`all_outputs_with_best_param_vals_exp_0.npz` was not reproducible** — see below.

## The npz (`e37ce615`)

Across five runs of one study, identical model and identical code, the file came back with 76 keys four times and 77 the fifth. The extra was `volume_sum_module.t`, holding an array bit-identical to `environment.time`.

The model connects them, and Myokit merges connected variables on import, keeping one qname for the pair:

```xml
<map_components component_1="environment" component_2="volume_sum_module"/>
<map_variables variable_1="time" variable_2="t"/>
```

`environment.time` is not in the model at all — CA synthesises it as a stable name — and the log arrives keyed both ways. CA appended its stable key *alongside* whatever the log had rather than instead of it. Fixing the key set alone was not enough: the time's position still tracked the log's shape, so it is now written once and first.

## Verification

A full pipeline run was captured before any of this and diffed at every commit. **All 22 artifacts byte-identical**, including `error_vec_names.npy` (a documented external contract) and `prediction_variable_names.csv` (which proves the `operands` reshape moved no qname). The npz was excluded mid-branch because it could not be trusted, and is back under the contract as of `e37ce615` — two consecutive runs identical, and identical to the pre-branch baseline.

Suite: **2215 passed, 4 failed** — the AADC/CasADi four, verified to fail identically on clean `master`. Also run under `-W error::DeprecationWarning` to prove the normaliser is silent on every parser-produced dict.

## Downstream

Paired with **physiomelinks/CUFLynx#331**. CUFLynx is not broken in the meantime — its three reads are `or`-fallbacks whose first arm is `item_names_for_plotting`, which the parser always populates. Merge this, bump the two `ref:` lines in CUFLynx's `ci.yml`, then merge that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mk1rvBawTUN3SP7VwHVGhh