### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ next release; add to that section as you land a change.
 
 ## Unreleased
 
+## 0.7.0 — 2026-09-01
+
 ### Changed — one spelling per concept in `obs_info` and `prediction_info`
 
 The obs_data *file* vocabulary was split by #466; the parsed dicts were not, and kept the old

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "libcuflynx"
 # the `libcuflynx` namespace. The flat import names (`parsers`, `param_id`, ...) keep working
 # through this release as deprecation shims and are removed in 0.6.0 -- see
 # libcuflynx/_deprecated_aliases.py::REMOVAL_VERSION, which the shims' warning text quotes.
-version = "0.6.0"
+version = "0.7.0"
 description = "Generation and calibration of CellML circulatory system models from module/vessel arrays"
 readme = "README.md"
 # 3.9 is the real floor, not a conservative label: utilities/package_resources.py needs


### PR DESCRIPTION
Version bump and changelog date for **0.7.0**, which carries the obs_info / prediction_info vocabulary change (#507).

## Breaking

The parsed dicts no longer carry their old key names:

| old | new |
|---|---|
| `obs_info["obs_names"]` | `data_item_names` |
| `obs_info["names_for_plotting"]` | `item_names_for_plotting` |
| `prediction_info["names"]` | `operands` (a list per item) |
| `prediction_info["names_for_plotting"]` | `trace_names_for_plotting` |

Code reading through `obs_item_names` / `obs_item_labels` / `obs_trace_labels` / `obs_operand_lists` needs no change — those accessors now work on both dicts. A dict assembled by hand is normalised at `ParamID`'s boundary, warning once per superseded key.

**Downstream:** CUFLynx `main` already reads through the accessors (#331). The shipped CUFLynx v0.4.1 does not, which is why `test-cuflynx-executable` is red on master until CUFLynx 0.5.0 ships — that release is prepared in physiomelinks/CUFLynx#332 and will bundle this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mk1rvBawTUN3SP7VwHVGhh