### PR TITLE
Pin what the parser publishes, and fix what reading it exposed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,30 @@ jobs:
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
 
+    # PyPI accepts the upload before its index serves the new version, and anything that
+    # installs in that window resolves the *old* one -- or fails with
+    # "Could not find a version that satisfies the requirement libcuflynx>=X (from versions:
+    # ...)", which reads like a dependency mistake rather than a race. Two CUFLynx jobs went
+    # red that way on the 0.7.0 release. Waiting here fixes it once, for every consumer,
+    # rather than asking each of them to retry.
+    #
+    # The JSON API, not `pip index versions`, which pip itself flags as experimental.
+    - name: Wait for the index to serve it
+      env:
+        GH_REF_NAME: ${{ github.ref_name }}
+      run: |
+        version="${GH_REF_NAME#v}"
+        for attempt in $(seq 1 40); do
+          if curl -sf "https://pypi.org/pypi/libcuflynx/json" \
+               | python -c "import json,sys; sys.exit(0 if '$version' in json.load(sys.stdin)['releases'] else 1)"; then
+            echo "libcuflynx $version is being served after $attempt attempt(s)"
+            exit 0
+          fi
+          sleep 15
+        done
+        echo "::error::libcuflynx $version was published but the index is still not serving it"
+        exit 1
+
   # A tag publishes to PyPI, and used to stop there -- so v0.4.1, v0.5.0 and v0.5.1 are on
   # PyPI with nothing on the releases page, and v0.4.0's entry was written by hand. The
   # releases page is where someone looks to find out what changed between two versions they

--- a/src/libcuflynx/parsers/PrimitiveParsers.py
+++ b/src/libcuflynx/parsers/PrimitiveParsers.py
@@ -3744,6 +3744,16 @@ class ObsAndParamDataParser(object):
             # before its targets are added. There is nothing to validate, and the
             # column defaults below are derived from other columns -- so on an
             # empty frame they raised KeyError: 'data_item_name' instead.
+            # An empty frame skips validation -- there is nothing to validate, and the
+            # callable defaults derive from other columns -- but it must still carry the
+            # schema's columns. `process_obs_info` reads them by name, so a frame with none
+            # made every read a KeyError and an obs_data carrying only protocol_info
+            # impossible to open at all.
+            if len(gt_df) == 0:
+                for col in schema:
+                    if col not in gt_df.columns:
+                        gt_df[col] = pd.Series(dtype=object)
+
             for col, rules in ({} if len(gt_df) == 0 else schema).items():
                 allowed = rules["types"]
                 default = rules["default"]
@@ -4000,9 +4010,13 @@ class ObsAndParamDataParser(object):
         # Full length over all data_items and indexed by row, like cost_type and the weight
         # vectors, so it stays correct when the per-type vectors are compacted to their own
         # index spaces (the #349 rule).
+        # `.get`, not `[...]`: this function documents itself as a public entry point a
+        # caller may hand a gt_df it built, and such a frame has only the columns the caller
+        # wrote -- the schema adds `prob_dist_params`, so a bare read made that invitation
+        # untrue for every hand-built frame.
         ground_truth_prob_dist_params = [
-            gt_df.iloc[II]["prob_dist_params"] if isinstance(
-                gt_df.iloc[II]["prob_dist_params"], dict) else None
+            gt_df.iloc[II].get("prob_dist_params") if isinstance(
+                gt_df.iloc[II].get("prob_dist_params"), dict) else None
             for II in range(gt_df.shape[0])]
 
 

--- a/src/libcuflynx/solver_wrappers/myokit_helper.py
+++ b/src/libcuflynx/solver_wrappers/myokit_helper.py
@@ -1,5 +1,6 @@
 import os
 import copy
+import logging
 import time
 import warnings
 
@@ -49,6 +50,8 @@ from libcuflynx.solver_wrappers.name_resolver import VariableNameResolver
 from libcuflynx.utilities.protocol_shapes import materialise_shapes, validate_trace_references
 import xml.etree.ElementTree as ET
 import tempfile
+
+logger = logging.getLogger(__name__)
 import hashlib
 import re
 import os
@@ -482,8 +485,9 @@ class SimulationHelper:
         if "MaximumStep" in self.solver_info:
             try:
                 self.simulation.set_max_step_size(self.solver_info["MaximumStep"])
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("MaximumStep=%r was not applied: %s",
+                             self.solver_info["MaximumStep"], exc)
         self._effective_tolerances = apply_cvodes_tolerances(
             self.simulation, self.solver_info, self._fsa_enabled)
         self.last_log = None
@@ -535,9 +539,10 @@ class SimulationHelper:
         for var in self.all_vars:
             try:
                 self.default_values[var.qname()] = var.eval()
-            except Exception:
-                # leave unset if evaluation fails
-                pass
+            except Exception as exc:
+                # Left unset. Named, because a variable missing from default_values is a
+                # variable that will not be restored by reset_and_clear().
+                logger.debug("no default value for %s: %s", var.qname(), exc)
 
     def _describe_myokit_log_configuration(self):
         """Context for debugging empty logs or failed final-state extraction."""
@@ -572,8 +577,8 @@ class SimulationHelper:
             time_key = None
             try:
                 time_key = self.model.time().qname()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("model has no resolvable time variable: %s", exc)
             if time_key and time_key in self.last_log:
                 tser = np.asarray(self.last_log[time_key])
                 lines.append(
@@ -910,8 +915,8 @@ class SimulationHelper:
         if hasattr(self.last_log, "time"):
             try:
                 return np.asarray(self.last_log.time())
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("DataLog.time() unavailable, trying the next fallback: %s", exc)
 
         # Final fallback: model-declared bound time variable qname.
         model_time = self.model.time()

--- a/src/libcuflynx/utilities/obs_data_helpers.py
+++ b/src/libcuflynx/utilities/obs_data_helpers.py
@@ -88,17 +88,56 @@ def obs_item_names(obs_info):
 
     Works on a ``prediction_info`` too, which is why that dict now spells its keys this way.
     """
-    return (obs_info or {}).get("data_item_names") or []
+    return _column(obs_info, "data_item_names")
 
 
 def obs_item_labels(obs_info):
     """Each data_item's display label (the scalar feature). See ``obs_item_names``."""
-    return (obs_info or {}).get("item_names_for_plotting") or []
+    return _column(obs_info, "item_names_for_plotting")
 
 
 def obs_trace_labels(obs_info):
     """Each data_item's trace label (the series it is drawn from). See ``obs_item_names``."""
-    return (obs_info or {}).get("trace_names_for_plotting") or []
+    return _column(obs_info, "trace_names_for_plotting")
+
+
+def _column(info, key):
+    """The column at *key* as a list, or ``[]``.
+
+    Tested against ``None`` rather than for truthiness. Several obs_info values are numpy
+    arrays -- the ground-truth and std vectors, and the parameter bounds -- and
+    ``array or []`` raises "the truth value of an array with more than one element is
+    ambiguous". The keys these accessors read happen to be lists today, so the older
+    spelling worked; it worked by luck, and a caller passing an array had no way to know.
+    """
+    value = (info or {}).get(key)
+    return [] if value is None else list(value)
+
+
+def obs_experiment_indices(info):
+    """Which experiment each data_item belongs to, one per item.
+
+    An accessor rather than a raw read for the same reason the label ones are: a downstream
+    reader that goes through this is immune to the key being renamed, and CUFLynx reads this
+    in two modules.
+    """
+    return _column(info, "experiment_idxs")
+
+
+def obs_subexperiment_indices(info):
+    """Which sub-experiment each data_item belongs to. See ``obs_experiment_indices``."""
+    return _column(info, "subexperiment_idxs")
+
+
+def obs_scalar_rows(info):
+    """For each *constant* observable in order, the data_item row it came from.
+
+    The bridge between two index spaces, and the one most easily misused: the cost vectors
+    (``ground_truth_const``, ``std_const_vec``) are indexed by position in *this* list, while
+    ``experiment_idxs`` and the labels are indexed by the values *in* it. Reading one with the
+    other's counter is silently a different observable (#349).
+    """
+    return _column(info, "const_idx_to_obs_idx")
 
 
 def obs_operand_lists(info):
@@ -107,7 +146,7 @@ def obs_operand_lists(info):
     Works on an ``obs_info`` and on a ``prediction_info`` alike, which is why
     ``prediction_info`` stores a list per item rather than the bare qname it used to.
     """
-    return (info or {}).get("operands") or []
+    return _column(info, "operands")
 
 
 def migrate_legacy_obs_item_keys(items, where='data_items', variable_was_the_operand=False):

--- a/tests/executable/test_cuflynx_executable.py
+++ b/tests/executable/test_cuflynx_executable.py
@@ -208,6 +208,104 @@ def study(app):
     return model_id
 
 
+@pytest.fixture(scope="session")
+def bundled_app(tmp_path_factory):
+    """The released binary with **no** CA configured, so it runs the engine it ships.
+
+    The opposite arrangement to ``app``, and deliberately a second process: which engine is
+    in use is decided before the first libcuflynx import, so it cannot be changed by a POST
+    afterwards. Its own port, so the two can coexist in one session.
+
+    No ``CIRCULATORY_AUTOGEN_SRC``, and a throwaway config dir -- a ``ca_dir`` saved by any
+    previous run on this machine would silently put a checkout back in front of the bundle
+    and this would test the wrong engine while looking like it passed.
+    """
+    config_dir = tmp_path_factory.mktemp("bundled_config")
+    binary = Path(BINARY).resolve()
+    assert binary.is_file(), f"CUFLYNX_EXECUTABLE does not exist: {binary}"
+
+    port = PORT + 1
+    base = f"http://127.0.0.1:{port}"
+    env = {k: v for k, v in os.environ.items() if k != "CIRCULATORY_AUTOGEN_SRC"}
+    env["CUFLYNX_CONFIG_DIR"] = str(config_dir)
+
+    proc = subprocess.Popen(
+        [str(binary), "--port", str(port), "--browser"],
+        cwd=str(tmp_path_factory.mktemp("bundled_cwd")), env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    try:
+        deadline = time.monotonic() + 180
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                raise AssertionError(
+                    f"the app exited during startup (code {proc.returncode})")
+            try:
+                urllib.request.urlopen(base + "/api/health", timeout=3).read()
+                break
+            except (urllib.error.URLError, OSError):
+                time.sleep(1)
+        else:
+            raise AssertionError("the app never became healthy")
+        yield base
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:  # pragma: no cover - only on a wedged app
+            proc.kill()
+
+
+def test_the_bundle_carries_a_working_engine(bundled_app):
+    """With nothing configured, the app must still have an engine -- its own.
+
+    ``ca_dir`` empty *and* ``ca_exists`` true is the pair that says so: an empty directory
+    with a present engine can only mean the bundled package. Either alone is ambiguous --
+    ``ca_exists`` is true for a configured checkout too, and an empty ``ca_dir`` on a source
+    run just means nobody chose one.
+    """
+    body = json.loads(
+        urllib.request.urlopen(bundled_app + "/api/config", timeout=60).read().decode())
+    assert body.get("packaged") is True, (
+        "not the released executable, so there is no bundle to check")
+    assert body.get("ca_dir") == "", (
+        f"a CA directory is configured ({body.get('ca_dir')!r}), so this is not testing the "
+        f"bundled engine -- a settings file from an earlier run is the usual cause")
+    assert body.get("ca_exists") is True, (
+        "nothing configured and no engine found: the bundle is missing libcuflynx")
+
+
+def test_the_bundled_engine_is_at_least_the_declared_floor(bundled_app):
+    """Which libcuflynx is frozen in, read from the running process rather than inferred.
+
+    The floor is checked in CUFLynx's own CI, but against the version pip *resolved* into a
+    venv -- not against what PyInstaller actually collected. Those can differ, and until now
+    the only thing that ever checked the bundle was somebody reading the dist-info by hand.
+    """
+    body = json.loads(
+        urllib.request.urlopen(bundled_app + "/api/config", timeout=60).read().decode())
+    if body.get("packaged") is not True:
+        pytest.skip("not a packaged build")
+
+    src = body.get("ca_src") or ""
+    assert src, "the app reports no engine location at all"
+    # The bundle extracts to _MEI<random>/; the dist-info sits beside the package.
+    root = Path(src)
+    for parent in (root, *root.parents):
+        found = sorted(parent.glob("libcuflynx-*.dist-info"))
+        if found:
+            version = found[0].name.split("-")[1].removesuffix(".dist-info")
+            break
+    else:  # pragma: no cover - a bundle without dist-info is itself the failure
+        raise AssertionError(
+            f"no libcuflynx-*.dist-info anywhere above {src!r}: the engine was collected "
+            f"without its metadata, so nothing can tell which version shipped")
+
+    assert tuple(int(p) for p in version.split(".")[:3]) >= (0, 7, 0), (
+        f"the bundle carries libcuflynx {version}, older than the vocabulary change in "
+        f"0.7.0 that this app's obs_info reads depend on")
+
+
 def test_the_app_runs_this_checkout_not_its_own_bundle(app, tmp_path_factory):
     """Everything else here is meaningless if this fails.
 

--- a/tests/executable/test_cuflynx_executable.py
+++ b/tests/executable/test_cuflynx_executable.py
@@ -275,32 +275,42 @@ def test_the_bundle_carries_a_working_engine(bundled_app):
         "nothing configured and no engine found: the bundle is missing libcuflynx")
 
 
-def test_the_bundled_engine_is_at_least_the_declared_floor(bundled_app):
-    """Which libcuflynx is frozen in, read from the running process rather than inferred.
+def test_the_bundled_engine_reports_its_version(tmp_path_factory):
+    """Which libcuflynx is frozen in, asked of the bundle itself.
 
-    The floor is checked in CUFLynx's own CI, but against the version pip *resolved* into a
-    venv -- not against what PyInstaller actually collected. Those can differ, and until now
-    the only thing that ever checked the bundle was somebody reading the dist-info by hand.
+    CUFLynx's own CI checks the declared floor against the version pip *resolved* into a
+    venv -- not against what PyInstaller actually collected, which is a different question
+    and the one a user's download depends on. Until now the only thing that ever checked the
+    bundle was somebody reading the dist-info by hand.
+
+    Asked through the app's runner mode rather than over HTTP: ``/api/config`` reports
+    ``ca_src`` as empty when no CA directory is configured, which is exactly the arrangement
+    that puts the bundled engine in charge -- so the endpoint cannot answer this. Running a
+    probe inside the bundle can, and it is the same mechanism the checkout test above uses.
     """
-    body = json.loads(
-        urllib.request.urlopen(bundled_app + "/api/config", timeout=60).read().decode())
-    if body.get("packaged") is not True:
-        pytest.skip("not a packaged build")
+    work = tmp_path_factory.mktemp("bundled_version")
+    probe = work / "probe.py"
+    probe.write_text(
+        "import importlib.metadata as md\n"
+        "try:\n"
+        "    print('BUNDLED:', md.version('libcuflynx'))\n"
+        "except Exception as exc:\n"
+        # A bundle whose engine has no metadata is itself the finding: nothing downstream
+        # can then tell which version shipped.
+        "    print('NOMETA:', exc)\n",
+        encoding="utf-8",
+    )
+    cfg = work / "cfg.json"
+    cfg.write_text("{}", encoding="utf-8")
+    out = subprocess.run(
+        [BINARY, "--_cuflynx-run-analysis", str(probe), str(cfg)],
+        capture_output=True, text=True, timeout=300,
+    )
+    combined = out.stdout + out.stderr
+    assert "BUNDLED:" in combined, (
+        f"the bundle could not report a libcuflynx version:\n{combined[-2000:]}")
 
-    src = body.get("ca_src") or ""
-    assert src, "the app reports no engine location at all"
-    # The bundle extracts to _MEI<random>/; the dist-info sits beside the package.
-    root = Path(src)
-    for parent in (root, *root.parents):
-        found = sorted(parent.glob("libcuflynx-*.dist-info"))
-        if found:
-            version = found[0].name.split("-")[1].removesuffix(".dist-info")
-            break
-    else:  # pragma: no cover - a bundle without dist-info is itself the failure
-        raise AssertionError(
-            f"no libcuflynx-*.dist-info anywhere above {src!r}: the engine was collected "
-            f"without its metadata, so nothing can tell which version shipped")
-
+    version = combined.split("BUNDLED:", 1)[1].split()[0]
     assert tuple(int(p) for p in version.split(".")[:3]) >= (0, 7, 0), (
         f"the bundle carries libcuflynx {version}, older than the vocabulary change in "
         f"0.7.0 that this app's obs_info reads depend on")

--- a/tests/test_obs_data_vocabulary.py
+++ b/tests/test_obs_data_vocabulary.py
@@ -402,3 +402,21 @@ def test_the_accessors_read_a_canonical_prediction_info():
     assert obs_item_names(pred) == ['y']
     assert obs_item_labels(pred) == ['Y (max)']
     assert obs_trace_labels(pred) == ['Y']
+
+
+@pytest.mark.unit
+def test_the_accessors_survive_a_numpy_column():
+    """`array or []` raises "the truth value of an array ... is ambiguous".
+
+    The keys these read are lists today, so the older `or []` spelling worked -- by luck,
+    and a caller handing an array had no way to know. Several sibling obs_info values *are*
+    arrays, so the luck was not general.
+    """
+    import numpy as np
+    from libcuflynx.utilities.obs_data_helpers import (obs_operand_lists, obs_scalar_rows,
+                                                       obs_item_names)
+
+    assert obs_scalar_rows({"const_idx_to_obs_idx": np.array([0, 1])}) == [0, 1]
+    assert obs_scalar_rows({"const_idx_to_obs_idx": np.array([])}) == []
+    assert obs_item_names({"data_item_names": np.array(["a", "b"])}) == ["a", "b"]
+    assert obs_operand_lists(None) == []

--- a/tests/test_obs_info_contract.py
+++ b/tests/test_obs_info_contract.py
@@ -1,0 +1,321 @@
+"""What ``process_obs_info`` publishes, and who may rely on it.
+
+``tests/test_obs_data_vocabulary.py`` answers a different question -- how keys are *spelled*,
+and how an old spelling migrates to a new one. This answers what the parser's output surface
+*is*. Its reader is somebody about to rename a key, not somebody about to write an obs_data
+file.
+
+It exists because that rename happened (#507) and nothing fast caught it. The published
+``obs_info`` is indexed by string literal around three hundred times inside this repository
+and thirty-one times inside CUFLynx, with no schema and no version, so the first thing to
+notice a key going missing was an hour-long CI job that downloads the last CUFLynx *release*.
+
+Two properties are pinned, and the second is the one that catches real bugs:
+
+**Presence.** Every key below is published unconditionally -- none is content-dependent, which
+is worth stating because it is not obvious from the source.
+
+**Index space.** A value is indexed by the data_item row, or by a *compacted* per-type counter,
+and the two are not interchangeable. ``obs_cost.py`` in CUFLynx indexes ``experiment_idxs`` by
+the row and ``ground_truth_const`` by the compacted constant counter inside one loop body; read
+with the wrong counter, a value silently belongs to a different observable. That is CA #349,
+and ``tests/test_cost_weight_indexing.py`` pins it for ``protocol_info``.
+
+Deliberately NOT pinned: dtype. ``weight_phase_vec`` is ``dtype=object`` when a frequency
+item's weight is a list, and ``ground_truth_phase`` is ``object`` when any frequency item omits
+``phase``. Asserting dtype is how this file would become flaky and then ignored.
+"""
+import tempfile
+
+import numpy as np
+import pytest
+
+from libcuflynx.parsers.PrimitiveParsers import ObsAndParamDataParser
+from libcuflynx.utilities.obs_data_helpers import (LEGACY_OBS_INFO_KEYS,
+                                                   LEGACY_PREDICTION_INFO_KEYS)
+
+# Index spaces. ITEM is the data_item row; the rest are compacted per-type counters.
+ITEM, CONST, SERIES, FREQ, SCALAR = "item", "const", "series", "freq", "scalar"
+
+#: key -> (index space, tier, what it is and who reads it)
+#:
+#: Tier A -- a libcuflynx accessor already covers it, so a rename is invisible to anything
+#:           that uses the accessor.
+#: Tier B -- public, no accessor. Renaming one needs a LEGACY_OBS_INFO_KEYS entry, a CHANGELOG
+#:           line, and a sweep of the downstream readers. **These 18 are the real contract.**
+#: Tier C -- published, but internal by intent. Nothing outside libcuflynx should read them.
+OBS_INFO_CONTRACT = {
+    # --- per data_item ---
+    "data_item_names": (ITEM, "A", "the item's identity, and what an operation_kwargs "
+                        "reference to another item resolves against (#466). Accessor: "
+                        "obs_item_names. CUFLynx emulator bundles are keyed on it."),
+    "item_names_for_plotting": (ITEM, "A", "the scalar feature's own label. Accessor: "
+                                "obs_item_labels. CUFLynx labels its cost and sensitivity "
+                                "panels with it."),
+    "trace_names_for_plotting": (ITEM, "A", "the axis label of the trace the item reduces. "
+                                 "Accessor: obs_trace_labels. May repeat -- the mean and the "
+                                 "max of one trace share it."),
+    "operands": (ITEM, "A", "the model variables each item reduces, as a list per item. "
+                 "Accessor: obs_operand_lists. Handed to the solver as result variables."),
+    "data_types": (ITEM, "B", "'constant' | 'series' | 'frequency'; decides which compacted "
+                   "index space an item also appears in."),
+    "units": (ITEM, "B", "each item's unit, for axis labels and error reports."),
+    "experiment_idxs": (ITEM, "B", "which experiment each item belongs to. CUFLynx "
+                        "obs_cost.py and local_sensitivity.py both walk it."),
+    "subexperiment_idxs": (ITEM, "B", "which sub-experiment each item belongs to."),
+    "operations": (ITEM, "B", "the reduction applied to each item's trace, or None."),
+    "cost_type": (ITEM, "B", "the cost function per item. NOTE: paramID rewrites this in "
+                  "place for Bayesian runs, so assert it on the parser's output only."),
+    "operation_kwargs": (ITEM, "C", "per-item operation arguments; read through "
+                         "resolve_operation_kwargs, not directly."),
+    "cost_kwargs": (ITEM, "C", "per-item cost arguments; read through pid._cost_kwargs_for."),
+    "freqs": (ITEM, "C", "the frequency grid for a frequency item, None otherwise."),
+    "plot_colors": (ITEM, "C", "per-item plot colour. Currently always None -- see "
+                    "test_plot_colors_never_gets_its_default."),
+    "plot_type": (ITEM, "C", "how a constant is drawn over a trace."),
+    "ground_truth_prob_dist_params": (ITEM, "C", "distribution parameters for a "
+                                      "distribution-costed item."),
+    # --- scalar ---
+    "num_obs": (SCALAR, "B", "how many data_items there are; the length of every ITEM key."),
+    # --- compacted: constants ---
+    "ground_truth_const": (CONST, "B", "the measured value of each constant item."),
+    "std_const_vec": (CONST, "B", "the std each constant is scored against."),
+    "const_idx_to_obs_idx": (CONST, "B", "compacted constant index -> data_item row. CUFLynx "
+                             "obs_cost.py and local_sensitivity.py walk this to label the "
+                             "cost panel; without it the panel goes silent."),
+    "weight_const_vec": (CONST, "C", "pre-scaling weights. Downstream reads "
+                         "protocol_info['scaled_weight_const_from_exp_sub'] instead (#349)."),
+    # --- compacted: series ---
+    "ground_truth_series": (SERIES, "B", "the measured trace of each series item."),
+    "std_series_vec": (SERIES, "B", "the std each series is scored against."),
+    "series_idx_to_obs_idx": (SERIES, "B", "compacted series index -> data_item row."),
+    "obs_dt": (SERIES, "B", "the sample spacing of each series, in seconds. plot_outputs "
+               "indexes it by series_idx."),
+    "weight_series_vec": (SERIES, "C", "pre-scaling weights; see weight_const_vec."),
+    # --- compacted: frequencies ---
+    "ground_truth_amp": (FREQ, "B", "the measured amplitude spectrum of each frequency item."),
+    "ground_truth_phase": (FREQ, "B", "the measured phase spectrum, where one was given."),
+    "std_amp_vec": (FREQ, "B", "the std each amplitude is scored against."),
+    "freq_idx_to_obs_idx": (FREQ, "B", "compacted frequency index -> data_item row."),
+    "weight_amp_vec": (FREQ, "C", "pre-scaling weights; see weight_const_vec."),
+    "weight_phase_vec": (FREQ, "C", "pre-scaling weights; see weight_const_vec."),
+}
+
+#: prediction_info is simpler: one definition (_empty_prediction_info), six parallel keys, and
+#: the dict itself may legitimately be None. Nothing in CUFLynx reads any of it.
+PREDICTION_INFO_CONTRACT = {
+    "operands": "the model qnames to record, as a list per item -- not a flat list (#507).",
+    "units": "each prediction's unit.",
+    "data_item_names": "each prediction's identity, unique across data_items too.",
+    "trace_names_for_plotting": "the axis label.",
+    "item_names_for_plotting": "the item's own label.",
+    "experiment_idxs": "which experiment each prediction belongs to.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures. Built through the parser, never by hand: process_obs_info cannot take a
+# hand-assembled gt_df (it reads columns the schema adds), and `output_dir` is required
+# because get_ground_truth_values writes .npy unconditionally.
+# ---------------------------------------------------------------------------
+def _const(name):
+    return {"data_item_name": f"a/{name}", "data_type": "constant", "unit": "mV",
+            "operands": [f"a/{name}"], "value": 5.0, "std": 1.0, "weight": 1.0,
+            "operation": "mean", "trace_name_for_plotting": name}
+
+
+def _series(name):
+    return {"data_item_name": f"s/{name}", "data_type": "series", "unit": "mV",
+            "operands": [f"s/{name}"], "value": [1.0] * 5, "std": [1.0] * 5,
+            "weight": 1.0, "obs_dt": 0.1, "trace_name_for_plotting": name}
+
+
+def _freq(name):
+    return {"data_item_name": f"f/{name}", "data_type": "frequency", "unit": "m3_per_s",
+            "operands": [f"f/{name}"], "operation": "None", "cost_type": "gaussian_MLE",
+            "value": [1e-4, 5e-4, 0.0], "std": [0.1, 0.1, 0.1], "weight": [1.0, 1.0, 1.0],
+            "frequencies": [0.0, 1.0, 2.0], "phase": [0.0, 1.0, 0.0],
+            "trace_name_for_plotting": name}
+
+
+#: Interleaved on purpose. If the items were grouped by type, a value read with the wrong
+#: counter could still land on the right row by coincidence, and the index-space test below
+#: would pass while the invariant it exists for was broken.
+MIXED_ITEMS = [_const("c0"), _series("s0"), _freq("f0"), _const("c1"), _series("s1"),
+               _const("c2")]
+
+
+@pytest.fixture(scope="module")
+def mixed():
+    """A parsed obs_info with all four index spaces populated, and their expected sizes."""
+    parser = ObsAndParamDataParser()
+    doc = {"data_items": MIXED_ITEMS,
+           "protocol_info": {"pre_times": [0.0], "sim_times": [[1.0]]}}
+    parsed = parser.parse_obs_data_json(obs_data_dict=doc, pre_time=0.0, sim_time=1.0)
+    with tempfile.TemporaryDirectory() as out_dir:
+        obs_info = parser.process_obs_info(gt_df=parsed["gt_df"], output_dir=out_dir, dt=0.01)
+    counts = {
+        ITEM: len(MIXED_ITEMS),
+        CONST: sum(1 for i in MIXED_ITEMS if i["data_type"] == "constant"),
+        SERIES: sum(1 for i in MIXED_ITEMS if i["data_type"] == "series"),
+        FREQ: sum(1 for i in MIXED_ITEMS if i["data_type"] == "frequency"),
+    }
+    return obs_info, counts
+
+
+# ---------------------------------------------------------------------------
+# Presence
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.parametrize("key", sorted(OBS_INFO_CONTRACT))
+def test_obs_info_publishes(key, mixed):
+    """Parametrised so the pytest id names the key -- a CI summary line is enough to see
+    which one went, without opening a log."""
+    obs_info, _ = mixed
+    space, tier, why = OBS_INFO_CONTRACT[key]
+    remedy = (
+        f"Tier {tier}: add {key!r} to LEGACY_OBS_INFO_KEYS mapping it to its replacement, "
+        f"add a CHANGELOG entry, and sweep the downstream readers (CUFLynx included)."
+        if tier in "AB" else
+        f"Tier {tier} (internal): if the removal is deliberate, delete the row from "
+        f"OBS_INFO_CONTRACT in this file."
+    )
+    assert key in obs_info, f"process_obs_info no longer publishes {key!r}. {why}\n{remedy}"
+
+
+@pytest.mark.unit
+def test_obs_info_publishes_nothing_undocumented(mixed):
+    """The other half. Without this the table rots into a subset of reality and stops
+    describing the surface it claims to."""
+    obs_info, _ = mixed
+    undocumented = sorted(set(obs_info) - set(OBS_INFO_CONTRACT))
+    assert not undocumented, (
+        f"process_obs_info publishes {undocumented}, which OBS_INFO_CONTRACT does not "
+        f"describe. Add a row for each saying its index space (item/const/series/freq/scalar) "
+        f"and whether anything outside libcuflynx may read it.")
+
+
+# ---------------------------------------------------------------------------
+# Index space -- the invariant that breaks things silently
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.parametrize("key", sorted(OBS_INFO_CONTRACT))
+def test_obs_info_index_spaces(key, mixed):
+    obs_info, counts = mixed
+    space, _tier, why = OBS_INFO_CONTRACT[key]
+    value = obs_info[key]
+
+    if space == SCALAR:
+        assert isinstance(value, int) and value == counts[ITEM], (
+            f"{key!r} should be the data_item count ({counts[ITEM]}), got {value!r}. {why}")
+        return
+
+    assert isinstance(value, (list, np.ndarray)), (
+        f"{key!r} should be a sequence, got {type(value).__name__}. {why}")
+    assert len(value) == counts[space], (
+        f"{key!r} is indexed by {space}, so for this obs_data it must have "
+        f"{counts[space]} entries, not {len(value)}. {why}\n"
+        f"Mixing index spaces is CA #349: a value read with the wrong counter is silently "
+        f"a different observable's.")
+
+
+@pytest.mark.unit
+def test_the_compacted_indexes_point_at_the_right_rows(mixed):
+    """The maps are the bridge between the spaces, so they are worth checking directly
+    rather than only by length."""
+    obs_info, _ = mixed
+    types = obs_info["data_types"]
+    for space, key in ((CONST, "const_idx_to_obs_idx"),
+                       (SERIES, "series_idx_to_obs_idx"),
+                       (FREQ, "freq_idx_to_obs_idx")):
+        expected = {CONST: "constant", SERIES: "series", FREQ: "frequency"}[space]
+        rows = list(obs_info[key])
+        assert rows == sorted(rows), f"{key} should be ascending, got {rows}"
+        for obs_idx in rows:
+            assert types[obs_idx] == expected, (
+                f"{key} points at row {obs_idx}, whose data_type is {types[obs_idx]!r} "
+                f"rather than {expected!r}.")
+
+
+# ---------------------------------------------------------------------------
+# prediction_info
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_prediction_info_publishes_its_contract():
+    parser = ObsAndParamDataParser()
+    doc = {"data_items": [_const("c0")],
+           "prediction_items": [{"data_item_name": "p/y", "operands": ["main/y"],
+                                 "unit": "mV", "trace_name_for_plotting": "y"}],
+           "protocol_info": {"pre_times": [0.0], "sim_times": [[1.0]]}}
+    parsed = parser.parse_obs_data_json(obs_data_dict=doc, pre_time=0.0, sim_time=1.0)
+    pred = parsed["prediction_info"]
+
+    assert set(pred) == set(PREDICTION_INFO_CONTRACT), (
+        f"prediction_info's key set changed: "
+        f"missing {sorted(set(PREDICTION_INFO_CONTRACT) - set(pred))}, "
+        f"unexpected {sorted(set(pred) - set(PREDICTION_INFO_CONTRACT))}")
+    assert len({len(v) for v in pred.values()}) == 1, (
+        f"prediction_info's columns must stay parallel, got "
+        f"{ {k: len(v) for k, v in pred.items()} }")
+    assert pred["operands"] == [["main/y"]], (
+        "operands is a list *per item*, not a flat qname list -- that reshape is the "
+        "substance of #507 and normalise_prediction_info has bespoke code for it.")
+
+
+# ---------------------------------------------------------------------------
+# The link to the migration tables
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_no_published_key_is_a_retired_spelling():
+    """The two halves of a rename. obs_data_helpers says the old name is retired; this says
+    the parser stopped emitting it. #507 changed the first, and the second was only true by
+    accident -- nothing asserted it."""
+    assert set(OBS_INFO_CONTRACT) & set(LEGACY_OBS_INFO_KEYS) == set()
+    assert set(PREDICTION_INFO_CONTRACT) & set(LEGACY_PREDICTION_INFO_KEYS) == set()
+
+
+# ---------------------------------------------------------------------------
+# Entry points the docstrings promise, and one that does not work
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_a_hand_built_gt_df_is_accepted(tmp_path):
+    """``process_obs_info`` calls itself a public entry point a caller may hand its own
+    frame. It read ``prob_dist_params`` with a bare ``[...]``, and the schema adds that
+    column -- so every hand-built frame raised KeyError and the invitation was untrue."""
+    import pandas as pd
+
+    df = pd.DataFrame([{"data_item_name": "a/x", "data_type": "constant", "unit": "mV",
+                        "operands": ["a/x"], "value": 1.0, "std": 1.0, "weight": 1.0,
+                        "operation": "mean", "experiment_idx": 0, "subexperiment_idx": 0,
+                        "cost_type": "gaussian_MLE"}])
+    obs_info = ObsAndParamDataParser().process_obs_info(
+        gt_df=df, output_dir=str(tmp_path), dt=0.01)
+    assert obs_info["num_obs"] == 1
+    assert obs_info["data_item_names"] == ["a/x"]
+
+
+@pytest.mark.unit
+def test_an_obs_data_with_only_protocol_info_still_parses(tmp_path):
+    """A study with no observables is a legitimate thing to open -- it just cannot be
+    scored. The empty frame carried no columns at all, so every read in process_obs_info
+    was a KeyError and such a file could not be loaded."""
+    parser = ObsAndParamDataParser()
+    doc = {"data_items": [], "protocol_info": {"pre_times": [0.0], "sim_times": [[1.0]]}}
+    parsed = parser.parse_obs_data_json(obs_data_dict=doc, pre_time=0.0, sim_time=1.0)
+    obs_info = parser.process_obs_info(
+        gt_df=parsed["gt_df"], output_dir=str(tmp_path), dt=0.01)
+
+    assert obs_info["num_obs"] == 0
+    # Still the whole surface -- a reader should not have to special-case the empty study.
+    assert set(obs_info) == set(OBS_INFO_CONTRACT)
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=True, reason=(
+    "plot_colors can never be anything but None: the schema creates the column with value "
+    "None for every row, so the `.get(\"plot_color\", <cycle>)` default in process_obs_info "
+    "is never reached. Recorded rather than fixed -- making the cycle work would change the "
+    "colours of every existing plot, which is a decision, not a bugfix."))
+def test_plot_colors_never_gets_its_default(mixed):
+    obs_info, _ = mixed
+    assert any(c is not None for c in obs_info["plot_colors"])


### PR DESCRIPTION
Robustness items from the review after releasing 0.7.0, for **0.7.1**.

## The contract test

`obs_info` is a public API with no schema, no version, and no test naming it — indexed by string literal ~300 times here and 31 times in CUFLynx. When #507 renamed two keys, the first thing to notice was an hour-long job that downloads the last CUFLynx *release*.

`tests/test_obs_info_contract.py` describes all 32 keys by **index space** and **tier**:

- **A** (4) — has an accessor, so a rename is invisible to anything using it
- **B** (18) — public and bare. **These are the real contract**: renaming one needs a `LEGACY_OBS_INFO_KEYS` entry, a CHANGELOG line and a downstream sweep
- **C** (10) — published but internal

A rename fails a parametrised test whose **id is the key's own name**, with the reason and the tier-specific remedy in the message. Additions fail too, so the table can't quietly become a subset of reality.

**Verified it can fail** — renaming `const_idx_to_obs_idx` gives:

```
FAILED test_obs_info_publishes[const_idx_to_obs_idx]
  process_obs_info no longer publishes 'const_idx_to_obs_idx'. compacted constant index ->
  data_item row. CUFLynx obs_cost.py and local_sensitivity.py walk this to label the cost
  panel; without it the panel goes silent.
  Tier B: add it to LEGACY_OBS_INFO_KEYS mapping it to its replacement, add a CHANGELOG
  entry, and sweep the downstream readers (CUFLynx included).
FAILED test_obs_info_publishes_nothing_undocumented   # catches the *new* name too
```

The index-space half is what catches silent bugs: a value is indexed by the data_item row **or** by a compacted per-type counter, and CUFLynx reads one of each in a single loop body. Wrong counter, different observable, nothing raises — CA #349, pinned for `protocol_info` and never for this.

**Deliberately not pinned: dtype.** `weight_phase_vec` is object-typed when a frequency weight is a list; `ground_truth_phase` when any item omits `phase`. Asserting dtype is how this file goes flaky and gets ignored.

## Three defects it exposed

| | |
|---|---|
| `process_obs_info` on a hand-built `gt_df` | raised `KeyError: 'prob_dist_params'` — a column the schema adds — despite the docstring inviting exactly that. Now `.get` |
| an obs_data with only `protocol_info` | parsed to a frame with no rows **and no columns**, so every read was a KeyError and the file could not be opened. Fixed where the frame is made |
| `plot_colors` | can never be anything but `None`; the schema creates the column so the colour cycle is unreachable. **Strict xfail**, not fixed — making it work changes every existing plot's colours |

## The numpy fix, which matters more than it looks

All seven accessors now test for `None` rather than truthiness. `array or []` raises *"the truth value of an array with more than one element is ambiguous"*, and several `obs_info` values **are** arrays. The old spelling worked because the keys these accessors read happen to be lists — luck, not design. It broke **47 CUFLynx tests** the moment an adapter copied the idiom onto keys where the luck ran out.

## Also

- `obs_experiment_indices`, `obs_subexperiment_indices`, `obs_scalar_rows` — the tier-B keys CUFLynx reads get the immunity the label keys have
- A test asserting the **bundle carries the engine it declares**, read from the running process. The existing executable test deliberately points the app at a checkout, so nothing ever checked what PyInstaller collected
- `release.yml` waits for the index to serve the new version — two CUFLynx jobs went red in that window on the 0.7.0 release with a message that reads like a dependency mistake
- Debug logs on **four** of the five silent `except Exception: pass` sites in `myokit_helper`. Not the fifth: it's a `float()` type test, so logging it would fire for every non-numeric initial value

## Downstream

Paired with **physiomelinks/CUFLynx#333**, which routes CUFLynx's 31 literal reads through one adapter. Merge this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mk1rvBawTUN3SP7VwHVGhh