### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ next release; add to that section as you land a change.
 
 ## Unreleased
 
+## 0.7.1 — 2026-09-01
+
+### Added — a contract for what `process_obs_info` publishes
+
+`obs_info` is a public API with no schema and no version, indexed by string literal around
+three hundred times here and thirty-one times in CUFLynx. Renaming two of its keys in 0.7.0
+broke the then-current CUFLynx release, and the first thing to notice was an hour-long CI job
+that downloads a built binary.
+
+`tests/test_obs_info_contract.py` now describes all thirty-two keys: which index space each
+belongs to, and whether anything outside this repository may read it. Renaming one fails a
+test whose id is the key's own name, in seconds. Eighteen of them are public with no
+accessor; those are the ones a rename has to plan for.
+
+### Fixed — `process_obs_info` on frames it said it accepted
+
+Two crashes, both on inputs the docstrings invite:
+
+* A caller handing it a `gt_df` it built itself hit `KeyError: 'prob_dist_params'` -- a column
+  the schema adds, read with a bare `[...]`.
+* An obs_data carrying only `protocol_info` parsed to a frame with no rows *and no columns*,
+  so every read raised and such a file could not be opened at all.
+
+### Fixed — the obs_info accessors on numpy columns
+
+`obs_item_names` and its siblings returned `... or []`, which raises "the truth value of an
+array with more than one element is ambiguous" when handed a numpy array. The keys they read
+happen to be lists, so this never fired here; several sibling `obs_info` values *are* arrays,
+and a downstream adapter copying the idiom onto them broke forty-seven tests. They now test
+for `None`.
+
+### Added — `obs_experiment_indices`, `obs_subexperiment_indices`, `obs_scalar_rows`
+
+So the keys CUFLynx reads have the same rename-immunity the label keys already had.
+
+### Changed — the release waits for PyPI to serve what it published
+
+PyPI accepts an upload before its index offers it, and two downstream jobs went red in that
+window on the 0.7.0 release with a message that reads like a dependency mistake.
+
+### Changed — the solver wrapper says what it skipped
+
+Four `except Exception: pass` sites in `myokit_helper` now log at debug. A dropped
+`MaximumStep`, or a variable with no default value, was previously silent.
+
 ## 0.7.0 — 2026-09-01
 
 ### Changed — one spelling per concept in `obs_info` and `prediction_info`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "libcuflynx"
 # the `libcuflynx` namespace. The flat import names (`parsers`, `param_id`, ...) keep working
 # through this release as deprecation shims and are removed in 0.6.0 -- see
 # libcuflynx/_deprecated_aliases.py::REMOVAL_VERSION, which the shims' warning text quotes.
-version = "0.7.0"
+version = "0.7.1"
 description = "Generation and calibration of CellML circulatory system models from module/vessel arrays"
 readme = "README.md"
 # 3.9 is the real floor, not a conservative label: utilities/package_resources.py needs


### PR DESCRIPTION
Version bump and changelog for **0.7.1** — the robustness work from #509.

- A contract test for the 32 keys `process_obs_info` publishes; a rename now fails in seconds rather than in an hour-long release job
- Two crashes fixed on inputs the docstrings invite: a hand-built `gt_df`, and an obs_data carrying only `protocol_info`
- The obs_info accessors no longer raise on numpy columns (`array or []`)
- Three new accessors for the keys CUFLynx reads
- The release waits for PyPI's index to serve what it published
- Debug logs on four silent skips in `myokit_helper`

Tagging `v0.7.1` after merge publishes to PyPI **and** creates the GitHub release — the `github-release` job added in #506, which is why 0.7.0 has an entry and 0.4.1/0.5.0/0.5.1 do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mk1rvBawTUN3SP7VwHVGhh