### PR TITLE
Release 0.7.2 — one reconstruction page per trace, not per feature (#515)

### DIFF
--- a/.github/actions/install-system-deps/action.yml
+++ b/.github/actions/install-system-deps/action.yml
@@ -37,5 +37,42 @@ runs:
     - name: Install the packages
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libopenmpi-dev openmpi-bin libsundials-dev build-essential
+        # `apt-get update` exits 0 when it could not fetch an index. It prints
+        #   "Some index files failed to download. They have been ignored, or old
+        #    ones used instead."
+        # and carries on with the *stale* index it already had. The install then
+        # asks for the package version that index names, the mirror has since
+        # moved to a newer point release, and the fetch 404s -- so a mirror
+        # wobble lands as a hard failure in a later step instead of as a slow
+        # update. Seen on PR #516: after four InRelease timeouts against
+        # archive.ubuntu.com, `libcurl4-openssl-dev 8.5.0-2ubuntu10.12` 404'd and
+        # took out test-uq and test-param-id-serial-full-scale, neither of which
+        # had anything to do with the change under test.
+        #
+        # The timeouts/retries set above bound a single *fetch*; they cannot
+        # notice that the update as a whole came back partial. So: notice it, and
+        # re-run. Retrying the update is cheap next to a lost job, and a stale
+        # index is exactly what a second update fixes.
+        packages=(libopenmpi-dev openmpi-bin libsundials-dev build-essential)
+
+        apt_update_is_complete() {
+          sudo apt-get update 2>&1 | tee /tmp/ca-apt-update.log
+          ! grep -q 'Some index files failed to download' /tmp/ca-apt-update.log
+        }
+
+        for attempt in 1 2 3; do
+          if apt_update_is_complete; then
+            break
+          fi
+          echo "::warning::apt-get update fell back to a stale index (attempt ${attempt}/3); retrying"
+          sleep $((attempt * 10))
+        done
+
+        # Even a complete update can race a mirror mid-publish, so the install
+        # gets one refresh-and-retry of its own rather than failing the job on a
+        # 404 that a second attempt resolves.
+        if ! sudo apt-get install -y "${packages[@]}"; then
+          echo "::warning::apt-get install failed; refreshing the indexes and retrying once"
+          sudo apt-get update
+          sudo apt-get install -y "${packages[@]}"
+        fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@ Not affected: the error vectors stay one entry per data_item. Grouping changes h
 figures are drawn, not what is scored — `percent_error_vec` / `std_error_vec` and the
 `error_vec_names` beside them (#341) are untouched.
 
+### Fixed — a partial `apt-get update` no longer fails a job several steps later
+
+`apt-get update` exits 0 when it could not fetch an index: it says *"Some index files failed
+to download. They have been ignored, or old ones used instead"* and carries on with the stale
+one. The install then asks for the package version that index names, the mirror has moved to
+a newer point release, and the fetch 404s — so a mirror wobble arrives as a hard failure in an
+unrelated job rather than as a slow update. On this release's own PR it took out `test-uq` and
+`test-param-id-serial-full-scale` over `libcurl4-openssl-dev`.
+
+`install-system-deps` now notices the partial update and re-runs it (three attempts, backing
+off), and gives the install one refresh-and-retry of its own. The per-fetch timeouts and
+retries already there bound a single request; neither can see that the update as a whole came
+back incomplete. A genuinely broken apt still fails the job — the retries do not swallow it.
+
 ## 0.7.1 — 2026-09-01
 
 ### Added — a contract for what `process_obs_info` publishes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ next release; add to that section as you land a change.
 
 ## Unreleased
 
+## 0.7.2 — 2026-09-04
+
+### Fixed — one reconstruction page per trace, not per feature (#515)
+
+Before #466 a data_item's `variable` was both its identity and the model variable it reduced,
+so `max` and `min` of one pressure shared a `variable` and were drawn on one figure. #466
+split those two jobs and made `data_item_name` unique by construction — and
+`plot_reconstruction_pages` still grouped on it. Every feature therefore got a page of its
+own: the 3compartment example went from four figures to six, and a study with several
+features per trace lost the merged figures entirely.
+
+Pages are now keyed on `trace_name_for_plotting` — the series a feature is measured on, which
+is allowed to repeat and is already what the y-axis is labelled with. On the shipped fixtures
+that is 3compartment back to four pages from six, with `mean`/`max` of `v_{AR}` and
+`mean`/`max_minus_min` of `u_{AR}` reunited, while the four-experiment multi-trace fixture
+stays at eight, one per trace per experiment.
+
+Subexperiment is deliberately *not* part of the key, which is the second half of the issue: a
+trace measured on several subexperiments is one page carrying a segment for each, drawn along
+the experiment's timeline and sharing a single legend entry. `Lotka_Volterra_multisub` goes
+from four pages to two, each spanning both subexperiments. A subexperiment nothing was
+measured on is still left out, so #474's narrowed axis is unchanged — the window is the union
+of the segments actually measured, not the whole experiment.
+
+The y-axis label now comes from the same resolved name the page is grouped by, so a page
+cannot be grouped under one name and labelled with another.
+
+Not affected: the error vectors stay one entry per data_item. Grouping changes how many
+figures are drawn, not what is scored — `percent_error_vec` / `std_error_vec` and the
+`error_vec_names` beside them (#341) are untouched.
+
 ## 0.7.1 — 2026-09-01
 
 ### Added — a contract for what `process_obs_info` publishes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "libcuflynx"
 # the `libcuflynx` namespace. The flat import names (`parsers`, `param_id`, ...) keep working
 # through this release as deprecation shims and are removed in 0.6.0 -- see
 # libcuflynx/_deprecated_aliases.py::REMOVAL_VERSION, which the shims' warning text quotes.
-version = "0.7.1"
+version = "0.7.2"
 description = "Generation and calibration of CellML circulatory system models from module/vessel arrays"
 readme = "README.md"
 # 3.9 is the real floor, not a conservative label: utilities/package_resources.py needs

--- a/src/libcuflynx/param_id/plot_outputs.py
+++ b/src/libcuflynx/param_id/plot_outputs.py
@@ -294,10 +294,24 @@ class ParamIDPlotOutputs:
         prefix = self.client.file_name_prefix
         obs_stub = self.client.param_id_obs_file_prefix
 
-        obs_tuples_unique = []
+        # One figure per (trace, experiment), not per (item, experiment). A data_item_name is
+        # unique by construction since #466, so grouping on it gave every feature its own page
+        # -- max and min of the same pressure became two figures instead of two lines on one.
+        # trace_name_for_plotting is the name of the series a feature is measured on, is
+        # allowed to repeat, and is already what the y-axis is labelled with, so it is the
+        # thing a page is about. Subexperiment is deliberately not in the key: features of one
+        # trace measured on different subexperiments belong on one page, drawn side by side
+        # along the experiment's timeline (#515).
         item_names = obs_item_names(obs_info)
-        for idx, obs_name in enumerate(item_names):
-            tup = (obs_name, obs_info["experiment_idxs"][idx])
+        trace_labels = obs_trace_labels(obs_info)
+        group_keys = [
+            str(trace_labels[idx]) if idx < len(trace_labels) and trace_labels[idx]
+            else str(item_names[idx])
+            for idx in range(obs_info["num_obs"])
+        ]
+        obs_tuples_unique = []
+        for idx, group_name in enumerate(group_keys):
+            tup = (group_name, obs_info["experiment_idxs"][idx])
             if tup not in obs_tuples_unique:
                 obs_tuples_unique.append(tup)
 
@@ -317,7 +331,12 @@ class ParamIDPlotOutputs:
         plot_saved = False
 
         for unique_obs_count in range(len(obs_tuples_unique)):
-            this_obs_waveform_plotted = False
+            # Which subexperiments this page has already drawn the trace for. Per
+            # subexperiment rather than a single flag, so a group spanning several of them
+            # shows the whole trace instead of only the first segment (#515); still once per
+            # subexperiment, so several features measured on the same segment share one line.
+            subexps_drawn = set()
+            trace_x_window = []
             const_idx = -1
             series_idx = -1
             freq_idx = -1
@@ -331,7 +350,7 @@ class ParamIDPlotOutputs:
                     freq_idx += 1
 
                 if (
-                    item_names[II],
+                    group_keys[II],
                     obs_info["experiment_idxs"][II],
                 ) != obs_tuples_unique[unique_obs_count]:
                     continue
@@ -356,7 +375,10 @@ class ParamIDPlotOutputs:
                             len(best_fit_obs_series[0]),
                         )
 
-                obs_name_for_plot = obs_trace_labels(obs_info)[II]
+                # The same resolved name the page was grouped by, so the y-axis label and the
+                # grouping cannot disagree -- an item whose trace name is empty would
+                # otherwise be grouped under its item name and labelled '$$'.
+                obs_name_for_plot = group_keys[II]
                 if obs_name_for_plot.count("_") > 1:
                     print(
                         f'obs_data variable "{obs_name_for_plot}" has too many underscores',
@@ -387,31 +409,38 @@ class ParamIDPlotOutputs:
 
                 # An observable built from other observables has no trace of its own to draw:
                 # its operation takes its inputs from operation_kwargs, not from a model
-                # variable, so the "series" reconstruction is the scalar it returns. Before
-                # #466 such an item shared its `variable` with the items it was built from and
-                # so was grouped with them, and the group's waveform had already been drawn by
-                # the time it came round -- it never reached here. Names are unique now, so it
-                # gets its own group and does, with nothing to plot.
+                # variable, so the "series" reconstruction is the scalar it returns. It has no
+                # operand either, so its trace_name_for_plotting defaults to its own name and
+                # it lands on a page of its own -- reaching here with nothing to plot, which
+                # `has_waveform` is what handles.
                 reconstruction = series_per_sub[II] if II < len(series_per_sub) else None
                 has_waveform = reconstruction is not None and np.ndim(reconstruction) > 0
 
-                if not this_obs_waveform_plotted and (
+                if subexp_count not in subexps_drawn and (
                         has_waveform or obs_info["data_types"][II] == "frequency"):
                     axs.set_ylabel(f"${obs_name_for_plot}$ ${unit_label}$", fontsize=18)
                     if obs_info["data_types"][II] != "frequency":
-                        # Only the subexperiment this observable belongs to. A
-                        # settle/pre subexperiment is not what the observable was
-                        # measured on, so drawing it stretches the axis over a
-                        # window the ground truth says nothing about.
+                        # Only the subexperiments this page's features were measured on. A
+                        # settle/pre subexperiment nothing is measured on is still left out,
+                        # so the axis never stretches over a window the ground truth says
+                        # nothing about -- but a trace measured on two of them gets both.
                         axs.plot(
                             tSim_per_sub_count[subexp_count],
                             conversion * reconstruction[:],
                             color=protocol_info["experiment_colors"][exp_idx],
-                            label="output",
+                            # One legend entry for the trace, however many segments it has.
+                            # '_nolegend_' rather than None: it is the documented way to keep
+                            # an artist out of the legend, and does not depend on legend()
+                            # happening to skip a None label.
+                            label="output" if not subexps_drawn else "_nolegend_",
+                        )
+                        trace_x_window.append(
+                            (tSim_per_sub_count[subexp_count][0],
+                             tSim_per_sub_count[subexp_count][-1])
                         )
                         axs.set_xlim(
-                            tSim_per_sub_count[subexp_count][0],
-                            tSim_per_sub_count[subexp_count][-1],
+                            min(lo for lo, _ in trace_x_window),
+                            max(hi for _, hi in trace_x_window),
                         )
                         axs.set_xlabel("Time [$s$]", fontsize=18)
                     else:
@@ -437,7 +466,7 @@ class ParamIDPlotOutputs:
                             )
                         axs.set_xlim(0.0, obs_info["freqs"][II][-1])
                         axs.set_xlabel("frequency [$Hz$]", fontsize=18)
-                    this_obs_waveform_plotted = True
+                    subexps_drawn.add(subexp_count)
 
                 dt = self.client.dt
 

--- a/tests/test_reconstruction_page_grouping.py
+++ b/tests/test_reconstruction_page_grouping.py
@@ -1,0 +1,248 @@
+"""One reconstruction page per trace, not per feature (issue #515).
+
+Before #466 a data_item's ``variable`` was both its identity and the name of the model
+variable it reduced, so ``max`` and ``min`` of the same pressure shared a ``variable`` and
+were grouped onto one page. #466 split those jobs and made ``data_item_name`` unique by
+construction -- and the page grouping still keyed on it, so every feature got a page of its
+own and the merged figures disappeared.
+
+The key is ``trace_name_for_plotting``: the series a feature is measured on, allowed to
+repeat, and already what the y-axis is labelled with. Subexperiment is deliberately not part
+of it, so a trace measured on several subexperiments is drawn as one figure with a segment
+each.
+
+No model and no MPI: the plotting method is driven directly with a synthetic obs_info.
+"""
+import os
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+
+from libcuflynx.param_id.plot_outputs import ParamIDPlotOutputs
+
+
+N_STEPS = 4
+DT = 0.25
+SUB_SIM_TIME = 1.0
+
+
+class _Client:
+    def __init__(self, plot_dir, obs_info, protocol_info):
+        self.obs_info = obs_info
+        self.protocol_info = protocol_info
+        self.plot_dir = str(plot_dir)
+        self.output_dir = str(plot_dir)
+        self.file_name_prefix = "model"
+        self.param_id_obs_file_prefix = "obs"
+        self.dt = DT
+
+
+def _obs_info(items):
+    """``items`` are ``(data_item_name, trace_name_for_plotting, subexperiment_idx)``."""
+    num_obs = len(items)
+    return {
+        "num_obs": num_obs,
+        "data_item_names": [name for name, _, _ in items],
+        "trace_names_for_plotting": [trace for _, trace, _ in items],
+        "item_names_for_plotting": [f"{name} (max)" for name, _, _ in items],
+        "experiment_idxs": [0] * num_obs,
+        "subexperiment_idxs": [sub for _, _, sub in items],
+        "data_types": ["constant"] * num_obs,
+        "operations": ["max"] * num_obs,
+        "operation_kwargs": [{} for _ in range(num_obs)],
+        "units": ["J_per_m3"] * num_obs,
+        "plot_type": ["horizontal"] * num_obs,
+        "plot_colors": ["tab:blue"] * num_obs,
+        "ground_truth_const": np.ones(num_obs),
+        "std_const_vec": np.ones(num_obs),
+        "weight_const_vec": np.ones(num_obs),
+        "ground_truth_prob_dist_params": [None] * num_obs,
+        "ground_truth_series": [],
+        "obs_dt": [],
+        "freqs": [None] * num_obs,
+    }
+
+
+def _protocol_info(num_sub):
+    return {
+        "num_experiments": 1,
+        "num_sub_per_exp": [num_sub],
+        "sim_times": [[SUB_SIM_TIME] * num_sub],
+        "pre_times": [0.0],
+        "experiment_colors": ["tab:green"],
+    }
+
+
+def _run(tmp_path, items, num_sub, monkeypatch):
+    """Drive ``plot_reconstruction_pages`` and capture each page's axes before it closes."""
+    obs_info = _obs_info(items)
+    protocol_info = _protocol_info(num_sub)
+
+    plotter = ParamIDPlotOutputs.__new__(ParamIDPlotOutputs)
+    plotter.client = _Client(tmp_path, obs_info, protocol_info)
+
+    pages = []
+
+    def _capture(plot_dir, prefix, obs_stub, plot_idx, fig, axs, fig_phase, axs_phase, phase):
+        pages.append(
+            {
+                "xlim": axs.get_xlim(),
+                "labels": [line.get_label() for line in axs.get_lines()],
+                "ylabel": axs.get_ylabel(),
+                "n_lines": len(axs.get_lines()),
+            }
+        )
+
+    monkeypatch.setattr(
+        ParamIDPlotOutputs, "_save_reconstruction_figure_bundle", staticmethod(_capture)
+    )
+
+    num_obs = obs_info["num_obs"]
+    # One time grid per subexperiment, laid end to end along the experiment's timeline --
+    # the same absolute axis _compute_subexperiment_time_axes builds.
+    tSim_per_sub_count = [
+        np.linspace(sub * SUB_SIM_TIME, (sub + 1) * SUB_SIM_TIME, N_STEPS + 1)
+        for sub in range(num_sub)
+    ]
+    # A reconstruction per item, per subexperiment: series_per_sub[II] is item II's trace.
+    list_of_all_series = [
+        np.ones((num_obs, N_STEPS + 1)) * (sub + 1) for sub in range(num_sub)
+    ]
+    list_of_obs_dicts = [
+        {
+            "const": np.ones(num_obs),
+            "series": np.ones((num_obs, N_STEPS + 1)),
+            "amp": [],
+            "phase": [],
+        }
+        for _ in range(num_sub)
+    ]
+
+    percent, std, phase_err = plotter.plot_reconstruction_pages(
+        False,
+        list_of_obs_dicts,
+        list_of_all_series,
+        tSim_per_sub_count,
+        [SUB_SIM_TIME * num_sub],
+        [N_STEPS] * num_sub,
+    )
+    return pages, percent, std
+
+
+def test_two_features_of_one_trace_share_a_page(tmp_path, monkeypatch):
+    """The regression in the issue: max and min of one pressure are one figure, not two."""
+    pages, _, _ = _run(
+        tmp_path,
+        [("u_ar_max", "u_ar", 0), ("u_ar_min", "u_ar", 0)],
+        num_sub=1,
+        monkeypatch=monkeypatch,
+    )
+    assert len(pages) == 1
+
+
+def test_distinct_traces_stay_on_separate_pages(tmp_path, monkeypatch):
+    """Grouping merges a trace's features; it does not merge two different traces."""
+    pages, _, _ = _run(
+        tmp_path,
+        [("u_ar_max", "u_ar", 0), ("u_ar_min", "u_ar", 0), ("q_lv_mean", "q_lv", 0)],
+        num_sub=1,
+        monkeypatch=monkeypatch,
+    )
+    assert len(pages) == 2
+    assert sorted(page["ylabel"] for page in pages) == [
+        "$q_lv$ $[kPa]$",
+        "$u_ar$ $[kPa]$",
+    ]
+
+
+def test_a_trace_measured_on_two_subexperiments_is_one_page(tmp_path, monkeypatch):
+    """The issue's "even across different subexperiments"."""
+    pages, _, _ = _run(
+        tmp_path,
+        [("u_ar_max_sub0", "u_ar", 0), ("u_ar_max_sub1", "u_ar", 1)],
+        num_sub=2,
+        monkeypatch=monkeypatch,
+    )
+    assert len(pages) == 1
+
+
+def test_both_subexperiment_segments_are_drawn(tmp_path, monkeypatch):
+    """Merging the pages is only half of it -- the combined trace has to be drawn.
+
+    A single "already plotted" flag per page would draw the first segment and silently
+    drop the second, which looks like a correct plot of the wrong window.
+    """
+    pages, _, _ = _run(
+        tmp_path,
+        [("u_ar_max_sub0", "u_ar", 0), ("u_ar_max_sub1", "u_ar", 1)],
+        num_sub=2,
+        monkeypatch=monkeypatch,
+    )
+    outputs = [lab for lab in pages[0]["labels"] if lab == "output"]
+    segments = [lab for lab in pages[0]["labels"] if lab in ("output", "_nolegend_")]
+    assert len(segments) == 2, "expected one trace segment per subexperiment"
+    assert len(outputs) == 1, "the trace should take one legend entry, not one per segment"
+
+
+def test_the_x_axis_spans_every_subexperiment_the_trace_was_measured_on(
+    tmp_path, monkeypatch
+):
+    pages, _, _ = _run(
+        tmp_path,
+        [("u_ar_max_sub0", "u_ar", 0), ("u_ar_max_sub1", "u_ar", 1)],
+        num_sub=2,
+        monkeypatch=monkeypatch,
+    )
+    lo, hi = pages[0]["xlim"]
+    assert lo == pytest.approx(0.0)
+    assert hi == pytest.approx(2 * SUB_SIM_TIME)
+
+
+def test_a_subexperiment_nothing_was_measured_on_is_still_left_out(
+    tmp_path, monkeypatch
+):
+    """The #474 behaviour this must not undo: a settle window the ground truth says
+    nothing about does not stretch the axis."""
+    pages, _, _ = _run(
+        tmp_path,
+        [("u_ar_max_sub1", "u_ar", 1)],
+        num_sub=2,
+        monkeypatch=monkeypatch,
+    )
+    lo, hi = pages[0]["xlim"]
+    assert lo == pytest.approx(SUB_SIM_TIME)
+    assert hi == pytest.approx(2 * SUB_SIM_TIME)
+
+
+def test_an_item_with_no_trace_name_falls_back_to_its_own_name(tmp_path, monkeypatch):
+    """An item built from other items has no operand, so its trace name defaults to its
+    own name -- it gets a page of its own rather than joining an unrelated group.
+
+    The parser fills this in (``default_trace_names_for_plotting``), so an empty one only
+    reaches here from a hand-assembled obs_info. It still must not collapse every such item
+    onto one nameless page, nor label that page '$$'.
+    """
+    pages, _, _ = _run(
+        tmp_path,
+        [("u_ar_max", "u_ar", 0), ("difference", "", 0)],
+        num_sub=1,
+        monkeypatch=monkeypatch,
+    )
+    assert len(pages) == 2
+    assert sorted(page["ylabel"] for page in pages) == [
+        "$difference$ $[kPa]$",
+        "$u_ar$ $[kPa]$",
+    ]
+
+
+def test_the_error_vectors_stay_one_entry_per_item(tmp_path, monkeypatch):
+    """Pages are grouped; the error vectors are not. Entry i still belongs to
+    data_items[i], which every consumer of these artefacts depends on (#341)."""
+    items = [("u_ar_max", "u_ar", 0), ("u_ar_min", "u_ar", 0), ("q_lv_mean", "q_lv", 0)]
+    pages, percent, std = _run(tmp_path, items, num_sub=1, monkeypatch=monkeypatch)
+    assert len(pages) == 2
+    assert percent.shape == (len(items),)
+    assert std.shape == (len(items),)


### PR DESCRIPTION
Fixes #515, and cuts **0.7.2**.

## The bug

Before #466, a data_item's `variable` was both its identity and the model variable it reduced, so `max` and `min` of one pressure shared a `variable` and were grouped onto one figure. #466 split those two jobs and made `data_item_name` unique by construction — and `plot_reconstruction_pages` still grouped on it.

Every feature therefore got a page of its own, which is what @MOH-Shafizadegan reported: standalone figures per feature and per subexperiment instead of consolidated ones.

## The fix

Pages are keyed on **`trace_name_for_plotting`** — the series a feature is measured on. It is allowed to repeat, and it is already what the y-axis is labelled with, so it is the thing a page is *about*.

Subexperiment is deliberately **not** in the key, which is the second half of the issue ("even across different subexperiments"). That needed more than the key change: a single `this_obs_waveform_plotted` flag would have merged the pages and then drawn only the first segment — a plot that looks right and shows the wrong window. It is now a set of the subexperiments drawn, so a trace measured on several gets a segment for each, sharing one legend entry, with the x-axis spanning their union.

**#474's narrowed axis is preserved**: a subexperiment nothing was measured on (a settle window) is still left out. The axis is the union of the segments actually measured, not the whole experiment. There is a test for exactly that, and it is the one test in the new file that passes both before and after this change.

The y-axis label now reads the same resolved name the grouping uses, so a page cannot be grouped under one name and labelled with another (an item with an empty trace name was grouped under its item name but labelled `$$`, which is a mathtext parse error at render time).

## Effect on the shipped fixtures

| obs_data | pages before | pages after |
|---|---|---|
| `3compartment_obs_data.json` | 6 | **4** — `mean`/`max` of `v_{AR}` and `mean`/`max_minus_min` of `u_{AR}` reunited |
| `Lotka_Volterra_multisub_obs_data.json` | 4 | **2** — each spanning both subexperiments |
| `Lotka_Volterra_forced_multi_trace_obs_data.json` | 8 | **8** — distinct traces stay separate, no over-merging |

## Not affected

The error vectors stay one entry per data_item. Grouping changes how many figures are drawn, not what is scored: `percent_error_vec` / `std_error_vec` and the `error_vec_names` written beside them (#341) are untouched, and there is a test pinning that.

## Tests

`tests/test_reconstruction_page_grouping.py` — 8 tests driving `plot_reconstruction_pages` directly with a synthetic obs_info (no model, no MPI, Agg backend), capturing each page's axes before it closes. **7 of the 8 fail on the parent commit**; the eighth is the #474 regression guard, which must pass both ways.

Full fast suite: 2097 passed, 16 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158HoQTMZKkMnpCwfLt6eKz
